### PR TITLE
MCP 本番接続の WebSocket タイムアウトを修正

### DIFF
--- a/apps/mcp-server/src/client/board-connection.ts
+++ b/apps/mcp-server/src/client/board-connection.ts
@@ -33,7 +33,7 @@ export class BoardConnection {
 		if (this.connected) return;
 		if (this.connectPromise) return this.connectPromise;
 
-		this.connectPromise = new Promise<void>((resolve, reject) => {
+		const promise = new Promise<void>((resolve, reject) => {
 			const userId = this.config.devMode ? this.config.devUserId : "mcp-client";
 			const wsUrl = `${this.config.wsUrl}/api/boards/${this.boardId}/ws?boardId=${this.boardId}&userId=${userId}${this.config.devMode ? `&devUserId=${userId}` : ""}`;
 
@@ -45,26 +45,35 @@ export class BoardConnection {
 			ws.binaryType = "arraybuffer";
 			this.ws = ws;
 
-			let syncReceived = false;
 			let settled = false;
-			const syncTimeout = setTimeout(() => {
-				if (!syncReceived && !settled) {
-					if (ws.readyState === WebSocket.OPEN) {
-						// 接続はあるが同期データなし — 空ボードとみなす
-						settled = true;
-						this.connected = true;
-						resolve();
-					} else {
-						// 接続が確立されていない
-						settled = true;
-						reject(new Error("WebSocket connection timed out"));
-					}
+			let postOpenSyncTimer: ReturnType<typeof setTimeout> | null = null;
+
+			// 全体の接続タイムアウト（TLS + WS アップグレード + 初期同期を含む）
+			const overallTimeout = setTimeout(() => {
+				if (!settled) {
+					settled = true;
+					if (postOpenSyncTimer) clearTimeout(postOpenSyncTimer);
+					reject(new Error("WebSocket connection timed out"));
 				}
-			}, 200);
+			}, 10_000);
+
+			const clearTimers = () => {
+				clearTimeout(overallTimeout);
+				if (postOpenSyncTimer) clearTimeout(postOpenSyncTimer);
+			};
 
 			ws.on("open", () => {
-				// MSG_SYNC_STEP1 を送信して初期同期をリクエスト
 				ws.send(new Uint8Array([MSG_SYNC_STEP1]));
+				// OPEN 後に短いウィンドウだけ SYNC_STEP2 を待つ。
+				// 届かなければ空ボードとみなして resolve する。
+				postOpenSyncTimer = setTimeout(() => {
+					if (!settled && ws.readyState === WebSocket.OPEN) {
+						settled = true;
+						clearTimeout(overallTimeout);
+						this.connected = true;
+						resolve();
+					}
+				}, 1_000);
 			});
 
 			ws.on("message", (raw: ArrayBuffer | Buffer) => {
@@ -82,10 +91,9 @@ export class BoardConnection {
 					case MSG_SYNC_STEP2:
 					case MSG_YJS_UPDATE: {
 						Y.applyUpdate(this.doc, payload, "remote");
-						if (msgType === MSG_SYNC_STEP2 && !syncReceived && !settled) {
-							syncReceived = true;
+						if (msgType === MSG_SYNC_STEP2 && !settled) {
 							settled = true;
-							clearTimeout(syncTimeout);
+							clearTimers();
 							this.connected = true;
 							resolve();
 						}
@@ -97,7 +105,7 @@ export class BoardConnection {
 			ws.on("unexpected-response", (_req, res) => {
 				if (!settled) {
 					settled = true;
-					clearTimeout(syncTimeout);
+					clearTimers();
 					reject(new Error(`WebSocket upgrade rejected: ${res.statusCode}`));
 				}
 			});
@@ -105,7 +113,7 @@ export class BoardConnection {
 			ws.on("error", (err) => {
 				if (!settled) {
 					settled = true;
-					clearTimeout(syncTimeout);
+					clearTimers();
 					reject(new Error(`WebSocket connection failed: ${err.message}`));
 				}
 			});
@@ -113,13 +121,19 @@ export class BoardConnection {
 			ws.on("close", () => {
 				if (!settled) {
 					settled = true;
-					clearTimeout(syncTimeout);
+					clearTimers();
 					reject(new Error("WebSocket closed before sync completed"));
 				}
 				this.connected = false;
 				this.ws = null;
 				this.connectPromise = null;
 			});
+		});
+
+		// reject 時に connectPromise をクリアして再試行可能にする
+		this.connectPromise = promise.catch((err) => {
+			this.connectPromise = null;
+			throw err;
 		});
 
 		return this.connectPromise;

--- a/apps/mcp-server/src/client/board-connection.ts
+++ b/apps/mcp-server/src/client/board-connection.ts
@@ -125,6 +125,7 @@ export class BoardConnection {
 				if (!settled) {
 					settled = true;
 					clearTimers();
+					terminateSocket();
 					reject(new Error(`WebSocket upgrade rejected: ${res.statusCode}`));
 				}
 			});
@@ -133,6 +134,7 @@ export class BoardConnection {
 				if (!settled) {
 					settled = true;
 					clearTimers();
+					terminateSocket();
 					reject(new Error(`WebSocket connection failed: ${err.message}`));
 				}
 			});

--- a/apps/mcp-server/src/client/board-connection.ts
+++ b/apps/mcp-server/src/client/board-connection.ts
@@ -9,6 +9,12 @@ import WebSocket from "ws";
 import * as Y from "yjs";
 import type { McpConfig } from "../config.js";
 
+/** TLS + WS アップグレード + 初期同期を含む全体接続タイムアウト */
+const OVERALL_CONNECT_TIMEOUT_MS = 10_000;
+
+/** OPEN 後に SYNC_STEP2 を待つ猶予時間（届かなければ空ボードとみなす） */
+const POST_OPEN_SYNC_TIMEOUT_MS = 1_000;
+
 export class BoardConnection {
 	readonly doc: Y.Doc;
 	private ws: WebSocket | null = null;
@@ -48,14 +54,25 @@ export class BoardConnection {
 			let settled = false;
 			let postOpenSyncTimer: ReturnType<typeof setTimeout> | null = null;
 
+			// タイムアウト時にハンドシェイク中のソケットを確実に破棄する
+			const terminateSocket = () => {
+				try {
+					ws.terminate();
+				} catch {
+					// already closed
+				}
+				if (this.ws === ws) this.ws = null;
+			};
+
 			// 全体の接続タイムアウト（TLS + WS アップグレード + 初期同期を含む）
 			const overallTimeout = setTimeout(() => {
 				if (!settled) {
 					settled = true;
 					if (postOpenSyncTimer) clearTimeout(postOpenSyncTimer);
+					terminateSocket();
 					reject(new Error("WebSocket connection timed out"));
 				}
-			}, 10_000);
+			}, OVERALL_CONNECT_TIMEOUT_MS);
 
 			const clearTimers = () => {
 				clearTimeout(overallTimeout);
@@ -63,6 +80,8 @@ export class BoardConnection {
 			};
 
 			ws.on("open", () => {
+				// 既に settle 済みなら何もしない（タイムアウト後の遅延 open など）
+				if (settled) return;
 				ws.send(new Uint8Array([MSG_SYNC_STEP1]));
 				// OPEN 後に短いウィンドウだけ SYNC_STEP2 を待つ。
 				// 届かなければ空ボードとみなして resolve する。
@@ -73,7 +92,7 @@ export class BoardConnection {
 						this.connected = true;
 						resolve();
 					}
-				}, 1_000);
+				}, POST_OPEN_SYNC_TIMEOUT_MS);
 			});
 
 			ws.on("message", (raw: ArrayBuffer | Buffer) => {


### PR DESCRIPTION
## Summary

本番の Cloudflare Workers への WebSocket 接続で `canvas_snapshot` / `shape_list` / `shape_create` などが `WebSocket connection timed out` で失敗していたバグを修正。

## Root Cause

`board-connection.ts` の sync タイムアウトが **200ms** 固定で、**WebSocket OPEN より前に発火**していた。本番の Cloudflare Workers への接続は TLS ハンドシェイク + WebSocket アップグレード + Durable Object 起動で **800ms 以上**かかるため、タイマーが発火した時点では `ws.readyState !== OPEN` となり `reject` されていた。

手動測定結果:
- OPEN まで: 801ms
- 最初の SYNC_STEP2 受信まで: 844ms

## Changes

- 全体タイムアウトを **10 秒** に延長（TLS + WS アップグレード + 初期同期を含む）
- SYNC_STEP2 待機のタイマーを **OPEN イベント後**に開始（1 秒）— 届かなければ空ボードとして resolve
- `reject` 時に `connectPromise` を `null` にクリアして再試行可能に

## Test plan

- [x] ローカルで本番 MCP ツール `shape_list` を叩き、空配列 `[]` を返すことを確認
- [x] `pnpm typecheck` パス
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)