### PR TITLE
直接ドラッグ時にオーバーレイが非表示にならないバグを修正

### DIFF
--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useApp } from "../context.js";
 import { screenToWorld } from "../coordinate-transformer.js";
 import { useFilterPredicate } from "../hooks/use-filter-predicate.js";
+import { useInteracting } from "../hooks/use-interacting.js";
 import { useStoreSubscribe } from "../hooks/use-store-subscribe.js";
 import { useTimeTravelShapes } from "../hooks/use-time-travel.js";
 
@@ -31,6 +32,11 @@ function toCanvasEvent(
 export function Canvas() {
 	const app = useApp();
 	const containerRef = useRef<HTMLDivElement | null>(null);
+
+	// Keep interacting-state listeners alive at all times so that overlays
+	// mounted *during* a drag (direct-drag on unselected shape) still see
+	// the correct interacting flag via the shared module-scoped store.
+	useInteracting(app.events);
 
 	const viewport = useStoreSubscribe(app.store, (s) => s.getViewport());
 	const shapes = useStoreSubscribe(app.store, (s) => s.getShapes());

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useApp } from "../context.js";
 import { screenToWorld } from "../coordinate-transformer.js";
 import { useFilterPredicate } from "../hooks/use-filter-predicate.js";
-import { useInteracting } from "../hooks/use-interacting.js";
+import { useInteractingListeners } from "../hooks/use-interacting.js";
 import { useStoreSubscribe } from "../hooks/use-store-subscribe.js";
 import { useTimeTravelShapes } from "../hooks/use-time-travel.js";
 
@@ -36,7 +36,8 @@ export function Canvas() {
 	// Keep interacting-state listeners alive at all times so that overlays
 	// mounted *during* a drag (direct-drag on unselected shape) still see
 	// the correct interacting flag via the shared module-scoped store.
-	useInteracting(app.events);
+	// Uses the listener-only variant to avoid unnecessary re-renders.
+	useInteractingListeners(app.events);
 
 	const viewport = useStoreSubscribe(app.store, (s) => s.getViewport());
 	const shapes = useStoreSubscribe(app.store, (s) => s.getShapes());

--- a/packages/canvas-engine/src/hooks/use-interacting.ts
+++ b/packages/canvas-engine/src/hooks/use-interacting.ts
@@ -8,15 +8,19 @@ import { useEffect, useSyncExternalStore } from "react";
  * via the EventBus, so only canvas interactions are detected (not scrollbar drags,
  * panel resizes, etc.).
  *
+ * Event listeners are ref-counted: only one set of listeners exists regardless
+ * of how many components call this hook. Cleanup only detaches listeners when
+ * the last subscriber unmounts, preventing premature reset of global state.
+ *
  * Also handles pointercancel and window blur to avoid stuck state.
  */
 
 let interacting = false;
 let pointerIsDown = false;
-const listeners = new Set<() => void>();
+const storeListeners = new Set<() => void>();
 
 function notify() {
-	for (const fn of listeners) fn();
+	for (const fn of storeListeners) fn();
 }
 
 function setInteracting(value: boolean) {
@@ -30,13 +34,65 @@ function getInteracting(): boolean {
 }
 
 function subscribe(cb: () => void): () => void {
-	listeners.add(cb);
-	return () => listeners.delete(cb);
+	storeListeners.add(cb);
+	return () => storeListeners.delete(cb);
 }
 
 function reset() {
 	pointerIsDown = false;
 	setInteracting(false);
+}
+
+// ── Singleton event listener management ──
+
+let refCount = 0;
+let teardown: (() => void) | null = null;
+
+function attach(events: EventBus) {
+	refCount++;
+	if (refCount > 1) return; // already attached
+
+	const offDown = events.on("canvas:pointerdown", () => {
+		pointerIsDown = true;
+	});
+
+	const offMove = events.on("canvas:pointermove", () => {
+		if (pointerIsDown && !interacting) {
+			setInteracting(true);
+		}
+	});
+
+	const offUp = events.on("canvas:pointerup", () => {
+		reset();
+	});
+
+	function onPointerCancel() {
+		reset();
+	}
+	function onBlur() {
+		reset();
+	}
+
+	window.addEventListener("pointercancel", onPointerCancel, true);
+	window.addEventListener("blur", onBlur);
+	document.addEventListener("visibilitychange", onBlur);
+
+	teardown = () => {
+		offDown();
+		offMove();
+		offUp();
+		window.removeEventListener("pointercancel", onPointerCancel, true);
+		window.removeEventListener("blur", onBlur);
+		document.removeEventListener("visibilitychange", onBlur);
+		reset();
+		teardown = null;
+	};
+}
+
+function detach() {
+	refCount--;
+	if (refCount > 0) return; // still has subscribers
+	teardown?.();
 }
 
 /**
@@ -45,41 +101,8 @@ function reset() {
  */
 export function useInteracting(events: EventBus): boolean {
 	useEffect(() => {
-		const offDown = events.on("canvas:pointerdown", () => {
-			pointerIsDown = true;
-		});
-
-		const offMove = events.on("canvas:pointermove", () => {
-			if (pointerIsDown && !interacting) {
-				setInteracting(true);
-			}
-		});
-
-		const offUp = events.on("canvas:pointerup", () => {
-			reset();
-		});
-
-		// Safety: reset on pointercancel / window blur / visibility change
-		function onPointerCancel() {
-			reset();
-		}
-		function onBlur() {
-			reset();
-		}
-
-		window.addEventListener("pointercancel", onPointerCancel, true);
-		window.addEventListener("blur", onBlur);
-		document.addEventListener("visibilitychange", onBlur);
-
-		return () => {
-			offDown();
-			offMove();
-			offUp();
-			window.removeEventListener("pointercancel", onPointerCancel, true);
-			window.removeEventListener("blur", onBlur);
-			document.removeEventListener("visibilitychange", onBlur);
-			reset();
-		};
+		attach(events);
+		return () => detach();
 	}, [events]);
 
 	return useSyncExternalStore(subscribe, getInteracting, getInteracting);

--- a/packages/canvas-engine/src/hooks/use-interacting.ts
+++ b/packages/canvas-engine/src/hooks/use-interacting.ts
@@ -8,9 +8,9 @@ import { useEffect, useSyncExternalStore } from "react";
  * via the EventBus, so only canvas interactions are detected (not scrollbar drags,
  * panel resizes, etc.).
  *
- * Event listeners are ref-counted: only one set of listeners exists regardless
- * of how many components call this hook. Cleanup only detaches listeners when
- * the last subscriber unmounts, preventing premature reset of global state.
+ * Event listeners are ref-counted per EventBus instance: multiple components
+ * sharing the same EventBus reuse one set of listeners. Cleanup only detaches
+ * listeners when the last subscriber for that EventBus unmounts.
  *
  * Also handles pointercancel and window blur to avoid stuck state.
  */
@@ -43,14 +43,21 @@ function reset() {
 	setInteracting(false);
 }
 
-// ── Singleton event listener management ──
+// ── Per-EventBus ref-counted listener management ──
 
-let refCount = 0;
-let teardown: (() => void) | null = null;
+interface BusEntry {
+	refCount: number;
+	teardown: () => void;
+}
+
+const busMap = new WeakMap<EventBus, BusEntry>();
 
 function attach(events: EventBus) {
-	refCount++;
-	if (refCount > 1) return; // already attached
+	const existing = busMap.get(events);
+	if (existing) {
+		existing.refCount++;
+		return;
+	}
 
 	const offDown = events.on("canvas:pointerdown", () => {
 		pointerIsDown = true;
@@ -77,22 +84,27 @@ function attach(events: EventBus) {
 	window.addEventListener("blur", onBlur);
 	document.addEventListener("visibilitychange", onBlur);
 
-	teardown = () => {
-		offDown();
-		offMove();
-		offUp();
-		window.removeEventListener("pointercancel", onPointerCancel, true);
-		window.removeEventListener("blur", onBlur);
-		document.removeEventListener("visibilitychange", onBlur);
-		reset();
-		teardown = null;
-	};
+	busMap.set(events, {
+		refCount: 1,
+		teardown: () => {
+			offDown();
+			offMove();
+			offUp();
+			window.removeEventListener("pointercancel", onPointerCancel, true);
+			window.removeEventListener("blur", onBlur);
+			document.removeEventListener("visibilitychange", onBlur);
+			reset();
+		},
+	});
 }
 
-function detach() {
-	refCount--;
-	if (refCount > 0) return; // still has subscribers
-	teardown?.();
+function detach(events: EventBus) {
+	const entry = busMap.get(events);
+	if (!entry) return;
+	entry.refCount--;
+	if (entry.refCount > 0) return;
+	entry.teardown();
+	busMap.delete(events);
 }
 
 /**
@@ -102,7 +114,7 @@ function detach() {
 export function useInteracting(events: EventBus): boolean {
 	useEffect(() => {
 		attach(events);
-		return () => detach();
+		return () => detach(events);
 	}, [events]);
 
 	return useSyncExternalStore(subscribe, getInteracting, getInteracting);

--- a/packages/canvas-engine/src/hooks/use-interacting.ts
+++ b/packages/canvas-engine/src/hooks/use-interacting.ts
@@ -108,7 +108,23 @@ function detach(events: EventBus) {
 }
 
 /**
+ * Side-effect-only hook that ensures interacting-state event listeners
+ * are attached to the given EventBus. Does NOT subscribe to the store,
+ * so calling this does not cause re-renders when `interacting` changes.
+ *
+ * Use this in components (like Canvas) that only need to keep listeners
+ * alive without reading the interacting value.
+ */
+export function useInteractingListeners(events: EventBus): void {
+	useEffect(() => {
+		attach(events);
+		return () => detach(events);
+	}, [events]);
+}
+
+/**
  * Returns `true` when the user is currently dragging on the canvas.
+ * Also ensures listeners are attached (ref-counted).
  * @param events - The app EventBus to listen for canvas pointer events.
  */
 export function useInteracting(events: EventBus): boolean {

--- a/packages/canvas-engine/src/index.ts
+++ b/packages/canvas-engine/src/index.ts
@@ -6,7 +6,7 @@ export { ShapeLayer } from "./components/shape-layer.js";
 export { TransientLayer } from "./components/transient-layer.js";
 export { AppProvider, useApp } from "./context.js";
 export { getTransformStyle, screenToWorld, worldToScreen } from "./coordinate-transformer.js";
-export { useInteracting } from "./hooks/use-interacting.js";
+export { useInteracting, useInteractingListeners } from "./hooks/use-interacting.js";
 export { useShapeAnchorPosition } from "./hooks/use-shape-anchor-position.js";
 export { useStoreSubscribe } from "./hooks/use-store-subscribe.js";
 export { useViewportClamp } from "./hooks/use-viewport-clamp.js";


### PR DESCRIPTION
## Summary

- 未選択シェイプを直接ドラッグした際、プロパティバーやAIアクションバー等の `ShapeAnchorOverlay` がドラッグ中も表示されたままになるバグを修正
- `Canvas` コンポーネントで `useInteracting` を常時呼び出すことで、ポインターイベントリスナーを常に登録

## Root Cause

`useInteracting` は `useEffect` でイベントリスナーを登録するため、直接ドラッグで `ShapeAnchorOverlay` がマウントされた時点では `canvas:pointerdown` を見逃している。結果として `pointerIsDown` が `false` のまま、`canvas:pointermove` でも `interacting` が `true` にならない。

## Test plan

- [ ] 未選択シェイプを直接ドラッグ → オーバーレイが非表示になることを確認
- [ ] クリック → ドラッグの通常フローも引き続き動作することを確認
- [ ] `pnpm typecheck` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)