### PR TITLE
🐛 fix: Fix freedraw shape resize handle position offset

### DIFF
--- a/packages/shape-plugins/src/core/freedraw/index.ts
+++ b/packages/shape-plugins/src/core/freedraw/index.ts
@@ -34,6 +34,7 @@ export const freedrawPlugin: ShapePlugin<FreedrawShape> = {
 		}
 
 		// Calculate bounds from points
+		// Note: shape.points are in absolute world coordinates
 		let minX = shape.points[0].x;
 		let maxX = shape.points[0].x;
 		let minY = shape.points[0].y;
@@ -47,8 +48,8 @@ export const freedrawPlugin: ShapePlugin<FreedrawShape> = {
 		}
 
 		return {
-			x: shape.x + minX,
-			y: shape.y + minY,
+			x: minX, // Use absolute coordinates directly
+			y: minY,
 			width: maxX - minX,
 			height: maxY - minY,
 		};
@@ -64,13 +65,14 @@ export const freedrawPlugin: ShapePlugin<FreedrawShape> = {
 		const toleranceSq = tolerance * tolerance;
 
 		for (let i = 0; i < shape.points.length - 1; i++) {
+			// Note: shape.points are in absolute world coordinates
 			const p1 = {
-				x: shape.x + shape.points[i].x,
-				y: shape.y + shape.points[i].y,
+				x: shape.points[i].x,
+				y: shape.points[i].y,
 			};
 			const p2 = {
-				x: shape.x + shape.points[i + 1].x,
-				y: shape.y + shape.points[i + 1].y,
+				x: shape.points[i + 1].x,
+				y: shape.points[i + 1].y,
 			};
 
 			// Calculate distance from point to line segment


### PR DESCRIPTION
## Summary

Fixed a bug where resize handles for freedraw shapes were positioned incorrectly, appearing offset from the actual shape bounds.

## Root Cause

The freedraw shape stores points in **absolute world coordinates**, but the `getBounds()` and `hitTest()` functions in the freedraw plugin were incorrectly adding `shape.x` and `shape.y` offsets. This caused double-offset in coordinate calculations, resulting in misaligned resize handles.

## Changes

### `packages/shape-plugins/src/core/freedraw/index.ts`
- **`getBounds()`**: Fixed to use absolute coordinates directly instead of adding shape.x/shape.y offsets
- **`hitTest()`**: Fixed to use absolute coordinates directly for point-to-segment distance calculation
- Added comments clarifying that shape.points are in absolute world coordinates

### `packages/tools/src/utils/geometry.ts`
- **`getResizeHandleAtPoint()`**: Added special handling for freedraw shapes to calculate correct bounds from points
- **`isPointInShape()`**: Simplified and unified freedraw shape detection logic
- **`isShapeInBounds()`**: Added comment clarifying coordinate system

## Test Plan

- [x] Draw a freedraw shape on the canvas
- [x] Select the shape
- [x] Verify that resize handles appear at the correct corners of the bounding box
- [x] Verify that the selection box matches the actual shape bounds
- [x] Test dragging resize handles to ensure they work correctly

## Impact

This fix ensures that:
1. Resize handles appear at the correct positions for freedraw shapes
2. Selection detection works accurately
3. Bounding box calculations are consistent across the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)