### PR TITLE
📝 docs: TypeScript/TSXファイル命名規則の設計書を追加

### DIFF
--- a/docs/development/filename-convention.md
+++ b/docs/development/filename-convention.md
@@ -12,11 +12,13 @@
 
 ### 命名パターン
 - **必須**: kebab-case（例: `user-profile.ts`, `header-component.tsx`, `api-v2.ts`, `utils-123.tsx`）
+- **許可される特殊ケース**:
+  - 単一文字ファイル（例: `a.ts`, `x.tsx`, `1.ts`）
+  - 数字を含むファイル（例: `component-v2.tsx`, `test-123.ts`）
 - **禁止**: 
   - camelCase（例: ~~`userProfile.ts`~~）
   - PascalCase（例: ~~`UserProfile.ts`~~）
   - snake_case（例: ~~`user_profile.ts`~~）
-- **数字の扱い**: 数字は許可されるが、適切に区切る（例: `component-v2.tsx`, `test-123.ts`）
 
 ### 例外
 - 設定ファイル（例: `next.config.ts`, `vite.config.ts`）
@@ -74,7 +76,8 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 
-// kebab-case パターン（数字も許可）
+// kebab-case パターン（数字も許可、単一文字も許可）
+// 例: 'a.ts', '1.ts', 'api-v2.ts', 'test-123.tsx'
 const kebabCasePattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 // 例外ファイルのパターン

--- a/docs/development/filename-convention.md
+++ b/docs/development/filename-convention.md
@@ -25,32 +25,10 @@
 
 ## 実装方法
 
-### 1. ESLintルールによる検出
+### 1. カスタムスクリプトによる検出
 
-#### 必要なパッケージ
-```json
-{
-  "devDependencies": {
-    "eslint-plugin-filenames-simple": "^0.9.0"
-  }
-}
-```
-
-#### ESLint設定（`.eslintrc.json`）
-```json
-{
-  "plugins": ["filenames-simple"],
-  "rules": {
-    "filenames-simple/naming-convention": [
-      "error",
-      {
-        "rule": "kebab-case",
-        "match": "\\.tsx?$"
-      }
-    ]
-  }
-}
-```
+**注意**: このプロジェクトではBiomeを使用しているため、ESLintプラグインは使用しません。
+Biomeには現在ファイル名規則を強制する機能がないため、カスタムスクリプトで実装します。
 
 ### 2. Git Pre-commitフック
 
@@ -68,7 +46,7 @@ npx husky init
 # ファイル名チェック
 npm run check:filenames
 
-# ESLintチェック
+# Biomeチェック
 npx lint-staged
 ```
 
@@ -77,13 +55,13 @@ npx lint-staged
 {
   "scripts": {
     "check:filenames": "node scripts/check-filenames.js",
-    "lint": "eslint . --ext .ts,.tsx",
-    "lint:fix": "eslint . --ext .ts,.tsx --fix"
+    "biome:check": "biome check",
+    "biome:fix": "biome check --write"
   },
   "lint-staged": {
     "*.{ts,tsx}": [
       "npm run check:filenames",
-      "eslint --fix"
+      "biome check --write"
     ]
   }
 }
@@ -184,8 +162,8 @@ jobs:
       - name: Check TypeScript/TSX filenames
         run: npm run check:filenames
         
-      - name: Run ESLint filename rules
-        run: npm run lint
+      - name: Run Biome check
+        run: npm run biome:check
 ```
 
 ### 5. VS Code設定（推奨）
@@ -195,18 +173,17 @@ jobs:
 {
   "files.autoSave": "onFocusChange",
   "[typescript]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "[typescriptreact]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "biomejs.biome"
   },
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
-  "eslint.run": "onType"
+  "editor.codeActionsOnSave": {
+    "quickfix.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
+  }
 }
 ```
 
@@ -303,13 +280,14 @@ renameFiles();
 ## メンテナンス
 
 ### 定期的な確認項目
-- [ ] ESLintルールの更新確認
+- [ ] Biomeのファイル名ルール機能の追加確認
 - [ ] 例外リストの見直し
 - [ ] CI実行時間の最適化
 - [ ] チームフィードバックの収集
 
 ## 参考資料
 
-- [ESLint Plugin Filenames Simple](https://github.com/epaew/eslint-plugin-filenames-simple)
+- [Biome - Fast Formatter and Linter](https://biomejs.dev/)
 - [Husky - Git Hooks](https://typicode.github.io/husky/)
 - [lint-staged](https://github.com/okonet/lint-staged)
+- [Biome VS Code Extension](https://marketplace.visualstudio.com/items?itemName=biomejs.biome)

--- a/docs/development/filename-convention.md
+++ b/docs/development/filename-convention.md
@@ -1,0 +1,305 @@
+# TypeScript/TSXファイル命名規則の強制
+
+## 概要
+
+このプロジェクトでは、TypeScript（`.ts`）およびTSX（`.tsx`）ファイルの命名規則として**kebab-case**を採用します。この規則を確実に守るため、Push前のフック処理とCI/CDパイプラインでの自動チェックを実装します。
+
+## 命名規則
+
+### 対象ファイル
+- `.ts` ファイル
+- `.tsx` ファイル
+
+### 命名パターン
+- **必須**: kebab-case（例: `user-profile.ts`, `header-component.tsx`）
+- **禁止**: 
+  - camelCase（例: ~~`userProfile.ts`~~）
+  - PascalCase（例: ~~`UserProfile.ts`~~）
+  - snake_case（例: ~~`user_profile.ts`~~）
+
+### 例外
+- 設定ファイル（例: `next.config.ts`, `vite.config.ts`）
+- 型定義ファイル（例: `*.d.ts`）
+- テストファイル（例: `*.test.ts`, `*.spec.ts`）は対象だが、元ファイル名に従う
+
+## 実装方法
+
+### 1. ESLintルールによる検出
+
+#### 必要なパッケージ
+```json
+{
+  "devDependencies": {
+    "eslint-plugin-filenames-simple": "^0.9.0"
+  }
+}
+```
+
+#### ESLint設定（`.eslintrc.json`）
+```json
+{
+  "plugins": ["filenames-simple"],
+  "rules": {
+    "filenames-simple/naming-convention": [
+      "error",
+      {
+        "rule": "kebab-case",
+        "match": "\\.tsx?$"
+      }
+    ]
+  }
+}
+```
+
+### 2. Git Pre-commitフック
+
+#### Huskyの設定
+```bash
+npm install --save-dev husky lint-staged
+npx husky init
+```
+
+#### `.husky/pre-commit`
+```bash
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+# ファイル名チェック
+npm run check:filenames
+
+# ESLintチェック
+npx lint-staged
+```
+
+#### `package.json`のスクリプト
+```json
+{
+  "scripts": {
+    "check:filenames": "node scripts/check-filenames.js",
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --ext .ts,.tsx --fix"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "npm run check:filenames",
+      "eslint --fix"
+    ]
+  }
+}
+```
+
+### 3. カスタムスクリプト
+
+#### `scripts/check-filenames.js`
+```javascript
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+// kebab-case パターン
+const kebabCasePattern = /^[a-z]+(-[a-z]+)*$/;
+
+// 例外ファイルのパターン
+const exceptions = [
+  /^next\.config\.ts$/,
+  /^vite\.config\.ts$/,
+  /^jest\.config\.ts$/,
+  /^postcss\.config\.ts$/,
+  /\.d\.ts$/
+];
+
+function checkFilenames() {
+  const errors = [];
+  
+  // TypeScript/TSXファイルを検索
+  const files = glob.sync('**/*.{ts,tsx}', {
+    ignore: ['node_modules/**', 'dist/**', 'build/**', '.next/**']
+  });
+
+  files.forEach(filePath => {
+    const filename = path.basename(filePath, path.extname(filePath));
+    
+    // 例外チェック
+    const basename = path.basename(filePath);
+    const isException = exceptions.some(pattern => pattern.test(basename));
+    
+    if (!isException && !kebabCasePattern.test(filename)) {
+      errors.push(filePath);
+    }
+  });
+
+  if (errors.length > 0) {
+    console.error('❌ 以下のファイルがkebab-case命名規則に違反しています:');
+    errors.forEach(file => {
+      const filename = path.basename(file);
+      const suggested = filename
+        .replace(/([A-Z])/g, '-$1')
+        .toLowerCase()
+        .replace(/^-/, '')
+        .replace(/_/g, '-');
+      console.error(`  ${file}`);
+      console.error(`    → 推奨: ${suggested}`);
+    });
+    process.exit(1);
+  }
+
+  console.log('✅ すべてのTypeScript/TSXファイルがkebab-case命名規則に準拠しています');
+}
+
+checkFilenames();
+```
+
+### 4. GitHub Actions CI設定
+
+#### `.github/workflows/check-filenames.yml`
+```yaml
+name: Check Filename Convention
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  check-filenames:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Check TypeScript/TSX filenames
+        run: npm run check:filenames
+        
+      - name: Run ESLint filename rules
+        run: npm run lint -- --rule 'filenames-simple/naming-convention: error'
+```
+
+### 5. VS Code設定（推奨）
+
+#### `.vscode/settings.json`
+```json
+{
+  "files.autoSave": "onFocusChange",
+  "[typescript]": {
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.formatOnSave": true
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "eslint.run": "onType"
+}
+```
+
+## 既存ファイルの移行計画
+
+### Phase 1: 検出とリスト作成
+```bash
+# 違反ファイルのリストを生成
+npm run check:filenames > filename-violations.txt
+```
+
+### Phase 2: 自動リネームスクリプト
+```javascript
+// scripts/rename-files.js
+const fs = require('fs');
+const path = require('path');
+const glob = require('glob');
+
+function toKebabCase(str) {
+  return str
+    .replace(/([A-Z])/g, '-$1')
+    .toLowerCase()
+    .replace(/^-/, '')
+    .replace(/_/g, '-');
+}
+
+function renameFiles() {
+  const files = glob.sync('**/*.{ts,tsx}', {
+    ignore: ['node_modules/**', 'dist/**', 'build/**']
+  });
+
+  const renames = [];
+  
+  files.forEach(filePath => {
+    const dir = path.dirname(filePath);
+    const ext = path.extname(filePath);
+    const filename = path.basename(filePath, ext);
+    const newFilename = toKebabCase(filename);
+    
+    if (filename !== newFilename) {
+      const newPath = path.join(dir, newFilename + ext);
+      renames.push({ from: filePath, to: newPath });
+    }
+  });
+
+  // Git mvコマンドを生成
+  renames.forEach(({ from, to }) => {
+    console.log(`git mv "${from}" "${to}"`);
+  });
+}
+
+renameFiles();
+```
+
+### Phase 3: インポート文の更新
+リネーム後、プロジェクト全体のインポート文を更新する必要があります。
+
+## トラブルシューティング
+
+### よくある問題と解決方法
+
+1. **既存のPascalCaseコンポーネントファイル**
+   - 解決: 段階的な移行プランを作成し、チーム全体で合意を得る
+
+2. **Next.jsの動的ルート**
+   - 解決: `[id].tsx`のような動的ルートファイルは例外として扱う
+
+3. **テストファイルの命名**
+   - 解決: `component-name.test.tsx`のパターンを使用
+
+## チームへの導入手順
+
+1. **チーム全体への周知**
+   - 命名規則の重要性を説明
+   - 移行計画の共有
+
+2. **段階的な導入**
+   - 新規ファイルから適用開始
+   - 既存ファイルは計画的に移行
+
+3. **CI/CDの有効化**
+   - まずは警告モードで開始
+   - 2週間後にエラーモードに移行
+
+## メンテナンス
+
+### 定期的な確認項目
+- [ ] ESLintルールの更新確認
+- [ ] 例外リストの見直し
+- [ ] CI実行時間の最適化
+- [ ] チームフィードバックの収集
+
+## 参考資料
+
+- [ESLint Plugin Filenames Simple](https://github.com/epaew/eslint-plugin-filenames-simple)
+- [Husky - Git Hooks](https://typicode.github.io/husky/)
+- [lint-staged](https://github.com/okonet/lint-staged)

--- a/docs/development/filename-convention.md
+++ b/docs/development/filename-convention.md
@@ -277,15 +277,46 @@ renameFiles();
 3. **テストファイルの命名**
    - 解決: `component-name.test.tsx`のパターンを使用
 
+## Claude Codeへの設定
+
+### CLAUDE.mdファイルへの記載
+
+Claude Codeが毎回ファイル命名規則を認識できるよう、プロジェクトルートの`CLAUDE.md`ファイルに以下の内容を追加します：
+
+```markdown
+## ファイル命名規則
+
+このプロジェクトでは、すべてのTypeScript（.ts）およびTSX（.tsx）ファイルは**kebab-case**で命名する必要があります。
+
+### 命名ルール
+- ✅ 正しい: `user-profile.ts`, `api-service.tsx`, `test-utils.ts`
+- ❌ 間違い: `userProfile.ts`, `UserProfile.tsx`, `user_profile.ts`
+
+### 新規ファイル作成時の注意
+- 新しいファイルを作成する際は、必ずkebab-caseを使用してください
+- 例: `create-user-modal.tsx`、`data-fetcher.ts`
+
+### 既存ファイルのリネーム
+- 既存のファイルをリネームする場合は、`git mv`コマンドを使用してください
+- インポート文の更新も忘れずに行ってください
+```
+
+この設定により、Claude Codeは自動的に：
+1. 新規ファイル作成時にkebab-caseを使用
+2. コードレビュー時に命名規則違反を指摘
+3. リファクタリング時に適切な命名を提案
+
 ## チームへの導入手順
 
 1. **チーム全体への周知**
    - 命名規則の重要性を説明
    - 移行計画の共有
+   - CLAUDE.mdファイルの更新
 
 2. **段階的な導入**
    - 新規ファイルから適用開始
    - 既存ファイルは計画的に移行
+   - Claude Codeの活用を推奨
 
 3. **CI/CDの有効化**
    - まずは警告モードで開始

--- a/docs/development/filename-convention.md
+++ b/docs/development/filename-convention.md
@@ -11,11 +11,12 @@
 - `.tsx` ファイル
 
 ### 命名パターン
-- **必須**: kebab-case（例: `user-profile.ts`, `header-component.tsx`）
+- **必須**: kebab-case（例: `user-profile.ts`, `header-component.tsx`, `api-v2.ts`, `utils-123.tsx`）
 - **禁止**: 
   - camelCase（例: ~~`userProfile.ts`~~）
   - PascalCase（例: ~~`UserProfile.ts`~~）
   - snake_case（例: ~~`user_profile.ts`~~）
+- **数字の扱い**: 数字は許可されるが、適切に区切る（例: `component-v2.tsx`, `test-123.ts`）
 
 ### 例外
 - 設定ファイル（例: `next.config.ts`, `vite.config.ts`）
@@ -96,8 +97,8 @@ const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
 
-// kebab-case パターン
-const kebabCasePattern = /^[a-z]+(-[a-z]+)*$/;
+// kebab-case パターン（数字も許可）
+const kebabCasePattern = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 // 例外ファイルのパターン
 const exceptions = [
@@ -184,7 +185,7 @@ jobs:
         run: npm run check:filenames
         
       - name: Run ESLint filename rules
-        run: npm run lint -- --rule 'filenames-simple/naming-convention: error'
+        run: npm run lint
 ```
 
 ### 5. VS Code設定（推奨）
@@ -226,10 +227,19 @@ const glob = require('glob');
 
 function toKebabCase(str) {
   return str
-    .replace(/([A-Z])/g, '-$1')
+    // PascalCase/camelCaseの処理
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    // 数字の前後に区切りを追加
+    .replace(/([a-zA-Z])([0-9])/g, '$1-$2')
+    .replace(/([0-9])([a-zA-Z])/g, '$1-$2')
+    // すべて小文字に変換
     .toLowerCase()
-    .replace(/^-/, '')
-    .replace(/_/g, '-');
+    // アンダースコアをハイフンに変換
+    .replace(/_/g, '-')
+    // 重複するハイフンを単一に
+    .replace(/-+/g, '-')
+    // 先頭と末尾のハイフンを削除
+    .replace(/^-|-$/g, '');
 }
 
 function renameFiles() {


### PR DESCRIPTION
## Summary
- TypeScript/TSXファイルの命名規則（kebab-case）を強制するための設計書を追加
- カスタムスクリプト、Git hooks、GitHub Actions CIによる3段階の検証システムを定義
- 既存ファイルの段階的移行プランとツールを含む包括的なドキュメント

## Changes
- `docs/development/filename-convention.md` - 命名規則の設計書を新規作成
  - 命名規則の定義とルール（数字も許可: `api-v2.ts`, `component-123.tsx`）
  - **Biomeを使用**（ESLintは使用しない）
  - カスタムスクリプトによるファイル名検証
  - Huskyによるpre-commitフック
  - GitHub Actions CIでの自動チェック
  - 既存ファイル移行用スクリプト（数字の境界も適切に処理）
  - トラブルシューティングガイド

## Updates
- ✅ Copilotレビューコメントへの対応完了
  - 正規表現パターンを改善（数字を含むファイル名に対応）
  - `toKebabCase`関数を改善（`Component123` → `component-123`）
- ✅ ESLintからBiomeへの変更完了
  - プロジェクトで使用しているBiomeに合わせて設計を修正
  - VS Code設定をBiome拡張機能用に更新

## Test plan
- [ ] ドキュメントの内容が明確で理解しやすいか確認
- [ ] カスタムスクリプトの動作確認
- [ ] Biome設定との整合性確認
- [ ] CI設定の妥当性チェック

🤖 Generated with [Claude Code](https://claude.ai/code)