### PR TITLE
🔧 fix: E2Eテスト実行時のポート競合を解消

### DIFF
--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 	timeout: 30 * 1000,
 	reporter: "html",
 	use: {
-		baseURL: "http://localhost:5173",
+		baseURL: process.env.E2E_BASE_URL || "http://localhost:6173",
 		trace: "on-first-retry",
 	},
 	projects: [
@@ -19,9 +19,9 @@ export default defineConfig({
 		},
 	],
 	webServer: {
-		command: "cd ../whiteboard && pnpm dev",
-		port: 5173,
-		reuseExistingServer: true, // Use existing server if available
+		command: "cd ../whiteboard && pnpm dev:e2e",
+		port: 6173,
+		reuseExistingServer: !process.env.CI, // Don't reuse in CI
 		timeout: 120 * 1000,
 		stdout: "pipe",
 		stderr: "pipe",

--- a/apps/whiteboard/package.json
+++ b/apps/whiteboard/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
+		"dev:e2e": "VITE_PORT=6173 vite",
 		"build": "tsc && vite build",
 		"lint": "biome check --no-errors-on-unmatched .",
 		"preview": "vite preview",

--- a/apps/whiteboard/vite.config.ts
+++ b/apps/whiteboard/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
 	plugins: [react()],
 	server: {
-		port: 5173,
+		port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT, 10) : 5173,
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
## 概要
開発サーバーとE2Eテストサーバーのポート競合を解消し、同時実行を可能にしました。

## 変更内容
- ✅ Viteサーバーを環境変数（`VITE_PORT`）でポート指定可能に変更
- ✅ E2Eテスト用の起動スクリプト（`dev:e2e`）を追加（6173番ポート）
- ✅ Playwright設定を6173番ポートに更新

## 動作確認
### 通常の開発時（5173番ポート）
```bash
cd apps/whiteboard
pnpm dev
```

### E2Eテスト実行時（6173番ポート）
```bash
cd apps/e2e
pnpm test
```

## メリット
- 🚀 手元で開発サーバーを起動したままE2Eテストを実行可能
- 🔧 ポート競合によるエラーを解消
- 📝 CI環境では既存サーバーを再利用しない設定で安定性向上

🤖 Generated with [Claude Code](https://claude.ai/code)