### PR TITLE
🐛 fix: HTMLカスタムシェイプの登録名を統一

### DIFF
--- a/apps/whiteboard/src/custom-shapes/animated-logo.tsx
+++ b/apps/whiteboard/src/custom-shapes/animated-logo.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 // Define the animated logo shape data structure
 export interface AnimatedLogoShape {
 	id: string;
-	type: "animated-logo-unified";
+	type: "animated-logo";
 	x: number;
 	y: number;
 	width: number;
@@ -264,11 +264,11 @@ function generateTrianglePoints(radius: number): string {
 
 // Create the plugin using the adapter
 export const animatedLogoPlugin = UnifiedShapePluginAdapter.fromBaseShape(
-	"animated-logo-unified",
+	"animated-logo",
 	AnimatedLogo,
 	(props: { id: string; x: number; y: number; width?: number; height?: number }) => ({
 		id: props.id,
-		type: "animated-logo-unified",
+		type: "animated-logo",
 		x: props.x,
 		y: props.y,
 		width: props.width || 200,

--- a/apps/whiteboard/src/custom-shapes/chart-hybrid.tsx
+++ b/apps/whiteboard/src/custom-shapes/chart-hybrid.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 // Define the chart shape data structure
 export interface ChartHybridShape {
 	id: string;
-	type: "chart-hybrid-unified";
+	type: "chart-hybrid";
 	x: number;
 	y: number;
 	width: number;
@@ -232,11 +232,11 @@ const ChartComponent: React.FC<{
 
 // Create the plugin using the adapter
 export const chartHybridPlugin = UnifiedShapePluginAdapter.fromBaseShape(
-	"chart-hybrid-unified",
+	"chart-hybrid",
 	ChartHybrid,
 	(props: { id: string; x: number; y: number; width?: number; height?: number }) => ({
 		id: props.id,
-		type: "chart-hybrid-unified",
+		type: "chart-hybrid",
 		x: props.x,
 		y: props.y,
 		width: props.width || 300,

--- a/apps/whiteboard/src/custom-shapes/color-picker.tsx
+++ b/apps/whiteboard/src/custom-shapes/color-picker.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 // Define the color picker shape data structure
 export interface ColorPickerShape {
 	id: string;
-	type: "color-picker-unified";
+	type: "color-picker";
 	x: number;
 	y: number;
 	width: number;
@@ -184,11 +184,11 @@ const ColorPickerComponent: React.FC<{
 
 // Create the plugin using the adapter
 export const colorPickerPlugin = UnifiedShapePluginAdapter.fromBaseShape(
-	"color-picker-unified",
+	"color-picker",
 	ColorPicker,
 	(props: { id: string; x: number; y: number; width?: number; height?: number }) => ({
 		id: props.id,
-		type: "color-picker-unified",
+		type: "color-picker",
 		x: props.x,
 		y: props.y,
 		width: props.width || 220,

--- a/apps/whiteboard/src/custom-shapes/html-counter.tsx
+++ b/apps/whiteboard/src/custom-shapes/html-counter.tsx
@@ -6,7 +6,7 @@ import React, { useState } from "react";
 // Define the counter shape data structure
 export interface HtmlCounterShape {
 	id: string;
-	type: "html-counter-unified";
+	type: "html-counter";
 	x: number;
 	y: number;
 	width: number;
@@ -210,11 +210,11 @@ const CounterUI: React.FC<{
 
 // Create the plugin using the adapter
 export const htmlCounterPlugin = UnifiedShapePluginAdapter.fromBaseShape(
-	"html-counter-unified",
+	"html-counter",
 	HtmlCounter,
 	(props: { id: string; x: number; y: number; width?: number; height?: number }) => ({
 		id: props.id,
-		type: "html-counter-unified",
+		type: "html-counter",
 		x: props.x,
 		y: props.y,
 		width: props.width || 160,

--- a/apps/whiteboard/src/custom-shapes/video-player.tsx
+++ b/apps/whiteboard/src/custom-shapes/video-player.tsx
@@ -7,7 +7,7 @@ import { useRef, useState } from "react";
 // Define the video player shape data structure
 export interface VideoPlayerShape {
 	id: string;
-	type: "video-player-unified";
+	type: "video-player";
 	x: number;
 	y: number;
 	width: number;
@@ -247,11 +247,11 @@ const VideoPlayerComponent: React.FC<{ shape: VideoPlayerShape }> = ({ shape }) 
 
 // Create the plugin using the adapter
 export const videoPlayerPlugin = UnifiedShapePluginAdapter.fromBaseShape(
-	"video-player-unified",
+	"video-player",
 	VideoPlayer,
 	(props: { id: string; x: number; y: number; width?: number; height?: number }) => ({
 		id: props.id,
-		type: "video-player-unified",
+		type: "video-player",
 		x: props.x,
 		y: props.y,
 		width: props.width || 320,


### PR DESCRIPTION
## 概要
HTMLタイプのカスタムShapeが描画されない問題を修正しました。

## 問題
- カスタムシェイプのタイプ名に不要な`-unified`サフィックスが付いていた
- App.tsxで使用されているタイプ名と実際の登録名が不一致
- これにより「No plugin registered for shape type」エラーが発生

## 変更内容
すべてのHTMLベースのカスタムシェイプから`-unified`サフィックスを削除：
- `color-picker-unified` → `color-picker`
- `chart-hybrid-unified` → `chart-hybrid`  
- `animated-logo-unified` → `animated-logo`
- `video-player-unified` → `video-player`
- `html-counter-unified` → `html-counter`

## 修正箇所
各カスタムシェイプファイルで以下の3箇所を修正：
1. Interface定義のtypeフィールド
2. Factory関数内のtypeフィールド  
3. UnifiedShapePluginAdapter.fromBaseShapeの第1引数

## テスト
- [x] 開発サーバーでHTMLカスタムシェイプが正しく描画されることを確認
- [x] ビルドが正常に完了することを確認
- [x] Lintチェックがパスすることを確認

🤖 Generated with Claude Code