### PR TITLE
スナップ改善とドラッグ中ツールバー非表示

### DIFF
--- a/packages/canvas-engine/src/components/shape-anchor-overlay.tsx
+++ b/packages/canvas-engine/src/components/shape-anchor-overlay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { useAnchorStack, useAnchorStackOffset } from "../hooks/use-anchor-stack.js";
+import { useInteracting } from "../hooks/use-interacting.js";
 import { useShapeAnchorPosition } from "../hooks/use-shape-anchor-position.js";
 import { useViewportClamp } from "../hooks/use-viewport-clamp.js";
 import type { AnchorPosition, ShapeAnchorOptions } from "../types/shape-anchor.js";
@@ -128,6 +129,8 @@ export function ShapeAnchorOverlay({
 		return () => registry.unregister(overlayId);
 	}, [registry, overlayId]);
 
+	const interacting = useInteracting();
+
 	if (!anchorResult.visible) return null;
 
 	return (
@@ -138,7 +141,8 @@ export function ShapeAnchorOverlay({
 				position: "absolute",
 				left: clamped.left,
 				top: clamped.top,
-				pointerEvents: "auto",
+				pointerEvents: interacting ? "none" : "auto",
+				visibility: interacting ? "hidden" : "visible",
 				...style,
 			}}
 		>

--- a/packages/canvas-engine/src/components/shape-anchor-overlay.tsx
+++ b/packages/canvas-engine/src/components/shape-anchor-overlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from "react";
+import { useApp } from "../context.js";
 import { useAnchorStack, useAnchorStackOffset } from "../hooks/use-anchor-stack.js";
 import { useInteracting } from "../hooks/use-interacting.js";
 import { useShapeAnchorPosition } from "../hooks/use-shape-anchor-position.js";
@@ -129,7 +130,8 @@ export function ShapeAnchorOverlay({
 		return () => registry.unregister(overlayId);
 	}, [registry, overlayId]);
 
-	const interacting = useInteracting();
+	const app = useApp();
+	const interacting = useInteracting(app.events);
 
 	if (!anchorResult.visible) return null;
 

--- a/packages/canvas-engine/src/hooks/use-interacting.ts
+++ b/packages/canvas-engine/src/hooks/use-interacting.ts
@@ -1,0 +1,82 @@
+import { useEffect, useSyncExternalStore } from "react";
+
+/**
+ * Global "interacting" state — true when user is dragging (pointerdown + pointermove).
+ *
+ * Used by ShapeAnchorOverlay to hide toolbars during drag operations.
+ * Purely DOM-level detection, no dependency on specific tools or plugins.
+ */
+
+let interacting = false;
+let pointerIsDown = false;
+const listeners = new Set<() => void>();
+
+function notify() {
+	for (const fn of listeners) fn();
+}
+
+function setInteracting(value: boolean) {
+	if (interacting === value) return;
+	interacting = value;
+	notify();
+}
+
+function getInteracting(): boolean {
+	return interacting;
+}
+
+function subscribe(cb: () => void): () => void {
+	listeners.add(cb);
+	return () => listeners.delete(cb);
+}
+
+// Single global listener setup (shared across all hook instances)
+let listenerCount = 0;
+
+function onPointerDown() {
+	pointerIsDown = true;
+}
+
+function onPointerMove() {
+	if (pointerIsDown && !interacting) {
+		setInteracting(true);
+	}
+}
+
+function onPointerUp() {
+	pointerIsDown = false;
+	if (interacting) {
+		setInteracting(false);
+	}
+}
+
+function addGlobalListeners() {
+	window.addEventListener("pointerdown", onPointerDown, true);
+	window.addEventListener("pointermove", onPointerMove, true);
+	window.addEventListener("pointerup", onPointerUp, true);
+}
+
+function removeGlobalListeners() {
+	window.removeEventListener("pointerdown", onPointerDown, true);
+	window.removeEventListener("pointermove", onPointerMove, true);
+	window.removeEventListener("pointerup", onPointerUp, true);
+	pointerIsDown = false;
+	setInteracting(false);
+}
+
+/**
+ * Returns `true` when the user is currently dragging (pointerdown + pointermove).
+ * Automatically manages global pointer listeners.
+ */
+export function useInteracting(): boolean {
+	useEffect(() => {
+		listenerCount++;
+		if (listenerCount === 1) addGlobalListeners();
+		return () => {
+			listenerCount--;
+			if (listenerCount === 0) removeGlobalListeners();
+		};
+	}, []);
+
+	return useSyncExternalStore(subscribe, getInteracting, getInteracting);
+}

--- a/packages/canvas-engine/src/hooks/use-interacting.ts
+++ b/packages/canvas-engine/src/hooks/use-interacting.ts
@@ -1,10 +1,14 @@
+import type { EventBus } from "@edv4h/usketch-shared";
 import { useEffect, useSyncExternalStore } from "react";
 
 /**
- * Global "interacting" state — true when user is dragging (pointerdown + pointermove).
+ * Canvas-scoped "interacting" state — true when user is dragging on the canvas.
  *
- * Used by ShapeAnchorOverlay to hide toolbars during drag operations.
- * Purely DOM-level detection, no dependency on specific tools or plugins.
+ * Listens to canvas:pointerdown / canvas:pointermove / canvas:pointerup events
+ * via the EventBus, so only canvas interactions are detected (not scrollbar drags,
+ * panel resizes, etc.).
+ *
+ * Also handles pointercancel and window blur to avoid stuck state.
  */
 
 let interacting = false;
@@ -30,53 +34,53 @@ function subscribe(cb: () => void): () => void {
 	return () => listeners.delete(cb);
 }
 
-// Single global listener setup (shared across all hook instances)
-let listenerCount = 0;
-
-function onPointerDown() {
-	pointerIsDown = true;
-}
-
-function onPointerMove() {
-	if (pointerIsDown && !interacting) {
-		setInteracting(true);
-	}
-}
-
-function onPointerUp() {
-	pointerIsDown = false;
-	if (interacting) {
-		setInteracting(false);
-	}
-}
-
-function addGlobalListeners() {
-	window.addEventListener("pointerdown", onPointerDown, true);
-	window.addEventListener("pointermove", onPointerMove, true);
-	window.addEventListener("pointerup", onPointerUp, true);
-}
-
-function removeGlobalListeners() {
-	window.removeEventListener("pointerdown", onPointerDown, true);
-	window.removeEventListener("pointermove", onPointerMove, true);
-	window.removeEventListener("pointerup", onPointerUp, true);
+function reset() {
 	pointerIsDown = false;
 	setInteracting(false);
 }
 
 /**
- * Returns `true` when the user is currently dragging (pointerdown + pointermove).
- * Automatically manages global pointer listeners.
+ * Returns `true` when the user is currently dragging on the canvas.
+ * @param events - The app EventBus to listen for canvas pointer events.
  */
-export function useInteracting(): boolean {
+export function useInteracting(events: EventBus): boolean {
 	useEffect(() => {
-		listenerCount++;
-		if (listenerCount === 1) addGlobalListeners();
+		const offDown = events.on("canvas:pointerdown", () => {
+			pointerIsDown = true;
+		});
+
+		const offMove = events.on("canvas:pointermove", () => {
+			if (pointerIsDown && !interacting) {
+				setInteracting(true);
+			}
+		});
+
+		const offUp = events.on("canvas:pointerup", () => {
+			reset();
+		});
+
+		// Safety: reset on pointercancel / window blur / visibility change
+		function onPointerCancel() {
+			reset();
+		}
+		function onBlur() {
+			reset();
+		}
+
+		window.addEventListener("pointercancel", onPointerCancel, true);
+		window.addEventListener("blur", onBlur);
+		document.addEventListener("visibilitychange", onBlur);
+
 		return () => {
-			listenerCount--;
-			if (listenerCount === 0) removeGlobalListeners();
+			offDown();
+			offMove();
+			offUp();
+			window.removeEventListener("pointercancel", onPointerCancel, true);
+			window.removeEventListener("blur", onBlur);
+			document.removeEventListener("visibilitychange", onBlur);
+			reset();
 		};
-	}, []);
+	}, [events]);
 
 	return useSyncExternalStore(subscribe, getInteracting, getInteracting);
 }

--- a/packages/canvas-engine/src/index.ts
+++ b/packages/canvas-engine/src/index.ts
@@ -6,6 +6,7 @@ export { ShapeLayer } from "./components/shape-layer.js";
 export { TransientLayer } from "./components/transient-layer.js";
 export { AppProvider, useApp } from "./context.js";
 export { getTransformStyle, screenToWorld, worldToScreen } from "./coordinate-transformer.js";
+export { useInteracting } from "./hooks/use-interacting.js";
 export { useShapeAnchorPosition } from "./hooks/use-shape-anchor-position.js";
 export { useStoreSubscribe } from "./hooks/use-store-subscribe.js";
 export { useViewportClamp } from "./hooks/use-viewport-clamp.js";

--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -122,6 +122,7 @@ export const snapPlugin: UsketchPlugin = {
 			pointerDown = true;
 			frameSnapResult = null;
 			frameCandidateBoxes = null;
+			setState({ lines: [] });
 		});
 
 		const offPointerUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", () => {
@@ -181,6 +182,13 @@ export const snapPlugin: UsketchPlugin = {
 			const shape = ctx.store.getShape(id);
 			if (!shape) {
 				originalUpdateShape(id, updates);
+				return;
+			}
+
+			// Skip snap for connectors — they have their own anchor/snap logic
+			if (shape.type === "connector") {
+				originalUpdateShape(id, updates);
+				setState({ lines: [] });
 				return;
 			}
 
@@ -453,12 +461,40 @@ function getCandidateBoxes(
 	viewport: Viewport | null,
 ): Map<string, BoundingBox> {
 	const visibleRect = viewport ? getVisibleWorldRect(viewport) : null;
+
+	// Determine the parent context of moving shapes.
+	// All moving shapes should share the same parent (or all be top-level).
+	let movingParentId: string | null | undefined;
+	for (const id of movingIds) {
+		const s = store.getShape(id);
+		if (!s) continue;
+		const pid = (s.parentId as string | undefined) ?? null;
+		if (movingParentId === undefined) {
+			movingParentId = pid;
+		} else if (movingParentId !== pid) {
+			// Mixed parents — skip frame-based filtering
+			movingParentId = undefined;
+			break;
+		}
+	}
+
 	const boxes = new Map<string, BoundingBox>();
 	for (const [id, shape] of store.getShapes()) {
 		if (movingIds.has(id)) continue;
+		// Connectors are never snap targets
+		if (shape.type === "connector") continue;
 		// Exclude children of moving shapes so a frame doesn't snap to its own children
-		const parentId = shape.parentId as string | undefined;
+		const parentId = (shape.parentId as string | undefined) ?? null;
 		if (parentId && movingIds.has(parentId)) continue;
+
+		// Only snap within the same frame context:
+		// - If moving shapes are inside a frame, only snap to siblings in the same frame
+		//   (also allow snapping to the parent frame itself)
+		// - If moving shapes are top-level, don't snap to shapes inside frames
+		if (movingParentId !== undefined) {
+			if (parentId !== movingParentId && id !== movingParentId) continue;
+		}
+
 		const def = ctx.shapes.get(shape.type);
 		const box = def
 			? def.getBounds(shape)

--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -462,18 +462,17 @@ function getCandidateBoxes(
 ): Map<string, BoundingBox> {
 	const visibleRect = viewport ? getVisibleWorldRect(viewport) : null;
 
-	// Determine the parent context of moving shapes.
-	// All moving shapes should share the same parent (or all be top-level).
-	let movingParentId: string | null | undefined;
+	// Determine the nearest frame ancestor of moving shapes.
+	// Walk up the parentId chain to find the first "frame" type ancestor.
+	// This correctly handles shapes inside groups within frames.
+	let movingFrameId: string | null | undefined;
 	for (const id of movingIds) {
-		const s = store.getShape(id);
-		if (!s) continue;
-		const pid = (s.parentId as string | undefined) ?? null;
-		if (movingParentId === undefined) {
-			movingParentId = pid;
-		} else if (movingParentId !== pid) {
-			// Mixed parents — skip frame-based filtering
-			movingParentId = undefined;
+		const frameId = getNearestFrameAncestor(store, id);
+		if (movingFrameId === undefined) {
+			movingFrameId = frameId;
+		} else if (movingFrameId !== frameId) {
+			// Mixed frame contexts — skip frame-based filtering
+			movingFrameId = undefined;
 			break;
 		}
 	}
@@ -484,15 +483,16 @@ function getCandidateBoxes(
 		// Connectors are never snap targets
 		if (shape.type === "connector") continue;
 		// Exclude children of moving shapes so a frame doesn't snap to its own children
-		const parentId = (shape.parentId as string | undefined) ?? null;
+		const parentId = shape.parentId as string | undefined;
 		if (parentId && movingIds.has(parentId)) continue;
 
 		// Only snap within the same frame context:
-		// - If moving shapes are inside a frame, only snap to siblings in the same frame
+		// - If moving shapes are inside a frame, only snap to shapes in the same frame
 		//   (also allow snapping to the parent frame itself)
 		// - If moving shapes are top-level, don't snap to shapes inside frames
-		if (movingParentId !== undefined) {
-			if (parentId !== movingParentId && id !== movingParentId) continue;
+		if (movingFrameId !== undefined) {
+			const candidateFrameId = getNearestFrameAncestor(store, id);
+			if (candidateFrameId !== movingFrameId && id !== movingFrameId) continue;
 		}
 
 		const def = ctx.shapes.get(shape.type);
@@ -503,4 +503,22 @@ function getCandidateBoxes(
 		boxes.set(id, box);
 	}
 	return boxes;
+}
+
+/** Walk up the parentId chain to find the nearest frame-type ancestor. Returns null if top-level. */
+function getNearestFrameAncestor(store: BoardStore, shapeId: string): string | null {
+	let currentId = shapeId;
+	const visited = new Set<string>();
+	for (;;) {
+		const shape = store.getShape(currentId);
+		if (!shape) return null;
+		const pid = shape.parentId as string | undefined;
+		if (!pid) return null;
+		if (visited.has(pid)) return null; // circular reference guard
+		visited.add(pid);
+		const parent = store.getShape(pid);
+		if (!parent) return null;
+		if (parent.type === "frame") return pid;
+		currentId = pid;
+	}
 }


### PR DESCRIPTION
## Summary

- フレーム内外のシェイプ間でスナップしないよう制御を追加
- コネクタをスナップ対象から除外（独自アンカーロジックのため）
- ドラッグ中にShapeAnchorOverlay（スタイルパネル・AIバー・コネクタプロパティバー）を非表示にする共通ロジックを追加

## Test plan

- [ ] フレーム内のシェイプを移動 → フレーム外のシェイプにスナップしないこと
- [ ] フレーム外のシェイプを移動 → フレーム内のシェイプにスナップしないこと
- [ ] フレーム内のシェイプを移動 → 同じフレーム内の兄弟・親フレームにスナップすること
- [ ] コネクタ作成・移動時にスナップガイドが表示されないこと
- [ ] シェイプをドラッグ中にツールバー類が非表示になること
- [ ] ドラッグ終了後にツールバーが正しい位置で再表示されること（位置ずれなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)