### PR TITLE
フレーム内シェイプのドラッグ時ガタつきを修正

### DIFF
--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -184,6 +184,18 @@ export const snapPlugin: UsketchPlugin = {
 				return;
 			}
 
+			// Skip snap for child shapes whose parent is being dragged (in selection).
+			// Children follow their parent's snap offset; snapping them individually
+			// causes jitter because each child gets its own snap delta.
+			const parentId = shape.parentId as string | undefined;
+			if (parentId) {
+				const sel = ctx.store.getSelection();
+				if (sel.has(parentId)) {
+					originalUpdateShape(id, updates);
+					return;
+				}
+			}
+
 			const isResize = isResizeUpdate(updates);
 
 			// Get current frame ID to cache snap results across multi-shape updates


### PR DESCRIPTION
## Summary
- フレーム（子シェイプ有り）をドラッグするとガタガタ動くバグを修正
- 原因: スナッププラグインが子シェイプを個別にスナップ計算し、親フレームと異なるオフセットが適用されていた
- 修正: `parentId` を持つシェイプの親が selection に含まれている場合、スナップをスキップして親のオフセットに追従するよう変更

## Test plan
- [ ] フレーム内にrect/ellipse/text等を配置してフレームをドラッグ → ガタつかずスムーズに移動
- [ ] フレーム内のシェイプを単独で選択してドラッグ → 通常通りスナップが効く
- [ ] フレームなしのシェイプのドラッグ → 通常通りスナップが効く
- [ ] Alt 押しでスナップ無効 → 従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)