### PR TITLE
コネクタプラグイン大幅アップデート — Bezier曲線・プロパティUI・端点編集・LOD・ラベル

### DIFF
--- a/plugins/usketch-plugin-shape-connector/package.json
+++ b/plugins/usketch-plugin-shape-connector/package.json
@@ -19,6 +19,7 @@
 		"clean": "rm -rf dist"
 	},
 	"dependencies": {
+		"@edv4h/usketch-canvas-engine": "workspace:*",
 		"@edv4h/usketch-core": "workspace:*",
 		"@edv4h/usketch-shared": "workspace:*",
 		"@edv4h/usketch-store": "workspace:*"

--- a/plugins/usketch-plugin-shape-connector/src/connector-label.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/connector-label.tsx
@@ -1,0 +1,178 @@
+import type { PluginContext, Point, ShapeData, Viewport } from "@edv4h/usketch-shared";
+import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
+import { getPathMidpoint, type PathType } from "./path-utils.js";
+
+// ── Label editing state ──
+
+let editingConnectorId: string | null = null;
+const editListeners: Set<() => void> = new Set();
+
+function notifyEdit() {
+	for (const fn of editListeners) fn();
+}
+
+export function setEditingLabel(id: string | null): void {
+	editingConnectorId = id;
+	notifyEdit();
+}
+
+export function getEditingLabel(): string | null {
+	return editingConnectorId;
+}
+
+function subscribeEditingLabel(cb: () => void): () => void {
+	editListeners.add(cb);
+	return () => editListeners.delete(cb);
+}
+
+// ── Double-click detection ──
+
+let lastClickTime = 0;
+let lastClickConnectorId: string | null = null;
+const DOUBLE_CLICK_THRESHOLD = 400;
+
+export function handleConnectorClick(connectorId: string): void {
+	const now = Date.now();
+	if (lastClickConnectorId === connectorId && now - lastClickTime < DOUBLE_CLICK_THRESHOLD) {
+		setEditingLabel(connectorId);
+		lastClickTime = 0;
+		lastClickConnectorId = null;
+	} else {
+		lastClickTime = now;
+		lastClickConnectorId = connectorId;
+	}
+}
+
+// ── Label editor overlay ──
+
+interface ConnectorLabelEditorProps {
+	ctx: PluginContext;
+	viewport: Viewport;
+}
+
+export function ConnectorLabelEditor({ ctx, viewport }: ConnectorLabelEditorProps) {
+	const editingId = useSyncExternalStore(subscribeEditingLabel, getEditingLabel);
+
+	const shapes = useSyncExternalStore(
+		(cb) => ctx.store.subscribe(cb),
+		() => ctx.store.getShapes(),
+	);
+
+	if (!editingId) return null;
+	const connector = shapes.get(editingId);
+	if (!connector || connector.type !== "connector") return null;
+
+	return <LabelInput connectorId={editingId} connector={connector} ctx={ctx} viewport={viewport} />;
+}
+
+function LabelInput({
+	connectorId,
+	connector,
+	ctx,
+	viewport,
+}: {
+	connectorId: string;
+	connector: ShapeData;
+	ctx: PluginContext;
+	viewport: Viewport;
+}) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const currentLabel = (connector.label as string) ?? "";
+
+	const midpoint = getMidpointScreen(connector, viewport);
+
+	const commit = useCallback(
+		(newLabel: string) => {
+			const trimmed = newLabel.trim();
+			const oldLabel = (connector.label as string | undefined) ?? undefined;
+			const nextLabel = trimmed || undefined;
+			if (oldLabel !== nextLabel) {
+				ctx.commands.execute(
+					createBatchUpdateShapesCommand(ctx.store, [
+						{ id: connectorId, from: { label: oldLabel }, to: { label: nextLabel } },
+					]),
+				);
+			}
+			setEditingLabel(null);
+		},
+		[connectorId, connector.label, ctx],
+	);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter") {
+				commit((e.target as HTMLInputElement).value);
+			} else if (e.key === "Escape") {
+				setEditingLabel(null);
+			}
+		},
+		[commit],
+	);
+
+	const handleBlur = useCallback(
+		(e: React.FocusEvent<HTMLInputElement>) => {
+			commit(e.target.value);
+		},
+		[commit],
+	);
+
+	useEffect(() => {
+		const el = inputRef.current;
+		if (el) {
+			el.focus();
+			el.select();
+		}
+	}, []);
+
+	return (
+		<div
+			onPointerDown={(e) => e.stopPropagation()}
+			style={{
+				position: "absolute",
+				left: midpoint.x,
+				top: midpoint.y,
+				transform: "translate(-50%, -50%)",
+				pointerEvents: "auto",
+			}}
+		>
+			<input
+				ref={inputRef}
+				type="text"
+				defaultValue={currentLabel}
+				onKeyDown={handleKeyDown}
+				onBlur={handleBlur}
+				style={{
+					width: Math.max(80, currentLabel.length * 8 + 24),
+					height: 24,
+					padding: "2px 8px",
+					fontSize: 12,
+					fontFamily: "system-ui, sans-serif",
+					border: `2px solid #2680eb`,
+					borderRadius: 4,
+					outline: "none",
+					textAlign: "center",
+					background: "white",
+				}}
+			/>
+		</div>
+	);
+}
+
+function getMidpointScreen(connector: ShapeData, viewport: Viewport): Point {
+	const sourcePoint = connector.sourcePoint as Point | undefined;
+	const targetPoint = connector.targetPoint as Point | undefined;
+	if (!sourcePoint || !targetPoint) {
+		return {
+			x: connector.x * viewport.zoom + viewport.x,
+			y: connector.y * viewport.zoom + viewport.y,
+		};
+	}
+	const pathType = (connector.pathType as PathType) ?? "straight";
+	const controlPoint = connector.controlPoint as Point | undefined;
+	const mid = getPathMidpoint(pathType, sourcePoint, targetPoint, controlPoint);
+	return {
+		x: mid.x * viewport.zoom + viewport.x,
+		y: mid.y * viewport.zoom + viewport.y,
+	};
+}

--- a/plugins/usketch-plugin-shape-connector/src/connector-property-bar.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/connector-property-bar.tsx
@@ -1,0 +1,238 @@
+import { ShapeAnchorOverlay, useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
+import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
+import { useCallback } from "react";
+import type { ArrowHead, PathType } from "./shapes/connector.js";
+
+// ── Icons ──
+
+function ArrowNoneIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<line x1="3" y1="8" x2="13" y2="8" stroke="currentColor" strokeWidth="1.5" />
+		</svg>
+	);
+}
+
+function ArrowForwardIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<line x1="3" y1="8" x2="12" y2="8" stroke="currentColor" strokeWidth="1.5" />
+			<polygon points="13,8 9,5.5 9,10.5" fill="currentColor" />
+		</svg>
+	);
+}
+
+function ArrowBackwardIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<line x1="4" y1="8" x2="13" y2="8" stroke="currentColor" strokeWidth="1.5" />
+			<polygon points="3,8 7,5.5 7,10.5" fill="currentColor" />
+		</svg>
+	);
+}
+
+function ArrowBothIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<line x1="5" y1="8" x2="11" y2="8" stroke="currentColor" strokeWidth="1.5" />
+			<polygon points="3,8 6,5.5 6,10.5" fill="currentColor" />
+			<polygon points="13,8 10,5.5 10,10.5" fill="currentColor" />
+		</svg>
+	);
+}
+
+function PathStraightIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<line x1="3" y1="13" x2="13" y2="3" stroke="currentColor" strokeWidth="1.5" />
+		</svg>
+	);
+}
+
+function PathElbowIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<polyline points="3,13 3,3 13,3" fill="none" stroke="currentColor" strokeWidth="1.5" />
+		</svg>
+	);
+}
+
+function PathCurveIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<path d="M 3,13 Q 3,3 13,3" fill="none" stroke="currentColor" strokeWidth="1.5" />
+		</svg>
+	);
+}
+
+// ── Component ──
+
+export function ConnectorPropertyBar() {
+	const app = useApp();
+	const store = app.store;
+	const selection = useStoreSubscribe(store, (s) => s.getSelection());
+	const shapes = useStoreSubscribe(store, (s) => s.getShapes());
+
+	// Only show for single connector selection
+	const ids = [...selection];
+	if (ids.length !== 1) return null;
+	const shape = shapes.get(ids[0]);
+	if (!shape || shape.type !== "connector") return null;
+
+	const connectorId = ids[0];
+	const arrowHead = (shape.arrowHead as ArrowHead) ?? "forward";
+	const pathType = (shape.pathType as PathType) ?? "straight";
+
+	return (
+		<ShapeAnchorOverlay shapeIds={[connectorId]} position="bottom" fallback="top" gap={12}>
+			<ConnectorControls connectorId={connectorId} arrowHead={arrowHead} pathType={pathType} />
+		</ShapeAnchorOverlay>
+	);
+}
+
+function ConnectorControls({
+	connectorId,
+	arrowHead,
+	pathType,
+}: {
+	connectorId: string;
+	arrowHead: ArrowHead;
+	pathType: PathType;
+}) {
+	const app = useApp();
+	const store = app.store;
+
+	const updateProp = useCallback(
+		(key: string, from: unknown, to: unknown) => {
+			app.commands.execute(
+				createBatchUpdateShapesCommand(store, [
+					{ id: connectorId, from: { [key]: from }, to: { [key]: to } },
+				]),
+			);
+		},
+		[app.commands, store, connectorId],
+	);
+
+	const setArrowHead = useCallback(
+		(value: ArrowHead) => {
+			if (value === arrowHead) return;
+			updateProp("arrowHead", arrowHead, value);
+		},
+		[arrowHead, updateProp],
+	);
+
+	const setPathType = useCallback(
+		(value: PathType) => {
+			if (value === pathType) return;
+			updateProp("pathType", pathType, value);
+		},
+		[pathType, updateProp],
+	);
+
+	return (
+		<div onPointerDown={(e) => e.stopPropagation()} style={barStyle}>
+			<ToggleButton
+				active={arrowHead === "none"}
+				onClick={() => setArrowHead("none")}
+				title="矢印なし"
+			>
+				<ArrowNoneIcon />
+			</ToggleButton>
+			<ToggleButton
+				active={arrowHead === "forward"}
+				onClick={() => setArrowHead("forward")}
+				title="前方矢印"
+			>
+				<ArrowForwardIcon />
+			</ToggleButton>
+			<ToggleButton
+				active={arrowHead === "backward"}
+				onClick={() => setArrowHead("backward")}
+				title="後方矢印"
+			>
+				<ArrowBackwardIcon />
+			</ToggleButton>
+			<ToggleButton
+				active={arrowHead === "both"}
+				onClick={() => setArrowHead("both")}
+				title="双方向矢印"
+			>
+				<ArrowBothIcon />
+			</ToggleButton>
+
+			<div style={sepStyle} />
+
+			<ToggleButton
+				active={pathType === "straight"}
+				onClick={() => setPathType("straight")}
+				title="直線"
+			>
+				<PathStraightIcon />
+			</ToggleButton>
+			<ToggleButton active={pathType === "elbow"} onClick={() => setPathType("elbow")} title="L字">
+				<PathElbowIcon />
+			</ToggleButton>
+			<ToggleButton active={pathType === "curve"} onClick={() => setPathType("curve")} title="曲線">
+				<PathCurveIcon />
+			</ToggleButton>
+		</div>
+	);
+}
+
+function ToggleButton({
+	active,
+	onClick,
+	title,
+	children,
+}: {
+	active: boolean;
+	onClick: () => void;
+	title: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<button type="button" onClick={onClick} title={title} style={toggleBtnStyle(active)}>
+			{children}
+		</button>
+	);
+}
+
+// ── Styles ──
+
+const barStyle: React.CSSProperties = {
+	display: "flex",
+	alignItems: "center",
+	gap: 2,
+	padding: "4px 6px",
+	background: "#fff",
+	borderRadius: 8,
+	boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+	fontFamily: "system-ui, sans-serif",
+	fontSize: 11,
+	whiteSpace: "nowrap",
+	pointerEvents: "auto",
+};
+
+const sepStyle: React.CSSProperties = {
+	width: 1,
+	height: 18,
+	background: "#e0e0e0",
+	flexShrink: 0,
+	margin: "0 2px",
+};
+
+function toggleBtnStyle(active: boolean): React.CSSProperties {
+	return {
+		width: 26,
+		height: 26,
+		padding: 0,
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		background: active ? "#e8f0fe" : "transparent",
+		border: active ? "1px solid #2680eb" : "1px solid transparent",
+		borderRadius: 4,
+		cursor: "pointer",
+		color: active ? "#2680eb" : "#333",
+	};
+}

--- a/plugins/usketch-plugin-shape-connector/src/endpoint-drag-state.ts
+++ b/plugins/usketch-plugin-shape-connector/src/endpoint-drag-state.ts
@@ -1,0 +1,29 @@
+import type { Point } from "@edv4h/usketch-shared";
+
+export interface EndpointDragState {
+	connectorId: string;
+	endpoint: "source" | "target" | "controlPoint";
+	currentPoint: Point;
+	targetShapeId: string | null;
+}
+
+let state: EndpointDragState | null = null;
+const listeners: Set<() => void> = new Set();
+
+function notify() {
+	for (const fn of listeners) fn();
+}
+
+export function setEndpointDrag(s: EndpointDragState | null): void {
+	state = s;
+	notify();
+}
+
+export function getEndpointDrag(): EndpointDragState | null {
+	return state;
+}
+
+export function subscribeEndpointDrag(cb: () => void): () => void {
+	listeners.add(cb);
+	return () => listeners.delete(cb);
+}

--- a/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
@@ -1,0 +1,397 @@
+import type { PluginContext, Point, ShapeData, Viewport } from "@edv4h/usketch-shared";
+import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
+import { useCallback, useSyncExternalStore } from "react";
+import { getAnchorPoint } from "./anchor-utils.js";
+import {
+	type EndpointDragState,
+	getEndpointDrag,
+	setEndpointDrag,
+	subscribeEndpointDrag,
+} from "./endpoint-drag-state.js";
+import { getDefaultControlPoint } from "./path-utils.js";
+import { findShapeAtPoint } from "./plugin.js";
+
+const HANDLE_RADIUS = 5;
+const STROKE_COLOR = "#2680eb";
+
+interface EndpointOverlayProps {
+	ctx: PluginContext;
+	viewport: Viewport;
+}
+
+export function EndpointOverlay({ ctx, viewport }: EndpointOverlayProps) {
+	const selection = useSyncExternalStore(
+		(cb) => ctx.store.subscribe(cb),
+		() => ctx.store.getSelection(),
+	);
+
+	const activeToolId = useSyncExternalStore(
+		(cb) => ctx.store.subscribe(cb),
+		() => ctx.store.getActiveToolId(),
+	);
+
+	const shapes = useSyncExternalStore(
+		(cb) => ctx.store.subscribe(cb),
+		() => ctx.store.getShapes(),
+	);
+
+	const dragState = useSyncExternalStore(subscribeEndpointDrag, getEndpointDrag);
+
+	if (activeToolId !== "select") return null;
+	if (selection.size !== 1) return null;
+
+	const connectorId = [...selection][0];
+	const connector = shapes.get(connectorId);
+	if (!connector || connector.type !== "connector") return null;
+
+	const sourcePoint = connector.sourcePoint as Point | undefined;
+	const targetPoint = connector.targetPoint as Point | undefined;
+	if (!sourcePoint || !targetPoint) return null;
+
+	const controlPoint = connector.controlPoint as Point | undefined;
+	const pathType = (connector.pathType as string) ?? "straight";
+	const showControlHandle = pathType === "curve";
+	const cp = controlPoint ?? getDefaultControlPoint(sourcePoint, targetPoint);
+
+	return (
+		<div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+			<svg
+				width="100%"
+				height="100%"
+				style={{
+					position: "absolute",
+					left: 0,
+					top: 0,
+					overflow: "visible",
+					pointerEvents: "none",
+				}}
+			>
+				{/* Preview line during drag */}
+				{dragState && dragState.connectorId === connectorId && (
+					<DragPreview dragState={dragState} connector={connector} viewport={viewport} />
+				)}
+
+				{/* Target shape highlight during drag */}
+				{dragState?.targetShapeId && (
+					<TargetHighlight
+						shapeId={dragState.targetShapeId}
+						shapes={shapes}
+						shapesDefs={ctx.shapes}
+						viewport={viewport}
+					/>
+				)}
+			</svg>
+
+			{/* Source handle */}
+			<EndpointHandle
+				point={sourcePoint}
+				viewport={viewport}
+				endpoint="source"
+				connectorId={connectorId}
+				connector={connector}
+				ctx={ctx}
+			/>
+
+			{/* Target handle */}
+			<EndpointHandle
+				point={targetPoint}
+				viewport={viewport}
+				endpoint="target"
+				connectorId={connectorId}
+				connector={connector}
+				ctx={ctx}
+			/>
+
+			{/* Control point handle (for curve) */}
+			{showControlHandle && (
+				<EndpointHandle
+					point={cp}
+					viewport={viewport}
+					endpoint="controlPoint"
+					connectorId={connectorId}
+					connector={connector}
+					ctx={ctx}
+					isControlPoint
+				/>
+			)}
+		</div>
+	);
+}
+
+function DragPreview({
+	dragState,
+	connector,
+	viewport,
+}: {
+	dragState: EndpointDragState;
+	connector: ShapeData;
+	viewport: Viewport;
+}) {
+	const sourcePoint = connector.sourcePoint as Point;
+	const targetPoint = connector.targetPoint as Point;
+	const dragScreen = worldToScreen(dragState.currentPoint, viewport);
+
+	if (dragState.endpoint === "source") {
+		const tgtScreen = worldToScreen(targetPoint, viewport);
+		return (
+			<line
+				x1={dragScreen.x}
+				y1={dragScreen.y}
+				x2={tgtScreen.x}
+				y2={tgtScreen.y}
+				stroke={STROKE_COLOR}
+				strokeWidth={1.5}
+				strokeDasharray="4 3"
+			/>
+		);
+	}
+	if (dragState.endpoint === "target") {
+		const srcScreen = worldToScreen(sourcePoint, viewport);
+		return (
+			<line
+				x1={srcScreen.x}
+				y1={srcScreen.y}
+				x2={dragScreen.x}
+				y2={dragScreen.y}
+				stroke={STROKE_COLOR}
+				strokeWidth={1.5}
+				strokeDasharray="4 3"
+			/>
+		);
+	}
+	return null;
+}
+
+function TargetHighlight({
+	shapeId,
+	shapes,
+	shapesDefs,
+	viewport,
+}: {
+	shapeId: string;
+	shapes: ReadonlyMap<string, ShapeData>;
+	shapesDefs: PluginContext["shapes"];
+	viewport: Viewport;
+}) {
+	const shape = shapes.get(shapeId);
+	if (!shape) return null;
+	const def = shapesDefs.get(shape.type);
+	const bounds = def
+		? def.getBounds(shape)
+		: { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+	const sx = bounds.x * viewport.zoom + viewport.x;
+	const sy = bounds.y * viewport.zoom + viewport.y;
+	const sw = bounds.width * viewport.zoom;
+	const sh = bounds.height * viewport.zoom;
+	return (
+		<rect
+			x={sx}
+			y={sy}
+			width={sw}
+			height={sh}
+			fill="none"
+			stroke={STROKE_COLOR}
+			strokeWidth={2}
+			strokeDasharray="5 3"
+			rx={3}
+		/>
+	);
+}
+
+function EndpointHandle({
+	point,
+	viewport,
+	endpoint,
+	connectorId,
+	connector,
+	ctx,
+	isControlPoint,
+}: {
+	point: Point;
+	viewport: Viewport;
+	endpoint: "source" | "target" | "controlPoint";
+	connectorId: string;
+	connector: ShapeData;
+	ctx: PluginContext;
+	isControlPoint?: boolean;
+}) {
+	const screen = worldToScreen(point, viewport);
+
+	const handlePointerDown = useCallback(
+		(e: React.PointerEvent) => {
+			e.stopPropagation();
+			e.preventDefault();
+
+			const el = e.currentTarget as HTMLElement;
+			el.setPointerCapture(e.pointerId);
+
+			setEndpointDrag({
+				connectorId,
+				endpoint,
+				currentPoint: point,
+				targetShapeId: null,
+			});
+
+			const onMove = (me: PointerEvent) => {
+				const worldPoint = screenToWorld({ x: me.clientX, y: me.clientY }, viewport);
+
+				if (endpoint === "controlPoint") {
+					// Control point drag: just update position
+					setEndpointDrag({
+						connectorId,
+						endpoint,
+						currentPoint: worldPoint,
+						targetShapeId: null,
+					});
+					return;
+				}
+
+				const targetShape = findShapeAtPoint(ctx, worldPoint);
+				const otherEndShapeId =
+					endpoint === "source"
+						? (connector.targetId as string | undefined)
+						: (connector.sourceId as string | undefined);
+
+				setEndpointDrag({
+					connectorId,
+					endpoint,
+					currentPoint: worldPoint,
+					targetShapeId: targetShape && targetShape.id !== otherEndShapeId ? targetShape.id : null,
+				});
+			};
+
+			const onUp = () => {
+				const drag = getEndpointDrag();
+				if (drag && drag.connectorId === connectorId) {
+					if (drag.endpoint === "controlPoint") {
+						// Commit control point position
+						const before = {
+							controlPoint: connector.controlPoint,
+							controlPointAuto: connector.controlPointAuto,
+						};
+						const after = { controlPoint: drag.currentPoint, controlPointAuto: false };
+						ctx.commands.execute(
+							createBatchUpdateShapesCommand(ctx.store, [
+								{ id: connectorId, from: before, to: after },
+							]),
+						);
+					} else if (drag.targetShapeId) {
+						// Reconnect endpoint
+						const newTarget = ctx.store.getShape(drag.targetShapeId);
+						if (newTarget) {
+							commitEndpointReconnect(ctx, connectorId, connector, drag.endpoint, newTarget);
+						}
+					}
+				}
+				setEndpointDrag(null);
+				el.removeEventListener("pointermove", onMove);
+				el.removeEventListener("pointerup", onUp);
+			};
+
+			el.addEventListener("pointermove", onMove);
+			el.addEventListener("pointerup", onUp);
+		},
+		[connectorId, connector, endpoint, point, viewport, ctx],
+	);
+
+	const r = isControlPoint ? HANDLE_RADIUS - 1 : HANDLE_RADIUS;
+
+	return (
+		<div
+			onPointerDown={handlePointerDown}
+			style={{
+				position: "absolute",
+				left: screen.x - r - 1,
+				top: screen.y - r - 1,
+				width: (r + 1) * 2,
+				height: (r + 1) * 2,
+				pointerEvents: "auto",
+				cursor: "grab",
+			}}
+		>
+			<svg width={(r + 1) * 2} height={(r + 1) * 2} style={{ overflow: "visible" }}>
+				<circle
+					cx={r + 1}
+					cy={r + 1}
+					r={r}
+					fill={isControlPoint ? STROKE_COLOR : "white"}
+					stroke={STROKE_COLOR}
+					strokeWidth={1.5}
+				/>
+			</svg>
+		</div>
+	);
+}
+
+function commitEndpointReconnect(
+	ctx: PluginContext,
+	connectorId: string,
+	connector: ShapeData,
+	endpoint: "source" | "target",
+	newShape: ShapeData,
+) {
+	const otherShapeId =
+		endpoint === "source" ? (connector.targetId as string) : (connector.sourceId as string);
+	const otherShape = ctx.store.getShape(otherShapeId);
+	if (!otherShape) return;
+
+	const newCenter = { x: newShape.x + newShape.width / 2, y: newShape.y + newShape.height / 2 };
+	const otherCenter = {
+		x: otherShape.x + otherShape.width / 2,
+		y: otherShape.y + otherShape.height / 2,
+	};
+
+	let sourcePoint: Point;
+	let targetPoint: Point;
+
+	if (endpoint === "source") {
+		sourcePoint = getAnchorPoint(newShape, "auto", otherCenter);
+		targetPoint = getAnchorPoint(otherShape, "auto", newCenter);
+	} else {
+		sourcePoint = getAnchorPoint(otherShape, "auto", newCenter);
+		targetPoint = getAnchorPoint(newShape, "auto", otherCenter);
+	}
+
+	const fromData: Partial<ShapeData> = {
+		[endpoint === "source" ? "sourceId" : "targetId"]:
+			endpoint === "source" ? connector.sourceId : connector.targetId,
+		sourcePoint: connector.sourcePoint,
+		targetPoint: connector.targetPoint,
+		sourceAnchor: connector.sourceAnchor,
+		targetAnchor: connector.targetAnchor,
+		x: connector.x,
+		y: connector.y,
+		width: connector.width,
+		height: connector.height,
+	};
+
+	const toData: Partial<ShapeData> = {
+		[endpoint === "source" ? "sourceId" : "targetId"]: newShape.id,
+		sourcePoint,
+		targetPoint,
+		sourceAnchor: "auto",
+		targetAnchor: "auto",
+		x: Math.min(sourcePoint.x, targetPoint.x),
+		y: Math.min(sourcePoint.y, targetPoint.y),
+		width: Math.abs(targetPoint.x - sourcePoint.x),
+		height: Math.abs(targetPoint.y - sourcePoint.y),
+	};
+
+	ctx.commands.execute(
+		createBatchUpdateShapesCommand(ctx.store, [{ id: connectorId, from: fromData, to: toData }]),
+	);
+}
+
+function worldToScreen(point: Point, viewport: Viewport): Point {
+	return {
+		x: point.x * viewport.zoom + viewport.x,
+		y: point.y * viewport.zoom + viewport.y,
+	};
+}
+
+function screenToWorld(point: Point, viewport: Viewport): Point {
+	return {
+		x: (point.x - viewport.x) / viewport.zoom,
+		y: (point.y - viewport.y) / viewport.zoom,
+	};
+}

--- a/plugins/usketch-plugin-shape-connector/src/path-utils.ts
+++ b/plugins/usketch-plugin-shape-connector/src/path-utils.ts
@@ -1,0 +1,117 @@
+import type { BoundingBox, Point } from "@edv4h/usketch-shared";
+
+// ── Line segment distance ──
+
+/** Compute the minimum distance from a point to a line segment (a → b). */
+export function distanceToLineSegment(point: Point, a: Point, b: Point): number {
+	const dx = b.x - a.x;
+	const dy = b.y - a.y;
+	const lengthSq = dx * dx + dy * dy;
+
+	if (lengthSq === 0) return Math.hypot(point.x - a.x, point.y - a.y);
+
+	let t = ((point.x - a.x) * dx + (point.y - a.y) * dy) / lengthSq;
+	t = Math.max(0, Math.min(1, t));
+
+	const nearestX = a.x + t * dx;
+	const nearestY = a.y + t * dy;
+	return Math.hypot(point.x - nearestX, point.y - nearestY);
+}
+
+/** Compute the minimum distance from a point to a polyline (array of vertices). */
+export function distanceToPolyline(point: Point, polyline: Point[]): number {
+	let minDist = Number.POSITIVE_INFINITY;
+	for (let i = 0; i < polyline.length - 1; i++) {
+		const dist = distanceToLineSegment(point, polyline[i], polyline[i + 1]);
+		if (dist < minDist) minDist = dist;
+	}
+	return minDist;
+}
+
+// ── Elbow path ──
+
+/** Compute the 4 vertices of an elbow (L-shaped) path: source → mid-h → mid-v → target. */
+export function getElbowPoints(source: Point, target: Point): Point[] {
+	const midX = (source.x + target.x) / 2;
+	return [source, { x: midX, y: source.y }, { x: midX, y: target.y }, target];
+}
+
+// ── Quadratic Bezier ──
+
+/** Compute a default control point for a quadratic Bezier between source and target. */
+export function getDefaultControlPoint(source: Point, target: Point): Point {
+	const mx = (source.x + target.x) / 2;
+	const my = (source.y + target.y) / 2;
+	const dx = target.x - source.x;
+	const dy = target.y - source.y;
+	const len = Math.hypot(dx, dy);
+	if (len === 0) return { x: mx, y: my - 50 };
+	// Perpendicular offset = 25% of the distance
+	const offset = len * 0.25;
+	return { x: mx - (dy / len) * offset, y: my + (dx / len) * offset };
+}
+
+/** Sample N+1 points along a quadratic Bezier Q(p0, cp, p2). */
+export function sampleQuadraticBezier(p0: Point, cp: Point, p2: Point, n: number): Point[] {
+	const points: Point[] = [];
+	for (let i = 0; i <= n; i++) {
+		const t = i / n;
+		const u = 1 - t;
+		points.push({
+			x: u * u * p0.x + 2 * u * t * cp.x + t * t * p2.x,
+			y: u * u * p0.y + 2 * u * t * cp.y + t * t * p2.y,
+		});
+	}
+	return points;
+}
+
+/** Check if a point is within tolerance of a quadratic Bezier curve. */
+export function isNearBezier(
+	point: Point,
+	p0: Point,
+	cp: Point,
+	p2: Point,
+	tolerance: number,
+): boolean {
+	const samples = sampleQuadraticBezier(p0, cp, p2, 20);
+	return distanceToPolyline(point, samples) <= tolerance;
+}
+
+/** Compute the bounding box that contains the quadratic Bezier (including control point). */
+export function bezierBounds(p0: Point, cp: Point, p2: Point): BoundingBox {
+	const minX = Math.min(p0.x, cp.x, p2.x);
+	const minY = Math.min(p0.y, cp.y, p2.y);
+	const maxX = Math.max(p0.x, cp.x, p2.x);
+	const maxY = Math.max(p0.y, cp.y, p2.y);
+	return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+// ── Path midpoint ──
+
+export type PathType = "straight" | "elbow" | "curve";
+
+/** Compute the midpoint of a connector path. */
+export function getPathMidpoint(
+	pathType: PathType,
+	source: Point,
+	target: Point,
+	controlPoint?: Point,
+): Point {
+	switch (pathType) {
+		case "straight":
+			return { x: (source.x + target.x) / 2, y: (source.y + target.y) / 2 };
+		case "elbow": {
+			const midX = (source.x + target.x) / 2;
+			const midY = (source.y + target.y) / 2;
+			return { x: midX, y: midY };
+		}
+		case "curve": {
+			const cp = controlPoint ?? getDefaultControlPoint(source, target);
+			// Q(0.5) = 0.25*p0 + 0.5*cp + 0.25*p2
+			return {
+				x: 0.25 * source.x + 0.5 * cp.x + 0.25 * target.x,
+				y: 0.25 * source.y + 0.5 * cp.y + 0.25 * target.y,
+			};
+		}
+	}
+}

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -9,11 +9,16 @@ import type {
 import { generateId } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { type AnchorType, getAnchorPoint } from "./anchor-utils.js";
+import { ConnectorLabelEditor, handleConnectorClick, setEditingLabel } from "./connector-label.js";
+import { ConnectorPropertyBar } from "./connector-property-bar.js";
+import { EndpointOverlay } from "./endpoint-overlay.js";
+import { getDefaultControlPoint } from "./path-utils.js";
 import {
 	createDefaultConnector,
 	getBoundsConnector,
 	hitTestConnector,
 	renderConnector,
+	SimplifiedConnector,
 } from "./shapes/connector.js";
 
 function ConnectorIcon() {
@@ -26,7 +31,7 @@ function ConnectorIcon() {
 }
 
 /** Find a shape at a point (excluding connectors and frames/groups — prefer their children) */
-function findShapeAtPoint(ctx: ToolContext, point: Point): ShapeData | null {
+export function findShapeAtPoint(ctx: ToolContext | PluginContext, point: Point): ShapeData | null {
 	const shapes = ctx.store.getShapes();
 	const entries = [...shapes.entries()].reverse();
 	let fallbackContainer: ShapeData | null = null;
@@ -34,7 +39,6 @@ function findShapeAtPoint(ctx: ToolContext, point: Point): ShapeData | null {
 		if (data.type === "connector") continue;
 		const def = ctx.shapes.get(data.type);
 		if (!def?.hitTest(data, point)) continue;
-		// Prefer non-container shapes; remember container as fallback
 		if (data.type === "frame" || data.type === "group") {
 			if (!fallbackContainer) fallbackContainer = data;
 			continue;
@@ -58,9 +62,11 @@ export const connectorPlugin: UsketchPlugin = {
 			createDefault: createDefaultConnector,
 			renderTarget: "svg",
 			resizable: false,
+			simplifiedComponent: SimplifiedConnector,
 		});
 
-		// Drawing tool state
+		// ── Drawing tool ──
+
 		let drawState: {
 			connectorId: string;
 			sourceShape: ShapeData;
@@ -96,7 +102,6 @@ export const connectorPlugin: UsketchPlugin = {
 			const targetShape = findShapeAtPoint(toolCtx, event.worldPoint);
 			const targetPoint = event.worldPoint;
 
-			// Recalculate source anchor towards current target
 			const sourcePoint = getAnchorPoint(
 				drawState.sourceShape,
 				drawState.sourceAnchor,
@@ -108,7 +113,6 @@ export const connectorPlugin: UsketchPlugin = {
 				targetPoint: targetShape ? getAnchorPoint(targetShape, "auto", sourcePoint) : targetPoint,
 			};
 
-			// Update bounding box for proper rendering
 			const sp = updates.sourcePoint as Point;
 			const tp = updates.targetPoint as Point;
 			updates.x = Math.min(sp.x, tp.x);
@@ -126,13 +130,11 @@ export const connectorPlugin: UsketchPlugin = {
 			const connector = toolCtx.store.getShape(drawState.connectorId);
 
 			if (!connector || !targetShape || targetShape.id === drawState.sourceShape.id) {
-				// Invalid connection — remove preview
 				toolCtx.store.deleteShape(drawState.connectorId);
 				drawState = null;
 				return;
 			}
 
-			// Finalize connector
 			const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, {
 				x: targetShape.x + targetShape.width / 2,
 				y: targetShape.y + targetShape.height / 2,
@@ -150,7 +152,6 @@ export const connectorPlugin: UsketchPlugin = {
 				height: Math.abs(targetPoint.y - sourcePoint.y),
 			};
 
-			// Delete preview, then create undoable command
 			toolCtx.store.deleteShape(drawState.connectorId);
 			const finalShape: ShapeData = { ...connector, ...finalUpdates };
 			toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, finalShape));
@@ -175,8 +176,53 @@ export const connectorPlugin: UsketchPlugin = {
 			},
 		});
 
+		// ── Connector property bar (Phase 4) ──
+
+		ctx.layers.register({
+			id: "connector-properties",
+			order: 82,
+			fixed: true,
+			render: () => <ConnectorPropertyBar />,
+		});
+
+		// ── Endpoint overlay (Phase 5) ──
+
+		ctx.layers.register({
+			id: "connector-endpoints",
+			order: 81,
+			fixed: true,
+			render: (renderCtx) => <EndpointOverlay ctx={ctx} viewport={renderCtx.viewport} />,
+		});
+
+		// ── Label editor overlay (Phase 6) ──
+
+		ctx.layers.register({
+			id: "connector-label-editor",
+			order: 83,
+			fixed: true,
+			render: (renderCtx) => <ConnectorLabelEditor ctx={ctx} viewport={renderCtx.viewport} />,
+		});
+
+		// Double-click detection for label editing
+		const unsubLabelClick = ctx.store.onMutation((event) => {
+			if (event.type !== "selection:changed") return;
+			// Clear label editing when selection changes
+			setEditingLabel(null);
+		});
+
+		// Listen for pointer events on connectors for double-click
+		const unsubPointerForLabel = ctx.events.on<{ shapeId: string }>(
+			"shape:clicked",
+			({ shapeId }) => {
+				const shape = ctx.store.getShape(shapeId);
+				if (shape?.type === "connector") {
+					handleConnectorClick(shapeId);
+				}
+			},
+		);
+
 		// ── Position tracking: update connectors when source/target shapes move ──
-		// Build an index: shapeId -> connectorIds[] for O(1) lookup
+
 		const connectorIndex = new Map<string, Set<string>>();
 
 		function rebuildIndex() {
@@ -196,7 +242,6 @@ export const connectorPlugin: UsketchPlugin = {
 			}
 		}
 
-		// Rebuild on add/remove
 		const unsubIndex = ctx.store.onMutation((event) => {
 			if (event.type === "shape:added" || event.type === "shape:removed") {
 				rebuildIndex();
@@ -209,7 +254,6 @@ export const connectorPlugin: UsketchPlugin = {
 			const payload = event.payload as { id: string } | undefined;
 			if (!payload?.id) return;
 
-			// Fast path: skip if no connectors reference this shape
 			const connIds = connectorIndex.get(payload.id);
 			if (!connIds || connIds.size === 0) return;
 
@@ -233,24 +277,31 @@ export const connectorPlugin: UsketchPlugin = {
 				const sourcePoint = getAnchorPoint(source, sourceAnchor, targetCenter);
 				const targetPoint = getAnchorPoint(target, targetAnchor, sourceCenter);
 
-				ctx.store.updateShape(connId, {
+				const updates: Partial<ShapeData> = {
 					sourcePoint,
 					targetPoint,
 					x: Math.min(sourcePoint.x, targetPoint.x),
 					y: Math.min(sourcePoint.y, targetPoint.y),
 					width: Math.abs(targetPoint.x - sourcePoint.x),
 					height: Math.abs(targetPoint.y - sourcePoint.y),
-				});
+				};
+
+				// Update control point if auto-calculated
+				if (conn.controlPointAuto && conn.pathType === "curve") {
+					updates.controlPoint = getDefaultControlPoint(sourcePoint, targetPoint);
+				}
+
+				ctx.store.updateShape(connId, updates);
 			}
 		});
 
-		// ── Cascade delete: remove connectors when source/target is deleted ──
+		// ── Cascade delete ──
+
 		const unsubDelete = ctx.store.onMutation((event) => {
 			if (event.type !== "shape:removed") return;
 			const payload = event.payload as { id: string } | undefined;
 			if (!payload?.id) return;
 
-			// Find connectors referencing this deleted shape
 			const shapes = ctx.store.getShapes();
 			const toDelete: string[] = [];
 			for (const [id, shape] of shapes) {
@@ -270,6 +321,11 @@ export const connectorPlugin: UsketchPlugin = {
 			unsubIndex();
 			unsubMove();
 			unsubDelete();
+			unsubLabelClick();
+			unsubPointerForLabel();
+			ctx.layers.unregister("connector-properties");
+			ctx.layers.unregister("connector-endpoints");
+			ctx.layers.unregister("connector-label-editor");
 		};
 	},
 };

--- a/plugins/usketch-plugin-shape-connector/src/shapes/connector.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/shapes/connector.tsx
@@ -1,9 +1,37 @@
 import type { BoundingBox, Point, ShapeData } from "@edv4h/usketch-shared";
+import { safeRotation } from "@edv4h/usketch-shared";
+import {
+	bezierBounds,
+	distanceToLineSegment,
+	distanceToPolyline,
+	getDefaultControlPoint,
+	getElbowPoints,
+	getPathMidpoint,
+	isNearBezier,
+	type PathType,
+} from "../path-utils.js";
 
 export type ArrowHead = "none" | "forward" | "backward" | "both";
-export type PathType = "straight" | "elbow";
+export type { PathType } from "../path-utils.js";
 
 const ARROW_SIZE = 10;
+const LABEL_FONT_SIZE = 12;
+const LABEL_PADDING_X = 6;
+const LABEL_PADDING_Y = 3;
+
+// ── Helpers to extract endpoints ──
+
+function sourceXY(data: ShapeData): Point {
+	const p = data.sourcePoint as Point | undefined;
+	return { x: p?.x ?? data.x, y: p?.y ?? data.y };
+}
+
+function targetXY(data: ShapeData): Point {
+	const p = data.targetPoint as Point | undefined;
+	return { x: p?.x ?? data.x + data.width, y: p?.y ?? data.y + data.height };
+}
+
+// ── Arrow head rendering ──
 
 function renderArrowHead(tip: Point, from: Point, color: string): React.ReactElement {
 	const dx = tip.x - from.x;
@@ -24,11 +52,44 @@ function renderArrowHead(tip: Point, from: Point, color: string): React.ReactEle
 	return <polygon points={`${tip.x},${tip.y} ${p1x},${p1y} ${p2x},${p2y}`} fill={color} />;
 }
 
+// ── Label rendering ──
+
+function renderLabel(label: string, midpoint: Point, color: string): React.ReactElement {
+	const estimatedWidth = label.length * LABEL_FONT_SIZE * 0.6 + LABEL_PADDING_X * 2;
+	const height = LABEL_FONT_SIZE + LABEL_PADDING_Y * 2;
+	return (
+		<g key="label">
+			<rect
+				x={midpoint.x - estimatedWidth / 2}
+				y={midpoint.y - height / 2}
+				width={estimatedWidth}
+				height={height}
+				rx={3}
+				fill="white"
+				opacity={0.85}
+			/>
+			<text
+				x={midpoint.x}
+				y={midpoint.y}
+				textAnchor="middle"
+				dominantBaseline="central"
+				fontSize={LABEL_FONT_SIZE}
+				fill={color}
+				style={{ pointerEvents: "none", userSelect: "none" }}
+			>
+				{label}
+			</text>
+		</g>
+	);
+}
+
+// ── Main render ──
+
 export function renderConnector(data: ShapeData) {
-	const x1 = (data.sourcePoint as { x: number; y: number } | undefined)?.x ?? data.x;
-	const y1 = (data.sourcePoint as { x: number; y: number } | undefined)?.y ?? data.y;
-	const x2 = (data.targetPoint as { x: number; y: number } | undefined)?.x ?? data.x + data.width;
-	const y2 = (data.targetPoint as { x: number; y: number } | undefined)?.y ?? data.y + data.height;
+	const src = sourceXY(data);
+	const tgt = targetXY(data);
+	const { x: x1, y: y1 } = src;
+	const { x: x2, y: y2 } = tgt;
 
 	const color = data.style.stroke;
 	const strokeWidth = data.style.strokeWidth;
@@ -38,7 +99,28 @@ export function renderConnector(data: ShapeData) {
 
 	const elements: React.ReactElement[] = [];
 
-	if (pathType === "elbow") {
+	if (pathType === "curve") {
+		const cp = (data.controlPoint as Point | undefined) ?? getDefaultControlPoint(src, tgt);
+		elements.push(
+			<path
+				key="line"
+				d={`M ${x1},${y1} Q ${cp.x},${cp.y} ${x2},${y2}`}
+				fill="none"
+				stroke={color}
+				strokeWidth={strokeWidth}
+				opacity={opacity}
+			/>,
+		);
+		// Arrow heads use tangent direction at endpoints
+		if (arrowHead === "forward" || arrowHead === "both") {
+			// Tangent at t=1: direction from cp to p2
+			elements.push(<g key="arrow-fwd">{renderArrowHead({ x: x2, y: y2 }, cp, color)}</g>);
+		}
+		if (arrowHead === "backward" || arrowHead === "both") {
+			// Tangent at t=0: direction from cp to p0
+			elements.push(<g key="arrow-bwd">{renderArrowHead({ x: x1, y: y1 }, cp, color)}</g>);
+		}
+	} else if (pathType === "elbow") {
 		const midX = (x1 + x2) / 2;
 		const points = `${x1},${y1} ${midX},${y1} ${midX},${y2} ${x2},${y2}`;
 		elements.push(
@@ -62,6 +144,7 @@ export function renderConnector(data: ShapeData) {
 			);
 		}
 	} else {
+		// straight
 		elements.push(
 			<line
 				key="line"
@@ -86,46 +169,61 @@ export function renderConnector(data: ShapeData) {
 		}
 	}
 
+	// Label
+	const label = data.label as string | undefined;
+	if (label) {
+		const cp = (data.controlPoint as Point | undefined) ?? undefined;
+		const midpoint = getPathMidpoint(pathType, src, tgt, cp);
+		elements.push(renderLabel(label, midpoint, color));
+	}
+
 	return <g>{elements}</g>;
 }
 
-export function getBoundsConnector(data: ShapeData): BoundingBox {
-	const x1 = (data.sourcePoint as { x: number; y: number } | undefined)?.x ?? data.x;
-	const y1 = (data.sourcePoint as { x: number; y: number } | undefined)?.y ?? data.y;
-	const x2 = (data.targetPoint as { x: number; y: number } | undefined)?.x ?? data.x + data.width;
-	const y2 = (data.targetPoint as { x: number; y: number } | undefined)?.y ?? data.y + data.height;
+// ── Bounds ──
 
-	const minX = Math.min(x1, x2);
-	const minY = Math.min(y1, y2);
+export function getBoundsConnector(data: ShapeData): BoundingBox {
+	const src = sourceXY(data);
+	const tgt = targetXY(data);
+	const pathType = (data.pathType as PathType) ?? "straight";
+
+	if (pathType === "curve") {
+		const cp = (data.controlPoint as Point | undefined) ?? getDefaultControlPoint(src, tgt);
+		return bezierBounds(src, cp, tgt);
+	}
+
+	const minX = Math.min(src.x, tgt.x);
+	const minY = Math.min(src.y, tgt.y);
 	return {
 		x: minX,
 		y: minY,
-		width: Math.abs(x2 - x1),
-		height: Math.abs(y2 - y1),
+		width: Math.abs(tgt.x - src.x),
+		height: Math.abs(tgt.y - src.y),
 	};
 }
 
+// ── Hit test ──
+
 export function hitTestConnector(data: ShapeData, point: Point, tolerance = 6): boolean {
-	const x1 = (data.sourcePoint as { x: number; y: number } | undefined)?.x ?? data.x;
-	const y1 = (data.sourcePoint as { x: number; y: number } | undefined)?.y ?? data.y;
-	const x2 = (data.targetPoint as { x: number; y: number } | undefined)?.x ?? data.x + data.width;
-	const y2 = (data.targetPoint as { x: number; y: number } | undefined)?.y ?? data.y + data.height;
+	const src = sourceXY(data);
+	const tgt = targetXY(data);
+	const pathType = (data.pathType as PathType) ?? "straight";
 
-	const dx = x2 - x1;
-	const dy = y2 - y1;
-	const lengthSq = dx * dx + dy * dy;
-
-	if (lengthSq === 0) {
-		return Math.hypot(point.x - x1, point.y - y1) <= tolerance;
+	if (pathType === "curve") {
+		const cp = (data.controlPoint as Point | undefined) ?? getDefaultControlPoint(src, tgt);
+		return isNearBezier(point, src, cp, tgt, tolerance);
 	}
 
-	let t = ((point.x - x1) * dx + (point.y - y1) * dy) / lengthSq;
-	t = Math.max(0, Math.min(1, t));
+	if (pathType === "elbow") {
+		const elbowPts = getElbowPoints(src, tgt);
+		return distanceToPolyline(point, elbowPts) <= tolerance;
+	}
 
-	const nearestX = x1 + t * dx;
-	const nearestY = y1 + t * dy;
-	return Math.hypot(point.x - nearestX, point.y - nearestY) <= tolerance;
+	// straight
+	return distanceToLineSegment(point, src, tgt) <= tolerance;
 }
+
+// ── Default shape ──
 
 export function createDefaultConnector(params: { id: string; x: number; y: number }): ShapeData {
 	return {
@@ -144,5 +242,62 @@ export function createDefaultConnector(params: { id: string; x: number; y: numbe
 		pathType: "straight" as PathType,
 		sourcePoint: { x: params.x, y: params.y },
 		targetPoint: { x: params.x + 100, y: params.y },
+		controlPoint: undefined,
+		controlPointAuto: true,
+		label: undefined,
 	};
+}
+
+// ── Simplified (LOD) component ──
+
+export function SimplifiedConnector({ shape }: { shape: ShapeData }) {
+	const src = sourceXY(shape);
+	const tgt = targetXY(shape);
+	const bounds = getBoundsConnector(shape);
+	const rotation = safeRotation(shape.rotation);
+	const color = shape.style.stroke ?? "#1e1e1e";
+	const arrowHead = (shape.arrowHead as ArrowHead) ?? "forward";
+
+	// Minimum size to avoid zero-dimension SVGs
+	const w = Math.max(bounds.width, 2);
+	const h = Math.max(bounds.height, 2);
+
+	return (
+		<div
+			style={{
+				position: "absolute",
+				left: bounds.x,
+				top: bounds.y,
+				width: w,
+				height: h,
+				pointerEvents: "none",
+				transform: rotation ? `rotate(${rotation}deg)` : undefined,
+				transformOrigin: "center center",
+			}}
+		>
+			<svg
+				width={w}
+				height={h}
+				viewBox={`${bounds.x} ${bounds.y} ${w} ${h}`}
+				style={{ overflow: "visible" }}
+			>
+				<line
+					x1={src.x}
+					y1={src.y}
+					x2={tgt.x}
+					y2={tgt.y}
+					stroke={color}
+					strokeWidth={1.5}
+					opacity={0.7}
+				/>
+				{(arrowHead === "forward" || arrowHead === "both") && (
+					<polygon
+						points={`${tgt.x},${tgt.y} ${tgt.x - 6},${tgt.y - 3} ${tgt.x - 6},${tgt.y + 3}`}
+						fill={color}
+						opacity={0.7}
+					/>
+				)}
+			</svg>
+		</div>
+	);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1231,6 +1231,9 @@ importers:
 
   plugins/usketch-plugin-shape-connector:
     dependencies:
+      '@edv4h/usketch-canvas-engine':
+        specifier: workspace:*
+        version: link:../../packages/canvas-engine
       '@edv4h/usketch-core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
## Summary

コネクタプラグインを本格的なダイアグラムツールレベルに引き上げる大幅アップデート。

- **Phase 1**: elbow パスのヒットテスト修正 — L字の折れ曲がり部分もクリック可能に
- **Phase 2**: 2次Bezier曲線パスタイプ追加 — 制御点ドラッグで曲率調整可能
- **Phase 3**: LOD対応 — ズームアウト時にSimplifiedConnectorで軽量描画（矩形フォールバック回避）
- **Phase 4**: コネクタプロパティバー — 矢印タイプ(none/forward/backward/both)とパスタイプ(straight/elbow/curve)をワンクリックで切替
- **Phase 5**: 端点ドラッグ編集 — 作成後に端点をドラッグして別シェイプに繋ぎ替え、curve時は制御点もドラッグ可能
- **Phase 6**: テキストラベル — パス中点にラベル描画、ダブルクリックで編集

### 新規ファイル
- `path-utils.ts` — 距離計算、Bezierサンプリング、パス中点、elbowポイント算出
- `connector-property-bar.tsx` — ShapeAnchorOverlayベースのプロパティUI
- `endpoint-overlay.tsx` — 端点/制御点ドラッグハンドル
- `endpoint-drag-state.ts` — 端点ドラッグのモジュールスコープ状態
- `connector-label.tsx` — ラベル編集オーバーレイ

## Test plan

- [ ] `pnpm typecheck` が通ること
- [ ] elbow コネクタの折れ曲がり部分をクリックして選択できること
- [ ] コネクタ選択時に下部プロパティバーが表示され、矢印/パスタイプを切替えられること
- [ ] curve パスで滑らかなBezier曲線が描画され、制御点ドラッグで曲率変更可能
- [ ] 端点ハンドルをドラッグして別シェイプに繋ぎ替えできること
- [ ] コネクタダブルクリックでラベル編集、パス中点にラベル表示
- [ ] ズームアウト（LODモード）でコネクタが簡略線として表示されること
- [ ] 全変更が Ctrl+Z で undo 可能であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)