### PR TITLE
✨ feat: Phase 2 - 包括的なスナップポイントと視覚強化実装

### DIFF
--- a/packages/react-canvas/src/components/snap-guidelines.tsx
+++ b/packages/react-canvas/src/components/snap-guidelines.tsx
@@ -1,6 +1,10 @@
 import type { SnapGuide } from "@usketch/tools";
 import type React from "react";
 
+// Constants for label positioning
+const DISTANCE_LABEL_X_OFFSET = 20;
+const DISTANCE_LABEL_Y_OFFSET = 4;
+
 interface SnapGuidelinesProps {
 	guides: SnapGuide[];
 	camera: {
@@ -118,8 +122,8 @@ export const SnapGuidelines: React.FC<SnapGuidelinesProps> = ({ guides, camera }
 									{/* Show distance value next to = sign if both are present */}
 									{guide.label === "=" && (
 										<text
-											x={(guide.start.x + guide.end.x) / 2 + 20}
-											y={(guide.start.y + guide.end.y) / 2 + 4}
+											x={(guide.start.x + guide.end.x) / 2 + DISTANCE_LABEL_X_OFFSET / camera.zoom}
+											y={(guide.start.y + guide.end.y) / 2 + DISTANCE_LABEL_Y_OFFSET}
 											fill={strokeColor}
 											fontSize={10 / camera.zoom}
 											textAnchor="start"

--- a/packages/react-canvas/src/components/snap-guidelines.tsx
+++ b/packages/react-canvas/src/components/snap-guidelines.tsx
@@ -26,12 +26,14 @@ export const SnapGuidelines: React.FC<SnapGuidelinesProps> = ({ guides, camera }
 		}
 	};
 
-	const getStrokeColor = (type: string) => {
+	const getStrokeColor = (type: string, style?: string) => {
 		switch (type) {
 			case "distance":
 				return "#FF9500"; // Orange for distance
 			default:
-				return "#007AFF"; // Blue for alignment
+				// Use different blue shades for different styles
+				if (style === "solid") return "#0066CC"; // Darker blue for solid alignment
+				return "#007AFF"; // Default blue for dashed guides
 		}
 	};
 
@@ -52,8 +54,10 @@ export const SnapGuidelines: React.FC<SnapGuidelinesProps> = ({ guides, camera }
 		>
 			<g transform={`translate(${camera.x}, ${camera.y}) scale(${camera.zoom})`}>
 				{guides.map((guide, index) => {
-					const strokeColor = getStrokeColor(guide.type);
+					const strokeColor = getStrokeColor(guide.type, guide.style);
 					const strokeDasharray = getStrokeDashArray(guide.style);
+					const strokeOpacity = guide.style === "solid" ? 0.8 : 0.6;
+					const strokeWidth = guide.style === "solid" ? 1.5 / camera.zoom : 1 / camera.zoom;
 
 					return (
 						<g key={`${guide.type}-${guide.position}-${index}`}>
@@ -63,17 +67,36 @@ export const SnapGuidelines: React.FC<SnapGuidelinesProps> = ({ guides, camera }
 								x2={guide.end.x}
 								y2={guide.end.y}
 								stroke={strokeColor}
-								strokeWidth={1 / camera.zoom}
+								strokeWidth={strokeWidth}
 								strokeDasharray={strokeDasharray}
-								opacity={0.6}
+								opacity={strokeOpacity}
 							/>
+							{/* Add end caps for solid alignment guides */}
+							{guide.style === "solid" && guide.type !== "distance" && (
+								<>
+									<circle
+										cx={guide.start.x}
+										cy={guide.start.y}
+										r={3 / camera.zoom}
+										fill={strokeColor}
+										opacity={strokeOpacity}
+									/>
+									<circle
+										cx={guide.end.x}
+										cy={guide.end.y}
+										r={3 / camera.zoom}
+										fill={strokeColor}
+										opacity={strokeOpacity}
+									/>
+								</>
+							)}
 							{guide.type === "distance" && guide.distance !== undefined && (
 								<>
 									{/* Distance label background */}
 									<rect
-										x={(guide.start.x + guide.end.x) / 2 - 15}
+										x={(guide.start.x + guide.end.x) / 2 - (guide.label === "=" ? 10 : 15)}
 										y={(guide.start.y + guide.end.y) / 2 - 8}
-										width={30}
+										width={guide.label === "=" ? 20 : 30}
 										height={16}
 										fill="white"
 										opacity={0.9}
@@ -90,8 +113,22 @@ export const SnapGuidelines: React.FC<SnapGuidelinesProps> = ({ guides, camera }
 										fontFamily="monospace"
 										fontWeight="bold"
 									>
-										{guide.distance}
+										{guide.label === "=" ? "=" : guide.distance}
 									</text>
+									{/* Show distance value next to = sign if both are present */}
+									{guide.label === "=" && (
+										<text
+											x={(guide.start.x + guide.end.x) / 2 + 20}
+											y={(guide.start.y + guide.end.y) / 2 + 4}
+											fill={strokeColor}
+											fontSize={10 / camera.zoom}
+											textAnchor="start"
+											fontFamily="monospace"
+											opacity={0.7}
+										>
+											{guide.distance}px
+										</text>
+									)}
 								</>
 							)}
 						</g>

--- a/packages/tools/src/tools/select-tool.ts
+++ b/packages/tools/src/tools/select-tool.ts
@@ -423,6 +423,10 @@ export const selectToolMachine = setup({
 
 				// If no shape snapping occurred, try grid snapping
 				if (!snapped && snapSettings.gridSnap && snapSettings.enabled) {
+					// Update snap engine settings
+					snapEngine.setGridSize(snapSettings.gridSize);
+					snapEngine.setSnapThreshold(snapSettings.snapThreshold || SNAP_THRESHOLD);
+
 					const gridSnapResult = snapEngine.snap(snappedPosition, {
 						snapEnabled: snapSettings.enabled,
 						gridSnap: snapSettings.gridSnap,

--- a/packages/tools/src/utils/snap-engine.ts
+++ b/packages/tools/src/utils/snap-engine.ts
@@ -40,6 +40,9 @@ export type DistributionType = "horizontal" | "vertical";
 // Constants for smart guides
 const MAX_GUIDE_DISTANCE = 100; // Maximum distance to show distance guides
 const ALIGNMENT_THRESHOLD = 5; // Threshold for detecting alignment
+const EQUAL_SPACING_THRESHOLD = 5; // Tolerance for equal spacing detection
+const ALIGNMENT_Y_TOLERANCE = 50; // Y-axis tolerance for horizontal alignment detection
+const ALIGNMENT_X_TOLERANCE = 50; // X-axis tolerance for vertical alignment detection
 
 export class SnapEngine {
 	private gridSize = 20;
@@ -200,6 +203,8 @@ export class SnapEngine {
 			});
 
 			// Corner snapping (x-axis)
+			// Note: Left corners (TL, BL) share same X value, as do right corners (TR, BR)
+			// This is intentional to enable corner-to-corner alignment
 			// Top-left corner to top-left
 			snapPoints.push({
 				axis: "x",
@@ -218,7 +223,7 @@ export class SnapEngine {
 				edgeType: "corner-tr-to-tr",
 				targetPosition: target.x + targetWidth,
 			});
-			// Bottom-left corner to bottom-left
+			// Bottom-left corner to bottom-left (same X as TL)
 			snapPoints.push({
 				axis: "x",
 				value: target.x,
@@ -227,7 +232,7 @@ export class SnapEngine {
 				edgeType: "corner-bl-to-bl",
 				targetPosition: target.x,
 			});
-			// Bottom-right corner to bottom-right
+			// Bottom-right corner to bottom-right (same X as TR)
 			snapPoints.push({
 				axis: "x",
 				value: target.x + targetWidth - width,
@@ -286,6 +291,8 @@ export class SnapEngine {
 			});
 
 			// Corner snapping (y-axis)
+			// Note: Top corners (TL, TR) share same Y value, as do bottom corners (BL, BR)
+			// This is intentional to enable corner-to-corner alignment
 			// Top-left corner to top-left
 			snapPoints.push({
 				axis: "y",
@@ -295,7 +302,7 @@ export class SnapEngine {
 				edgeType: "corner-tl-to-tl",
 				targetPosition: target.y,
 			});
-			// Top-right corner to top-right
+			// Top-right corner to top-right (same Y as TL)
 			snapPoints.push({
 				axis: "y",
 				value: target.y,
@@ -313,7 +320,7 @@ export class SnapEngine {
 				edgeType: "corner-bl-to-bl",
 				targetPosition: target.y + targetHeight,
 			});
-			// Bottom-right corner to bottom-right
+			// Bottom-right corner to bottom-right (same Y as BL)
 			snapPoints.push({
 				axis: "y",
 				value: target.y + targetHeight - height,
@@ -623,7 +630,6 @@ export class SnapEngine {
 		}>,
 	): SnapGuide[] {
 		const guides: SnapGuide[] = [];
-		const SPACING_THRESHOLD = 5; // Tolerance for equal spacing detection
 
 		// Find pairs of shapes with similar spacing
 		if (targetShapes.length >= 2) {
@@ -645,7 +651,7 @@ export class SnapEngine {
 
 					// Check if shapes are horizontally aligned (roughly same Y position)
 					const yDiff = Math.abs(shape1.y - shape2.y);
-					if (yDiff < 50) {
+					if (yDiff < ALIGNMENT_Y_TOLERANCE) {
 						if (shape1Right < shape2.x) {
 							const spacing = shape2.x - shape1Right;
 							horizontalSpacings.push({
@@ -674,7 +680,7 @@ export class SnapEngine {
 					const targetRight = target.x + target.width;
 					// Check if moving shape is aligned with this target
 					const yDiff = Math.abs(movingShape.y - target.y);
-					if (yDiff < 50) {
+					if (yDiff < ALIGNMENT_Y_TOLERANCE) {
 						// Check spacing between moving shape and target
 						let currentSpacing = 0;
 						if (movingRight < target.x) {
@@ -684,7 +690,10 @@ export class SnapEngine {
 						}
 
 						// If spacing is similar, show equal spacing indicator
-						if (Math.abs(currentSpacing - spacing) < SPACING_THRESHOLD && currentSpacing > 0) {
+						if (
+							Math.abs(currentSpacing - spacing) < EQUAL_SPACING_THRESHOLD &&
+							currentSpacing > 0
+						) {
 							// Add visual indicator for equal spacing
 							guides.push({
 								type: "distance",
@@ -724,7 +733,7 @@ export class SnapEngine {
 
 					// Check if shapes are vertically aligned (roughly same X position)
 					const xDiff = Math.abs(shape1.x - shape2.x);
-					if (xDiff < 50) {
+					if (xDiff < ALIGNMENT_X_TOLERANCE) {
 						if (shape1Bottom < shape2.y) {
 							const spacing = shape2.y - shape1Bottom;
 							verticalSpacings.push({
@@ -753,7 +762,7 @@ export class SnapEngine {
 					const targetBottom = target.y + target.height;
 					// Check if moving shape is aligned with this target
 					const xDiff = Math.abs(movingShape.x - target.x);
-					if (xDiff < 50) {
+					if (xDiff < ALIGNMENT_X_TOLERANCE) {
 						// Check spacing between moving shape and target
 						let currentSpacing = 0;
 						if (movingBottom < target.y) {
@@ -763,7 +772,10 @@ export class SnapEngine {
 						}
 
 						// If spacing is similar, show equal spacing indicator
-						if (Math.abs(currentSpacing - spacing) < SPACING_THRESHOLD && currentSpacing > 0) {
+						if (
+							Math.abs(currentSpacing - spacing) < EQUAL_SPACING_THRESHOLD &&
+							currentSpacing > 0
+						) {
 							// Add visual indicator for equal spacing
 							guides.push({
 								type: "distance",

--- a/packages/tools/src/utils/snap-engine.ts
+++ b/packages/tools/src/utils/snap-engine.ts
@@ -44,6 +44,15 @@ const EQUAL_SPACING_THRESHOLD = 5; // Tolerance for equal spacing detection
 const ALIGNMENT_Y_TOLERANCE = 50; // Y-axis tolerance for horizontal alignment detection
 const ALIGNMENT_X_TOLERANCE = 50; // X-axis tolerance for vertical alignment detection
 
+// Shape type for equal spacing detection
+type ShapeWithBounds = {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	[key: string]: any;
+};
+
 export class SnapEngine {
 	private gridSize = 20;
 	private snapThreshold = 15;
@@ -621,13 +630,7 @@ export class SnapEngine {
 	// Detect equal spacing between shapes
 	private detectEqualSpacing(
 		movingShape: { x: number; y: number; width: number; height: number },
-		targetShapes: Array<{
-			x: number;
-			y: number;
-			width: number;
-			height: number;
-			[key: string]: any;
-		}>,
+		targetShapes: Array<ShapeWithBounds>,
 	): SnapGuide[] {
 		const guides: SnapGuide[] = [];
 
@@ -635,8 +638,8 @@ export class SnapEngine {
 		if (targetShapes.length >= 2) {
 			// Check horizontal spacing
 			const horizontalSpacings: Array<{
-				shape1: any;
-				shape2: any;
+				shape1: ShapeWithBounds;
+				shape2: ShapeWithBounds;
 				spacing: number;
 				midpoint: number;
 			}> = [];
@@ -717,8 +720,8 @@ export class SnapEngine {
 
 			// Similar logic for vertical spacing
 			const verticalSpacings: Array<{
-				shape1: any;
-				shape2: any;
+				shape1: ShapeWithBounds;
+				shape2: ShapeWithBounds;
 				spacing: number;
 				midpoint: number;
 			}> = [];

--- a/packages/tools/src/utils/snap-engine.ts
+++ b/packages/tools/src/utils/snap-engine.ts
@@ -199,6 +199,44 @@ export class SnapEngine {
 				targetPosition: targetCenterX,
 			});
 
+			// Corner snapping (x-axis)
+			// Top-left corner to top-left
+			snapPoints.push({
+				axis: "x",
+				value: target.x,
+				priority: 2,
+				targetId,
+				edgeType: "corner-tl-to-tl",
+				targetPosition: target.x,
+			});
+			// Top-right corner to top-right
+			snapPoints.push({
+				axis: "x",
+				value: target.x + targetWidth - width,
+				priority: 2,
+				targetId,
+				edgeType: "corner-tr-to-tr",
+				targetPosition: target.x + targetWidth,
+			});
+			// Bottom-left corner to bottom-left
+			snapPoints.push({
+				axis: "x",
+				value: target.x,
+				priority: 2,
+				targetId,
+				edgeType: "corner-bl-to-bl",
+				targetPosition: target.x,
+			});
+			// Bottom-right corner to bottom-right
+			snapPoints.push({
+				axis: "x",
+				value: target.x + targetWidth - width,
+				priority: 2,
+				targetId,
+				edgeType: "corner-br-to-br",
+				targetPosition: target.x + targetWidth,
+			});
+
 			// Vertical snap points (y-axis)
 			// Top edge to top edge
 			snapPoints.push({
@@ -245,6 +283,44 @@ export class SnapEngine {
 				targetId,
 				edgeType: "center-to-center",
 				targetPosition: targetCenterY,
+			});
+
+			// Corner snapping (y-axis)
+			// Top-left corner to top-left
+			snapPoints.push({
+				axis: "y",
+				value: target.y,
+				priority: 2,
+				targetId,
+				edgeType: "corner-tl-to-tl",
+				targetPosition: target.y,
+			});
+			// Top-right corner to top-right
+			snapPoints.push({
+				axis: "y",
+				value: target.y,
+				priority: 2,
+				targetId,
+				edgeType: "corner-tr-to-tr",
+				targetPosition: target.y,
+			});
+			// Bottom-left corner to bottom-left
+			snapPoints.push({
+				axis: "y",
+				value: target.y + targetHeight - height,
+				priority: 2,
+				targetId,
+				edgeType: "corner-bl-to-bl",
+				targetPosition: target.y + targetHeight,
+			});
+			// Bottom-right corner to bottom-right
+			snapPoints.push({
+				axis: "y",
+				value: target.y + targetHeight - height,
+				priority: 2,
+				targetId,
+				edgeType: "corner-br-to-br",
+				targetPosition: target.y + targetHeight,
 			});
 		});
 
@@ -310,23 +386,38 @@ export class SnapEngine {
 	): T | null {
 		if (snapPoints.length === 0) return null;
 
-		// Sort by distance and priority
-		const sorted = snapPoints
-			.map((point) => ({
-				...point,
-				distance: Math.abs(value - point.value),
-			}))
-			.filter((point) => point.distance < this.snapThreshold)
+		// Calculate weighted score for each snap point
+		const scoredPoints = snapPoints
+			.map((point) => {
+				const distance = Math.abs(value - point.value);
+				// Only consider points within threshold
+				if (distance >= this.snapThreshold) return null;
+
+				// Calculate score: lower priority and closer distance = better score
+				// Priority weight: 1.0 for priority 1, 1.5 for priority 2, 2.0 for priority 3
+				const priorityWeight = 0.5 + point.priority * 0.5;
+				// Distance weight: normalized from 0 to 1
+				const distanceWeight = distance / this.snapThreshold;
+				// Combined score (lower is better)
+				const score = priorityWeight * (1 + distanceWeight);
+
+				return {
+					...point,
+					distance,
+					score,
+				};
+			})
+			.filter((point): point is NonNullable<typeof point> => point !== null)
 			.sort((a, b) => {
-				// First sort by priority (lower is better)
-				if (a.priority !== b.priority) {
-					return a.priority - b.priority;
+				// Sort by score (lower is better)
+				if (Math.abs(a.score - b.score) > 0.01) {
+					return a.score - b.score;
 				}
-				// Then by distance
+				// If scores are very close, prefer smaller distance
 				return a.distance - b.distance;
 			});
 
-		return sorted[0] || null;
+		return scoredPoints[0] || null;
 	}
 
 	private generateGuidesFromActivePoints(
@@ -406,6 +497,10 @@ export class SnapEngine {
 		}>,
 	): SnapGuide[] {
 		const guides: SnapGuide[] = [];
+
+		// Check for equal spacing between shapes
+		const equalSpacingGuides = this.detectEqualSpacing(movingShape, targetShapes);
+		guides.push(...equalSpacingGuides);
 
 		targetShapes.forEach((target) => {
 			const movingRight = movingShape.x + movingShape.width;
@@ -512,6 +607,184 @@ export class SnapEngine {
 				});
 			}
 		});
+
+		return guides;
+	}
+
+	// Detect equal spacing between shapes
+	private detectEqualSpacing(
+		movingShape: { x: number; y: number; width: number; height: number },
+		targetShapes: Array<{
+			x: number;
+			y: number;
+			width: number;
+			height: number;
+			[key: string]: any;
+		}>,
+	): SnapGuide[] {
+		const guides: SnapGuide[] = [];
+		const SPACING_THRESHOLD = 5; // Tolerance for equal spacing detection
+
+		// Find pairs of shapes with similar spacing
+		if (targetShapes.length >= 2) {
+			// Check horizontal spacing
+			const horizontalSpacings: Array<{
+				shape1: any;
+				shape2: any;
+				spacing: number;
+				midpoint: number;
+			}> = [];
+
+			// Calculate all horizontal spacings between target shapes
+			for (let i = 0; i < targetShapes.length; i++) {
+				for (let j = i + 1; j < targetShapes.length; j++) {
+					const shape1 = targetShapes[i];
+					const shape2 = targetShapes[j];
+					const shape1Right = shape1.x + shape1.width;
+					const shape2Right = shape2.x + shape2.width;
+
+					// Check if shapes are horizontally aligned (roughly same Y position)
+					const yDiff = Math.abs(shape1.y - shape2.y);
+					if (yDiff < 50) {
+						if (shape1Right < shape2.x) {
+							const spacing = shape2.x - shape1Right;
+							horizontalSpacings.push({
+								shape1,
+								shape2,
+								spacing,
+								midpoint: (shape1Right + shape2.x) / 2,
+							});
+						} else if (shape2Right < shape1.x) {
+							const spacing = shape1.x - shape2Right;
+							horizontalSpacings.push({
+								shape1: shape2,
+								shape2: shape1,
+								spacing,
+								midpoint: (shape2Right + shape1.x) / 2,
+							});
+						}
+					}
+				}
+			}
+
+			// Check if moving shape creates equal spacing
+			const movingRight = movingShape.x + movingShape.width;
+			horizontalSpacings.forEach(({ spacing }) => {
+				targetShapes.forEach((target) => {
+					const targetRight = target.x + target.width;
+					// Check if moving shape is aligned with this target
+					const yDiff = Math.abs(movingShape.y - target.y);
+					if (yDiff < 50) {
+						// Check spacing between moving shape and target
+						let currentSpacing = 0;
+						if (movingRight < target.x) {
+							currentSpacing = target.x - movingRight;
+						} else if (targetRight < movingShape.x) {
+							currentSpacing = movingShape.x - targetRight;
+						}
+
+						// If spacing is similar, show equal spacing indicator
+						if (Math.abs(currentSpacing - spacing) < SPACING_THRESHOLD && currentSpacing > 0) {
+							// Add visual indicator for equal spacing
+							guides.push({
+								type: "distance",
+								position: 0,
+								start: {
+									x: movingRight < target.x ? movingRight : targetRight,
+									y: movingShape.y + movingShape.height / 2,
+								},
+								end: {
+									x: movingRight < target.x ? target.x : movingShape.x,
+									y: movingShape.y + movingShape.height / 2,
+								},
+								distance: Math.round(spacing),
+								style: "dotted",
+								label: "=", // Equal spacing indicator
+							});
+						}
+					}
+				});
+			});
+
+			// Similar logic for vertical spacing
+			const verticalSpacings: Array<{
+				shape1: any;
+				shape2: any;
+				spacing: number;
+				midpoint: number;
+			}> = [];
+
+			// Calculate all vertical spacings between target shapes
+			for (let i = 0; i < targetShapes.length; i++) {
+				for (let j = i + 1; j < targetShapes.length; j++) {
+					const shape1 = targetShapes[i];
+					const shape2 = targetShapes[j];
+					const shape1Bottom = shape1.y + shape1.height;
+					const shape2Bottom = shape2.y + shape2.height;
+
+					// Check if shapes are vertically aligned (roughly same X position)
+					const xDiff = Math.abs(shape1.x - shape2.x);
+					if (xDiff < 50) {
+						if (shape1Bottom < shape2.y) {
+							const spacing = shape2.y - shape1Bottom;
+							verticalSpacings.push({
+								shape1,
+								shape2,
+								spacing,
+								midpoint: (shape1Bottom + shape2.y) / 2,
+							});
+						} else if (shape2Bottom < shape1.y) {
+							const spacing = shape1.y - shape2Bottom;
+							verticalSpacings.push({
+								shape1: shape2,
+								shape2: shape1,
+								spacing,
+								midpoint: (shape2Bottom + shape1.y) / 2,
+							});
+						}
+					}
+				}
+			}
+
+			// Check if moving shape creates equal vertical spacing
+			const movingBottom = movingShape.y + movingShape.height;
+			verticalSpacings.forEach(({ spacing }) => {
+				targetShapes.forEach((target) => {
+					const targetBottom = target.y + target.height;
+					// Check if moving shape is aligned with this target
+					const xDiff = Math.abs(movingShape.x - target.x);
+					if (xDiff < 50) {
+						// Check spacing between moving shape and target
+						let currentSpacing = 0;
+						if (movingBottom < target.y) {
+							currentSpacing = target.y - movingBottom;
+						} else if (targetBottom < movingShape.y) {
+							currentSpacing = movingShape.y - targetBottom;
+						}
+
+						// If spacing is similar, show equal spacing indicator
+						if (Math.abs(currentSpacing - spacing) < SPACING_THRESHOLD && currentSpacing > 0) {
+							// Add visual indicator for equal spacing
+							guides.push({
+								type: "distance",
+								position: 0,
+								start: {
+									x: movingShape.x + movingShape.width / 2,
+									y: movingBottom < target.y ? movingBottom : targetBottom,
+								},
+								end: {
+									x: movingShape.x + movingShape.width / 2,
+									y: movingBottom < target.y ? target.y : movingShape.y,
+								},
+								distance: Math.round(spacing),
+								style: "dotted",
+								label: "=", // Equal spacing indicator
+							});
+						}
+					}
+				});
+			});
+		}
 
 		return guides;
 	}


### PR DESCRIPTION
## 概要

スナップ機能のPhase 2実装として、包括的なスナップポイントとビジュアルフィードバックの強化を行いました。

## 変更内容

### 🎯 スナップポイントの拡充
- **全コーナースナップ**: TL（左上）、TR（右上）、BL（左下）、BR（右下）の4コーナーすべてにスナップ対応
- **エッジスナップ**: 既存の上下左右エッジに加え、コーナー同士のアラインメントも追加

### ⚡ スナップ優先度システム
- **重み付けスコアリング**: 距離と優先度を組み合わせたスコアリングアルゴリズムを実装
  - Priority 1 (エッジ): 基本重み 1.0
  - Priority 2 (コーナー): 基本重み 1.5  
  - Priority 3 (中心点): 基本重み 2.0
- **動的な選択**: 最も適切なスナップポイントを自動選択

### 📐 等間隔検出機能
- **自動検出**: 複数の形状間で等間隔を自動検出
- **視覚的インジケーター**: 等間隔を「=」記号で表示し、実際の距離値も併記
- **水平・垂直対応**: 両方向での等間隔を検出可能

### 🎨 ビジュアルフィードバック強化
- **ラインスタイル**:
  - ソリッド: 強いアラインメント（整列ガイド）
  - ダッシュ: 通常のスナップガイド
  - ドット: 距離表示ライン
- **エンドキャップ**: アラインメントガイドの端点に円形マーカー追加
- **カラーコーディング**:
  - 青系（#0066CC, #007AFF）: アラインメント関連
  - オレンジ（#FF9500）: 距離・間隔関連

### ⚙️ 設定の動的調整
- グリッドサイズとスナップ閾値の動的更新対応
- ユーザー設定に基づいたリアルタイム反映

## テスト方法

1. 開発サーバーを起動
2. 複数の図形を配置
3. 図形をドラッグして以下を確認:
   - コーナー同士のスナップ動作
   - 等間隔配置時の「=」インジケーター表示
   - アラインメントガイドのエンドキャップ表示
   - 距離表示の正確性

## 関連Issue
- Phase 1 PR: #73

## 次のステップ（Phase 3）
- スナップエンジンのパフォーマンス最適化
- キーボードショートカットの拡張
- スナッププリセット機能の追加
- ユーザー設定の永続化

🤖 Generated with [Claude Code](https://claude.ai/code)