### PR TITLE
グループのショートカットキーを修正

### DIFF
--- a/plugins/usketch-plugin-shape-group/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-group/src/plugin.tsx
@@ -79,10 +79,10 @@ export const groupPlugin: UsketchPlugin = {
 			ctx.store.setSelection(restoredChildIds);
 		}
 
-		// Cmd+G / Ctrl+G to group
-		ctx.shortcuts.register("Cmd+g", groupSelected);
-		// Cmd+Shift+G / Ctrl+Shift+G to ungroup
-		ctx.shortcuts.register("Cmd+Shift+g", ungroupSelected);
+		// Ctrl+G (Cmd+G on Mac) to group
+		ctx.shortcuts.register("Ctrl+g", groupSelected);
+		// Ctrl+Shift+G (Cmd+Shift+G on Mac) to ungroup
+		ctx.shortcuts.register("Ctrl+Shift+g", ungroupSelected);
 
 		// Override delete for groups to cascade
 		ctx.events.on<{ shapeId: string }>("group:delete-request", (data) => {


### PR DESCRIPTION
## Summary

- ShortcutRegistry は `metaKey` (Mac の Cmd) を `"ctrl"` に正規化するため、`"Cmd+g"` では一致しなかった
- 既存のショートカット (`Ctrl+Z` 等) と同じ `"Ctrl+g"` / `"Ctrl+Shift+g"` に修正

## Test plan

- [ ] Mac: Cmd+G でグループ化、Cmd+Shift+G で解除
- [ ] Windows/Linux: Ctrl+G でグループ化、Ctrl+Shift+G で解除

🤖 Generated with [Claude Code](https://claude.com/claude-code)