### PR TITLE
フレームが自身の子シェイプにスナップする問題を修正

### DIFF
--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -456,6 +456,9 @@ function getCandidateBoxes(
 	const boxes = new Map<string, BoundingBox>();
 	for (const [id, shape] of store.getShapes()) {
 		if (movingIds.has(id)) continue;
+		// Exclude children of moving shapes so a frame doesn't snap to its own children
+		const parentId = shape.parentId as string | undefined;
+		if (parentId && movingIds.has(parentId)) continue;
 		const def = ctx.shapes.get(shape.type);
 		const box = def
 			? def.getBounds(shape)


### PR DESCRIPTION
## Summary
- フレームをドラッグすると自身の子シェイプにスナップしてガタつく問題を修正
- 原因: `getCandidateBoxes` で `movingIds`（= selection = フレームのみ）しか除外していなかったため、子シェイプがスナップ候補に残っていた
- 修正: `parentId` が `movingIds` に含まれるシェイプもスナップ候補から除外

## Test plan
- [ ] フレーム内にシェイプを配置してフレームをドラッグ → 子にスナップしてガタつかない
- [ ] フレーム外のシェイプにはスナップが効く
- [ ] 子シェイプを単独で選択してドラッグ → 他のシェイプにスナップする（正常）
- [ ] Alt 押しでスナップ無効 → 従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)