### PR TITLE
画像ファイルのドラッグ&ドロップ貼り付けに対応

### DIFF
--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -113,6 +113,28 @@ export function Canvas() {
 		[viewport, activeTool, toolCtx, app.events],
 	);
 
+	const handleDragOver = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.dataTransfer.dropEffect = "copy";
+	}, []);
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			const rect = containerRef.current?.getBoundingClientRect();
+			const screenPoint = {
+				x: rect ? e.clientX - rect.left : e.clientX,
+				y: rect ? e.clientY - rect.top : e.clientY,
+			};
+			app.events.emit("canvas:drop", {
+				files: e.dataTransfer.files,
+				worldPoint: screenToWorld(screenPoint, viewport),
+				screenPoint,
+			});
+		},
+		[viewport, app.events],
+	);
+
 	// ── Re-render when layers change dynamically ──
 	// Plugins that register/unregister layers at runtime must emit
 	// "layers:changed" via ctx.events after mutation.
@@ -221,6 +243,7 @@ export function Canvas() {
 	const viewportTransform = `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`;
 
 	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: Canvas is the interactive drawing surface
 		<div
 			ref={containerRef}
 			style={{
@@ -235,6 +258,8 @@ export function Canvas() {
 			onPointerDown={handlePointerDown}
 			onPointerMove={handlePointerMove}
 			onPointerUp={handlePointerUp}
+			onDragOver={handleDragOver}
+			onDrop={handleDrop}
 		>
 			{layers.map((layer) => {
 				if (layer.fixed) {

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -171,6 +171,7 @@ export interface CoreEventMap {
 	"shapes:move-end": { shapeIds: string[] };
 	"snap:configure": { enabled: boolean };
 	"partition:request": { partitions: string[] };
+	"canvas:drop": { files: FileList; worldPoint: Point; screenPoint: Point };
 }
 
 export interface EventBus {

--- a/plugins/usketch-plugin-ai-image/src/plugin.ts
+++ b/plugins/usketch-plugin-ai-image/src/plugin.ts
@@ -130,17 +130,16 @@ export function createAiImagePlugin(options: ImageOptions): UsketchPlugin {
 			}
 
 			/** Handle file drop on canvas */
-			const unsubDrop = ctx.events.on<{
-				files: FileList;
-				worldPoint: { x: number; y: number };
-			}>("canvas:drop", (data) => {
+			const unsubDrop = ctx.events.on("canvas:drop", async (data) => {
 				const imageFiles = Array.from(data.files).filter((f) => f.type.startsWith("image/"));
 				if (imageFiles.length === 0) return;
 
+				const maxRenderedWidth = 400;
+				const gap = 20;
 				let offsetX = 0;
 				for (const file of imageFiles) {
-					placeImageShape(file, { x: data.worldPoint.x + offsetX, y: data.worldPoint.y });
-					offsetX += 220;
+					await placeImageShape(file, { x: data.worldPoint.x + offsetX, y: data.worldPoint.y });
+					offsetX += maxRenderedWidth + gap;
 				}
 			});
 

--- a/plugins/usketch-plugin-ai-image/src/plugin.ts
+++ b/plugins/usketch-plugin-ai-image/src/plugin.ts
@@ -13,7 +13,10 @@ export function createAiImagePlugin(options: ImageOptions): UsketchPlugin {
 
 		setup(ctx: PluginContext) {
 			/** 画像をimageシェイプとしてキャンバスに配置 */
-			async function placeImageShape(file: File): Promise<void> {
+			async function placeImageShape(
+				file: File,
+				dropWorldPoint?: { x: number; y: number },
+			): Promise<void> {
 				const validation = validateImage(file, maxSizeMB);
 				if (!validation.valid) {
 					ctx.events.emit("ai:status", {
@@ -27,10 +30,17 @@ export function createAiImagePlugin(options: ImageOptions): UsketchPlugin {
 					let dataUrl = await fileToBase64(file);
 					dataUrl = await resizeImage(dataUrl, maxDimension);
 
-					// ビューポート中央にシェイプを配置
-					const viewport = ctx.store.getViewport();
-					const centerX = -viewport.x / viewport.zoom + window.innerWidth / 2 / viewport.zoom;
-					const centerY = -viewport.y / viewport.zoom + window.innerHeight / 2 / viewport.zoom;
+					// 配置位置: ドロップ位置があればそこ、なければビューポート中央
+					let centerX: number;
+					let centerY: number;
+					if (dropWorldPoint) {
+						centerX = dropWorldPoint.x;
+						centerY = dropWorldPoint.y;
+					} else {
+						const viewport = ctx.store.getViewport();
+						centerX = -viewport.x / viewport.zoom + window.innerWidth / 2 / viewport.zoom;
+						centerY = -viewport.y / viewport.zoom + window.innerHeight / 2 / viewport.zoom;
+					}
 
 					// 画像サイズを取得してアスペクト比を維持
 					const { width, height } = await getImageDimensions(dataUrl);
@@ -119,12 +129,28 @@ export function createAiImagePlugin(options: ImageOptions): UsketchPlugin {
 				input.click();
 			}
 
+			/** Handle file drop on canvas */
+			const unsubDrop = ctx.events.on<{
+				files: FileList;
+				worldPoint: { x: number; y: number };
+			}>("canvas:drop", (data) => {
+				const imageFiles = Array.from(data.files).filter((f) => f.type.startsWith("image/"));
+				if (imageFiles.length === 0) return;
+
+				let offsetX = 0;
+				for (const file of imageFiles) {
+					placeImageShape(file, { x: data.worldPoint.x + offsetX, y: data.worldPoint.y });
+					offsetX += 220;
+				}
+			});
+
 			window.addEventListener("paste", handlePaste);
 			const unsubUpload = ctx.events.on("image:upload", handleUpload);
 
 			cleanup = () => {
 				window.removeEventListener("paste", handlePaste);
 				unsubUpload();
+				unsubDrop();
 			};
 		},
 


### PR DESCRIPTION
## Summary
- canvas-engine に `onDragOver` / `onDrop` ハンドラを追加し、`canvas:drop` イベントを EventBus 経由で emit
- ai-image プラグインが `canvas:drop` を購読し、ドロップ位置のワールド座標に画像シェイプを配置
- 複数画像の同時ドロップにも対応（横並びに配置）

## Test plan
- [ ] 画像ファイルをキャンバスにD&D → ドロップ位置に画像シェイプが出現
- [ ] 複数画像を同時にD&D → 横に並んで配置
- [ ] 画像以外のファイル（.txt等）をD&D → 何も起きない
- [ ] 大きい画像（>4MB）をD&D → エラーステータスが表示
- [ ] ペースト（既存）が引き続き動作すること
- [ ] Undo で画像シェイプが消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)