### PR TITLE
フレーム回転の子シェイプ追従 + ドロップ時z-order修正 + LOD rotation対応

### DIFF
--- a/packages/dom-renderer/src/lod-fallback.tsx
+++ b/packages/dom-renderer/src/lod-fallback.tsx
@@ -1,4 +1,5 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
+import { safeRotation } from "@edv4h/usketch-shared";
 
 /**
  * Default lightweight component used when a shape has no `simplifiedComponent`
@@ -8,6 +9,7 @@ import type { ShapeData } from "@edv4h/usketch-shared";
  */
 export function LodFallback({ shape }: { shape: ShapeData }) {
 	const style = (shape.style ?? {}) as { fill?: string };
+	const rotation = safeRotation(shape.rotation);
 	return (
 		<div
 			style={{
@@ -18,6 +20,8 @@ export function LodFallback({ shape }: { shape: ShapeData }) {
 				height: shape.height,
 				backgroundColor: style.fill || "#cccccc",
 				pointerEvents: "none",
+				transform: rotation ? `rotate(${rotation}deg)` : undefined,
+				transformOrigin: "center center",
 			}}
 		/>
 	);

--- a/plugins/usketch-plugin-shape-counter/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-counter/src/plugin.tsx
@@ -19,6 +19,7 @@ import { createAddShapeCommand } from "@edv4h/usketch-store";
  */
 function SimplifiedCounter({ shape }: { shape: ShapeData }) {
 	const count = (shape.count as number) ?? 0;
+	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
 	return (
 		<div
 			style={{
@@ -38,6 +39,8 @@ function SimplifiedCounter({ shape }: { shape: ShapeData }) {
 				color: "#222",
 				pointerEvents: "none",
 				overflow: "hidden",
+				transform: rotation ? `rotate(${rotation}deg)` : undefined,
+				transformOrigin: "center center",
 			}}
 		>
 			{count}

--- a/plugins/usketch-plugin-shape-frame/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-frame/src/plugin.tsx
@@ -21,6 +21,7 @@ import {
  */
 function SimplifiedFrame({ shape }: { shape: ShapeData }) {
 	const label = (shape.name as string) || "Frame";
+	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
 	return (
 		<div
 			style={{
@@ -33,6 +34,8 @@ function SimplifiedFrame({ shape }: { shape: ShapeData }) {
 				background: "rgba(255,255,255,0.3)",
 				pointerEvents: "none",
 				overflow: "hidden",
+				transform: rotation ? `rotate(${rotation}deg)` : undefined,
+				transformOrigin: "center center",
 			}}
 		>
 			<div

--- a/plugins/usketch-plugin-shape-sticky/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-sticky/src/plugin.tsx
@@ -23,6 +23,7 @@ import { render } from "./render.js";
 function SimplifiedSticky({ shape }: { shape: ShapeData }) {
 	const fill = (shape.style?.fill as string) || (shape.color as string) || "#fff59d";
 	const text = String((shape.text as string) || "").split("\n")[0] ?? "";
+	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
 	return (
 		<div
 			style={{
@@ -40,6 +41,8 @@ function SimplifiedSticky({ shape }: { shape: ShapeData }) {
 				whiteSpace: "nowrap",
 				textOverflow: "ellipsis",
 				pointerEvents: "none",
+				transform: rotation ? `rotate(${rotation}deg)` : undefined,
+				transformOrigin: "center center",
 			}}
 		>
 			{text}

--- a/plugins/usketch-plugin-shape-text/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-text/src/plugin.tsx
@@ -20,6 +20,7 @@ import { createTextEditingService } from "./text-editing-machine.js";
 function SimplifiedText({ shape }: { shape: ShapeData }) {
 	const text = String((shape.text as string) || "").split("\n")[0] ?? "";
 	const color = (shape.style?.stroke as string) || "#222";
+	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
 	return (
 		<div
 			style={{
@@ -35,6 +36,8 @@ function SimplifiedText({ shape }: { shape: ShapeData }) {
 				whiteSpace: "nowrap",
 				textOverflow: "ellipsis",
 				pointerEvents: "none",
+				transform: rotation ? `rotate(${rotation}deg)` : undefined,
+				transformOrigin: "center center",
 			}}
 		>
 			{text}

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -188,6 +188,8 @@ type DragState =
 			startAngle: number;
 			startRotation: number;
 			center: Point;
+			/** Snapshots of child shapes for container rotation */
+			childSnapshots: Map<string, ShapeData>;
 	  }
 	| {
 			mode: "multi-resize";
@@ -266,6 +268,14 @@ export const selectToolPlugin: UsketchPlugin = {
 					const cy = shape.y + shape.height / 2;
 					const startAngle =
 						Math.atan2(event.worldPoint.y - cy, event.worldPoint.x - cx) * (180 / Math.PI);
+					// Collect child snapshots for container rotation
+					const childSnapshots = new Map<string, ShapeData>();
+					if (shape.type === "frame" || shape.type === "group" || shape.type === "island") {
+						const children = getChildShapes(toolCtx.store, rotationHit);
+						for (const child of children) {
+							childSnapshots.set(child.id, { ...child });
+						}
+					}
 					setOverrideCursor("grabbing");
 					dragState = {
 						mode: "rotate",
@@ -273,6 +283,7 @@ export const selectToolPlugin: UsketchPlugin = {
 						startAngle,
 						startRotation: safeRotation(shape.rotation),
 						center: { x: cx, y: cy },
+						childSnapshots,
 					};
 					return;
 				}
@@ -522,6 +533,28 @@ export const selectToolPlugin: UsketchPlugin = {
 				}
 				newRotation = normalizeAngle(newRotation);
 				toolCtx.store.updateShape(dragState.shapeId, { rotation: newRotation });
+
+				// Rotate child shapes around the container center
+				const deltaRad = ((newRotation - dragState.startRotation) * Math.PI) / 180;
+				const { center } = dragState;
+				for (const [childId, snap] of dragState.childSnapshots) {
+					const childCx = snap.x + snap.width / 2;
+					const childCy = snap.y + snap.height / 2;
+					const rx = childCx - center.x;
+					const ry = childCy - center.y;
+					const cos = Math.cos(deltaRad);
+					const sin = Math.sin(deltaRad);
+					const newCx = center.x + rx * cos - ry * sin;
+					const newCy = center.y + rx * sin + ry * cos;
+					const childRotation = normalizeAngle(
+						safeRotation(snap.rotation) + newRotation - dragState.startRotation,
+					);
+					toolCtx.store.updateShape(childId, {
+						x: newCx - snap.width / 2,
+						y: newCy - snap.height / 2,
+						rotation: childRotation,
+					});
+				}
 				return;
 			}
 
@@ -827,13 +860,53 @@ export const selectToolPlugin: UsketchPlugin = {
 				setOverrideCursor("");
 				const currentShape = toolCtx.store.getShape(dragState.shapeId);
 				if (currentShape) {
-					const from = { rotation: dragState.startRotation };
-					const to = { rotation: safeRotation(currentShape.rotation) };
-					if (from.rotation !== to.rotation) {
+					const parentFrom = { rotation: dragState.startRotation };
+					const parentTo = { rotation: safeRotation(currentShape.rotation) };
+					const hasMoved = parentFrom.rotation !== parentTo.rotation;
+
+					if (hasMoved) {
+						// Build before/after snapshots for parent + children
+						const beforeSnapshots = new Map<string, Partial<ShapeData>>();
+						const afterSnapshots = new Map<string, Partial<ShapeData>>();
+
 						const shapeId = dragState.shapeId;
+						beforeSnapshots.set(shapeId, { rotation: parentFrom.rotation });
+						afterSnapshots.set(shapeId, { rotation: parentTo.rotation });
+
+						for (const [childId, snap] of dragState.childSnapshots) {
+							const current = toolCtx.store.getShape(childId);
+							if (current) {
+								beforeSnapshots.set(childId, {
+									x: snap.x,
+									y: snap.y,
+									rotation: safeRotation(snap.rotation),
+								});
+								afterSnapshots.set(childId, {
+									x: current.x,
+									y: current.y,
+									rotation: safeRotation(current.rotation),
+								});
+							}
+						}
+
 						queueMicrotask(() => {
-							toolCtx.store.updateShape(shapeId, from);
-							toolCtx.commands.execute(createUpdateShapeCommand(toolCtx.store, shapeId, from, to));
+							// Revert to before state
+							for (const [id, props] of beforeSnapshots) {
+								toolCtx.store.updateShape(id, props);
+							}
+							// Execute undoable command
+							toolCtx.commands.execute({
+								execute: () => {
+									for (const [id, props] of afterSnapshots) {
+										toolCtx.store.updateShape(id, props);
+									}
+								},
+								undo: () => {
+									for (const [id, props] of beforeSnapshots) {
+										toolCtx.store.updateShape(id, props);
+									}
+								},
+							});
 						});
 					}
 				}


### PR DESCRIPTION
## Summary
- **フレーム回転時に子シェイプも一緒に回転**: フレーム中心を軸に子シェイプの位置・回転角度を連動更新。Undo も親+子をバッチ復元
- **ドロップターゲット検出時のみ zIndex boost**: 選択シェイプが常に最前面に来るのではなく、フレーム上にドラッグした時（drop-target:changed イベント）だけ boost。通常ドラッグ中はフレームの下に来る場合もある（従来通り）
- **コンテナ（frame/island/group）には boost を適用しない**: フレーム選択時に背景が子を覆い隠す問題を防止
- **全 simplifiedComponent と LodFallback に rotation 対応**: LOD モードでもシェイプの回転が正しく反映

## Test plan
- [ ] フレームを回転 → 子シェイプがフレーム中心を軸に一緒に回転する
- [ ] フレーム回転後に Undo → 親+子が元に戻る
- [ ] シェイプをフレーム上にドラッグ → フレーム背景の上に表示される
- [ ] 通常のドラッグ（フレーム外）→ z-order は変わらない（従来通り）
- [ ] フレームを選択してドラッグ → 子シェイプが消えない
- [ ] LOD モードで回転したシェイプが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)