### PR TITLE
✨ feat: Phase 3 - スマートガイド機能の実装

### DIFF
--- a/apps/e2e/tests/smart-guides.spec.ts
+++ b/apps/e2e/tests/smart-guides.spec.ts
@@ -1,0 +1,198 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Smart Guides", () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto("http://localhost:5173");
+		await page.waitForLoadState("networkidle");
+	});
+
+	test("should show distance guides between shapes", async ({ page }) => {
+		// Create first rectangle
+		await page.click('[data-testid="tool-rectangle"]');
+		await page.mouse.move(100, 100);
+		await page.mouse.down();
+		await page.mouse.move(200, 200);
+		await page.mouse.up();
+
+		// Create second rectangle with gap
+		await page.mouse.move(250, 100);
+		await page.mouse.down();
+		await page.mouse.move(350, 200);
+		await page.mouse.up();
+
+		// Switch to select tool
+		await page.click('[data-testid="tool-select"]');
+
+		// Select and start dragging the second rectangle
+		await page.mouse.move(300, 150);
+		await page.mouse.down();
+
+		// Move it to create a 50px gap
+		await page.mouse.move(250, 150);
+
+		// Check for distance guide
+		const distanceGuides = await page.locator(".snap-guidelines text").count();
+		expect(distanceGuides).toBeGreaterThan(0);
+
+		// Check that distance value is shown
+		const distanceText = await page.locator(".snap-guidelines text").first().textContent();
+		expect(distanceText).toBeTruthy();
+		expect(Number(distanceText)).toBeGreaterThan(0);
+
+		await page.mouse.up();
+	});
+
+	test("should show extension lines when shapes are aligned", async ({ page }) => {
+		// Create first rectangle
+		await page.click('[data-testid="tool-rectangle"]');
+		await page.mouse.move(100, 100);
+		await page.mouse.down();
+		await page.mouse.move(200, 200);
+		await page.mouse.up();
+
+		// Create second rectangle
+		await page.mouse.move(300, 100);
+		await page.mouse.down();
+		await page.mouse.move(400, 200);
+		await page.mouse.up();
+
+		// Switch to select tool
+		await page.click('[data-testid="tool-select"]');
+
+		// Select and drag to align horizontally
+		await page.mouse.move(350, 150);
+		await page.mouse.down();
+
+		// Move to align top edges
+		await page.mouse.move(350, 100);
+
+		// Check for solid extension lines
+		const guides = await page.locator(".snap-guidelines line").evaluateAll((lines) =>
+			lines.map((line) => ({
+				dashArray: line.getAttribute("stroke-dasharray"),
+				stroke: line.getAttribute("stroke"),
+			})),
+		);
+
+		// Should have at least one solid line (extension)
+		const solidLines = guides.filter((g) => g.dashArray === "none");
+		expect(solidLines.length).toBeGreaterThan(0);
+
+		await page.mouse.up();
+	});
+
+	test("should show different colors for different guide types", async ({ page }) => {
+		// Create three rectangles
+		await page.click('[data-testid="tool-rectangle"]');
+
+		// First rectangle
+		await page.mouse.move(100, 100);
+		await page.mouse.down();
+		await page.mouse.move(200, 200);
+		await page.mouse.up();
+
+		// Second rectangle
+		await page.mouse.move(250, 100);
+		await page.mouse.down();
+		await page.mouse.move(350, 200);
+		await page.mouse.up();
+
+		// Third rectangle
+		await page.mouse.move(100, 250);
+		await page.mouse.down();
+		await page.mouse.move(200, 350);
+		await page.mouse.up();
+
+		// Switch to select tool
+		await page.click('[data-testid="tool-select"]');
+
+		// Select middle rectangle
+		await page.mouse.move(300, 150);
+		await page.mouse.down();
+
+		// Move to position with both alignment and distance guides
+		await page.mouse.move(225, 150);
+
+		// Check guide colors
+		const guides = await page
+			.locator(".snap-guidelines line")
+			.evaluateAll((lines) => lines.map((line) => line.getAttribute("stroke")));
+
+		// Should have both blue (#007AFF) and orange (#FF9500) guides
+		const blueGuides = guides.filter((color) => color === "#007AFF");
+		const orangeGuides = guides.filter((color) => color === "#FF9500");
+
+		expect(blueGuides.length).toBeGreaterThan(0); // Alignment guides
+		expect(orangeGuides.length).toBeGreaterThan(0); // Distance guides
+
+		await page.mouse.up();
+	});
+
+	test("should update guides dynamically while dragging", async ({ page }) => {
+		// Create two rectangles
+		await page.click('[data-testid="tool-rectangle"]');
+		await page.mouse.move(100, 100);
+		await page.mouse.down();
+		await page.mouse.move(200, 200);
+		await page.mouse.up();
+
+		await page.mouse.move(300, 100);
+		await page.mouse.down();
+		await page.mouse.move(400, 200);
+		await page.mouse.up();
+
+		// Switch to select tool
+		await page.click('[data-testid="tool-select"]');
+
+		// Select second rectangle
+		await page.mouse.move(350, 150);
+		await page.mouse.down();
+
+		// Move closer - should show distance guide
+		await page.mouse.move(250, 150);
+		const initialGuides = await page.locator(".snap-guidelines line").count();
+
+		// Move to align - guides should change
+		await page.mouse.move(100, 150);
+		const alignedGuides = await page.locator(".snap-guidelines line").count();
+
+		// Guide count should change as we move between positions
+		expect(initialGuides).toBeGreaterThan(0);
+		expect(alignedGuides).toBeGreaterThan(0);
+
+		await page.mouse.up();
+	});
+
+	test("should hide guides after releasing drag", async ({ page }) => {
+		// Create two rectangles
+		await page.click('[data-testid="tool-rectangle"]');
+		await page.mouse.move(100, 100);
+		await page.mouse.down();
+		await page.mouse.move(200, 200);
+		await page.mouse.up();
+
+		await page.mouse.move(300, 100);
+		await page.mouse.down();
+		await page.mouse.move(400, 200);
+		await page.mouse.up();
+
+		// Switch to select tool
+		await page.click('[data-testid="tool-select"]');
+
+		// Select and drag
+		await page.mouse.move(350, 150);
+		await page.mouse.down();
+		await page.mouse.move(250, 150);
+
+		// Guides should be visible while dragging
+		const guidesWhileDragging = await page.locator(".snap-guidelines line").count();
+		expect(guidesWhileDragging).toBeGreaterThan(0);
+
+		// Release drag
+		await page.mouse.up();
+
+		// Guides should be hidden after release
+		const guidesAfterRelease = await page.locator(".snap-guidelines line").count();
+		expect(guidesAfterRelease).toBe(0);
+	});
+});

--- a/apps/e2e/tests/smart-guides.spec.ts
+++ b/apps/e2e/tests/smart-guides.spec.ts
@@ -75,7 +75,7 @@ test.describe("Smart Guides", () => {
 		);
 
 		// Should have at least one solid line (extension)
-		const solidLines = guides.filter((g) => g.dashArray === "none");
+		const solidLines = guides.filter((g) => g.dashArray === "none" || !g.dashArray);
 		expect(solidLines.length).toBeGreaterThan(0);
 
 		await page.mouse.up();

--- a/packages/react-canvas/src/components/snap-guidelines.tsx
+++ b/packages/react-canvas/src/components/snap-guidelines.tsx
@@ -15,6 +15,29 @@ export const SnapGuidelines: React.FC<SnapGuidelinesProps> = ({ guides, camera }
 		return null;
 	}
 
+	const getStrokeDashArray = (style?: "solid" | "dashed" | "dotted") => {
+		switch (style) {
+			case "solid":
+				return "none";
+			case "dotted":
+				return "2,2";
+			case "dashed":
+			default:
+				return "5,5";
+		}
+	};
+
+	const getStrokeColor = (type: string) => {
+		switch (type) {
+			case "distance":
+				return "#FF9500"; // Orange for distance
+			case "vertical":
+			case "horizontal":
+			default:
+				return "#007AFF"; // Blue for alignment
+		}
+	};
+
 	return (
 		<svg
 			className="snap-guidelines"
@@ -31,19 +54,52 @@ export const SnapGuidelines: React.FC<SnapGuidelinesProps> = ({ guides, camera }
 			}}
 		>
 			<g transform={`translate(${camera.x}, ${camera.y}) scale(${camera.zoom})`}>
-				{guides.map((guide, index) => (
-					<line
-						key={`${guide.type}-${guide.position}-${index}`}
-						x1={guide.start.x}
-						y1={guide.start.y}
-						x2={guide.end.x}
-						y2={guide.end.y}
-						stroke="#007AFF"
-						strokeWidth={1 / camera.zoom}
-						strokeDasharray="5,5"
-						opacity={0.6}
-					/>
-				))}
+				{guides.map((guide, index) => {
+					const strokeColor = getStrokeColor(guide.type);
+					const strokeDasharray = getStrokeDashArray(guide.style);
+
+					return (
+						<g key={`${guide.type}-${guide.position}-${index}`}>
+							<line
+								x1={guide.start.x}
+								y1={guide.start.y}
+								x2={guide.end.x}
+								y2={guide.end.y}
+								stroke={strokeColor}
+								strokeWidth={1 / camera.zoom}
+								strokeDasharray={strokeDasharray}
+								opacity={0.6}
+							/>
+							{guide.type === "distance" && guide.distance !== undefined && (
+								<>
+									{/* Distance label background */}
+									<rect
+										x={(guide.start.x + guide.end.x) / 2 - 15}
+										y={(guide.start.y + guide.end.y) / 2 - 8}
+										width={30}
+										height={16}
+										fill="white"
+										opacity={0.9}
+										rx={2}
+										ry={2}
+									/>
+									{/* Distance label text */}
+									<text
+										x={(guide.start.x + guide.end.x) / 2}
+										y={(guide.start.y + guide.end.y) / 2 + 4}
+										fill={strokeColor}
+										fontSize={12 / camera.zoom}
+										textAnchor="middle"
+										fontFamily="monospace"
+										fontWeight="bold"
+									>
+										{guide.distance}
+									</text>
+								</>
+							)}
+						</g>
+					);
+				})}
 			</g>
 		</svg>
 	);

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -22,10 +22,14 @@ export interface SelectionIndicatorState {
 }
 
 export interface SnapGuide {
-	type: "horizontal" | "vertical";
+	type: "horizontal" | "vertical" | "distance";
 	position: number;
 	start: { x: number; y: number };
 	end: { x: number; y: number };
+	// Smart guide specific properties
+	distance?: number; // Distance value to display
+	label?: string; // Optional label for the guide
+	style?: "solid" | "dashed" | "dotted"; // Line style
 }
 
 export interface WhiteboardStore extends WhiteboardState {

--- a/packages/tools/src/tools/select-tool.ts
+++ b/packages/tools/src/tools/select-tool.ts
@@ -12,7 +12,7 @@ import {
 	updateShape,
 } from "../utils/geometry";
 import { calculateNewBounds } from "../utils/resize-calculator";
-import { SnapEngine } from "../utils/snap-engine";
+import { SnapEngine, type SnapGuide } from "../utils/snap-engine";
 
 // Constants for snap functionality
 const DEFAULT_SHAPE_SIZE = 100;
@@ -56,13 +56,6 @@ export interface SelectToolContext extends ToolContext {
 	initialBounds: Bounds | null;
 	// Snap guides
 	snapGuides: SnapGuide[];
-}
-
-export interface SnapGuide {
-	type: "horizontal" | "vertical";
-	position: number;
-	start: Point;
-	end: Point;
 }
 
 // === Select Tool Events ===
@@ -307,6 +300,10 @@ export const selectToolMachine = setup({
 						guides = shapeSnapResult.guides || [];
 						snapped = true;
 					}
+
+					// Always generate smart guides when moving near other shapes
+					const smartGuides = snapEngine.generateSmartGuides(movingShape, targetShapes);
+					guides = [...guides, ...smartGuides];
 				}
 
 				// If no shape snapping occurred, try grid snapping

--- a/packages/tools/src/utils/snap-engine.ts
+++ b/packages/tools/src/utils/snap-engine.ts
@@ -17,10 +17,14 @@ export interface SnapResult {
 }
 
 export interface SnapGuide {
-	type: "horizontal" | "vertical";
+	type: "horizontal" | "vertical" | "distance";
 	position: number;
 	start: Point;
 	end: Point;
+	// Smart guide specific properties
+	distance?: number; // Distance value to display
+	label?: string; // Optional label for the guide
+	style?: "solid" | "dashed" | "dotted"; // Line style
 }
 
 export type AlignmentType =
@@ -219,6 +223,7 @@ export class SnapEngine {
 				position: xSnap.value,
 				start: { x: xSnap.value, y: -1000 },
 				end: { x: xSnap.value, y: 1000 },
+				style: "dashed",
 			});
 		}
 
@@ -230,8 +235,117 @@ export class SnapEngine {
 				position: ySnap.value,
 				start: { x: -1000, y: ySnap.value },
 				end: { x: 1000, y: ySnap.value },
+				style: "dashed",
 			});
 		}
+
+		return guides;
+	}
+
+	// Generate smart guides with distance indicators
+	generateSmartGuides(
+		movingShape: { x: number; y: number; width: number; height: number },
+		targetShapes: Array<{
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+			[key: string]: any;
+		}>,
+	): SnapGuide[] {
+		const guides: SnapGuide[] = [];
+
+		targetShapes.forEach((target) => {
+			const movingRight = movingShape.x + movingShape.width;
+			const movingBottom = movingShape.y + movingShape.height;
+			const targetRight = target.x + target.width;
+			const targetBottom = target.y + target.height;
+
+			// Horizontal distance guides
+			const horizontalGap = Math.min(
+				Math.abs(target.x - movingRight),
+				Math.abs(movingShape.x - targetRight),
+			);
+
+			// Add distance guide between shapes (horizontal)
+			if (horizontalGap < 100 && horizontalGap > 0) {
+				if (target.x > movingRight) {
+					// Target is to the right
+					guides.push({
+						type: "distance",
+						position: 0,
+						start: { x: movingRight, y: movingShape.y + movingShape.height / 2 },
+						end: { x: target.x, y: target.y + target.height / 2 },
+						distance: Math.round(horizontalGap),
+						style: "dotted",
+					});
+				} else if (movingShape.x > targetRight) {
+					// Target is to the left
+					guides.push({
+						type: "distance",
+						position: 0,
+						start: { x: targetRight, y: target.y + target.height / 2 },
+						end: { x: movingShape.x, y: movingShape.y + movingShape.height / 2 },
+						distance: Math.round(horizontalGap),
+						style: "dotted",
+					});
+				}
+			}
+
+			// Vertical distance guides
+			const verticalGap = Math.min(
+				Math.abs(target.y - movingBottom),
+				Math.abs(movingShape.y - targetBottom),
+			);
+
+			// Add distance guide between shapes (vertical)
+			if (verticalGap < 100 && verticalGap > 0) {
+				if (target.y > movingBottom) {
+					// Target is below
+					guides.push({
+						type: "distance",
+						position: 0,
+						start: { x: movingShape.x + movingShape.width / 2, y: movingBottom },
+						end: { x: target.x + target.width / 2, y: target.y },
+						distance: Math.round(verticalGap),
+						style: "dotted",
+					});
+				} else if (movingShape.y > targetBottom) {
+					// Target is above
+					guides.push({
+						type: "distance",
+						position: 0,
+						start: { x: target.x + target.width / 2, y: targetBottom },
+						end: { x: movingShape.x + movingShape.width / 2, y: movingShape.y },
+						distance: Math.round(verticalGap),
+						style: "dotted",
+					});
+				}
+			}
+
+			// Extension lines for alignment
+			// Vertical alignment extension
+			if (Math.abs(movingShape.x - target.x) < 5) {
+				guides.push({
+					type: "vertical",
+					position: target.x,
+					start: { x: target.x, y: Math.min(movingShape.y, target.y) - 50 },
+					end: { x: target.x, y: Math.max(movingBottom, targetBottom) + 50 },
+					style: "solid",
+				});
+			}
+
+			// Horizontal alignment extension
+			if (Math.abs(movingShape.y - target.y) < 5) {
+				guides.push({
+					type: "horizontal",
+					position: target.y,
+					start: { x: Math.min(movingShape.x, target.x) - 50, y: target.y },
+					end: { x: Math.max(movingRight, targetRight) + 50, y: target.y },
+					style: "solid",
+				});
+			}
+		});
 
 		return guides;
 	}

--- a/packages/tools/src/utils/snap-engine.ts
+++ b/packages/tools/src/utils/snap-engine.ts
@@ -35,6 +35,10 @@ export type AlignmentType =
 	| "center-vertical"
 	| "bottom";
 
+// Constants for smart guides
+const MAX_GUIDE_DISTANCE = 100; // Maximum distance to show distance guides
+const ALIGNMENT_THRESHOLD = 5; // Threshold for detecting alignment
+
 export class SnapEngine {
 	private gridSize = 20;
 	private snapThreshold = 15;
@@ -262,14 +266,21 @@ export class SnapEngine {
 			const targetBottom = target.y + target.height;
 
 			// Horizontal distance guides
-			const horizontalGap = Math.min(
-				Math.abs(target.x - movingRight),
-				Math.abs(movingShape.x - targetRight),
-			);
+			let horizontalGap = 0;
+			if (movingRight < target.x) {
+				// movingShape is to the left of target
+				horizontalGap = target.x - movingRight;
+			} else if (targetRight < movingShape.x) {
+				// target is to the left of movingShape
+				horizontalGap = movingShape.x - targetRight;
+			} else {
+				// shapes overlap horizontally
+				horizontalGap = 0;
+			}
 
 			// Add distance guide between shapes (horizontal)
-			if (horizontalGap < 100 && horizontalGap > 0) {
-				if (target.x > movingRight) {
+			if (horizontalGap < MAX_GUIDE_DISTANCE && horizontalGap > 0) {
+				if (movingRight < target.x) {
 					// Target is to the right
 					guides.push({
 						type: "distance",
@@ -279,7 +290,7 @@ export class SnapEngine {
 						distance: Math.round(horizontalGap),
 						style: "dotted",
 					});
-				} else if (movingShape.x > targetRight) {
+				} else if (targetRight < movingShape.x) {
 					// Target is to the left
 					guides.push({
 						type: "distance",
@@ -293,14 +304,21 @@ export class SnapEngine {
 			}
 
 			// Vertical distance guides
-			const verticalGap = Math.min(
-				Math.abs(target.y - movingBottom),
-				Math.abs(movingShape.y - targetBottom),
-			);
+			let verticalGap = 0;
+			if (movingBottom < target.y) {
+				// movingShape is above target
+				verticalGap = target.y - movingBottom;
+			} else if (targetBottom < movingShape.y) {
+				// target is above movingShape
+				verticalGap = movingShape.y - targetBottom;
+			} else {
+				// shapes overlap vertically
+				verticalGap = 0;
+			}
 
 			// Add distance guide between shapes (vertical)
-			if (verticalGap < 100 && verticalGap > 0) {
-				if (target.y > movingBottom) {
+			if (verticalGap < MAX_GUIDE_DISTANCE && verticalGap > 0) {
+				if (movingBottom < target.y) {
 					// Target is below
 					guides.push({
 						type: "distance",
@@ -310,7 +328,7 @@ export class SnapEngine {
 						distance: Math.round(verticalGap),
 						style: "dotted",
 					});
-				} else if (movingShape.y > targetBottom) {
+				} else if (targetBottom < movingShape.y) {
 					// Target is above
 					guides.push({
 						type: "distance",
@@ -325,7 +343,7 @@ export class SnapEngine {
 
 			// Extension lines for alignment
 			// Vertical alignment extension
-			if (Math.abs(movingShape.x - target.x) < 5) {
+			if (Math.abs(movingShape.x - target.x) < ALIGNMENT_THRESHOLD) {
 				guides.push({
 					type: "vertical",
 					position: target.x,
@@ -336,7 +354,7 @@ export class SnapEngine {
 			}
 
 			// Horizontal alignment extension
-			if (Math.abs(movingShape.y - target.y) < 5) {
+			if (Math.abs(movingShape.y - target.y) < ALIGNMENT_THRESHOLD) {
 				guides.push({
 					type: "horizontal",
 					position: target.y,


### PR DESCRIPTION
## 概要
Phase 3として、ドラッグ中に動的な視覚ガイドを表示するスマートガイド機能を実装しました。

## 実装内容
### 🎯 Distance Guides (距離ガイド)
- オブジェクト間の距離をリアルタイムで表示
- オレンジ色の点線で視覚的に識別
- 距離値を数値で表示

### 📏 Extension Lines (延長線)
- オブジェクトが整列している時に表示される青色の実線
- 垂直・水平の両方向に対応
- エッジの延長を視覚化

### ⚡ Dynamic Updates
- ドラッグ中にガイドがリアルタイムで更新
- パフォーマンスを考慮した効率的な計算
- ドラッグ終了時に自動的にガイドをクリア

## 技術的な変更点
- `SnapEngine`に`generateSmartGuides()`メソッドを追加
- `SnapGuide`インターフェースを拡張（distance, label, style プロパティ）
- `SnapGuidelines`コンポーネントで異なるガイドタイプをサポート
- 包括的なE2Eテストを追加

## テスト
- [x] 距離ガイドの表示テスト
- [x] 延長線の表示テスト
- [x] ガイドタイプごとの色分けテスト
- [x] ドラッグ中の動的更新テスト
- [x] ドラッグ終了後のガイドクリアテスト

## スクリーンショット
スマートガイドが動作している様子：
- 距離ガイド: オレンジ色の点線と距離値
- 延長線: 青色の実線で整列を表示

## 今後の展望
- Phase 4: 分散配置 - 複数オブジェクトの等間隔配置
- Phase 5: 磁気スナップ - 近づくと自動的に吸着

🤖 Generated with [Claude Code](https://claude.ai/code)