### PR TITLE
✨ feat: Phase 6.4 プロパティパネルの統合機能

### DIFF
--- a/apps/whiteboard/src/app.tsx
+++ b/apps/whiteboard/src/app.tsx
@@ -11,6 +11,7 @@ import { DebugMenu } from "./components/debug-menu";
 import { PropertyPanel } from "./components/property-panel/property-panel";
 import { ToastContainer } from "./components/toast";
 import { ToolbarReact } from "./components/toolbar-react";
+import { ToastProvider } from "./contexts/toast-context";
 import { customShapePlugins } from "./custom-shapes";
 import type { EffectPlugin } from "./effects";
 import { fadingPinPlugin, pinPlugin, ripplePlugin } from "./effects";
@@ -28,7 +29,7 @@ const addShapeWithDelay = (shape: Shape, delay: number) => {
 // Calculate delay based on shape index
 const calculateDelay = (index: number, baseDelay = 100) => index * baseDelay;
 
-function App() {
+function AppContent() {
 	const canvasRef = useRef<any>(null);
 	const shapesAddedRef = useRef(false);
 	const backgroundsRegisteredRef = useRef(false);
@@ -144,6 +145,14 @@ function App() {
 			<DebugMenu />
 			<ToastContainer />
 		</div>
+	);
+}
+
+function App() {
+	return (
+		<ToastProvider>
+			<AppContent />
+		</ToastProvider>
 	);
 }
 

--- a/apps/whiteboard/src/app.tsx
+++ b/apps/whiteboard/src/app.tsx
@@ -9,11 +9,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { registerCustomBackgrounds } from "./backgrounds/register-backgrounds";
 import { DebugMenu } from "./components/debug-menu";
 import { PropertyPanel } from "./components/property-panel/property-panel";
+import { ToastContainer } from "./components/toast";
 import { ToolbarReact } from "./components/toolbar-react";
 import { customShapePlugins } from "./custom-shapes";
 import type { EffectPlugin } from "./effects";
 import { fadingPinPlugin, pinPlugin, ripplePlugin } from "./effects";
 import { createAppEffect } from "./effects/effect-factory";
+import { useKeyboardShortcuts } from "./hooks/use-keyboard-shortcuts";
 import "./styles/app.css";
 
 // Helper function to add shape with delay
@@ -32,6 +34,13 @@ function App() {
 	const backgroundsRegisteredRef = useRef(false);
 	const [shapePlugins, setShapePlugins] = useState<ShapePlugin<any>[]>([]);
 	const [effectPlugins] = useState<EffectPlugin<any>[]>([ripplePlugin, pinPlugin, fadingPinPlugin]);
+	const [isPanelOpen, setIsPanelOpen] = useState(true);
+
+	// Setup keyboard shortcuts
+	useKeyboardShortcuts({
+		onPanelToggle: () => setIsPanelOpen((prev) => !prev),
+	});
+
 	const [background, setBackground] = useState<any>({
 		id: "usketch.dots",
 		config: {
@@ -115,7 +124,11 @@ function App() {
 
 	return (
 		<div className="app">
-			<ToolbarReact onBackgroundChange={setBackground} />
+			<ToolbarReact
+				onBackgroundChange={setBackground}
+				isPanelOpen={isPanelOpen}
+				onPanelToggle={() => setIsPanelOpen(!isPanelOpen)}
+			/>
 			<div className="main-content">
 				<div className="whiteboard-container">
 					<WhiteboardCanvas
@@ -126,9 +139,10 @@ function App() {
 						onReady={handleCanvasReady}
 					/>
 				</div>
-				<PropertyPanel />
+				{isPanelOpen && <PropertyPanel />}
 			</div>
 			<DebugMenu />
+			<ToastContainer />
 		</div>
 	);
 }

--- a/apps/whiteboard/src/components/toast.tsx
+++ b/apps/whiteboard/src/components/toast.tsx
@@ -28,7 +28,7 @@ let toastList: Toast[] = [];
 
 export const showToast = (message: string, type?: "success" | "error" | "info") => {
 	const id = Math.random().toString(36).slice(2);
-	const newToast: Toast = { id, message, type };
+	const newToast: Toast = type ? { id, message, type } : { id, message };
 	toastList = [...toastList, newToast];
 	for (const listener of toastListeners) {
 		listener(toastList);

--- a/apps/whiteboard/src/components/toast.tsx
+++ b/apps/whiteboard/src/components/toast.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+
+interface Toast {
+	id: string;
+	message: string;
+	type?: "success" | "error" | "info";
+}
+
+interface ToastProps {
+	toast: Toast;
+	onRemove: (id: string) => void;
+}
+
+const ToastItem: React.FC<ToastProps> = ({ toast, onRemove }) => {
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			onRemove(toast.id);
+		}, 3000);
+		return () => clearTimeout(timer);
+	}, [toast.id, onRemove]);
+
+	return <div className={`toast toast-${toast.type || "info"}`}>{toast.message}</div>;
+};
+
+// Global toast state
+let toastListeners: ((toasts: Toast[]) => void)[] = [];
+let toastList: Toast[] = [];
+
+export const showToast = (message: string, type?: "success" | "error" | "info") => {
+	const id = Math.random().toString(36).slice(2);
+	const newToast: Toast = { id, message, type };
+	toastList = [...toastList, newToast];
+	for (const listener of toastListeners) {
+		listener(toastList);
+	}
+
+	// Auto-remove after 3 seconds
+	setTimeout(() => {
+		toastList = toastList.filter((t) => t.id !== id);
+		for (const listener of toastListeners) {
+			listener(toastList);
+		}
+	}, 3000);
+};
+
+export const ToastContainer: React.FC = () => {
+	const [toasts, setToasts] = useState<Toast[]>([]);
+
+	useEffect(() => {
+		const listener = (newToasts: Toast[]) => setToasts(newToasts);
+		toastListeners.push(listener);
+		return () => {
+			toastListeners = toastListeners.filter((l) => l !== listener);
+		};
+	}, []);
+
+	const removeToast = (id: string) => {
+		toastList = toastList.filter((t) => t.id !== id);
+		setToasts(toastList);
+	};
+
+	return (
+		<div className="toast-container">
+			<style>
+				{`
+					.toast-container {
+						position: fixed;
+						bottom: 24px;
+						right: 24px;
+						z-index: 1000;
+						display: flex;
+						flex-direction: column;
+						gap: 12px;
+						pointer-events: none;
+					}
+					
+					.toast {
+						padding: 12px 20px;
+						border-radius: 8px;
+						background: white;
+						box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+						font-size: 14px;
+						animation: slideIn 0.3s ease-out;
+						pointer-events: auto;
+						max-width: 320px;
+					}
+					
+					.toast-success {
+						background: #10b981;
+						color: white;
+					}
+					
+					.toast-error {
+						background: #ef4444;
+						color: white;
+					}
+					
+					.toast-info {
+						background: #3b82f6;
+						color: white;
+					}
+					
+					@keyframes slideIn {
+						from {
+							transform: translateX(100%);
+							opacity: 0;
+						}
+						to {
+							transform: translateX(0);
+							opacity: 1;
+						}
+					}
+				`}
+			</style>
+			{toasts.map((toast) => (
+				<ToastItem key={toast.id} toast={toast} onRemove={removeToast} />
+			))}
+		</div>
+	);
+};

--- a/apps/whiteboard/src/components/toolbar-react.tsx
+++ b/apps/whiteboard/src/components/toolbar-react.tsx
@@ -8,6 +8,8 @@ import { SnapSettingsButton } from "./snap-settings";
 
 export interface ToolbarProps {
 	onBackgroundChange?: (background: { id: string; config?: any }) => void;
+	isPanelOpen?: boolean;
+	onPanelToggle?: () => void;
 }
 
 // プリセット背景の設定
@@ -34,7 +36,11 @@ const PRESET_BACKGROUNDS = {
 	},
 };
 
-export const ToolbarReact: React.FC<ToolbarProps> = ({ onBackgroundChange }) => {
+export const ToolbarReact: React.FC<ToolbarProps> = ({
+	onBackgroundChange,
+	isPanelOpen,
+	onPanelToggle,
+}) => {
 	const currentTool = useStore((state) => state.currentTool);
 	const setCurrentTool = useStore((state) => state.setCurrentTool);
 	const selectedShapeIds = useStore((state) => state.selectedShapeIds);
@@ -615,6 +621,20 @@ export const ToolbarReact: React.FC<ToolbarProps> = ({ onBackgroundChange }) => 
 						</div>
 					)}
 				</div>
+			</div>
+
+			{/* Panel Toggle Button - aligned to the right */}
+			<div style={{ marginLeft: "auto" }}>
+				<button
+					type="button"
+					className={`tool-button ${isPanelOpen ? "active" : ""}`}
+					onClick={onPanelToggle}
+					data-testid="panel-toggle"
+					title={isPanelOpen ? "パネルを隠す" : "パネルを表示"}
+				>
+					<span className="tool-icon">{isPanelOpen ? "◀" : "▶"}</span>
+					<span>プロパティ</span>
+				</button>
 			</div>
 		</div>
 	);

--- a/apps/whiteboard/src/contexts/toast-context.tsx
+++ b/apps/whiteboard/src/contexts/toast-context.tsx
@@ -19,7 +19,11 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 	const [toasts, setToasts] = useState<Toast[]>([]);
 
 	const showToast = useCallback((message: string, type?: "success" | "error" | "info") => {
-		const id = crypto.randomUUID();
+		// Use crypto.randomUUID() with fallback for compatibility
+		const id =
+			typeof crypto !== "undefined" && crypto.randomUUID
+				? crypto.randomUUID()
+				: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
 		const newToast: Toast = type ? { id, message, type } : { id, message };
 
 		setToasts((prev) => [...prev, newToast]);

--- a/apps/whiteboard/src/contexts/toast-context.tsx
+++ b/apps/whiteboard/src/contexts/toast-context.tsx
@@ -20,10 +20,9 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
 	const showToast = useCallback((message: string, type?: "success" | "error" | "info") => {
 		// Use crypto.randomUUID() with fallback for compatibility
-		const id =
-			typeof crypto !== "undefined" && crypto.randomUUID
-				? crypto.randomUUID()
-				: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+		const id = crypto?.randomUUID
+			? crypto.randomUUID()
+			: `${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
 		const newToast: Toast = type ? { id, message, type } : { id, message };
 
 		setToasts((prev) => [...prev, newToast]);

--- a/apps/whiteboard/src/contexts/toast-context.tsx
+++ b/apps/whiteboard/src/contexts/toast-context.tsx
@@ -1,0 +1,50 @@
+import type React from "react";
+import { createContext, useCallback, useContext, useState } from "react";
+
+interface Toast {
+	id: string;
+	message: string;
+	type?: "success" | "error" | "info";
+}
+
+interface ToastContextType {
+	toasts: Toast[];
+	showToast: (message: string, type?: "success" | "error" | "info") => void;
+	removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+	const [toasts, setToasts] = useState<Toast[]>([]);
+
+	const showToast = useCallback((message: string, type?: "success" | "error" | "info") => {
+		const id = crypto.randomUUID();
+		const newToast: Toast = type ? { id, message, type } : { id, message };
+
+		setToasts((prev) => [...prev, newToast]);
+
+		// Auto-remove after 3 seconds
+		setTimeout(() => {
+			setToasts((prev) => prev.filter((t) => t.id !== id));
+		}, 3000);
+	}, []);
+
+	const removeToast = useCallback((id: string) => {
+		setToasts((prev) => prev.filter((t) => t.id !== id));
+	}, []);
+
+	return (
+		<ToastContext.Provider value={{ toasts, showToast, removeToast }}>
+			{children}
+		</ToastContext.Provider>
+	);
+};
+
+export const useToast = () => {
+	const context = useContext(ToastContext);
+	if (!context) {
+		throw new Error("useToast must be used within a ToastProvider");
+	}
+	return context;
+};

--- a/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,73 @@
+import { useWhiteboardStore } from "@usketch/store";
+import { useEffect } from "react";
+import { showToast } from "../components/toast";
+
+interface KeyboardShortcutsOptions {
+	onPanelToggle?: () => void;
+}
+
+export const useKeyboardShortcuts = ({ onPanelToggle }: KeyboardShortcutsOptions = {}) => {
+	const copyStyleFromSelection = useWhiteboardStore((state) => state.copyStyleFromSelection);
+	const pasteStyleToSelection = useWhiteboardStore((state) => state.pasteStyleToSelection);
+	const undo = useWhiteboardStore((state) => state.undo);
+	const redo = useWhiteboardStore((state) => state.redo);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			// Prevent shortcuts when typing in input fields
+			if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+				return;
+			}
+
+			const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+			const modKey = isMac ? e.metaKey : e.ctrlKey;
+
+			// Cmd/Ctrl + Shift + C: Copy style
+			if (modKey && e.shiftKey && e.key.toLowerCase() === "c") {
+				e.preventDefault();
+				copyStyleFromSelection();
+				showToast("スタイルをコピーしました", "success");
+				return;
+			}
+
+			// Cmd/Ctrl + Shift + V: Paste style
+			if (modKey && e.shiftKey && e.key.toLowerCase() === "v") {
+				e.preventDefault();
+				const result = pasteStyleToSelection();
+				if (result) {
+					showToast("スタイルを適用しました", "success");
+				} else {
+					showToast("コピーされたスタイルがありません", "error");
+				}
+				return;
+			}
+
+			// Cmd/Ctrl + ,: Toggle property panel
+			if (modKey && e.key === ",") {
+				e.preventDefault();
+				onPanelToggle?.();
+				return;
+			}
+
+			// Cmd/Ctrl + Z: Undo (without shift)
+			if (modKey && !e.shiftKey && e.key.toLowerCase() === "z") {
+				e.preventDefault();
+				undo();
+				return;
+			}
+
+			// Cmd/Ctrl + Shift + Z or Cmd/Ctrl + Y: Redo
+			if (
+				(modKey && e.shiftKey && e.key.toLowerCase() === "z") ||
+				(modKey && e.key.toLowerCase() === "y")
+			) {
+				e.preventDefault();
+				redo();
+				return;
+			}
+		};
+
+		window.addEventListener("keydown", handleKeyDown);
+		return () => window.removeEventListener("keydown", handleKeyDown);
+	}, [copyStyleFromSelection, pasteStyleToSelection, undo, redo, onPanelToggle]);
+};

--- a/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
@@ -20,7 +20,19 @@ export const useKeyboardShortcuts = ({ onPanelToggle }: KeyboardShortcutsOptions
 				return;
 			}
 
-			const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+			// Platform detection with fallback for deprecated navigator.platform
+			const isMac = (() => {
+				// Try modern approach first
+				if (navigator.userAgentData?.platform) {
+					return navigator.userAgentData.platform.toUpperCase().includes("MAC");
+				}
+				// Fallback to userAgent parsing
+				if (navigator.userAgent) {
+					return /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
+				}
+				// Last resort: deprecated but still widely supported
+				return navigator.platform?.toUpperCase().indexOf("MAC") >= 0;
+			})();
 			const modKey = isMac ? e.metaKey : e.ctrlKey;
 
 			// Cmd/Ctrl + Shift + C: Copy style

--- a/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
@@ -25,8 +25,12 @@ export const useKeyboardShortcuts = ({ onPanelToggle }: KeyboardShortcutsOptions
 			// Cmd/Ctrl + Shift + C: Copy style
 			if (modKey && e.shiftKey && e.key.toLowerCase() === "c") {
 				e.preventDefault();
-				copyStyleFromSelection();
-				showToast("スタイルをコピーしました", "success");
+				const result = copyStyleFromSelection();
+				if (result) {
+					showToast("スタイルをコピーしました", "success");
+				} else {
+					showToast("形状が選択されていません", "error");
+				}
 				return;
 			}
 

--- a/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
+++ b/apps/whiteboard/src/hooks/use-keyboard-shortcuts.ts
@@ -1,6 +1,6 @@
 import { useWhiteboardStore } from "@usketch/store";
 import { useEffect } from "react";
-import { showToast } from "../components/toast";
+import { useToast } from "../contexts/toast-context";
 
 interface KeyboardShortcutsOptions {
 	onPanelToggle?: () => void;
@@ -11,6 +11,7 @@ export const useKeyboardShortcuts = ({ onPanelToggle }: KeyboardShortcutsOptions
 	const pasteStyleToSelection = useWhiteboardStore((state) => state.pasteStyleToSelection);
 	const undo = useWhiteboardStore((state) => state.undo);
 	const redo = useWhiteboardStore((state) => state.redo);
+	const { showToast } = useToast();
 
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -73,5 +74,5 @@ export const useKeyboardShortcuts = ({ onPanelToggle }: KeyboardShortcutsOptions
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [copyStyleFromSelection, pasteStyleToSelection, undo, redo, onPanelToggle]);
+	}, [copyStyleFromSelection, pasteStyleToSelection, undo, redo, onPanelToggle, showToast]);
 };

--- a/apps/whiteboard/src/styles/app.css
+++ b/apps/whiteboard/src/styles/app.css
@@ -77,6 +77,7 @@
 	flex: 1;
 	display: flex;
 	overflow: hidden;
+	position: relative;
 }
 
 .whiteboard-container {
@@ -85,6 +86,44 @@
 	background-color: white;
 	cursor: default;
 	overflow: hidden;
+	transition: margin-right 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Property Panel animation styles */
+.property-panel {
+	transition:
+		transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+		opacity 0.3s ease;
+	transform: translateX(0);
+	opacity: 1;
+}
+
+.property-panel.panel-closing {
+	transform: translateX(100%);
+	opacity: 0;
+}
+
+/* Responsive adjustments */
+@media (max-width: 1024px) {
+	.property-panel {
+		position: absolute;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		z-index: 50;
+		box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+	}
+
+	.whiteboard-container {
+		margin-right: 0;
+	}
+}
+
+@media (max-width: 768px) {
+	.property-panel {
+		width: 100%;
+		max-width: 100%;
+	}
 }
 
 /* Shape selection styles */

--- a/apps/whiteboard/src/types/navigator.d.ts
+++ b/apps/whiteboard/src/types/navigator.d.ts
@@ -1,0 +1,13 @@
+// Type definitions for navigator.userAgentData
+interface NavigatorUAData {
+	platform: string;
+	brands: Array<{
+		brand: string;
+		version: string;
+	}>;
+	mobile: boolean;
+}
+
+interface Navigator {
+	userAgentData?: NavigatorUAData;
+}

--- a/packages/store/src/slices/style-slice.ts
+++ b/packages/store/src/slices/style-slice.ts
@@ -16,8 +16,8 @@ export interface StyleActions {
 	updateSelectedShapesStyle: (styles: Partial<StyleProperties>) => void;
 
 	// スタイルコピー/ペースト
-	copyStyleFromSelection: () => void;
-	pasteStyleToSelection: () => void;
+	copyStyleFromSelection: () => boolean;
+	pasteStyleToSelection: () => boolean;
 
 	// プリセット管理
 	saveStylePreset: (name: string) => void;
@@ -122,12 +122,12 @@ export const createStyleSlice: StateCreator<StoreState, [], [], StyleSlice> = (
 
 	copyStyleFromSelection: () => {
 		const { selectedShapeIds, shapes } = get();
-		if (selectedShapeIds.size === 0) return;
+		if (selectedShapeIds.size === 0) return false;
 
 		const firstId = Array.from(selectedShapeIds)[0];
-		if (!firstId) return;
+		if (!firstId) return false;
 		const shape = shapes[firstId];
-		if (!shape) return;
+		if (!shape) return false;
 
 		const style: StyleProperties = {
 			fillColor: shape.fillColor,
@@ -141,13 +141,15 @@ export const createStyleSlice: StateCreator<StoreState, [], [], StyleSlice> = (
 		set({
 			copiedStyle: style,
 		});
+		return true;
 	},
 
 	pasteStyleToSelection: () => {
 		const { copiedStyle, updateSelectedShapesStyle } = get();
-		if (!copiedStyle) return;
+		if (!copiedStyle) return false;
 
 		updateSelectedShapesStyle(copiedStyle);
+		return true;
 	},
 
 	saveStylePreset: (name) => {


### PR DESCRIPTION
## 概要
Phase 6.4: ホワイトボードアプリへの統合を実装しました。

## 実装内容

### 1. プロパティパネルの開閉機能
- ツールバーにパネル切り替えボタンを追加
- スムーズなアニメーション効果
- 開閉状態の管理

### 2. キーボードショートカット
- **Cmd/Ctrl + Shift + C**: スタイルをコピー
- **Cmd/Ctrl + Shift + V**: スタイルをペースト
- **Cmd/Ctrl + ,**: プロパティパネルの表示/非表示切り替え
- **Cmd/Ctrl + Z**: 元に戻す
- **Cmd/Ctrl + Y / Cmd/Ctrl + Shift + Z**: やり直し

### 3. トースト通知システム
- スタイル操作の成功/失敗を視覚的にフィードバック
- 3秒後に自動で消える
- 複数の通知を同時に表示可能

### 4. レスポンシブ対応
- 1024px以下: パネルが絶対位置で配置
- 768px以下: パネルが全画面幅で表示
- スムーズなトランジション効果

## テスト方法

1. プロパティパネルの開閉
   - ツールバー右端のボタンをクリック
   - Cmd+, キーを押す

2. スタイルのコピー&ペースト
   - 形状を選択してCmd+Shift+Cでコピー
   - 別の形状を選択してCmd+Shift+Vでペースト

3. トースト通知
   - スタイル操作時に自動表示

## Phase 6 全体の進捗

- ✅ Phase 6.1: 基盤整備とストア拡張（完了）
- ✅ Phase 6.2: プロパティパネルUI実装（完了）
- ✅ Phase 6.3: スタイル管理機能実装（完了）
- ✅ Phase 6.4: ホワイトボードアプリへの統合（完了）

**Phase 6 実装完了！** 🎉