### PR TITLE
MCP サーバー本番接続 + CLI 認証フロー (Device Authorization Grant)

### DIFF
--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -4,6 +4,13 @@
 			"command": "node",
 			"args": ["./apps/mcp-server/dist/index.js"],
 			"env": {
+				"USKETCH_SERVER_URL": "https://usketch-web.pages.dev"
+			}
+		},
+		"usketch-dev": {
+			"command": "node",
+			"args": ["./apps/mcp-server/dist/index.js"],
+			"env": {
 				"USKETCH_SERVER_URL": "http://localhost:8787",
 				"USKETCH_DEV_MODE": "true",
 				"USKETCH_DEV_USER_ID": "dev-user-1"

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -18,6 +18,7 @@
 		"@edv4h/usketch-shared": "workspace:*",
 		"@edv4h/usketch-sync": "workspace:*",
 		"@modelcontextprotocol/sdk": "^1.12.1",
+		"open": "11.0.0",
 		"ws": "^8.18.0",
 		"yjs": "^13.6.0",
 		"zod": "^3.24.0"

--- a/apps/mcp-server/src/auth/cli-auth.ts
+++ b/apps/mcp-server/src/auth/cli-auth.ts
@@ -1,0 +1,147 @@
+import { clearToken, loadToken, saveToken } from "./token-store.js";
+
+interface DeviceCodeResponse {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	verification_uri_complete: string;
+	expires_in: number;
+	interval: number;
+}
+
+interface TokenResponse {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	scope: string;
+}
+
+interface ErrorResponse {
+	error: string;
+	error_description: string;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Authenticate via Device Authorization Grant (RFC 8628).
+ * Opens a browser for the user to approve, then polls for the token.
+ */
+async function performDeviceAuth(serverUrl: string): Promise<{ token: string; expiresIn: number }> {
+	// Step 1: Request device code
+	const codeRes = await fetch(`${serverUrl}/api/auth/device/code`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ client_id: "usketch-mcp-cli" }),
+	});
+
+	if (!codeRes.ok) {
+		const err = (await codeRes.json().catch(() => null)) as ErrorResponse | null;
+		throw new Error(
+			`Failed to request device code: ${err?.error_description ?? codeRes.statusText}`,
+		);
+	}
+
+	const codeData = (await codeRes.json()) as DeviceCodeResponse;
+
+	// Step 2: Display instructions and open browser
+	console.error("");
+	console.error("=== uSketch CLI Authentication ===");
+	console.error(`Open this URL in your browser: ${codeData.verification_uri_complete}`);
+	console.error(`Your code: ${codeData.user_code}`);
+	console.error("");
+
+	// Dynamic import for ESM-only `open` package
+	try {
+		const { default: open } = await import("open");
+		await open(codeData.verification_uri_complete);
+		console.error("Browser opened automatically. Waiting for approval...");
+	} catch {
+		console.error("Could not open browser automatically. Please open the URL manually.");
+	}
+
+	// Step 3: Poll for token
+	let interval = codeData.interval * 1000; // Convert to ms
+	const deadline = Date.now() + codeData.expires_in * 1000;
+
+	while (Date.now() < deadline) {
+		await sleep(interval);
+
+		const tokenRes = await fetch(`${serverUrl}/api/auth/device/token`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+				device_code: codeData.device_code,
+				client_id: "usketch-mcp-cli",
+			}),
+		});
+
+		if (tokenRes.ok) {
+			const tokenData = (await tokenRes.json()) as TokenResponse;
+			console.error("Authentication successful!");
+			return { token: tokenData.access_token, expiresIn: tokenData.expires_in };
+		}
+
+		const errData = (await tokenRes.json().catch(() => null)) as ErrorResponse | null;
+		const errorCode = errData?.error;
+
+		if (errorCode === "authorization_pending") {
+			continue;
+		}
+		if (errorCode === "slow_down") {
+			interval += 5000;
+			continue;
+		}
+		if (errorCode === "expired_token") {
+			throw new Error("Authentication timed out. Please try again.");
+		}
+		if (errorCode === "access_denied") {
+			throw new Error("Authentication was denied by the user.");
+		}
+
+		throw new Error(
+			`Unexpected error during authentication: ${errData?.error_description ?? errorCode}`,
+		);
+	}
+
+	throw new Error("Authentication timed out. Please try again.");
+}
+
+/**
+ * Validate an existing token by calling the session endpoint.
+ */
+async function validateToken(serverUrl: string, token: string): Promise<boolean> {
+	try {
+		const res = await fetch(`${serverUrl}/api/auth/get-session`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		return res.ok;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Get a valid API token for the given server URL.
+ * Tries cached token first, falls back to CLI auth flow.
+ */
+export async function getApiToken(serverUrl: string): Promise<string> {
+	// Try cached token
+	const cached = loadToken(serverUrl);
+	if (cached) {
+		const valid = await validateToken(serverUrl, cached.token);
+		if (valid) {
+			return cached.token;
+		}
+		console.error("Cached token is invalid. Re-authenticating...");
+		clearToken(serverUrl);
+	}
+
+	// Run device auth flow
+	const { token, expiresIn } = await performDeviceAuth(serverUrl);
+	saveToken(serverUrl, token, expiresIn);
+	return token;
+}

--- a/apps/mcp-server/src/auth/token-store.ts
+++ b/apps/mcp-server/src/auth/token-store.ts
@@ -31,7 +31,7 @@ function readTokenFile(): TokenFile {
 
 function writeTokenFile(data: TokenFile): void {
 	ensureDir();
-	writeFileSync(TOKEN_FILE, JSON.stringify(data, null, 2), "utf-8");
+	writeFileSync(TOKEN_FILE, JSON.stringify(data, null, 2), { encoding: "utf-8", mode: 0o600 });
 }
 
 export function loadToken(serverUrl: string): StoredToken | null {
@@ -43,8 +43,10 @@ export function loadToken(serverUrl: string): StoredToken | null {
 	const expiresAt = new Date(entry.expiresAt).getTime();
 	const now = Date.now();
 	const oneHour = 60 * 60 * 1000;
-	if (expiresAt - oneHour < now) {
-		return null; // Expired or about to expire
+	if (Number.isNaN(expiresAt) || expiresAt - oneHour < now) {
+		delete data[serverUrl];
+		writeTokenFile(data);
+		return null; // Invalid, expired, or about to expire
 	}
 
 	return entry;

--- a/apps/mcp-server/src/auth/token-store.ts
+++ b/apps/mcp-server/src/auth/token-store.ts
@@ -1,0 +1,66 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface StoredToken {
+	token: string;
+	expiresAt: string; // ISO 8601
+}
+
+interface TokenFile {
+	[serverUrl: string]: StoredToken;
+}
+
+const CONFIG_DIR = join(homedir(), ".config", "usketch");
+const TOKEN_FILE = join(CONFIG_DIR, "tokens.json");
+
+function ensureDir(): void {
+	if (!existsSync(CONFIG_DIR)) {
+		mkdirSync(CONFIG_DIR, { recursive: true });
+	}
+}
+
+function readTokenFile(): TokenFile {
+	try {
+		const raw = readFileSync(TOKEN_FILE, "utf-8");
+		return JSON.parse(raw) as TokenFile;
+	} catch {
+		return {};
+	}
+}
+
+function writeTokenFile(data: TokenFile): void {
+	ensureDir();
+	writeFileSync(TOKEN_FILE, JSON.stringify(data, null, 2), "utf-8");
+}
+
+export function loadToken(serverUrl: string): StoredToken | null {
+	const data = readTokenFile();
+	const entry = data[serverUrl];
+	if (!entry) return null;
+
+	// Check expiry (with 1 hour buffer)
+	const expiresAt = new Date(entry.expiresAt).getTime();
+	const now = Date.now();
+	const oneHour = 60 * 60 * 1000;
+	if (expiresAt - oneHour < now) {
+		return null; // Expired or about to expire
+	}
+
+	return entry;
+}
+
+export function saveToken(serverUrl: string, token: string, expiresInSeconds: number): void {
+	const data = readTokenFile();
+	data[serverUrl] = {
+		token,
+		expiresAt: new Date(Date.now() + expiresInSeconds * 1000).toISOString(),
+	};
+	writeTokenFile(data);
+}
+
+export function clearToken(serverUrl: string): void {
+	const data = readTokenFile();
+	delete data[serverUrl];
+	writeTokenFile(data);
+}

--- a/apps/mcp-server/src/config.ts
+++ b/apps/mcp-server/src/config.ts
@@ -2,6 +2,8 @@
  * MCP サーバー設定
  * 環境変数から接続情報を読み取る
  */
+import { getApiToken } from "./auth/cli-auth.js";
+
 export interface McpConfig {
 	/** uSketch サーバーURL (例: http://localhost:8787) */
 	serverUrl: string;
@@ -15,17 +17,15 @@ export interface McpConfig {
 	apiToken: string | undefined;
 }
 
-export function loadConfig(): McpConfig {
+export async function loadConfig(): Promise<McpConfig> {
 	const serverUrl = (process.env.USKETCH_SERVER_URL ?? "http://localhost:8787").replace(/\/$/, "");
 	const devMode = process.env.USKETCH_DEV_MODE === "true";
 	const devUserId = process.env.USKETCH_DEV_USER_ID ?? "dev-user-1";
-	const apiToken = process.env.USKETCH_API_TOKEN;
+	let apiToken = process.env.USKETCH_API_TOKEN;
 
 	if (!devMode && !apiToken) {
-		throw new Error(
-			"USKETCH_API_TOKEN is required when USKETCH_DEV_MODE is not enabled. " +
-				"Set USKETCH_DEV_MODE=true for local development or provide an API token.",
-		);
+		// No token provided — try CLI authentication
+		apiToken = await getApiToken(serverUrl);
 	}
 
 	// HTTP → WS URL 変換

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -23,7 +23,7 @@ async function main(): Promise<void> {
 		}
 	}
 
-	const config = loadConfig();
+	const config = await loadConfig();
 	const { server, connections } = createMcpServer(config);
 
 	if (isHttp) {

--- a/apps/server/migrations/0004_magenta_warbird.sql
+++ b/apps/server/migrations/0004_magenta_warbird.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `device_code` (
+	`id` text PRIMARY KEY NOT NULL,
+	`deviceCode` text NOT NULL,
+	`userCode` text NOT NULL,
+	`userId` text,
+	`expiresAt` integer NOT NULL,
+	`status` text NOT NULL,
+	`lastPolledAt` integer,
+	`pollingInterval` integer,
+	`clientId` text,
+	`scope` text
+);

--- a/apps/server/migrations/meta/0004_snapshot.json
+++ b/apps/server/migrations/meta/0004_snapshot.json
@@ -1,0 +1,1066 @@
+{
+	"version": "6",
+	"dialect": "sqlite",
+	"id": "e451405b-daf2-46bc-b07a-94fbff631f33",
+	"prevId": "ae9e3cfc-caed-42a2-bcb3-56647dea0c2d",
+	"tables": {
+		"account": {
+			"name": "account",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accountId": {
+					"name": "accountId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"providerId": {
+					"name": "providerId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"accessToken": {
+					"name": "accessToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"idToken": {
+					"name": "idToken",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"refreshTokenExpiresAt": {
+					"name": "refreshTokenExpiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"password": {
+					"name": "password",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"account_userId_user_id_fk": {
+					"name": "account_userId_user_id_fk",
+					"tableFrom": "account",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"activity_log": {
+			"name": "activity_log",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"board_id": {
+					"name": "board_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"action": {
+					"name": "action",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"target_id": {
+					"name": "target_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"summary": {
+					"name": "summary",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_activity_log_board": {
+					"name": "idx_activity_log_board",
+					"columns": ["board_id", "created_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"activity_log_board_id_boards_id_fk": {
+					"name": "activity_log_board_id_boards_id_fk",
+					"tableFrom": "activity_log",
+					"tableTo": "boards",
+					"columnsFrom": ["board_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"board_members": {
+			"name": "board_members",
+			"columns": {
+				"board_id": {
+					"name": "board_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"role": {
+					"name": "role",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'editor'"
+				},
+				"last_viewport": {
+					"name": "last_viewport",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"last_seen_at": {
+					"name": "last_seen_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'offline'"
+				}
+			},
+			"indexes": {
+				"idx_board_members_user_id": {
+					"name": "idx_board_members_user_id",
+					"columns": ["user_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"board_members_board_id_boards_id_fk": {
+					"name": "board_members_board_id_boards_id_fk",
+					"tableFrom": "board_members",
+					"tableTo": "boards",
+					"columnsFrom": ["board_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"board_members_user_id_user_id_fk": {
+					"name": "board_members_user_id_user_id_fk",
+					"tableFrom": "board_members",
+					"tableTo": "user",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"board_members_board_id_user_id_pk": {
+					"columns": ["board_id", "user_id"],
+					"name": "board_members_board_id_user_id_pk"
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"boards": {
+			"name": "boards",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"title": {
+					"name": "title",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'Untitled'"
+				},
+				"owner_id": {
+					"name": "owner_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				},
+				"is_public": {
+					"name": "is_public",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"boards_owner_id_user_id_fk": {
+					"name": "boards_owner_id_user_id_fk",
+					"tableFrom": "boards",
+					"tableTo": "user",
+					"columnsFrom": ["owner_id"],
+					"columnsTo": ["id"],
+					"onDelete": "no action",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"chat_messages": {
+			"name": "chat_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"board_id": {
+					"name": "board_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"thread_id": {
+					"name": "thread_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'default'"
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_name": {
+					"name": "author_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_chat_messages_board": {
+					"name": "idx_chat_messages_board",
+					"columns": ["board_id"],
+					"isUnique": false
+				},
+				"idx_chat_messages_thread": {
+					"name": "idx_chat_messages_thread",
+					"columns": ["board_id", "thread_id", "created_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"chat_messages_board_id_boards_id_fk": {
+					"name": "chat_messages_board_id_boards_id_fk",
+					"tableFrom": "chat_messages",
+					"tableTo": "boards",
+					"columnsFrom": ["board_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comment_messages": {
+			"name": "comment_messages",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"comment_id": {
+					"name": "comment_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"author_id": {
+					"name": "author_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_comment_messages_comment": {
+					"name": "idx_comment_messages_comment",
+					"columns": ["comment_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"comment_messages_comment_id_comments_id_fk": {
+					"name": "comment_messages_comment_id_comments_id_fk",
+					"tableFrom": "comment_messages",
+					"tableTo": "comments",
+					"columnsFrom": ["comment_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"comments": {
+			"name": "comments",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"board_id": {
+					"name": "board_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"anchor_shape_id": {
+					"name": "anchor_shape_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"anchor_x": {
+					"name": "anchor_x",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"anchor_y": {
+					"name": "anchor_y",
+					"type": "real",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"resolved": {
+					"name": "resolved",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_by": {
+					"name": "created_by",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				},
+				"updated_at": {
+					"name": "updated_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_comments_board": {
+					"name": "idx_comments_board",
+					"columns": ["board_id"],
+					"isUnique": false
+				},
+				"idx_comments_shape": {
+					"name": "idx_comments_shape",
+					"columns": ["anchor_shape_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"comments_board_id_boards_id_fk": {
+					"name": "comments_board_id_boards_id_fk",
+					"tableFrom": "comments",
+					"tableTo": "boards",
+					"columnsFrom": ["board_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"community_boards": {
+			"name": "community_boards",
+			"columns": {
+				"board_id": {
+					"name": "board_id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"slug": {
+					"name": "slug",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"display_name": {
+					"name": "display_name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "''"
+				},
+				"theme_color": {
+					"name": "theme_color",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'#6366f1'"
+				},
+				"icon": {
+					"name": "icon",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'🏠'"
+				},
+				"grid_x": {
+					"name": "grid_x",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"grid_y": {
+					"name": "grid_y",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"sort_order": {
+					"name": "sort_order",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"community_boards_slug_unique": {
+					"name": "community_boards_slug_unique",
+					"columns": ["slug"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"community_boards_board_id_boards_id_fk": {
+					"name": "community_boards_board_id_boards_id_fk",
+					"tableFrom": "community_boards",
+					"tableTo": "boards",
+					"columnsFrom": ["board_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"device_code": {
+			"name": "device_code",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"deviceCode": {
+					"name": "deviceCode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userCode": {
+					"name": "userCode",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"status": {
+					"name": "status",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"lastPolledAt": {
+					"name": "lastPolledAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pollingInterval": {
+					"name": "pollingInterval",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"clientId": {
+					"name": "clientId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"scope": {
+					"name": "scope",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"notifications": {
+			"name": "notifications",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"board_id": {
+					"name": "board_id",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type": {
+					"name": "type",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"payload": {
+					"name": "payload",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"read": {
+					"name": "read",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": 0
+				},
+				"created_at": {
+					"name": "created_at",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+				}
+			},
+			"indexes": {
+				"idx_notifications_user": {
+					"name": "idx_notifications_user",
+					"columns": ["user_id", "read", "created_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"notifications_board_id_boards_id_fk": {
+					"name": "notifications_board_id_boards_id_fk",
+					"tableFrom": "notifications",
+					"tableTo": "boards",
+					"columnsFrom": ["board_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"session": {
+			"name": "session",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"token": {
+					"name": "token",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"ipAddress": {
+					"name": "ipAddress",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"userAgent": {
+					"name": "userAgent",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"userId": {
+					"name": "userId",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"session_token_unique": {
+					"name": "session_token_unique",
+					"columns": ["token"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {
+				"session_userId_user_id_fk": {
+					"name": "session_userId_user_id_fk",
+					"tableFrom": "session",
+					"tableTo": "user",
+					"columnsFrom": ["userId"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"user": {
+			"name": "user",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"emailVerified": {
+					"name": "emailVerified",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": false
+				},
+				"image": {
+					"name": "image",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"user_email_unique": {
+					"name": "user_email_unique",
+					"columns": ["email"],
+					"isUnique": true
+				}
+			},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		},
+		"verification": {
+			"name": "verification",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "text",
+					"primaryKey": true,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"value": {
+					"name": "value",
+					"type": "text",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"expiresAt": {
+					"name": "expiresAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"createdAt": {
+					"name": "createdAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"updatedAt": {
+					"name": "updatedAt",
+					"type": "integer",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {},
+			"uniqueConstraints": {},
+			"checkConstraints": {}
+		}
+	},
+	"views": {},
+	"enums": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"indexes": {}
+	}
+}

--- a/apps/server/migrations/meta/_journal.json
+++ b/apps/server/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1775022791874,
 			"tag": "0003_tan_hairball",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "6",
+			"when": 1776237902742,
+			"tag": "0004_magenta_warbird",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -51,7 +51,7 @@ export function createAuth(env: Env) {
 		plugins: [
 			bearer(),
 			deviceAuthorization({
-				verificationUri: `${env.BETTER_AUTH_URL}/device`,
+				verificationUri: new URL("/device", env.BETTER_AUTH_URL).toString(),
 			}),
 		],
 		advanced: {

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -1,5 +1,7 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { bearer } from "better-auth/plugins/bearer";
+import { deviceAuthorization } from "better-auth/plugins/device-authorization";
 import { drizzle } from "drizzle-orm/d1";
 import { ALLOWED_ORIGINS } from "./config.js";
 import * as schema from "./db/schema.js";
@@ -16,6 +18,7 @@ export function createAuth(env: Env) {
 				session: schema.sessions,
 				account: schema.accounts,
 				verification: schema.verifications,
+				deviceCode: schema.deviceCodes,
 			},
 		}),
 		secret: env.BETTER_AUTH_SECRET,
@@ -45,6 +48,12 @@ export function createAuth(env: Env) {
 				enabled: false,
 			},
 		},
+		plugins: [
+			bearer(),
+			deviceAuthorization({
+				verificationUri: `${env.BETTER_AUTH_URL}/device`,
+			}),
+		],
 		advanced: {
 			defaultCookieAttributes:
 				env.DEV_MODE === "true"

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -53,6 +53,19 @@ export const verifications = sqliteTable("verification", {
 	updatedAt: integer("updatedAt", { mode: "timestamp" }),
 });
 
+export const deviceCodes = sqliteTable("device_code", {
+	id: text("id").primaryKey(),
+	deviceCode: text("deviceCode").notNull(),
+	userCode: text("userCode").notNull(),
+	userId: text("userId"),
+	expiresAt: integer("expiresAt", { mode: "timestamp" }).notNull(),
+	status: text("status").notNull(),
+	lastPolledAt: integer("lastPolledAt", { mode: "timestamp" }),
+	pollingInterval: integer("pollingInterval"),
+	clientId: text("clientId"),
+	scope: text("scope"),
+});
+
 // ── アプリケーション テーブル ──
 
 export const boards = sqliteTable("boards", {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { App } from "./app.js";
 import { CommunityPage } from "./pages/community/index.js";
 import { DashboardPage } from "./pages/dashboard.js";
+import { DevicePage } from "./pages/device.js";
 import { LoginPage } from "./pages/login.js";
 
 const BenchmarkPage = lazy(() =>
@@ -21,6 +22,7 @@ if (root) {
 				<Suspense>
 					<Routes>
 						<Route path="/login" element={<LoginPage />} />
+						<Route path="/device" element={<DevicePage />} />
 						<Route path="/benchmark" element={<BenchmarkPage />} />
 						<Route path="/boards/:boardId" element={<App />} />
 						<Route path="/local/:boardId" element={<App />} />

--- a/apps/web/src/pages/device.tsx
+++ b/apps/web/src/pages/device.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "react-router";
 import { useAuth } from "../lib/use-auth.js";
 
@@ -151,7 +151,7 @@ export function DevicePage() {
 	);
 }
 
-function CenterLayout({ children }: { children: React.ReactNode }) {
+function CenterLayout({ children }: { children: ReactNode }) {
 	return (
 		<div
 			style={{

--- a/apps/web/src/pages/device.tsx
+++ b/apps/web/src/pages/device.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
+import { useAuth } from "../lib/use-auth.js";
+
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
+
+type Status = "idle" | "approving" | "approved" | "denied" | "error";
+
+export function DevicePage() {
+	const { user, isPending } = useAuth();
+	const [searchParams] = useSearchParams();
+	const userCode = searchParams.get("user_code");
+	const [status, setStatus] = useState<Status>("idle");
+	const [error, setError] = useState<string | null>(null);
+
+	// Redirect to login if not authenticated
+	useEffect(() => {
+		if (isPending) return;
+		if (!user) {
+			const redirect = `/device${userCode ? `?user_code=${userCode}` : ""}`;
+			window.location.href = `/login?redirect=${encodeURIComponent(redirect)}`;
+		}
+	}, [user, isPending, userCode]);
+
+	const handleApprove = useCallback(async () => {
+		if (!userCode) return;
+		setStatus("approving");
+		try {
+			const res = await fetch(`${API_URL}/api/auth/device/approve`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				credentials: "include",
+				body: JSON.stringify({ userCode }),
+			});
+			if (!res.ok) {
+				const data = await res.json().catch(() => null);
+				throw new Error(data?.error_description ?? `HTTP ${res.status}`);
+			}
+			setStatus("approved");
+		} catch (e) {
+			setError(e instanceof Error ? e.message : "Unknown error");
+			setStatus("error");
+		}
+	}, [userCode]);
+
+	const handleDeny = useCallback(async () => {
+		if (!userCode) return;
+		try {
+			await fetch(`${API_URL}/api/auth/device/deny`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				credentials: "include",
+				body: JSON.stringify({ userCode }),
+			});
+		} catch {
+			// ignore
+		}
+		setStatus("denied");
+	}, [userCode]);
+
+	if (isPending) {
+		return <CenterLayout>Loading...</CenterLayout>;
+	}
+
+	if (!userCode) {
+		return (
+			<CenterLayout>
+				<h2 style={{ margin: 0 }}>Invalid Request</h2>
+				<p style={{ color: "#666" }}>No user code provided.</p>
+			</CenterLayout>
+		);
+	}
+
+	if (status === "approved") {
+		return (
+			<CenterLayout>
+				<div style={{ fontSize: "48px" }}>✓</div>
+				<h2 style={{ margin: 0, color: "#16a34a" }}>Approved</h2>
+				<p style={{ color: "#666" }}>Device has been authorized. You can close this tab.</p>
+			</CenterLayout>
+		);
+	}
+
+	if (status === "denied") {
+		return (
+			<CenterLayout>
+				<h2 style={{ margin: 0, color: "#dc2626" }}>Denied</h2>
+				<p style={{ color: "#666" }}>Device authorization was denied. You can close this tab.</p>
+			</CenterLayout>
+		);
+	}
+
+	return (
+		<CenterLayout>
+			<h1 style={{ fontSize: "1.5rem", margin: 0 }}>uSketch</h1>
+			<h2 style={{ margin: 0 }}>Authorize Device</h2>
+			<p style={{ color: "#666" }}>A device is requesting access to your account.</p>
+
+			<div
+				style={{
+					background: "#f5f5f5",
+					padding: "16px 32px",
+					borderRadius: "8px",
+					fontFamily: "monospace",
+					fontSize: "1.5rem",
+					letterSpacing: "0.2em",
+					userSelect: "all",
+				}}
+			>
+				{userCode}
+			</div>
+
+			{error && <p style={{ color: "#dc2626", fontSize: "14px" }}>{error}</p>}
+
+			<div style={{ display: "flex", gap: "12px", marginTop: "8px" }}>
+				<button
+					type="button"
+					onClick={handleApprove}
+					disabled={status === "approving"}
+					style={{
+						padding: "12px 32px",
+						fontSize: "14px",
+						cursor: status === "approving" ? "wait" : "pointer",
+						border: "none",
+						borderRadius: "6px",
+						background: "#16a34a",
+						color: "#fff",
+						opacity: status === "approving" ? 0.7 : 1,
+					}}
+				>
+					{status === "approving" ? "Authorizing..." : "Approve"}
+				</button>
+				<button
+					type="button"
+					onClick={handleDeny}
+					disabled={status === "approving"}
+					style={{
+						padding: "12px 32px",
+						fontSize: "14px",
+						cursor: "pointer",
+						border: "1px solid #ddd",
+						borderRadius: "6px",
+						background: "#fff",
+						color: "#333",
+					}}
+				>
+					Deny
+				</button>
+			</div>
+		</CenterLayout>
+	);
+}
+
+function CenterLayout({ children }: { children: React.ReactNode }) {
+	return (
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				height: "100vh",
+				gap: "16px",
+				fontFamily: "system-ui, sans-serif",
+			}}
+		>
+			{children}
+		</div>
+	);
+}

--- a/apps/web/src/pages/device.tsx
+++ b/apps/web/src/pages/device.tsx
@@ -17,7 +17,7 @@ export function DevicePage() {
 	useEffect(() => {
 		if (isPending) return;
 		if (!user) {
-			const redirect = `/device${userCode ? `?user_code=${userCode}` : ""}`;
+			const redirect = `/device${userCode ? `?user_code=${encodeURIComponent(userCode)}` : ""}`;
 			window.location.href = `/login?redirect=${encodeURIComponent(redirect)}`;
 		}
 	}, [user, isPending, userCode]);
@@ -58,7 +58,7 @@ export function DevicePage() {
 		setStatus("denied");
 	}, [userCode]);
 
-	if (isPending) {
+	if (isPending || !user) {
 		return <CenterLayout>Loading...</CenterLayout>;
 	}
 

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -18,7 +18,8 @@ export function LoginPage() {
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
 	const redirectParam = searchParams.get("redirect");
-	const redirectTo = redirectParam?.startsWith("/") ? redirectParam : "/";
+	const redirectTo =
+		redirectParam?.startsWith("/") && !redirectParam.startsWith("//") ? redirectParam : "/";
 
 	return (
 		<div

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router";
+import { useNavigate, useSearchParams } from "react-router";
 import { signIn } from "../lib/auth-client.js";
 import { devLogin } from "../lib/dev-auth.js";
 
@@ -16,6 +16,8 @@ const isDev = import.meta.env.DEV;
 
 export function LoginPage() {
 	const navigate = useNavigate();
+	const [searchParams] = useSearchParams();
+	const redirectTo = searchParams.get("redirect") ?? "/";
 
 	return (
 		<div
@@ -43,7 +45,12 @@ export function LoginPage() {
 			>
 				<button
 					type="button"
-					onClick={() => signIn.social({ provider: "github", callbackURL: window.location.origin })}
+					onClick={() =>
+						signIn.social({
+							provider: "github",
+							callbackURL: `${window.location.origin}${redirectTo}`,
+						})
+					}
 					style={{ ...btnStyle, background: "#24292e", color: "#fff", border: "none" }}
 				>
 					Continue with GitHub
@@ -65,7 +72,7 @@ export function LoginPage() {
 							type="button"
 							onClick={() => {
 								devLogin("dev-user-1", "Dev User 1");
-								navigate("/");
+								navigate(redirectTo);
 							}}
 							style={{ ...btnStyle, background: "#f0f0f0", color: "#333" }}
 						>
@@ -75,7 +82,7 @@ export function LoginPage() {
 							type="button"
 							onClick={() => {
 								devLogin("dev-user-2", "Dev User 2");
-								navigate("/");
+								navigate(redirectTo);
 							}}
 							style={{ ...btnStyle, background: "#f0f0f0", color: "#333" }}
 						>

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -17,7 +17,8 @@ const isDev = import.meta.env.DEV;
 export function LoginPage() {
 	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
-	const redirectTo = searchParams.get("redirect") ?? "/";
+	const redirectParam = searchParams.get("redirect");
+	const redirectTo = redirectParam?.startsWith("/") ? redirectParam : "/";
 
 	return (
 		<div
@@ -48,7 +49,7 @@ export function LoginPage() {
 					onClick={() =>
 						signIn.social({
 							provider: "github",
-							callbackURL: `${window.location.origin}${redirectTo}`,
+							callbackURL: new URL(redirectTo, window.location.origin).toString(),
 						})
 					}
 					style={{ ...btnStyle, background: "#24292e", color: "#fff", border: "none" }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.1
         version: 1.27.1(zod@3.25.76)
+      open:
+        specifier: 11.0.0
+        version: 11.0.0
       ws:
         specifier: ^8.18.0
         version: 8.18.0
@@ -3456,6 +3459,10 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==, tarball: https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz}
+    engines: {node: '>=18'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -3653,8 +3660,20 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==, tarball: https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==, tarball: https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz}
+    engines: {node: '>=18'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==, tarball: https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz}
+    engines: {node: '>=12'}
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
@@ -4221,8 +4240,12 @@ packages:
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==, tarball: https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz}
+    engines: {node: '>=20'}
+
   is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==, tarball: https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz}
     engines: {node: '>=14.16'}
     hasBin: true
 
@@ -4234,7 +4257,7 @@ packages:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-wsl@3.1.1:
-    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==, tarball: https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz}
     engines: {node: '>=16'}
 
   isexe@2.0.0:
@@ -4635,6 +4658,10 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==, tarball: https://registry.npmjs.org/open/-/open-11.0.0.tgz}
+    engines: {node: '>=20'}
+
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
@@ -4741,6 +4768,10 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==, tarball: https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz}
+    engines: {node: '>=20'}
 
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
@@ -4919,6 +4950,10 @@ packages:
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==, tarball: https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz}
+    engines: {node: '>=18'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -5497,6 +5532,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==, tarball: https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz}
+    engines: {node: '>=20'}
 
   xid-ts@1.2.2:
     resolution: {integrity: sha512-pVhEAc09t9cJqB02+NY4bk9bOxs3Kw68OZzYRVpqEQyeyINXhya+4dUK8YCN4aXAtv01YERBOPStfWAHuRsI2g==}
@@ -7080,6 +7119,10 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -7236,10 +7279,19 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
     optional: true
+
+  define-lazy-prop@3.0.0: {}
 
   defu@6.1.4: {}
 
@@ -7933,6 +7985,8 @@ snapshots:
 
   is-hexadecimal@2.0.1: {}
 
+  is-in-ssh@1.0.0: {}
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -8574,6 +8628,15 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
   p-limit@6.2.0:
     dependencies:
       yocto-queue: 1.2.2
@@ -8680,6 +8743,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  powershell-utils@0.1.0: {}
 
   prismjs@1.30.0: {}
 
@@ -8956,6 +9021,8 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  run-applescript@7.1.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -9518,6 +9585,11 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.0: {}
+
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
 
   xid-ts@1.2.2: {}
 


### PR DESCRIPTION
## Summary

- Better Auth の `bearer` + `deviceAuthorization` プラグインを有効化し、CLI からの本番認証を実現
- `/device` ページを追加し、ブラウザ上でデバイス認証を承認可能に
- MCP サーバーに RFC 8628 Device Authorization Grant フローを実装、トークンを `~/.config/usketch/tokens.json` に永続化
- `.mcp.json` を `usketch`（本番）+ `usketch-dev`（ローカル開発）の並行構成に変更

## Changes

### Server (`apps/server/`)
- `bearer()` プラグイン: `Authorization: Bearer` ヘッダーでのセッション検証を有効化
- `deviceAuthorization()` プラグイン: `/api/auth/device/*` エンドポイントを自動追加
- `device_code` テーブルの D1 マイグレーション

### Web (`apps/web/`)
- `/device` ページ: user_code を表示し承認/拒否ボタンを提供
- ログインページ: `redirect` クエリパラメータ対応（認証後の遷移先制御）

### MCP Server (`apps/mcp-server/`)
- `auth/cli-auth.ts`: Device Authorization Grant フロー（ブラウザ自動起動 + ポーリング）
- `auth/token-store.ts`: トークン永続化（有効期限チェック付き）
- `config.ts`: async 化、トークン未設定時に自動で CLI 認証フローを実行

## Test plan
- [ ] サーバーデプロイ後、D1 マイグレーション適用
- [ ] `/device?user_code=TEST` にアクセスし承認ページが表示されること
- [ ] `pnpm build` 後、`usketch` MCP 起動でブラウザが開き認証フローが動作すること
- [ ] 2回目起動時はキャッシュトークンで即接続されること
- [ ] `mcp__usketch__board_list` で本番ボード一覧が取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)