### PR TITLE
選択中のシェイプをフレームの上にドラッグすると消える問題を修正

### DIFF
--- a/packages/dom-renderer/src/dom-shape-layer.tsx
+++ b/packages/dom-renderer/src/dom-shape-layer.tsx
@@ -53,21 +53,23 @@ function stableParentSort(
 	return result;
 }
 
-// Selected non-container shapes get a high zIndex so they render above
-// frames during drag. Containers (frame/island/group) are excluded so
-// their background doesn't cover their own children.
-const SELECTED_Z_BOOST = 100_000;
+// When dragging shapes onto a frame (drop target detected), boost their
+// zIndex so they render above the frame's opaque background.
+// Only applied when a drop target is active, not during normal selection.
+const DROP_TARGET_Z_BOOST = 100_000;
 const CONTAINER_SHAPE_TYPES = new Set(["frame", "island", "group"]);
 
 function ShapeWrapper({
 	shape,
 	index,
 	selected,
+	overDropTarget,
 	def,
 }: {
 	shape: ShapeData;
 	index: number;
 	selected: boolean;
+	overDropTarget: boolean;
 	def: { render: (data: ShapeData) => React.ReactElement; renderTarget?: string };
 }) {
 	const bounds = { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
@@ -82,7 +84,7 @@ function ShapeWrapper({
 
 	// Containers (island/frame/group) use pointerEvents: none to let children receive clicks
 	const isContainer = CONTAINER_SHAPE_TYPES.has(shape.type);
-	const boosted = selected && !isContainer;
+	const boosted = selected && !isContainer && overDropTarget;
 
 	return (
 		<div
@@ -92,7 +94,7 @@ function ShapeWrapper({
 				top: bounds.y,
 				width: bounds.width,
 				height: bounds.height,
-				zIndex: boosted ? index + SELECTED_Z_BOOST : index,
+				zIndex: boosted ? index + DROP_TARGET_Z_BOOST : index,
 				pointerEvents: isContainer ? "none" : "auto",
 				transform: rotation ? `rotate(${rotation}deg)` : undefined,
 				transformOrigin: "center center",
@@ -118,11 +120,14 @@ export function DomShapeLayer({
 	ctx,
 	shapeRegistry,
 	claimedIds,
+	dropTargetId,
 }: {
 	ctx: LayerRenderContext;
 	shapeRegistry: ShapeRegistry;
 	/** Shape IDs already claimed by another renderer (e.g. GPU). These are skipped. */
 	claimedIds?: ReadonlySet<string>;
+	/** Frame/group ID that the dragged shapes are hovering over. */
+	dropTargetId?: string | null;
 }) {
 	// `gpu-only` mode: hide the DOM layer entirely (reserved for future use).
 	if (ctx.renderMode === "gpu-only") return null;
@@ -229,6 +234,7 @@ export function DomShapeLayer({
 						shape={shape}
 						index={index}
 						selected={ctx.selection.has(shape.id)}
+						overDropTarget={!!dropTargetId}
 						def={def}
 					/>
 				);

--- a/packages/dom-renderer/src/dom-shape-layer.tsx
+++ b/packages/dom-renderer/src/dom-shape-layer.tsx
@@ -53,13 +53,20 @@ function stableParentSort(
 	return result;
 }
 
+// Selected shapes get a high zIndex so they render above frames/containers
+// during drag. Without this, shapes with a lower zIndex than the target
+// frame disappear behind the frame's opaque background while being dragged.
+const SELECTED_Z_BOOST = 100_000;
+
 function ShapeWrapper({
 	shape,
 	index,
+	selected,
 	def,
 }: {
 	shape: ShapeData;
 	index: number;
+	selected: boolean;
 	def: { render: (data: ShapeData) => React.ReactElement; renderTarget?: string };
 }) {
 	const bounds = { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
@@ -83,7 +90,7 @@ function ShapeWrapper({
 				top: bounds.y,
 				width: bounds.width,
 				height: bounds.height,
-				zIndex: index,
+				zIndex: selected ? index + SELECTED_Z_BOOST : index,
 				pointerEvents: isContainer ? "none" : "auto",
 				transform: rotation ? `rotate(${rotation}deg)` : undefined,
 				transformOrigin: "center center",
@@ -130,27 +137,7 @@ export function DomShapeLayer({
 	// This preserves user-controlled z-order within each sibling group while keeping
 	// the container-before-child invariant required by the DOM stacking context.
 	const CONTAINER_TYPES = new Set(["frame", "island", "group"]);
-	const sorted = stableParentSort(ctx.shapesSorted, CONTAINER_TYPES);
-
-	// Bring selected shapes to the front so they render above frames/containers
-	// during drag. Without this, shapes with a lower zIndex than the target
-	// frame disappear behind the frame's opaque background while being dragged.
-	const { selection } = ctx;
-	let shapes: ShapeData[];
-	if (selection.size > 0) {
-		const back: ShapeData[] = [];
-		const front: ShapeData[] = [];
-		for (const s of sorted) {
-			if (selection.has(s.id)) {
-				front.push(s);
-			} else {
-				back.push(s);
-			}
-		}
-		shapes = back.concat(front);
-	} else {
-		shapes = sorted;
-	}
+	const shapes = stableParentSort(ctx.shapesSorted, CONTAINER_TYPES);
 
 	return (
 		<div data-layer="shapes">
@@ -234,7 +221,15 @@ export function DomShapeLayer({
 						</div>
 					);
 				}
-				return <ShapeWrapper key={shape.id} shape={shape} index={index} def={def} />;
+				return (
+					<ShapeWrapper
+						key={shape.id}
+						shape={shape}
+						index={index}
+						selected={ctx.selection.has(shape.id)}
+						def={def}
+					/>
+				);
 			})}
 		</div>
 	);

--- a/packages/dom-renderer/src/dom-shape-layer.tsx
+++ b/packages/dom-renderer/src/dom-shape-layer.tsx
@@ -130,7 +130,27 @@ export function DomShapeLayer({
 	// This preserves user-controlled z-order within each sibling group while keeping
 	// the container-before-child invariant required by the DOM stacking context.
 	const CONTAINER_TYPES = new Set(["frame", "island", "group"]);
-	const shapes = stableParentSort(ctx.shapesSorted, CONTAINER_TYPES);
+	const sorted = stableParentSort(ctx.shapesSorted, CONTAINER_TYPES);
+
+	// Bring selected shapes to the front so they render above frames/containers
+	// during drag. Without this, shapes with a lower zIndex than the target
+	// frame disappear behind the frame's opaque background while being dragged.
+	const { selection } = ctx;
+	let shapes: ShapeData[];
+	if (selection.size > 0) {
+		const back: ShapeData[] = [];
+		const front: ShapeData[] = [];
+		for (const s of sorted) {
+			if (selection.has(s.id)) {
+				front.push(s);
+			} else {
+				back.push(s);
+			}
+		}
+		shapes = back.concat(front);
+	} else {
+		shapes = sorted;
+	}
 
 	return (
 		<div data-layer="shapes">

--- a/packages/dom-renderer/src/dom-shape-layer.tsx
+++ b/packages/dom-renderer/src/dom-shape-layer.tsx
@@ -53,10 +53,11 @@ function stableParentSort(
 	return result;
 }
 
-// Selected shapes get a high zIndex so they render above frames/containers
-// during drag. Without this, shapes with a lower zIndex than the target
-// frame disappear behind the frame's opaque background while being dragged.
+// Selected non-container shapes get a high zIndex so they render above
+// frames during drag. Containers (frame/island/group) are excluded so
+// their background doesn't cover their own children.
 const SELECTED_Z_BOOST = 100_000;
+const CONTAINER_SHAPE_TYPES = new Set(["frame", "island", "group"]);
 
 function ShapeWrapper({
 	shape,
@@ -80,7 +81,8 @@ function ShapeWrapper({
 	const svgH = Math.max(bounds.height, 1);
 
 	// Containers (island/frame/group) use pointerEvents: none to let children receive clicks
-	const isContainer = shape.type === "island" || shape.type === "group";
+	const isContainer = CONTAINER_SHAPE_TYPES.has(shape.type);
+	const boosted = selected && !isContainer;
 
 	return (
 		<div
@@ -90,7 +92,7 @@ function ShapeWrapper({
 				top: bounds.y,
 				width: bounds.width,
 				height: bounds.height,
-				zIndex: selected ? index + SELECTED_Z_BOOST : index,
+				zIndex: boosted ? index + SELECTED_Z_BOOST : index,
 				pointerEvents: isContainer ? "none" : "auto",
 				transform: rotation ? `rotate(${rotation}deg)` : undefined,
 				transformOrigin: "center center",

--- a/packages/dom-renderer/src/plugin.tsx
+++ b/packages/dom-renderer/src/plugin.tsx
@@ -11,6 +11,8 @@ export function createDomRendererPlugin(): UsketchPlugin {
 		setup(ctx: PluginContext) {
 			// Track shape IDs claimed by other renderers (e.g. GPU)
 			let claimedIds: ReadonlySet<string> = new Set();
+			// Track drop target frame (set by select tool during drag)
+			let dropTargetId: string | null = null;
 
 			const unsubClaim = ctx.events.on<{ ids: ReadonlySet<string> }>(
 				"renderer:claim-shapes",
@@ -38,6 +40,16 @@ export function createDomRendererPlugin(): UsketchPlugin {
 				},
 			);
 
+			const unsubDropTarget = ctx.events.on<{ id: string | null }>(
+				"drop-target:changed",
+				(data) => {
+					if (dropTargetId !== data.id) {
+						dropTargetId = data.id;
+						ctx.events.emit("layers:changed", {});
+					}
+				},
+			);
+
 			ctx.layers.register({
 				id: "dom-shapes",
 				order: 50,
@@ -46,12 +58,14 @@ export function createDomRendererPlugin(): UsketchPlugin {
 						ctx={renderCtx}
 						shapeRegistry={ctx.shapes}
 						claimedIds={claimedIds.size > 0 ? claimedIds : undefined}
+						dropTargetId={dropTargetId}
 					/>
 				),
 			});
 
 			cleanup = () => {
 				unsubClaim();
+				unsubDropTarget();
 				ctx.layers.unregister("dom-shapes");
 			};
 		},

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -214,6 +214,12 @@ export const selectToolPlugin: UsketchPlugin = {
 	name: "選択",
 
 	setup(ctx: PluginContext) {
+		// Wrap setDropTargetId to also emit on EventBus for DomShapeLayer
+		function updateDropTarget(id: string | null) {
+			setDropTargetId(id);
+			ctx.events.emit("drop-target:changed", { id });
+		}
+
 		// ── Local drag state (scoped to this setup closure) ──
 		let dragState: DragState = null;
 		let overrideCursor = "";
@@ -809,12 +815,12 @@ export const selectToolPlugin: UsketchPlugin = {
 					break;
 				}
 			}
-			setDropTargetId(dropTarget);
+			updateDropTarget(dropTarget);
 		}
 
 		function onPointerUp(toolCtx: ToolContext, _event: CanvasPointerEvent) {
 			enableTextSelection();
-			setDropTargetId(null);
+			updateDropTarget(null);
 			if (!dragState) return;
 
 			if (dragState.mode === "rotate") {
@@ -983,7 +989,7 @@ export const selectToolPlugin: UsketchPlugin = {
 			setOverrideCursor("");
 			setEditingGroupId(null);
 			setHoveredShapeId(null);
-			setDropTargetId(null);
+			updateDropTarget(null);
 		}
 
 		ctx.tools.register("select", {
@@ -1019,7 +1025,7 @@ export const selectToolPlugin: UsketchPlugin = {
 			setMarquee(null);
 			setEditingGroupId(null);
 			setHoveredShapeId(null);
-			setDropTargetId(null);
+			updateDropTarget(null);
 			clearMarqueeListeners();
 			clearMovingSelectionListeners();
 			clearEditingGroupListeners();


### PR DESCRIPTION
## Summary
- zIndex がフレームより小さいシェイプをフレーム上にドラッグすると、フレームの不透明背景の下に隠れて見えなくなる問題を修正
- DomShapeLayer のレンダリング順で、selection 内のシェイプを配列末尾（最前面）に移動
- PointerUp 後は autoReparent でフレームの子になり、stableParentSort でフレーム直後に並ぶので正常に表示される

## Test plan
- [ ] 複数シェイプを選択してフレーム上にドラッグ → ドラッグ中もシェイプが見える
- [ ] フレームの外から中にドラッグ → ドラッグ中にシェイプが消えない
- [ ] PointerUp でフレーム内に配置される（従来通り）
- [ ] 通常の z-order（選択なし）が壊れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)