### PR TITLE
コネクタUI改善 — アンカーハンドル・端点スライド・プロパティ拡張

### DIFF
--- a/apps/web/src/components/style-panel/style-panel.tsx
+++ b/apps/web/src/components/style-panel/style-panel.tsx
@@ -147,7 +147,7 @@ export function StylePanel() {
 	if (!isSelectionMode || hasOnlyNonStyleable) return null;
 
 	return (
-		<ShapeAnchorOverlay shapeIds={styleableIds} position="top" fallback="bottom" gap={12}>
+		<ShapeAnchorOverlay shapeIds={styleableIds} position="top" fallback="bottom">
 			<div onPointerDown={(e) => e.stopPropagation()} style={anchoredBarStyle}>
 				<CompactColorPicker
 					label="Fill"

--- a/packages/canvas-engine/src/components/shape-anchor-overlay.tsx
+++ b/packages/canvas-engine/src/components/shape-anchor-overlay.tsx
@@ -45,7 +45,7 @@ export function ShapeAnchorOverlay({
 	const anchorResult = useShapeAnchorPosition(anchorOptions);
 	const overlayRef = useRef<HTMLDivElement | null>(null);
 	const registry = useAnchorStack();
-	const gap = anchorOptions.gap ?? 12;
+	const gap = anchorOptions.gap ?? 48;
 	const pad = anchorOptions.edgePadding ?? DEFAULT_EDGE_PADDING;
 
 	// Track overlay dimensions

--- a/plugins/usketch-plugin-ai-actions/src/action-bar.tsx
+++ b/plugins/usketch-plugin-ai-actions/src/action-bar.tsx
@@ -318,6 +318,19 @@ export function ActionBar({ store, events, boardId }: ActionBarProps) {
 	// Hide when no selection and not in AI processing state
 	if (selection.size === 0 && mode !== "thinking") return null;
 
+	// Hide when selection contains only connectors (they have their own property bar)
+	if (mode !== "thinking") {
+		let allConnectors = true;
+		for (const id of selection) {
+			const shape = store.getShape(id);
+			if (shape && shape.type !== "connector") {
+				allConnectors = false;
+				break;
+			}
+		}
+		if (allConnectors) return null;
+	}
+
 	const shapeIds = Array.from(selection);
 
 	return (
@@ -325,7 +338,6 @@ export function ActionBar({ store, events, boardId }: ActionBarProps) {
 			shapeIds={shapeIds}
 			position="bottom"
 			fallback="top"
-			gap={12}
 			style={{ pointerEvents: "auto" }}
 		>
 			<div style={barStyle} onPointerDown={(e) => e.stopPropagation()}>

--- a/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
@@ -1,0 +1,513 @@
+import type {
+	CanvasPointerEvent,
+	PluginContext,
+	Point,
+	ShapeData,
+	Viewport,
+} from "@edv4h/usketch-shared";
+import { generateId } from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { useCallback, useSyncExternalStore } from "react";
+import { type AnchorType, clampToShapeEdge, getAnchorPoint } from "./anchor-utils.js";
+import { createDefaultConnector } from "./shapes/connector.js";
+
+const HANDLE_RADIUS = 5;
+const STROKE_COLOR = "#2680eb";
+const SELECTED_OFFSET = 16;
+/** Snap distance in world coordinates */
+const SNAP_DISTANCE = 12;
+
+// ── Pointer down state (to hide handles during shape drag) ──
+
+let pointerDown = false;
+const pointerListeners = new Set<() => void>();
+
+function setPointerDown(v: boolean) {
+	if (pointerDown === v) return;
+	pointerDown = v;
+	for (const fn of pointerListeners) fn();
+}
+
+function getPointerDown(): boolean {
+	return pointerDown;
+}
+
+function subscribePointerDown(cb: () => void): () => void {
+	pointerListeners.add(cb);
+	return () => pointerListeners.delete(cb);
+}
+
+// ── Hover state ──
+
+let hoveredShapeId: string | null = null;
+const hoverListeners = new Set<() => void>();
+
+function setAnchorHover(id: string | null) {
+	if (hoveredShapeId === id) return;
+	hoveredShapeId = id;
+	for (const fn of hoverListeners) fn();
+}
+
+function getAnchorHover(): string | null {
+	return hoveredShapeId;
+}
+
+function subscribeAnchorHover(cb: () => void): () => void {
+	hoverListeners.add(cb);
+	return () => hoverListeners.delete(cb);
+}
+
+// ── Drawing state ──
+
+interface AnchorDrawState {
+	connectorId: string;
+	sourceShape: ShapeData;
+	sourceAnchor: AnchorType;
+	/** Target shape being hovered during draw */
+	targetShapeId: string | null;
+	/** Resolved target anchor (snapped or custom) */
+	targetAnchor: AnchorType;
+	/** Resolved target point */
+	targetPoint: Point | null;
+}
+
+let drawState: AnchorDrawState | null = null;
+const drawListeners = new Set<() => void>();
+
+function setAnchorDraw(state: AnchorDrawState | null) {
+	drawState = state;
+	for (const fn of drawListeners) fn();
+}
+
+function getAnchorDraw(): AnchorDrawState | null {
+	return drawState;
+}
+
+function subscribeAnchorDraw(cb: () => void): () => void {
+	drawListeners.add(cb);
+	return () => drawListeners.delete(cb);
+}
+
+// ── Snap helpers ──
+
+const SNAP_ANCHORS: AnchorType[] = ["top", "right", "bottom", "left"];
+
+/** Penalty multiplier for center snap — makes edge anchors preferred over center. */
+const CENTER_SNAP_PENALTY = 3;
+
+/** Find the closest snap anchor on a shape. Returns the anchor type and distance. */
+function findSnapAnchor(
+	shape: ShapeData,
+	worldPoint: Point,
+): { anchor: AnchorType; point: Point; dist: number } {
+	const cx = shape.x + shape.width / 2;
+	const cy = shape.y + shape.height / 2;
+	const center: Point = { x: cx, y: cy };
+	const centerDist = Math.hypot(worldPoint.x - cx, worldPoint.y - cy);
+
+	// Center uses penalized distance so edge anchors are preferred
+	let best = {
+		anchor: "auto" as AnchorType,
+		point: center,
+		dist: centerDist * CENTER_SNAP_PENALTY,
+		realDist: centerDist,
+	};
+
+	for (const anchor of SNAP_ANCHORS) {
+		const p = getAnchorPoint(shape, anchor);
+		const dist = Math.hypot(worldPoint.x - p.x, worldPoint.y - p.y);
+		if (dist < best.dist) {
+			best = { anchor, point: p, dist, realDist: dist };
+		}
+	}
+
+	return { anchor: best.anchor, point: best.point, dist: best.realDist };
+}
+
+// ── Setup ──
+
+export function setupAnchorHandles(ctx: PluginContext): () => void {
+	const unsubMove = ctx.events.on<CanvasPointerEvent>("canvas:pointermove", (event) => {
+		if (drawState) {
+			handleDrawMove(ctx, event.worldPoint);
+			return;
+		}
+
+		const activeToolId = ctx.store.getActiveToolId();
+		if (activeToolId !== "select") {
+			setAnchorHover(null);
+			return;
+		}
+
+		const shape = findNonConnectorShape(ctx, event.worldPoint);
+		setAnchorHover(shape?.id ?? null);
+	});
+
+	const unsubDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", () => {
+		if (!drawState) setPointerDown(true);
+	});
+
+	const unsubUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", (event) => {
+		setPointerDown(false);
+		if (!drawState) return;
+		handleDrawEnd(ctx, event.worldPoint);
+	});
+
+	return () => {
+		unsubMove();
+		unsubDown();
+		unsubUp();
+		setAnchorHover(null);
+		setAnchorDraw(null);
+		setPointerDown(false);
+	};
+}
+
+function handleDrawMove(ctx: PluginContext, worldPoint: Point) {
+	if (!drawState) return;
+
+	const targetShape = findNonConnectorShape(ctx, worldPoint);
+
+	if (targetShape && targetShape.id !== drawState.sourceShape.id) {
+		// Over a target shape — snap to nearest anchor or clamp to edge
+		const snap = findSnapAnchor(targetShape, worldPoint);
+
+		let targetAnchor: AnchorType;
+		let targetPoint: Point;
+
+		if (snap.dist <= SNAP_DISTANCE) {
+			// Snap to cardinal anchor or center (auto)
+			targetAnchor = snap.anchor;
+			targetPoint = snap.point;
+		} else {
+			// Custom: clamp to shape edge
+			targetAnchor = "custom";
+			targetPoint = clampToShapeEdge(targetShape, worldPoint);
+		}
+
+		const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, targetPoint);
+
+		ctx.store.updateShape(drawState.connectorId, {
+			sourcePoint,
+			targetPoint,
+			x: Math.min(sourcePoint.x, targetPoint.x),
+			y: Math.min(sourcePoint.y, targetPoint.y),
+			width: Math.abs(targetPoint.x - sourcePoint.x),
+			height: Math.abs(targetPoint.y - sourcePoint.y),
+		});
+
+		setAnchorDraw({
+			...drawState,
+			targetShapeId: targetShape.id,
+			targetAnchor,
+			targetPoint,
+		});
+	} else {
+		// Not over a target shape — free line
+		const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, worldPoint);
+
+		ctx.store.updateShape(drawState.connectorId, {
+			sourcePoint,
+			targetPoint: worldPoint,
+			x: Math.min(sourcePoint.x, worldPoint.x),
+			y: Math.min(sourcePoint.y, worldPoint.y),
+			width: Math.abs(worldPoint.x - sourcePoint.x),
+			height: Math.abs(worldPoint.y - sourcePoint.y),
+		});
+
+		setAnchorDraw({
+			...drawState,
+			targetShapeId: null,
+			targetAnchor: "auto",
+			targetPoint: null,
+		});
+	}
+}
+
+function handleDrawEnd(ctx: PluginContext, worldPoint: Point) {
+	if (!drawState) return;
+
+	const targetShape = drawState.targetShapeId ? ctx.store.getShape(drawState.targetShapeId) : null;
+	const connector = ctx.store.getShape(drawState.connectorId);
+
+	if (!connector || !targetShape) {
+		// Also try to find shape at release point
+		const releaseTarget = findNonConnectorShape(ctx, worldPoint);
+		if (!connector || !releaseTarget || releaseTarget.id === drawState.sourceShape.id) {
+			ctx.store.deleteShape(drawState.connectorId);
+			setAnchorDraw(null);
+			return;
+		}
+		// Use release target with snap
+		const snap = findSnapAnchor(releaseTarget, worldPoint);
+		const targetAnchor = snap.dist <= SNAP_DISTANCE ? snap.anchor : "custom";
+		const targetPoint =
+			snap.dist <= SNAP_DISTANCE ? snap.point : clampToShapeEdge(releaseTarget, worldPoint);
+		const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, targetPoint);
+
+		ctx.store.deleteShape(drawState.connectorId);
+		const finalShape: ShapeData = {
+			...connector,
+			targetId: releaseTarget.id,
+			targetAnchor,
+			sourcePoint,
+			targetPoint,
+			x: Math.min(sourcePoint.x, targetPoint.x),
+			y: Math.min(sourcePoint.y, targetPoint.y),
+			width: Math.abs(targetPoint.x - sourcePoint.x),
+			height: Math.abs(targetPoint.y - sourcePoint.y),
+		};
+		ctx.commands.execute(createAddShapeCommand(ctx.store, finalShape));
+		setAnchorDraw(null);
+		return;
+	}
+
+	const targetAnchor = drawState.targetAnchor;
+	const targetPoint =
+		drawState.targetPoint ??
+		getAnchorPoint(targetShape, "auto", {
+			x: drawState.sourceShape.x + drawState.sourceShape.width / 2,
+			y: drawState.sourceShape.y + drawState.sourceShape.height / 2,
+		});
+	const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, targetPoint);
+
+	ctx.store.deleteShape(drawState.connectorId);
+	const finalShape: ShapeData = {
+		...connector,
+		targetId: targetShape.id,
+		targetAnchor,
+		sourcePoint,
+		targetPoint,
+		x: Math.min(sourcePoint.x, targetPoint.x),
+		y: Math.min(sourcePoint.y, targetPoint.y),
+		width: Math.abs(targetPoint.x - sourcePoint.x),
+		height: Math.abs(targetPoint.y - sourcePoint.y),
+	};
+	ctx.commands.execute(createAddShapeCommand(ctx.store, finalShape));
+	setAnchorDraw(null);
+}
+
+function findNonConnectorShape(ctx: PluginContext, point: Point): ShapeData | null {
+	const shapes = ctx.store.getShapes();
+	const entries = [...shapes.entries()].reverse();
+	let fallbackContainer: ShapeData | null = null;
+	for (const [, data] of entries) {
+		if (data.type === "connector") continue;
+		const def = ctx.shapes.get(data.type);
+		if (!def?.hitTest(data, point)) continue;
+		if (data.type === "frame" || data.type === "group") {
+			if (!fallbackContainer) fallbackContainer = data;
+			continue;
+		}
+		return data;
+	}
+	return fallbackContainer;
+}
+
+// ── Overlay Component ──
+
+interface AnchorHandleOverlayProps {
+	ctx: PluginContext;
+	viewport: Viewport;
+}
+
+export function AnchorHandleOverlay({ ctx, viewport }: AnchorHandleOverlayProps) {
+	const hoverId = useSyncExternalStore(subscribeAnchorHover, getAnchorHover);
+	const drawing = useSyncExternalStore(subscribeAnchorDraw, getAnchorDraw);
+	const isDragging = useSyncExternalStore(subscribePointerDown, getPointerDown);
+
+	const activeToolId = useSyncExternalStore(
+		(cb) => ctx.store.subscribe(cb),
+		() => ctx.store.getActiveToolId(),
+	);
+
+	const shapes = useSyncExternalStore(
+		(cb) => ctx.store.subscribe(cb),
+		() => ctx.store.getShapes(),
+	);
+
+	const selection = useSyncExternalStore(
+		(cb) => ctx.store.subscribe(cb),
+		() => ctx.store.getSelection(),
+	);
+
+	if (activeToolId !== "select") return null;
+
+	// During drawing: show target shape anchor indicators
+	if (drawing && drawing.targetShapeId) {
+		const targetShape = shapes.get(drawing.targetShapeId);
+		if (!targetShape) return null;
+
+		const anchors: AnchorType[] = ["top", "right", "bottom", "left", "auto"];
+		return (
+			<svg
+				style={{
+					position: "absolute",
+					left: 0,
+					top: 0,
+					width: "100%",
+					height: "100%",
+					overflow: "visible",
+					pointerEvents: "none",
+				}}
+			>
+				{anchors.map((anchor) => {
+					const point = getAnchorPoint(targetShape, anchor);
+					const screen = worldToScreen(point, viewport);
+					const isActive = drawing.targetAnchor === anchor;
+					return (
+						<circle
+							key={anchor}
+							cx={screen.x}
+							cy={screen.y}
+							r={isActive ? HANDLE_RADIUS + 2 : HANDLE_RADIUS}
+							fill={isActive ? STROKE_COLOR : "white"}
+							stroke={STROKE_COLOR}
+							strokeWidth={isActive ? 2 : 1.5}
+							opacity={isActive ? 1 : 0.6}
+						/>
+					);
+				})}
+			</svg>
+		);
+	}
+
+	if (drawing) return null;
+
+	// Hide anchor handles while dragging shapes
+	if (isDragging) return null;
+
+	// Not drawing: show anchor handles on selected + hovered shapes
+	const targets: { shape: ShapeData; isSelected: boolean }[] = [];
+
+	for (const id of selection) {
+		const s = shapes.get(id);
+		if (s && s.type !== "connector") {
+			targets.push({ shape: s, isSelected: true });
+		}
+	}
+
+	if (hoverId && !selection.has(hoverId)) {
+		const s = shapes.get(hoverId);
+		if (s && s.type !== "connector") {
+			targets.push({ shape: s, isSelected: false });
+		}
+	}
+
+	if (targets.length === 0) return null;
+
+	const anchors: AnchorType[] = ["top", "right", "bottom", "left"];
+
+	return (
+		<svg
+			style={{
+				position: "absolute",
+				left: 0,
+				top: 0,
+				width: "100%",
+				height: "100%",
+				overflow: "visible",
+				pointerEvents: "none",
+			}}
+		>
+			{targets.map(({ shape, isSelected }) =>
+				anchors.map((anchor) => {
+					const point = getAnchorPoint(shape, anchor);
+					const screen = worldToScreen(point, viewport);
+					const offsetScreen = isSelected ? applySelectedOffset(screen, anchor) : screen;
+					return (
+						<AnchorHandle
+							key={`${shape.id}-${anchor}`}
+							screen={offsetScreen}
+							anchor={anchor}
+							shape={shape}
+							ctx={ctx}
+						/>
+					);
+				}),
+			)}
+		</svg>
+	);
+}
+
+function applySelectedOffset(screen: Point, anchor: AnchorType): Point {
+	switch (anchor) {
+		case "top":
+			return { x: screen.x, y: screen.y - SELECTED_OFFSET };
+		case "bottom":
+			return { x: screen.x, y: screen.y + SELECTED_OFFSET };
+		case "left":
+			return { x: screen.x - SELECTED_OFFSET, y: screen.y };
+		case "right":
+			return { x: screen.x + SELECTED_OFFSET, y: screen.y };
+		default:
+			return screen;
+	}
+}
+
+function AnchorHandle({
+	screen,
+	anchor,
+	shape,
+	ctx,
+}: {
+	screen: Point;
+	anchor: AnchorType;
+	shape: ShapeData;
+	ctx: PluginContext;
+}) {
+	const handlePointerDown = useCallback(
+		(e: React.PointerEvent) => {
+			e.stopPropagation();
+			e.preventDefault();
+
+			const id = generateId();
+			const sourcePoint = getAnchorPoint(shape, anchor);
+
+			const connector: ShapeData = {
+				...createDefaultConnector({ id, x: sourcePoint.x, y: sourcePoint.y }),
+				sourceId: shape.id,
+				targetId: undefined,
+				sourceAnchor: anchor,
+				targetAnchor: "auto",
+				sourcePoint,
+				targetPoint: sourcePoint,
+				style: { ...ctx.store.getStyleSettings(), fill: "transparent" },
+			};
+
+			ctx.store.addShape(connector);
+			setAnchorDraw({
+				connectorId: id,
+				sourceShape: shape,
+				sourceAnchor: anchor,
+				targetShapeId: null,
+				targetAnchor: "auto",
+				targetPoint: null,
+			});
+		},
+		[shape, anchor, ctx],
+	);
+
+	return (
+		<g onPointerDown={handlePointerDown} style={{ cursor: "crosshair", pointerEvents: "auto" }}>
+			<circle cx={screen.x} cy={screen.y} r={HANDLE_RADIUS + 4} fill="transparent" />
+			<circle
+				cx={screen.x}
+				cy={screen.y}
+				r={HANDLE_RADIUS}
+				fill="white"
+				stroke={STROKE_COLOR}
+				strokeWidth={1.5}
+				opacity={0.8}
+			/>
+			<circle cx={screen.x} cy={screen.y} r={2} fill={STROKE_COLOR} />
+		</g>
+	);
+}
+
+function worldToScreen(point: Point, viewport: Viewport): Point {
+	return {
+		x: point.x * viewport.zoom + viewport.x,
+		y: point.y * viewport.zoom + viewport.y,
+	};
+}

--- a/plugins/usketch-plugin-shape-connector/src/anchor-utils.ts
+++ b/plugins/usketch-plugin-shape-connector/src/anchor-utils.ts
@@ -1,6 +1,6 @@
 import type { Point, ShapeData } from "@edv4h/usketch-shared";
 
-export type AnchorType = "auto" | "top" | "right" | "bottom" | "left";
+export type AnchorType = "auto" | "top" | "right" | "bottom" | "left" | "custom";
 
 /** Compute the anchor point on a shape's edge */
 export function getAnchorPoint(shape: ShapeData, anchor: AnchorType, otherCenter?: Point): Point {
@@ -16,6 +16,10 @@ export function getAnchorPoint(shape: ShapeData, anchor: AnchorType, otherCenter
 			return { x: cx, y: shape.y + shape.height };
 		case "left":
 			return { x: shape.x, y: cy };
+		case "custom":
+			// Custom anchor: caller manages the point directly.
+			// Return center as fallback (should not normally be called).
+			return { x: cx, y: cy };
 		case "auto": {
 			if (!otherCenter) return { x: cx, y: cy };
 			return computeAutoAnchor(shape, otherCenter);
@@ -95,4 +99,35 @@ export function findClosestAnchor(shape: ShapeData, point: Point): AnchorType {
 	}
 
 	return closest;
+}
+
+/** Clamp a point to the nearest position on a shape's bounding box edge. */
+export function clampToShapeEdge(shape: ShapeData, point: Point): Point {
+	const left = shape.x;
+	const right = shape.x + shape.width;
+	const top = shape.y;
+	const bottom = shape.y + shape.height;
+
+	// Project the point onto each of the 4 edges and pick the closest
+	const candidates: Point[] = [
+		{ x: clamp(point.x, left, right), y: top }, // top edge
+		{ x: clamp(point.x, left, right), y: bottom }, // bottom edge
+		{ x: left, y: clamp(point.y, top, bottom) }, // left edge
+		{ x: right, y: clamp(point.y, top, bottom) }, // right edge
+	];
+
+	let best = candidates[0];
+	let bestDist = Number.POSITIVE_INFINITY;
+	for (const c of candidates) {
+		const dist = Math.hypot(c.x - point.x, c.y - point.y);
+		if (dist < bestDist) {
+			bestDist = dist;
+			best = c;
+		}
+	}
+	return best;
+}
+
+function clamp(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
 }

--- a/plugins/usketch-plugin-shape-connector/src/connector-property-bar.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/connector-property-bar.tsx
@@ -1,9 +1,11 @@
 import { ShapeAnchorOverlay, useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
+import type { ShapeData } from "@edv4h/usketch-shared";
 import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
 import { useCallback } from "react";
+import { type AnchorType, getAnchorPoint } from "./anchor-utils.js";
 import type { ArrowHead, PathType } from "./shapes/connector.js";
 
-// ── Icons ──
+// ── Arrow Icons ──
 
 function ArrowNoneIcon() {
 	return (
@@ -41,6 +43,8 @@ function ArrowBothIcon() {
 	);
 }
 
+// ── Path Icons ──
+
 function PathStraightIcon() {
 	return (
 		<svg width="16" height="16" viewBox="0 0 16 16">
@@ -65,6 +69,17 @@ function PathCurveIcon() {
 	);
 }
 
+// ── Anchor labels ──
+
+const ANCHOR_OPTIONS: { value: AnchorType; label: string }[] = [
+	{ value: "auto", label: "自動" },
+	{ value: "top", label: "上" },
+	{ value: "right", label: "右" },
+	{ value: "bottom", label: "下" },
+	{ value: "left", label: "左" },
+	{ value: "custom", label: "手動" },
+];
+
 // ── Component ──
 
 export function ConnectorPropertyBar() {
@@ -73,7 +88,6 @@ export function ConnectorPropertyBar() {
 	const selection = useStoreSubscribe(store, (s) => s.getSelection());
 	const shapes = useStoreSubscribe(store, (s) => s.getShapes());
 
-	// Only show for single connector selection
 	const ids = [...selection];
 	if (ids.length !== 1) return null;
 	const shape = shapes.get(ids[0]);
@@ -82,22 +96,37 @@ export function ConnectorPropertyBar() {
 	const connectorId = ids[0];
 	const arrowHead = (shape.arrowHead as ArrowHead) ?? "forward";
 	const pathType = (shape.pathType as PathType) ?? "straight";
+	const sourceAnchor = (shape.sourceAnchor as AnchorType) ?? "auto";
+	const targetAnchor = (shape.targetAnchor as AnchorType) ?? "auto";
 
 	return (
-		<ShapeAnchorOverlay shapeIds={[connectorId]} position="bottom" fallback="top" gap={12}>
-			<ConnectorControls connectorId={connectorId} arrowHead={arrowHead} pathType={pathType} />
+		<ShapeAnchorOverlay shapeIds={[connectorId]} position="bottom" fallback="top">
+			<ConnectorControls
+				connectorId={connectorId}
+				connector={shape}
+				arrowHead={arrowHead}
+				pathType={pathType}
+				sourceAnchor={sourceAnchor}
+				targetAnchor={targetAnchor}
+			/>
 		</ShapeAnchorOverlay>
 	);
 }
 
 function ConnectorControls({
 	connectorId,
+	connector,
 	arrowHead,
 	pathType,
+	sourceAnchor,
+	targetAnchor,
 }: {
 	connectorId: string;
+	connector: ShapeData;
 	arrowHead: ArrowHead;
 	pathType: PathType;
+	sourceAnchor: AnchorType;
+	targetAnchor: AnchorType;
 }) {
 	const app = useApp();
 	const store = app.store;
@@ -129,8 +158,63 @@ function ConnectorControls({
 		[pathType, updateProp],
 	);
 
+	const setAnchor = useCallback(
+		(endpoint: "source" | "target", value: AnchorType) => {
+			const key = endpoint === "source" ? "sourceAnchor" : "targetAnchor";
+			const current = endpoint === "source" ? sourceAnchor : targetAnchor;
+			if (value === current) return;
+
+			// Recalculate endpoint position with new anchor
+			const sourceId = connector.sourceId as string | undefined;
+			const targetId = connector.targetId as string | undefined;
+			if (!sourceId || !targetId) return;
+
+			const sourceShape = store.getShape(sourceId);
+			const targetShape = store.getShape(targetId);
+			if (!sourceShape || !targetShape) return;
+
+			const targetCenter = {
+				x: targetShape.x + targetShape.width / 2,
+				y: targetShape.y + targetShape.height / 2,
+			};
+			const sourceCenter = {
+				x: sourceShape.x + sourceShape.width / 2,
+				y: sourceShape.y + sourceShape.height / 2,
+			};
+
+			const newSourceAnchor = endpoint === "source" ? value : sourceAnchor;
+			const newTargetAnchor = endpoint === "target" ? value : targetAnchor;
+
+			const newSourcePoint = getAnchorPoint(sourceShape, newSourceAnchor, targetCenter);
+			const newTargetPoint = getAnchorPoint(targetShape, newTargetAnchor, sourceCenter);
+
+			const from: Partial<ShapeData> = {
+				[key]: current,
+				sourcePoint: connector.sourcePoint,
+				targetPoint: connector.targetPoint,
+				x: connector.x,
+				y: connector.y,
+				width: connector.width,
+				height: connector.height,
+			};
+			const to: Partial<ShapeData> = {
+				[key]: value,
+				sourcePoint: newSourcePoint,
+				targetPoint: newTargetPoint,
+				x: Math.min(newSourcePoint.x, newTargetPoint.x),
+				y: Math.min(newSourcePoint.y, newTargetPoint.y),
+				width: Math.abs(newTargetPoint.x - newSourcePoint.x),
+				height: Math.abs(newTargetPoint.y - newSourcePoint.y),
+			};
+
+			app.commands.execute(createBatchUpdateShapesCommand(store, [{ id: connectorId, from, to }]));
+		},
+		[connectorId, connector, sourceAnchor, targetAnchor, store, app.commands],
+	);
+
 	return (
 		<div onPointerDown={(e) => e.stopPropagation()} style={barStyle}>
+			{/* Arrow head */}
 			<ToggleButton
 				active={arrowHead === "none"}
 				onClick={() => setArrowHead("none")}
@@ -162,6 +246,7 @@ function ConnectorControls({
 
 			<div style={sepStyle} />
 
+			{/* Path type */}
 			<ToggleButton
 				active={pathType === "straight"}
 				onClick={() => setPathType("straight")}
@@ -175,7 +260,40 @@ function ConnectorControls({
 			<ToggleButton active={pathType === "curve"} onClick={() => setPathType("curve")} title="曲線">
 				<PathCurveIcon />
 			</ToggleButton>
+
+			<div style={sepStyle} />
+
+			{/* Anchor selectors */}
+			<AnchorSelect label="始点" value={sourceAnchor} onChange={(v) => setAnchor("source", v)} />
+			<AnchorSelect label="終点" value={targetAnchor} onChange={(v) => setAnchor("target", v)} />
 		</div>
+	);
+}
+
+function AnchorSelect({
+	label,
+	value,
+	onChange,
+}: {
+	label: string;
+	value: AnchorType;
+	onChange: (v: AnchorType) => void;
+}) {
+	return (
+		<label style={anchorLabelStyle}>
+			<span style={{ fontSize: 10, color: "#888" }}>{label}</span>
+			<select
+				value={value}
+				onChange={(e) => onChange(e.target.value as AnchorType)}
+				style={selectStyle}
+			>
+				{ANCHOR_OPTIONS.map((opt) => (
+					<option key={opt.value} value={opt.value}>
+						{opt.label}
+					</option>
+				))}
+			</select>
+		</label>
 	);
 }
 
@@ -219,6 +337,24 @@ const sepStyle: React.CSSProperties = {
 	background: "#e0e0e0",
 	flexShrink: 0,
 	margin: "0 2px",
+};
+
+const anchorLabelStyle: React.CSSProperties = {
+	display: "flex",
+	flexDirection: "column",
+	alignItems: "center",
+	gap: 1,
+};
+
+const selectStyle: React.CSSProperties = {
+	width: 52,
+	height: 22,
+	border: "1px solid #e0e0e0",
+	borderRadius: 4,
+	padding: "0 2px",
+	fontSize: 10,
+	background: "#fff",
+	cursor: "pointer",
 };
 
 function toggleBtnStyle(active: boolean): React.CSSProperties {

--- a/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
@@ -1,7 +1,7 @@
 import type { PluginContext, Point, ShapeData, Viewport } from "@edv4h/usketch-shared";
 import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
 import { useCallback, useSyncExternalStore } from "react";
-import { getAnchorPoint } from "./anchor-utils.js";
+import { clampToShapeEdge, getAnchorPoint } from "./anchor-utils.js";
 import {
 	type EndpointDragState,
 	getEndpointDrag,
@@ -53,68 +53,97 @@ export function EndpointOverlay({ ctx, viewport }: EndpointOverlayProps) {
 	const showControlHandle = pathType === "curve";
 	const cp = controlPoint ?? getDefaultControlPoint(sourcePoint, targetPoint);
 
-	return (
-		<div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
-			<svg
-				width="100%"
-				height="100%"
-				style={{
-					position: "absolute",
-					left: 0,
-					top: 0,
-					overflow: "visible",
-					pointerEvents: "none",
-				}}
-			>
-				{/* Preview line during drag */}
-				{dragState && dragState.connectorId === connectorId && (
-					<DragPreview dragState={dragState} connector={connector} viewport={viewport} />
-				)}
+	const srcScreen = worldToScreen(sourcePoint, viewport);
+	const tgtScreen = worldToScreen(targetPoint, viewport);
+	const cpScreen = showControlHandle ? worldToScreen(cp, viewport) : null;
 
-				{/* Target shape highlight during drag */}
-				{dragState?.targetShapeId && (
-					<TargetHighlight
-						shapeId={dragState.targetShapeId}
-						shapes={shapes}
-						shapesDefs={ctx.shapes}
-						viewport={viewport}
+	return (
+		<svg
+			style={{
+				position: "absolute",
+				left: 0,
+				top: 0,
+				width: "100%",
+				height: "100%",
+				overflow: "visible",
+				pointerEvents: "none",
+			}}
+		>
+			{/* Preview line during drag */}
+			{dragState && dragState.connectorId === connectorId && (
+				<DragPreview dragState={dragState} connector={connector} viewport={viewport} />
+			)}
+
+			{/* Target shape highlight during drag */}
+			{dragState?.targetShapeId && (
+				<TargetHighlight
+					shapeId={dragState.targetShapeId}
+					shapes={shapes}
+					shapesDefs={ctx.shapes}
+					viewport={viewport}
+				/>
+			)}
+
+			{/* Control point guide line (for curve) */}
+			{cpScreen && (
+				<>
+					<line
+						x1={srcScreen.x}
+						y1={srcScreen.y}
+						x2={cpScreen.x}
+						y2={cpScreen.y}
+						stroke={STROKE_COLOR}
+						strokeWidth={0.5}
+						opacity={0.4}
 					/>
-				)}
-			</svg>
+					<line
+						x1={cpScreen.x}
+						y1={cpScreen.y}
+						x2={tgtScreen.x}
+						y2={tgtScreen.y}
+						stroke={STROKE_COLOR}
+						strokeWidth={0.5}
+						opacity={0.4}
+					/>
+				</>
+			)}
 
 			{/* Source handle */}
 			<EndpointHandle
-				point={sourcePoint}
-				viewport={viewport}
+				screen={srcScreen}
 				endpoint="source"
 				connectorId={connectorId}
 				connector={connector}
 				ctx={ctx}
+				viewport={viewport}
+				worldPoint={sourcePoint}
 			/>
 
 			{/* Target handle */}
 			<EndpointHandle
-				point={targetPoint}
-				viewport={viewport}
+				screen={tgtScreen}
 				endpoint="target"
 				connectorId={connectorId}
 				connector={connector}
 				ctx={ctx}
+				viewport={viewport}
+				worldPoint={targetPoint}
 			/>
 
 			{/* Control point handle (for curve) */}
-			{showControlHandle && (
+			{cpScreen && (
 				<EndpointHandle
-					point={cp}
-					viewport={viewport}
+					screen={cpScreen}
 					endpoint="controlPoint"
 					connectorId={connectorId}
 					connector={connector}
 					ctx={ctx}
+					viewport={viewport}
+					worldPoint={cp}
 					isControlPoint
 				/>
 			)}
-		</div>
+		</svg>
 	);
 }
 
@@ -199,72 +228,88 @@ function TargetHighlight({
 }
 
 function EndpointHandle({
-	point,
-	viewport,
+	screen,
 	endpoint,
 	connectorId,
 	connector,
 	ctx,
+	viewport,
+	worldPoint,
 	isControlPoint,
 }: {
-	point: Point;
-	viewport: Viewport;
+	screen: Point;
 	endpoint: "source" | "target" | "controlPoint";
 	connectorId: string;
 	connector: ShapeData;
 	ctx: PluginContext;
+	viewport: Viewport;
+	worldPoint: Point;
 	isControlPoint?: boolean;
 }) {
-	const screen = worldToScreen(point, viewport);
-
 	const handlePointerDown = useCallback(
 		(e: React.PointerEvent) => {
 			e.stopPropagation();
 			e.preventDefault();
 
-			const el = e.currentTarget as HTMLElement;
-			el.setPointerCapture(e.pointerId);
+			const svgEl = (e.currentTarget as SVGElement).ownerSVGElement;
+			if (!svgEl) return;
 
 			setEndpointDrag({
 				connectorId,
 				endpoint,
-				currentPoint: point,
+				currentPoint: worldPoint,
 				targetShapeId: null,
 			});
 
+			// The shape this endpoint is currently connected to
+			const currentShapeId =
+				endpoint === "source"
+					? (connector.sourceId as string | undefined)
+					: (connector.targetId as string | undefined);
+
 			const onMove = (me: PointerEvent) => {
-				const worldPoint = screenToWorld({ x: me.clientX, y: me.clientY }, viewport);
+				const wp = screenToWorld({ x: me.clientX, y: me.clientY }, viewport);
 
 				if (endpoint === "controlPoint") {
-					// Control point drag: just update position
 					setEndpointDrag({
 						connectorId,
 						endpoint,
-						currentPoint: worldPoint,
+						currentPoint: wp,
 						targetShapeId: null,
 					});
 					return;
 				}
 
-				const targetShape = findShapeAtPoint(ctx, worldPoint);
+				// Check if we're over the same shape (slide anchor) or a different one (reconnect)
+				const hoverShape = findShapeAtPoint(ctx, wp);
 				const otherEndShapeId =
 					endpoint === "source"
 						? (connector.targetId as string | undefined)
 						: (connector.sourceId as string | undefined);
 
-				setEndpointDrag({
-					connectorId,
-					endpoint,
-					currentPoint: worldPoint,
-					targetShapeId: targetShape && targetShape.id !== otherEndShapeId ? targetShape.id : null,
-				});
+				if (hoverShape && hoverShape.id === currentShapeId) {
+					// Sliding along current shape's edge
+					const edgePoint = clampToShapeEdge(hoverShape, wp);
+					setEndpointDrag({
+						connectorId,
+						endpoint,
+						currentPoint: edgePoint,
+						targetShapeId: null,
+					});
+				} else {
+					setEndpointDrag({
+						connectorId,
+						endpoint,
+						currentPoint: wp,
+						targetShapeId: hoverShape && hoverShape.id !== otherEndShapeId ? hoverShape.id : null,
+					});
+				}
 			};
 
 			const onUp = () => {
 				const drag = getEndpointDrag();
 				if (drag && drag.connectorId === connectorId) {
 					if (drag.endpoint === "controlPoint") {
-						// Commit control point position
 						const before = {
 							controlPoint: connector.controlPoint,
 							controlPointAuto: connector.controlPointAuto,
@@ -276,50 +321,54 @@ function EndpointHandle({
 							]),
 						);
 					} else if (drag.targetShapeId) {
-						// Reconnect endpoint
+						// Reconnect to a different shape
 						const newTarget = ctx.store.getShape(drag.targetShapeId);
 						if (newTarget) {
 							commitEndpointReconnect(ctx, connectorId, connector, drag.endpoint, newTarget);
 						}
+					} else if (currentShapeId) {
+						// Slide anchor: commit the new custom position on the same shape
+						const currentShape = ctx.store.getShape(currentShapeId);
+						if (currentShape) {
+							commitAnchorSlide(
+								ctx,
+								connectorId,
+								connector,
+								drag.endpoint,
+								currentShape,
+								drag.currentPoint,
+							);
+						}
 					}
 				}
 				setEndpointDrag(null);
-				el.removeEventListener("pointermove", onMove);
-				el.removeEventListener("pointerup", onUp);
+				window.removeEventListener("pointermove", onMove);
+				window.removeEventListener("pointerup", onUp);
 			};
 
-			el.addEventListener("pointermove", onMove);
-			el.addEventListener("pointerup", onUp);
+			window.addEventListener("pointermove", onMove);
+			window.addEventListener("pointerup", onUp);
 		},
-		[connectorId, connector, endpoint, point, viewport, ctx],
+		[connectorId, connector, endpoint, worldPoint, viewport, ctx],
 	);
 
 	const r = isControlPoint ? HANDLE_RADIUS - 1 : HANDLE_RADIUS;
+	const hitR = r + 4; // Larger invisible hit area
 
 	return (
-		<div
-			onPointerDown={handlePointerDown}
-			style={{
-				position: "absolute",
-				left: screen.x - r - 1,
-				top: screen.y - r - 1,
-				width: (r + 1) * 2,
-				height: (r + 1) * 2,
-				pointerEvents: "auto",
-				cursor: "grab",
-			}}
-		>
-			<svg width={(r + 1) * 2} height={(r + 1) * 2} style={{ overflow: "visible" }}>
-				<circle
-					cx={r + 1}
-					cy={r + 1}
-					r={r}
-					fill={isControlPoint ? STROKE_COLOR : "white"}
-					stroke={STROKE_COLOR}
-					strokeWidth={1.5}
-				/>
-			</svg>
-		</div>
+		<g onPointerDown={handlePointerDown} style={{ cursor: "grab", pointerEvents: "auto" }}>
+			{/* Invisible hit area */}
+			<circle cx={screen.x} cy={screen.y} r={hitR} fill="transparent" />
+			{/* Visible handle */}
+			<circle
+				cx={screen.x}
+				cy={screen.y}
+				r={r}
+				fill={isControlPoint ? STROKE_COLOR : "white"}
+				stroke={STROKE_COLOR}
+				strokeWidth={1.5}
+			/>
+		</g>
 	);
 }
 
@@ -380,6 +429,61 @@ function commitEndpointReconnect(
 	ctx.commands.execute(
 		createBatchUpdateShapesCommand(ctx.store, [{ id: connectorId, from: fromData, to: toData }]),
 	);
+}
+
+function commitAnchorSlide(
+	ctx: PluginContext,
+	connectorId: string,
+	connector: ShapeData,
+	endpoint: "source" | "target",
+	shape: ShapeData,
+	dragPoint: Point,
+) {
+	const edgePoint = clampToShapeEdge(shape, dragPoint);
+	const anchorKey = endpoint === "source" ? "sourceAnchor" : "targetAnchor";
+	const pointKey = endpoint === "source" ? "sourcePoint" : "targetPoint";
+
+	// Recalculate the other endpoint (it depends on the new position for "auto" anchors)
+	const otherShapeId =
+		endpoint === "source" ? (connector.targetId as string) : (connector.sourceId as string);
+	const otherShape = ctx.store.getShape(otherShapeId);
+	if (!otherShape) return;
+
+	const otherAnchor =
+		endpoint === "source"
+			? ((connector.targetAnchor as string) ?? "auto")
+			: ((connector.sourceAnchor as string) ?? "auto");
+	const otherPoint =
+		otherAnchor === "custom"
+			? (connector[endpoint === "source" ? "targetPoint" : "sourcePoint"] as Point)
+			: getAnchorPoint(otherShape, otherAnchor as "auto", edgePoint);
+
+	const newSourcePoint = endpoint === "source" ? edgePoint : otherPoint;
+	const newTargetPoint = endpoint === "target" ? edgePoint : otherPoint;
+
+	const from: Partial<ShapeData> = {
+		[anchorKey]: connector[anchorKey],
+		[pointKey]: connector[pointKey],
+		sourcePoint: connector.sourcePoint,
+		targetPoint: connector.targetPoint,
+		x: connector.x,
+		y: connector.y,
+		width: connector.width,
+		height: connector.height,
+	};
+
+	const to: Partial<ShapeData> = {
+		[anchorKey]: "custom",
+		[pointKey]: edgePoint,
+		sourcePoint: newSourcePoint,
+		targetPoint: newTargetPoint,
+		x: Math.min(newSourcePoint.x, newTargetPoint.x),
+		y: Math.min(newSourcePoint.y, newTargetPoint.y),
+		width: Math.abs(newTargetPoint.x - newSourcePoint.x),
+		height: Math.abs(newTargetPoint.y - newSourcePoint.y),
+	};
+
+	ctx.commands.execute(createBatchUpdateShapesCommand(ctx.store, [{ id: connectorId, from, to }]));
 }
 
 function worldToScreen(point: Point, viewport: Viewport): Point {

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -8,7 +8,8 @@ import type {
 } from "@edv4h/usketch-shared";
 import { generateId } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
-import { type AnchorType, getAnchorPoint } from "./anchor-utils.js";
+import { AnchorHandleOverlay, setupAnchorHandles } from "./anchor-handle-overlay.js";
+import { type AnchorType, clampToShapeEdge, getAnchorPoint } from "./anchor-utils.js";
 import { ConnectorLabelEditor, handleConnectorClick, setEditingLabel } from "./connector-label.js";
 import { ConnectorPropertyBar } from "./connector-property-bar.js";
 import { EndpointOverlay } from "./endpoint-overlay.js";
@@ -203,6 +204,17 @@ export const connectorPlugin: UsketchPlugin = {
 			render: (renderCtx) => <ConnectorLabelEditor ctx={ctx} viewport={renderCtx.viewport} />,
 		});
 
+		// ── Anchor handle overlay (hover to show anchor points) ──
+
+		ctx.layers.register({
+			id: "connector-anchor-handles",
+			order: 79,
+			fixed: true,
+			render: (renderCtx) => <AnchorHandleOverlay ctx={ctx} viewport={renderCtx.viewport} />,
+		});
+
+		const cleanupAnchorHandles = setupAnchorHandles(ctx);
+
 		// Double-click detection for label editing
 		const unsubLabelClick = ctx.store.onMutation((event) => {
 			if (event.type !== "selection:changed") return;
@@ -249,13 +261,42 @@ export const connectorPlugin: UsketchPlugin = {
 		});
 		rebuildIndex();
 
+		// Cache previous shape positions to compute deltas for custom anchors
+		const prevPositions = new Map<string, { x: number; y: number }>();
+		function cachePosition(id: string) {
+			const shape = ctx.store.getShape(id);
+			if (shape) prevPositions.set(id, { x: shape.x, y: shape.y });
+		}
+		// Initialize cache
+		for (const [id, shape] of ctx.store.getShapes()) {
+			if (shape.type !== "connector") {
+				prevPositions.set(id, { x: shape.x, y: shape.y });
+			}
+		}
+		const unsubCacheAdd = ctx.store.onMutation((event) => {
+			if (event.type === "shape:added") {
+				const payload = event.payload as { id: string } | undefined;
+				if (payload?.id) cachePosition(payload.id);
+			}
+		});
+
 		const unsubMove = ctx.store.onMutation((event) => {
 			if (event.type !== "shape:updated") return;
 			const payload = event.payload as { id: string } | undefined;
 			if (!payload?.id) return;
 
 			const connIds = connectorIndex.get(payload.id);
-			if (!connIds || connIds.size === 0) return;
+			if (!connIds || connIds.size === 0) {
+				// Still update the cache even if no connectors reference this shape
+				cachePosition(payload.id);
+				return;
+			}
+
+			// Compute move delta from cached position
+			const movedShape = ctx.store.getShape(payload.id);
+			const prev = prevPositions.get(payload.id);
+			const dx = movedShape && prev ? movedShape.x - prev.x : 0;
+			const dy = movedShape && prev ? movedShape.y - prev.y : 0;
 
 			for (const connId of connIds) {
 				const conn = ctx.store.getShape(connId);
@@ -274,8 +315,26 @@ export const connectorPlugin: UsketchPlugin = {
 				const targetCenter = { x: target.x + target.width / 2, y: target.y + target.height / 2 };
 				const sourceCenter = { x: source.x + source.width / 2, y: source.y + source.height / 2 };
 
-				const sourcePoint = getAnchorPoint(source, sourceAnchor, targetCenter);
-				const targetPoint = getAnchorPoint(target, targetAnchor, sourceCenter);
+				let sourcePoint: Point;
+				if (sourceAnchor === "custom" && sourceId === payload.id) {
+					// Source shape moved: shift the custom point by the delta, then clamp
+					const old = conn.sourcePoint as Point;
+					sourcePoint = clampToShapeEdge(source, { x: old.x + dx, y: old.y + dy });
+				} else if (sourceAnchor === "custom") {
+					sourcePoint = conn.sourcePoint as Point;
+				} else {
+					sourcePoint = getAnchorPoint(source, sourceAnchor, targetCenter);
+				}
+
+				let targetPoint: Point;
+				if (targetAnchor === "custom" && targetId === payload.id) {
+					const old = conn.targetPoint as Point;
+					targetPoint = clampToShapeEdge(target, { x: old.x + dx, y: old.y + dy });
+				} else if (targetAnchor === "custom") {
+					targetPoint = conn.targetPoint as Point;
+				} else {
+					targetPoint = getAnchorPoint(target, targetAnchor, sourceCenter);
+				}
 
 				const updates: Partial<ShapeData> = {
 					sourcePoint,
@@ -286,13 +345,15 @@ export const connectorPlugin: UsketchPlugin = {
 					height: Math.abs(targetPoint.y - sourcePoint.y),
 				};
 
-				// Update control point if auto-calculated
 				if (conn.controlPointAuto && conn.pathType === "curve") {
 					updates.controlPoint = getDefaultControlPoint(sourcePoint, targetPoint);
 				}
 
 				ctx.store.updateShape(connId, updates);
 			}
+
+			// Update cache after processing
+			cachePosition(payload.id);
 		});
 
 		// ── Cascade delete ──
@@ -319,13 +380,16 @@ export const connectorPlugin: UsketchPlugin = {
 
 		(this as UsketchPlugin).teardown = () => {
 			unsubIndex();
+			unsubCacheAdd();
 			unsubMove();
 			unsubDelete();
 			unsubLabelClick();
 			unsubPointerForLabel();
+			cleanupAnchorHandles();
 			ctx.layers.unregister("connector-properties");
 			ctx.layers.unregister("connector-endpoints");
 			ctx.layers.unregister("connector-label-editor");
+			ctx.layers.unregister("connector-anchor-handles");
 		};
 	},
 };


### PR DESCRIPTION
## Summary

PR #554 マージ後に追加したコネクタUI改善をまとめて適用。

- **端点ハンドル修正**: SVG座標ベースに変更し位置ずれ解消
- **AI Actionsバー競合回避**: コネクタ選択時にAI Actionsバーを非表示
- **アンカー位置セレクター**: プロパティバーで始点/終点のアンカー位置(auto/top/right/bottom/left/custom)を変更可能
- **端点スライド**: 端点ハンドルを同じシェイプ上でドラッグして辺上の任意位置にアンカー設定
- **customアンカー追従**: シェイプ移動時にデルタ計算+辺クランプで相対位置維持
- **アンカーハンドルオーバーレイ**: シェイプホバー時に上下左右のアンカーポイント表示、クリックでコネクタ描画開始
- **選択中常時表示**: 選択中シェイプはホバー不要でアンカーハンドル常時表示（オフセット付き）
- **終点スナップ**: 描画中にターゲットシェイプの上下左右+中心にスナップ（中心はペナルティ付き）
- **ShapeAnchorOverlay gap**: デフォルト48pxに拡大してハンドルとの重なり解消
- **ドラッグ中非表示**: シェイプ移動中はアンカーハンドルを非表示

## Test plan

- [ ] `pnpm typecheck` が通ること
- [ ] シェイプにホバーでアンカーハンドル表示、クリックでコネクタ描画開始
- [ ] 選択中シェイプのアンカーハンドルが常時表示（オフセット付き）
- [ ] 端点ドラッグで辺上スライド→customアンカーとして保存
- [ ] シェイプ移動時にcustomアンカーが辺上の相対位置を維持
- [ ] 描画中にターゲットシェイプの上下左右+中心にスナップ
- [ ] コネクタ選択時にAI ActionsバーではなくコネクタプロパティバーのみUI表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)