### PR TITLE
マーキー選択がパン中にずれる問題を修正

### DIFF
--- a/plugins/usketch-plugin-tool-select/src/marquee-state.ts
+++ b/plugins/usketch-plugin-tool-select/src/marquee-state.ts
@@ -1,5 +1,5 @@
 export interface MarqueeRect {
-	x: number; // screen-space
+	x: number; // world-space
 	y: number;
 	width: number;
 	height: number;

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -180,7 +180,6 @@ type DragState =
 	| {
 			mode: "marquee";
 			startWorldPoint: Point;
-			startScreenPoint: Point;
 			shiftKey: boolean;
 	  }
 	| null;
@@ -362,7 +361,6 @@ export const selectToolPlugin: UsketchPlugin = {
 				dragState = {
 					mode: "marquee",
 					startWorldPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
-					startScreenPoint: { x: event.screenPoint.x, y: event.screenPoint.y },
 					shiftKey: event.shiftKey,
 				};
 			}
@@ -410,24 +408,19 @@ export const selectToolPlugin: UsketchPlugin = {
 			}
 
 			if (dragState.mode === "marquee") {
-				const x = Math.min(dragState.startScreenPoint.x, event.screenPoint.x);
-				const y = Math.min(dragState.startScreenPoint.y, event.screenPoint.y);
-				const width = Math.abs(event.screenPoint.x - dragState.startScreenPoint.x);
-				const height = Math.abs(event.screenPoint.y - dragState.startScreenPoint.y);
-				const screenRect: MarqueeRect = { x, y, width, height };
-
 				// Alt key toggles between intersect and contain mode
 				const mode: MarqueeMode = event.altKey ? "contain" : "intersect";
 				setMarqueeMode(mode);
 
-				// Compute world-space marquee for hit testing
+				// Compute world-space marquee (used for both hit testing and rendering)
 				const wx = Math.min(dragState.startWorldPoint.x, event.worldPoint.x);
 				const wy = Math.min(dragState.startWorldPoint.y, event.worldPoint.y);
 				const ww = Math.abs(event.worldPoint.x - dragState.startWorldPoint.x);
 				const wh = Math.abs(event.worldPoint.y - dragState.startWorldPoint.y);
-				const hitIds = findShapesInRect(toolCtx, { x: wx, y: wy, width: ww, height: wh }, mode);
+				const worldRect: MarqueeRect = { x: wx, y: wy, width: ww, height: wh };
+				const hitIds = findShapesInRect(toolCtx, worldRect, mode);
 
-				setMarquee(screenRect, hitIds);
+				setMarquee(worldRect, hitIds);
 				return;
 			}
 

--- a/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
+++ b/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
@@ -259,13 +259,13 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 						shapeId={id}
 					/>
 				))}
-			{/* Marquee rectangle */}
+			{/* Marquee rectangle (world-space → screen-space) */}
 			{marqueeRect && (
 				<rect
-					x={marqueeRect.x}
-					y={marqueeRect.y}
-					width={marqueeRect.width}
-					height={marqueeRect.height}
+					x={marqueeRect.x * viewport.zoom + viewport.x}
+					y={marqueeRect.y * viewport.zoom + viewport.y}
+					width={marqueeRect.width * viewport.zoom}
+					height={marqueeRect.height * viewport.zoom}
 					fill={marqueeMode === "contain" ? "rgba(38, 128, 235, 0.08)" : "rgba(38, 128, 235, 0.1)"}
 					stroke={STROKE_COLOR}
 					strokeWidth={1}


### PR DESCRIPTION
## Summary

- マーキー矩形をスクリーン座標ベース → ワールド座標ベースに変更
- 描画時にビューポート変換してスクリーン座標に変換
- ドラッグ中にパン（スクロール）してもマーキーが正しいワールド範囲を維持

## Test plan

- [ ] 空白領域をドラッグしてマーキー選択開始 → ドラッグ中にホイールでパン → マーキーがワールド座標に固定されスクロール方向に拡大すること
- [ ] Alt+ドラッグで contain モードが正常に動作すること
- [ ] Shift+ドラッグで追加選択が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)