### PR TITLE
MCP 本番接続 — サーバーURL修正と verificationUri 修正

### DIFF
--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -4,7 +4,7 @@
 			"command": "node",
 			"args": ["./apps/mcp-server/dist/index.js"],
 			"env": {
-				"USKETCH_SERVER_URL": "https://usketch-web.pages.dev"
+				"USKETCH_SERVER_URL": "https://usketch-server.circlemountain-ym.workers.dev"
 			}
 		},
 		"usketch-dev": {

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -51,7 +51,7 @@ export function createAuth(env: Env) {
 		plugins: [
 			bearer(),
 			deviceAuthorization({
-				verificationUri: new URL("/device", env.BETTER_AUTH_URL).toString(),
+				verificationUri: new URL("/device", env.WEB_URL ?? env.BETTER_AUTH_URL).toString(),
 			}),
 		],
 		advanced: {

--- a/apps/server/src/auth.ts
+++ b/apps/server/src/auth.ts
@@ -51,7 +51,7 @@ export function createAuth(env: Env) {
 		plugins: [
 			bearer(),
 			deviceAuthorization({
-				verificationUri: new URL("/device", env.WEB_URL ?? env.BETTER_AUTH_URL).toString(),
+				verificationUri: new URL("/device", env.WEB_URL?.trim() || env.BETTER_AUTH_URL).toString(),
 			}),
 		],
 		advanced: {

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -5,6 +5,7 @@ import type * as schema from "./db/schema.js";
 export interface Env extends ServerBindings {
 	BETTER_AUTH_SECRET: string;
 	BETTER_AUTH_URL: string;
+	WEB_URL?: string;
 	GOOGLE_CLIENT_ID?: string;
 	GOOGLE_CLIENT_SECRET?: string;
 	GITHUB_CLIENT_ID?: string;

--- a/apps/server/wrangler.toml
+++ b/apps/server/wrangler.toml
@@ -3,6 +3,9 @@ compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 main = "src/index.ts"
 
+[vars]
+WEB_URL = "https://usketch-web.pages.dev"
+
 [[d1_databases]]
 binding = "DB"
 database_name = "usketch-db"


### PR DESCRIPTION
## Summary

- MCP サーバーの `USKETCH_SERVER_URL` を Pages URL (`usketch-web.pages.dev`) から Workers URL (`usketch-server.circlemountain-ym.workers.dev`) に修正
- `WEB_URL` 環境変数を追加し、Device Authorization の `verification_uri` をフロントエンド（Pages）に向ける
- `wrangler.toml` に `[vars] WEB_URL` を追加

## Background

MCP 本番サーバーが起動時に 405 エラーで失敗していた。原因は `USKETCH_SERVER_URL` がフロントエンド（Pages）を指していたため、API エンドポイントが存在しなかった。また `verification_uri` が Workers URL を指していたため、ブラウザでの認証ページに到達できなかった。

## Test plan

- [x] `POST /api/auth/device/code` が 200 を返すことを確認
- [x] `verification_uri` が `usketch-web.pages.dev/device` を指すことを確認
- [x] サーバーデプロイ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)