### PR TITLE
✨ feat: グリッド/ドット背景プラグインと切り替えUI

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,8 @@
 		"@edv4h/usketch-plugin-ai-recognize": "workspace:*",
 		"@edv4h/usketch-plugin-ai-voice": "workspace:*",
 		"@edv4h/usketch-plugin-avatar": "workspace:*",
+		"@edv4h/usketch-plugin-bg-dots": "workspace:*",
+		"@edv4h/usketch-plugin-bg-grid": "workspace:*",
 		"@edv4h/usketch-plugin-board-info-panel": "workspace:*",
 		"@edv4h/usketch-plugin-effect-ripple": "workspace:*",
 		"@edv4h/usketch-plugin-shape-board-portal": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -9,6 +9,8 @@ import { createAiCopilotPlugin } from "@edv4h/usketch-plugin-ai-copilot";
 import { createAiImagePlugin } from "@edv4h/usketch-plugin-ai-image";
 import { createAiRecognizePlugin } from "@edv4h/usketch-plugin-ai-recognize";
 import { createAiVoicePlugin } from "@edv4h/usketch-plugin-ai-voice";
+import { dotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
+import { gridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
 import { exportPlugin } from "@edv4h/usketch-plugin-export";
 import { createLaserPlugin, laserPlugin } from "@edv4h/usketch-plugin-laser";
@@ -48,6 +50,8 @@ import { useAuth } from "./lib/use-auth.js";
 import { useKeyboardShortcuts } from "./lib/use-keyboard-shortcuts.js";
 
 const basePlugins: UsketchPlugin[] = [
+	gridBgPlugin,
+	dotsBgPlugin,
 	selectToolPlugin,
 	panToolPlugin,
 	viewportNavPlugin,

--- a/apps/web/src/components/toolbar/bg-toggle.tsx
+++ b/apps/web/src/components/toolbar/bg-toggle.tsx
@@ -1,0 +1,42 @@
+import { useApp } from "@edv4h/usketch-canvas-engine";
+import { useCallback, useState } from "react";
+import { actionBtnStyle } from "../../lib/styles.js";
+
+type BgType = "grid" | "dots" | "none";
+
+const CYCLE: BgType[] = ["grid", "dots", "none"];
+const LABELS: Record<BgType, string> = { grid: "#", dots: ":", none: "/" };
+const TITLES: Record<BgType, string> = {
+	grid: "Background: Grid",
+	dots: "Background: Dots",
+	none: "Background: None",
+};
+
+export function BgToggle() {
+	const app = useApp();
+	const [bgType, setBgType] = useState<BgType>("grid");
+
+	const toggle = useCallback(() => {
+		const idx = CYCLE.indexOf(bgType);
+		const next = CYCLE[(idx + 1) % CYCLE.length];
+		setBgType(next);
+		app.events.emit("bg:set", { type: next });
+	}, [bgType, app.events]);
+
+	return (
+		<button
+			type="button"
+			onClick={toggle}
+			title={TITLES[bgType]}
+			style={{
+				...actionBtnStyle,
+				background: bgType !== "none" ? "#f0f4ff" : "transparent",
+				color: bgType !== "none" ? "#3b82f6" : "#999",
+				fontSize: 13,
+				fontFamily: "monospace",
+			}}
+		>
+			{LABELS[bgType]}
+		</button>
+	);
+}

--- a/apps/web/src/components/toolbar/toolbar.tsx
+++ b/apps/web/src/components/toolbar/toolbar.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { actionBtnStyle, dividerStyle } from "../../lib/styles.js";
 import { ShareDialog } from "../share-dialog.js";
 import { StylePanel } from "../style-panel/index.js";
+import { BgToggle } from "./bg-toggle.js";
 import { CopilotToggle } from "./copilot-toggle.js";
 import { ExportMenu } from "./export-menu.js";
 import { StatusBar } from "./status-bar.js";
@@ -89,6 +90,9 @@ export function Toolbar({
 				>
 					↪
 				</button>
+
+				<Divider />
+				<BgToggle />
 
 				{isCloudBoard && (
 					<>

--- a/apps/web/src/pages/community/community-page.tsx
+++ b/apps/web/src/pages/community/community-page.tsx
@@ -3,6 +3,8 @@ import { type AppInstance, createApp } from "@edv4h/usketch-core";
 import { createDomRendererPlugin } from "@edv4h/usketch-dom-renderer";
 import { createActivityFeedPlugin } from "@edv4h/usketch-plugin-activity-feed";
 import { createAvatarPlugin } from "@edv4h/usketch-plugin-avatar";
+import { dotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
+import { gridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createBoardInfoPanelPlugin } from "@edv4h/usketch-plugin-board-info-panel";
 import { createFilterPlugin } from "@edv4h/usketch-plugin-canvas-filter";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
@@ -193,6 +195,8 @@ export function CommunityPage() {
 				}
 
 				const basePlugins: UsketchPlugin[] = [
+					gridBgPlugin,
+					dotsBgPlugin,
 					selectToolPlugin,
 					panToolPlugin,
 					viewportNavPlugin,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,12 +2,13 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig(({ mode, command }) => ({
+export default defineConfig(({ mode }) => ({
 	plugins: [react()],
 	define: {
 		"process.env.NODE_ENV": JSON.stringify(mode),
 	},
-	resolve: command === "serve" && !process.env.CI ? { conditions: ["source"] } : {},
+	// source条件はexportプラグインのreact-dom/serverと非互換のため無効化 (#551)
+	// resolve: { conditions: ["source"] },
 	server: {
 		port: 4578,
 	},

--- a/plugins/usketch-plugin-bg-dots/package.json
+++ b/plugins/usketch-plugin-bg-dots/package.json
@@ -22,7 +22,11 @@
 		"@edv4h/usketch-core": "workspace:*",
 		"@edv4h/usketch-shared": "workspace:*"
 	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
 	"devDependencies": {
+		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
 	}

--- a/plugins/usketch-plugin-bg-dots/src/index.ts
+++ b/plugins/usketch-plugin-bg-dots/src/index.ts
@@ -1,1 +1,2 @@
 export const PLUGIN_NAME = "usketch-plugin-bg-dots" as const;
+export { dotsBgPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-bg-dots/src/plugin.tsx
+++ b/plugins/usketch-plugin-bg-dots/src/plugin.tsx
@@ -1,0 +1,91 @@
+import type { LayerRenderContext, PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import { useId, useSyncExternalStore } from "react";
+
+const DOT_SPACING = 20;
+const DOT_RADIUS = 1;
+const DOT_COLOR = "#c0c0c0";
+const DOT_OPACITY = 0.6;
+
+// ── Shared visibility state ──
+
+let visible = false;
+const listeners: Set<() => void> = new Set();
+
+function setVisible(v: boolean) {
+	visible = v;
+	for (const fn of listeners) fn();
+}
+
+function subscribe(cb: () => void): () => void {
+	listeners.add(cb);
+	return () => listeners.delete(cb);
+}
+
+function getVisible(): boolean {
+	return visible;
+}
+
+// ── React component ──
+
+function DotsBackground({ viewport }: { viewport: LayerRenderContext["viewport"] }) {
+	const show = useSyncExternalStore(subscribe, getVisible);
+	const patternId = useId();
+	if (!show) return null;
+
+	const size = DOT_SPACING * viewport.zoom;
+	const offsetX = viewport.x % size;
+	const offsetY = viewport.y % size;
+	const r = DOT_RADIUS * viewport.zoom;
+
+	return (
+		<div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+			<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+				<defs>
+					<pattern
+						id={patternId}
+						x={offsetX}
+						y={offsetY}
+						width={size}
+						height={size}
+						patternUnits="userSpaceOnUse"
+					>
+						<circle cx={size / 2} cy={size / 2} r={r} fill={DOT_COLOR} opacity={DOT_OPACITY} />
+					</pattern>
+				</defs>
+				<rect width="100%" height="100%" fill={`url(#${patternId})`} />
+			</svg>
+		</div>
+	);
+}
+
+// ── Plugin ──
+
+export const dotsBgPlugin: UsketchPlugin = {
+	id: "usketch-plugin-bg-dots",
+	name: "Dots Background",
+
+	setup(ctx: PluginContext) {
+		// Reset to default hidden state
+		visible = false;
+
+		ctx.layers.register({
+			id: "bg-dots",
+			order: 10,
+			fixed: true,
+			render: (renderCtx) => <DotsBackground viewport={renderCtx.viewport} />,
+		});
+
+		const off = ctx.events.on<{ type: string }>("bg:set", ({ type }) => {
+			setVisible(type === "dots");
+		});
+
+		(this as unknown as { _cleanup: () => void })._cleanup = () => {
+			off();
+			ctx.layers.unregister("bg-dots");
+		};
+	},
+
+	teardown() {
+		(this as unknown as { _cleanup?: () => void })._cleanup?.();
+	},
+};

--- a/plugins/usketch-plugin-bg-dots/tsconfig.json
+++ b/plugins/usketch-plugin-bg-dots/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "../../tsconfig.lib.json",
 	"compilerOptions": {
 		"outDir": "./dist",
-		"rootDir": "./src"
+		"rootDir": "./src",
+		"jsx": "react-jsx"
 	},
 	"include": ["src"]
 }

--- a/plugins/usketch-plugin-bg-grid/package.json
+++ b/plugins/usketch-plugin-bg-grid/package.json
@@ -22,7 +22,11 @@
 		"@edv4h/usketch-core": "workspace:*",
 		"@edv4h/usketch-shared": "workspace:*"
 	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
 	"devDependencies": {
+		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
 	}

--- a/plugins/usketch-plugin-bg-grid/src/index.ts
+++ b/plugins/usketch-plugin-bg-grid/src/index.ts
@@ -1,1 +1,2 @@
 export const PLUGIN_NAME = "usketch-plugin-bg-grid" as const;
+export { gridBgPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-bg-grid/src/plugin.tsx
+++ b/plugins/usketch-plugin-bg-grid/src/plugin.tsx
@@ -1,0 +1,95 @@
+import type { LayerRenderContext, PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import { useId, useSyncExternalStore } from "react";
+
+const GRID_SIZE = 20;
+const GRID_COLOR = "#e0e0e0";
+const GRID_OPACITY = 0.5;
+
+// ── Shared visibility state ──
+
+let visible = true;
+const listeners: Set<() => void> = new Set();
+
+function setVisible(v: boolean) {
+	visible = v;
+	for (const fn of listeners) fn();
+}
+
+function subscribe(cb: () => void): () => void {
+	listeners.add(cb);
+	return () => listeners.delete(cb);
+}
+
+function getVisible(): boolean {
+	return visible;
+}
+
+// ── React component ──
+
+function GridBackground({ viewport }: { viewport: LayerRenderContext["viewport"] }) {
+	const show = useSyncExternalStore(subscribe, getVisible);
+	const patternId = useId();
+	if (!show) return null;
+
+	const size = GRID_SIZE * viewport.zoom;
+	const offsetX = viewport.x % size;
+	const offsetY = viewport.y % size;
+
+	return (
+		<div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+			<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+				<defs>
+					<pattern
+						id={patternId}
+						x={offsetX}
+						y={offsetY}
+						width={size}
+						height={size}
+						patternUnits="userSpaceOnUse"
+					>
+						<path
+							d={`M ${size} 0 L 0 0 0 ${size}`}
+							fill="none"
+							stroke={GRID_COLOR}
+							strokeWidth={1}
+							opacity={GRID_OPACITY}
+						/>
+					</pattern>
+				</defs>
+				<rect width="100%" height="100%" fill={`url(#${patternId})`} />
+			</svg>
+		</div>
+	);
+}
+
+// ── Plugin ──
+
+export const gridBgPlugin: UsketchPlugin = {
+	id: "usketch-plugin-bg-grid",
+	name: "Grid Background",
+
+	setup(ctx: PluginContext) {
+		// Reset to default visible state
+		visible = true;
+
+		ctx.layers.register({
+			id: "bg-grid",
+			order: 10,
+			fixed: true,
+			render: (renderCtx) => <GridBackground viewport={renderCtx.viewport} />,
+		});
+
+		const off = ctx.events.on<{ type: string }>("bg:set", ({ type }) => {
+			setVisible(type === "grid");
+		});
+
+		(this as unknown as { _cleanup: () => void })._cleanup = () => {
+			off();
+			ctx.layers.unregister("bg-grid");
+		};
+	},
+
+	teardown() {
+		(this as unknown as { _cleanup?: () => void })._cleanup?.();
+	},
+};

--- a/plugins/usketch-plugin-bg-grid/tsconfig.json
+++ b/plugins/usketch-plugin-bg-grid/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "../../tsconfig.lib.json",
 	"compilerOptions": {
 		"outDir": "./dist",
-		"rootDir": "./src"
+		"rootDir": "./src",
+		"jsx": "react-jsx"
 	},
 	"include": ["src"]
 }

--- a/plugins/usketch-plugin-export/package.json
+++ b/plugins/usketch-plugin-export/package.json
@@ -7,7 +7,6 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"source": "./src/index.ts",
 			"types": "./dist/index.d.ts",
 			"import": "./dist/index.js"
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,12 @@ importers:
       '@edv4h/usketch-plugin-avatar':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-avatar
+      '@edv4h/usketch-plugin-bg-dots':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-bg-dots
+      '@edv4h/usketch-plugin-bg-grid':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-bg-grid
       '@edv4h/usketch-plugin-board-info-panel':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-board-info-panel
@@ -689,7 +695,13 @@ importers:
       '@edv4h/usketch-shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      react:
+        specifier: '>=19'
+        version: 19.2.4
     devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -705,7 +717,13 @@ importers:
       '@edv4h/usketch-shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      react:
+        specifier: '>=19'
+        version: 19.2.4
     devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- グリッド背景プラグイン（`bg-grid`）とドット背景プラグイン（`bg-dots`）を実装
- ツールバーに背景切り替えボタンを追加（grid → dots → none のサイクル）
- EventBus `bg:set` イベントでプラグイン間を連携
- `resolve.conditions: ["source"]` を無効化して `react-dom/server` エラーを修正（#551 で別方式を検討）

## Test plan

- [x] `pnpm typecheck` 成功
- [x] `pnpm test` 成功
- [x] `pnpm dev` でアプリ起動確認
- [ ] ボードページでグリッド背景がデフォルト表示されること
- [ ] パン/ズーム操作でグリッドが追従すること
- [ ] 切り替えボタンで grid → dots → none と切り替わること
- [ ] シェイプ操作が背景で邪魔されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)