### PR TITLE
✨ feat: プレゼンテーション flavor を追加 (/presentation/:boardId)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,7 @@
 		"@edv4h/usketch-plugin-laser": "workspace:*",
 		"@edv4h/usketch-plugin-presence-cursor": "workspace:*",
 		"@edv4h/usketch-plugin-presence-enhanced": "workspace:*",
+		"@edv4h/usketch-plugin-presentation": "workspace:*",
 		"@edv4h/usketch-plugin-reactions": "workspace:*",
 		"@edv4h/usketch-plugin-spatial-chat": "workspace:*",
 		"@edv4h/usketch-plugin-spotlight": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -13,9 +13,11 @@ import { dotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
 import { gridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
 import { exportPlugin } from "@edv4h/usketch-plugin-export";
+import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
 import { createLaserPlugin, laserPlugin } from "@edv4h/usketch-plugin-laser";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
 import { createPresenceEnhancedPlugin } from "@edv4h/usketch-plugin-presence-enhanced";
+import { createPresentationPlugin } from "@edv4h/usketch-plugin-presentation";
 import { basicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
 import { connectorPlugin } from "@edv4h/usketch-plugin-shape-connector";
 import { counterPlugin } from "@edv4h/usketch-plugin-shape-counter";
@@ -49,30 +51,36 @@ import { getErrorMessage } from "./lib/errors.js";
 import { useAuth } from "./lib/use-auth.js";
 import { useKeyboardShortcuts } from "./lib/use-keyboard-shortcuts.js";
 
-const basePlugins: UsketchPlugin[] = [
-	gridBgPlugin,
-	dotsBgPlugin,
-	selectToolPlugin,
-	panToolPlugin,
-	viewportNavPlugin,
-	basicShapePlugin,
-	groupPlugin,
-	framePlugin,
-	connectorPlugin,
-	freedrawPlugin,
-	textPlugin,
-	stickyPlugin,
-	imageShapePlugin,
-	counterPlugin,
-	wireframePlugin,
-	snapPlugin,
-	exportPlugin,
-	createGpuRendererPlugin(),
-	createDomRendererPlugin(),
-];
+type Flavor = "whiteboard" | "presentation";
 
-async function loadPlugins(extra: UsketchPlugin[]): Promise<UsketchPlugin[]> {
-	const plugins = [...basePlugins, ...extra];
+function buildBasePlugins(flavor: Flavor): UsketchPlugin[] {
+	const common: UsketchPlugin[] = [
+		selectToolPlugin,
+		panToolPlugin,
+		viewportNavPlugin,
+		basicShapePlugin,
+		groupPlugin,
+		framePlugin,
+		connectorPlugin,
+		freedrawPlugin,
+		textPlugin,
+		stickyPlugin,
+		imageShapePlugin,
+		counterPlugin,
+		wireframePlugin,
+		exportPlugin,
+		createGpuRendererPlugin(),
+		createDomRendererPlugin(),
+	];
+	if (flavor === "presentation") {
+		// 発表/編集ともに背景グリッドとスナップは外す（ノイズになる）
+		return common;
+	}
+	return [gridBgPlugin, dotsBgPlugin, snapPlugin, ...common];
+}
+
+async function loadPlugins(flavor: Flavor, extra: UsketchPlugin[]): Promise<UsketchPlugin[]> {
+	const plugins = [...buildBasePlugins(flavor), ...extra];
 	if (import.meta.env.DEV) {
 		const { debugHudPlugin } = await import("@edv4h/usketch-plugin-debug-hud");
 		return [...plugins, debugHudPlugin];
@@ -84,13 +92,19 @@ export function App() {
 	const { boardId } = useParams<{ boardId: string }>();
 	const location = useLocation();
 	const isCloudBoard = location.pathname.startsWith("/boards/");
+	const isPresentationFlavor = location.pathname.startsWith("/presentation/");
+	const flavor: Flavor = isPresentationFlavor ? "presentation" : "whiteboard";
+	const presentationMode: "edit" | "present" =
+		new URLSearchParams(location.search).get("mode") === "present" ? "present" : "edit";
+	// presentation flavor もクラウド（DB + Yjs 同期）を既定とする
+	const useCloudSync = isCloudBoard || isPresentationFlavor;
 	const { user: authUser } = useAuth();
 	const [app, setApp] = useState<AppInstance | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [wsStatus, setWsStatus] = useState<WsConnectionStatus | null>(null);
 	const wsProviderRef = useRef<WsProviderHandle | null>(null);
 
-	// ボード初期化（boardId/isCloudBoardのみに依存）
+	// ボード初期化（flavor/mode/boardId/useCloudSync に依存）
 	useEffect(() => {
 		if (!boardId) return;
 
@@ -104,7 +118,7 @@ export function App() {
 		const extraPlugins: UsketchPlugin[] = [];
 		let wsProvider: WsProviderHandle | null = null;
 
-		if (isCloudBoard) {
+		if (useCloudSync) {
 			const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
 			let wsUrl = `${apiUrl.replace(/^http/, "ws")}/api/boards/${boardId}/ws`;
 			// DEV_MODE: WebSocketはカスタムヘッダーを送れないのでクエリパラメータで認証
@@ -117,6 +131,18 @@ export function App() {
 			wsProvider = createWsProvider({ url: wsUrl, doc: syncHandle.doc });
 			wsProviderRef.current = wsProvider;
 			wsProvider.onStatusChange(setWsStatus);
+		}
+
+		if (flavor === "presentation") {
+			// プレゼン flavor は最小構成: presentation プラグイン + 協調プレゼン向けの3種
+			extraPlugins.push(createPresentationPlugin({ mode: presentationMode }));
+			if (wsProvider) {
+				extraPlugins.push(createLaserPlugin(wsProvider));
+				extraPlugins.push(createSpotlightPlugin(wsProvider));
+				extraPlugins.push(createFollowMePlugin({ wsProvider }));
+			}
+		} else if (isCloudBoard && wsProvider) {
+			const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
 
 			extraPlugins.push(createLaserPlugin(wsProvider));
 			extraPlugins.push(createSpotlightPlugin(wsProvider));
@@ -165,7 +191,7 @@ export function App() {
 			.then(() => {
 				if (cancelled) return;
 
-				return loadPlugins(extraPlugins)
+				return loadPlugins(flavor, extraPlugins)
 					.then((plugins) => createApp({ store, plugins }))
 					.then((created) => {
 						if (cancelled) {
@@ -198,7 +224,7 @@ export function App() {
 			delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
 			setApp(null);
 		};
-	}, [boardId, isCloudBoard]);
+	}, [boardId, isCloudBoard, flavor, presentationMode, useCloudSync]);
 
 	// ページ離脱時にビューポート位置を保存（ゴーストアバター用）
 	useEffect(() => {
@@ -255,12 +281,14 @@ export function App() {
 
 	if (!app) return null;
 
+	const hideToolbar = flavor === "presentation" && presentationMode === "present";
+
 	return (
 		<AppProvider app={app}>
 			<div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
 				<Canvas />
-				<Toolbar boardId={boardId} isCloudBoard={isCloudBoard} />
-				{isCloudBoard && wsStatus === "failed" && (
+				{!hideToolbar && <Toolbar boardId={boardId} isCloudBoard={isCloudBoard} />}
+				{useCloudSync && wsStatus === "failed" && (
 					<div
 						style={{
 							position: "fixed",
@@ -280,7 +308,7 @@ export function App() {
 						Unable to connect — you may not have access to this board
 					</div>
 				)}
-				{isCloudBoard && wsStatus === "connecting" && (
+				{useCloudSync && wsStatus === "connecting" && (
 					<div
 						style={{
 							position: "fixed",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -44,7 +44,7 @@ import {
 	type WsProviderHandle,
 } from "@edv4h/usketch-sync";
 import { useEffect, useRef, useState } from "react";
-import { useLocation, useParams } from "react-router";
+import { useLocation, useNavigate, useParams } from "react-router";
 import { Toolbar } from "./components/toolbar/index.js";
 import { getDevUser } from "./lib/dev-auth.js";
 import { getErrorMessage } from "./lib/errors.js";
@@ -91,6 +91,7 @@ async function loadPlugins(flavor: Flavor, extra: UsketchPlugin[]): Promise<Uske
 export function App() {
 	const { boardId } = useParams<{ boardId: string }>();
 	const location = useLocation();
+	const navigate = useNavigate();
 	const isCloudBoard = location.pathname.startsWith("/boards/");
 	const isPresentationFlavor = location.pathname.startsWith("/presentation/");
 	const flavor: Flavor = isPresentationFlavor ? "presentation" : "whiteboard";
@@ -143,7 +144,15 @@ export function App() {
 		if (flavor === "presentation") {
 			// プレゼン flavor は最小構成: presentation プラグイン + 協調プレゼン向けの3種
 			// mode は URL で動的に変わるので ref 経由で渡す（再レンダリングの契機は plugin が popstate で受ける）
-			extraPlugins.push(createPresentationPlugin({ getMode: () => modeRef.current }));
+			extraPlugins.push(
+				createPresentationPlugin({
+					getMode: () => modeRef.current,
+					// フル reload を避けるため react-router の navigate を注入する
+					navigateToBoard: () => {
+						if (boardId) navigate(`/boards/${boardId}`);
+					},
+				}),
+			);
 			if (wsProvider) {
 				extraPlugins.push(createLaserPlugin(wsProvider));
 				extraPlugins.push(createSpotlightPlugin(wsProvider));
@@ -234,11 +243,12 @@ export function App() {
 		};
 		// NOTE: presentationMode は依存に入れない。mode 切替では app を再作成せず、
 		// plugin 側が modeRef 経由で最新値を読む（undo 履歴・WebSocket を残すため）。
-	}, [boardId, isCloudBoard, flavor, useCloudSync]);
+	}, [boardId, isCloudBoard, flavor, useCloudSync, navigate]);
 
 	// ページ離脱時にビューポート位置を保存（ゴーストアバター用）
+	// プレゼン flavor も cloud 同期を使うので useCloudSync で判定する
 	useEffect(() => {
-		if (!isCloudBoard || !boardId) return;
+		if (!useCloudSync || !boardId) return;
 
 		const saveViewport = () => {
 			const ws = wsProviderRef.current;
@@ -263,7 +273,7 @@ export function App() {
 
 		window.addEventListener("beforeunload", saveViewport);
 		return () => window.removeEventListener("beforeunload", saveViewport);
-	}, [boardId, isCloudBoard]);
+	}, [boardId, useCloudSync]);
 
 	// セッション情報が確定したらAwarenessのローカル状態を更新
 	const authUserId = authUser?.id;

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -51,36 +51,44 @@ import { getErrorMessage } from "./lib/errors.js";
 import { useAuth } from "./lib/use-auth.js";
 import { useKeyboardShortcuts } from "./lib/use-keyboard-shortcuts.js";
 
-type Flavor = "whiteboard" | "presentation";
+type PresentationMode = "off" | "edit" | "present";
 
-function buildBasePlugins(flavor: Flavor): UsketchPlugin[] {
-	const common: UsketchPlugin[] = [
-		selectToolPlugin,
-		panToolPlugin,
-		viewportNavPlugin,
-		basicShapePlugin,
-		groupPlugin,
-		framePlugin,
-		connectorPlugin,
-		freedrawPlugin,
-		textPlugin,
-		stickyPlugin,
-		imageShapePlugin,
-		counterPlugin,
-		wireframePlugin,
-		exportPlugin,
-		createGpuRendererPlugin(),
-		createDomRendererPlugin(),
-	];
-	if (flavor === "presentation") {
-		// 発表/編集ともに背景グリッドとスナップは外す（ノイズになる）
-		return common;
-	}
-	return [gridBgPlugin, dotsBgPlugin, snapPlugin, ...common];
+/**
+ * URL から現在のプレゼンテーション状態を読む。
+ * - `?present=1` があれば edit（発表オフ時のプレゼン編集モード）
+ * - `?present=1&mode=present` があれば present（発表中）
+ * - いずれも無ければ off（通常のホワイトボード）
+ */
+function readPresentationMode(search: string): PresentationMode {
+	const params = new URLSearchParams(search);
+	if (params.get("present") !== "1") return "off";
+	return params.get("mode") === "present" ? "present" : "edit";
 }
 
-async function loadPlugins(flavor: Flavor, extra: UsketchPlugin[]): Promise<UsketchPlugin[]> {
-	const plugins = [...buildBasePlugins(flavor), ...extra];
+const basePlugins: UsketchPlugin[] = [
+	gridBgPlugin,
+	dotsBgPlugin,
+	selectToolPlugin,
+	panToolPlugin,
+	viewportNavPlugin,
+	basicShapePlugin,
+	groupPlugin,
+	framePlugin,
+	connectorPlugin,
+	freedrawPlugin,
+	textPlugin,
+	stickyPlugin,
+	imageShapePlugin,
+	counterPlugin,
+	wireframePlugin,
+	snapPlugin,
+	exportPlugin,
+	createGpuRendererPlugin(),
+	createDomRendererPlugin(),
+];
+
+async function loadPlugins(extra: UsketchPlugin[]): Promise<UsketchPlugin[]> {
+	const plugins = [...basePlugins, ...extra];
 	if (import.meta.env.DEV) {
 		const { debugHudPlugin } = await import("@edv4h/usketch-plugin-debug-hud");
 		return [...plugins, debugHudPlugin];
@@ -93,26 +101,22 @@ export function App() {
 	const location = useLocation();
 	const navigate = useNavigate();
 	const isCloudBoard = location.pathname.startsWith("/boards/");
-	const isPresentationFlavor = location.pathname.startsWith("/presentation/");
-	const flavor: Flavor = isPresentationFlavor ? "presentation" : "whiteboard";
-	const presentationMode: "edit" | "present" =
-		new URLSearchParams(location.search).get("mode") === "present" ? "present" : "edit";
-	// presentation flavor もクラウド（DB + Yjs 同期）を既定とする
-	const useCloudSync = isCloudBoard || isPresentationFlavor;
+	const presentationMode = readPresentationMode(location.search);
 	const { user: authUser } = useAuth();
 
-	// 最新の mode を useEffect 外部から参照するための ref。
-	// effect 依存に presentationMode を入れてしまうと切替のたびに app インスタンスが
-	// 作り直され、undo 履歴や WebSocket が吹き飛ぶ（Copilot 指摘）。
-	const modeRef = useRef<"edit" | "present">(presentationMode);
+	// 最新の presentation mode を useEffect 外部から参照するための ref。
+	// effect 依存に入れてしまうと ?present=1 切替のたびに app インスタンスが
+	// 作り直され、undo 履歴や WebSocket が吹き飛ぶ。presentation plugin 側が
+	// popstate で ref を読み直す設計。
+	const modeRef = useRef<PresentationMode>(presentationMode);
 	modeRef.current = presentationMode;
 	const [app, setApp] = useState<AppInstance | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [wsStatus, setWsStatus] = useState<WsConnectionStatus | null>(null);
 	const wsProviderRef = useRef<WsProviderHandle | null>(null);
 
-	// ボード初期化（boardId / isCloudBoard / flavor / useCloudSync に依存）。
-	// presentationMode は依存に入れていない（下の NOTE 参照）。
+	// ボード初期化（boardId / isCloudBoard に依存）。
+	// presentationMode は依存に入れない（presentation plugin が popstate で modeRef を読み直す）。
 	useEffect(() => {
 		if (!boardId) return;
 
@@ -126,7 +130,7 @@ export function App() {
 		const extraPlugins: UsketchPlugin[] = [];
 		let wsProvider: WsProviderHandle | null = null;
 
-		if (useCloudSync) {
+		if (isCloudBoard) {
 			const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
 			let wsUrl = `${apiUrl.replace(/^http/, "ws")}/api/boards/${boardId}/ws`;
 			// DEV_MODE: WebSocketはカスタムヘッダーを送れないのでクエリパラメータで認証
@@ -139,30 +143,10 @@ export function App() {
 			wsProvider = createWsProvider({ url: wsUrl, doc: syncHandle.doc });
 			wsProviderRef.current = wsProvider;
 			wsProvider.onStatusChange(setWsStatus);
-		}
-
-		if (flavor === "presentation") {
-			// プレゼン flavor は最小構成: presentation プラグイン + 協調プレゼン向けの3種
-			// mode は URL で動的に変わるので ref 経由で渡す（再レンダリングの契機は plugin が popstate で受ける）
-			extraPlugins.push(
-				createPresentationPlugin({
-					getMode: () => modeRef.current,
-					// フル reload を避けるため react-router の navigate を注入する
-					navigateToBoard: () => {
-						if (boardId) navigate(`/boards/${boardId}`);
-					},
-				}),
-			);
-			if (wsProvider) {
-				extraPlugins.push(createLaserPlugin(wsProvider));
-				extraPlugins.push(createSpotlightPlugin(wsProvider));
-				extraPlugins.push(createFollowMePlugin({ wsProvider }));
-			}
-		} else if (isCloudBoard && wsProvider) {
-			const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
 
 			extraPlugins.push(createLaserPlugin(wsProvider));
 			extraPlugins.push(createSpotlightPlugin(wsProvider));
+			extraPlugins.push(createFollowMePlugin({ wsProvider }));
 			extraPlugins.push(
 				createPresenceCursorPlugin({
 					wsProvider,
@@ -198,6 +182,17 @@ export function App() {
 			extraPlugins.push(createAiImagePlugin({ boardId }));
 			extraPlugins.push(createAiRecognizePlugin({ boardId }));
 			extraPlugins.push(createWhistlePlugin(wsProvider));
+
+			// プレゼンテーション: 常にロードし、`?present=1` が付いた時だけ UI を出す。
+			// ルート切替せず URL クエリで切替える設計なので、アプリ再生成は起きない。
+			extraPlugins.push(
+				createPresentationPlugin({
+					getMode: () => modeRef.current,
+					navigateToBoard: () => {
+						if (boardId) navigate(`/boards/${boardId}`);
+					},
+				}),
+			);
 		} else {
 			extraPlugins.push(laserPlugin);
 			extraPlugins.push(spotlightPlugin);
@@ -208,7 +203,7 @@ export function App() {
 			.then(() => {
 				if (cancelled) return;
 
-				return loadPlugins(flavor, extraPlugins)
+				return loadPlugins(extraPlugins)
 					.then((plugins) => createApp({ store, plugins }))
 					.then((created) => {
 						if (cancelled) {
@@ -241,14 +236,13 @@ export function App() {
 			delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
 			setApp(null);
 		};
-		// NOTE: presentationMode は依存に入れない。mode 切替では app を再作成せず、
-		// plugin 側が modeRef 経由で最新値を読む（undo 履歴・WebSocket を残すため）。
-	}, [boardId, isCloudBoard, flavor, useCloudSync, navigate]);
+		// NOTE: presentationMode は依存に入れない。?present の切替では app を再作成せず、
+		// presentation plugin が modeRef 経由で最新値を読む（undo 履歴・WebSocket を残すため）。
+	}, [boardId, isCloudBoard, navigate]);
 
 	// ページ離脱時にビューポート位置を保存（ゴーストアバター用）
-	// プレゼン flavor も cloud 同期を使うので useCloudSync で判定する
 	useEffect(() => {
-		if (!useCloudSync || !boardId) return;
+		if (!isCloudBoard || !boardId) return;
 
 		const saveViewport = () => {
 			const ws = wsProviderRef.current;
@@ -273,7 +267,7 @@ export function App() {
 
 		window.addEventListener("beforeunload", saveViewport);
 		return () => window.removeEventListener("beforeunload", saveViewport);
-	}, [boardId, useCloudSync]);
+	}, [boardId, isCloudBoard]);
 
 	// セッション情報が確定したらAwarenessのローカル状態を更新
 	const authUserId = authUser?.id;
@@ -301,14 +295,15 @@ export function App() {
 
 	if (!app) return null;
 
-	const hideToolbar = flavor === "presentation" && presentationMode === "present";
+	// 発表モード中だけ通常のツールバーを隠す（presentation overlay のみ表示）
+	const hideToolbar = presentationMode === "present";
 
 	return (
 		<AppProvider app={app}>
 			<div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
 				<Canvas />
 				{!hideToolbar && <Toolbar boardId={boardId} isCloudBoard={isCloudBoard} />}
-				{useCloudSync && wsStatus === "failed" && (
+				{isCloudBoard && wsStatus === "failed" && (
 					<div
 						style={{
 							position: "fixed",
@@ -328,7 +323,7 @@ export function App() {
 						Unable to connect — you may not have access to this board
 					</div>
 				)}
-				{useCloudSync && wsStatus === "connecting" && (
+				{isCloudBoard && wsStatus === "connecting" && (
 					<div
 						style={{
 							position: "fixed",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -110,7 +110,8 @@ export function App() {
 	const [wsStatus, setWsStatus] = useState<WsConnectionStatus | null>(null);
 	const wsProviderRef = useRef<WsProviderHandle | null>(null);
 
-	// ボード初期化（flavor/mode/boardId/useCloudSync に依存）
+	// ボード初期化（boardId / isCloudBoard / flavor / useCloudSync に依存）。
+	// presentationMode は依存に入れていない（下の NOTE 参照）。
 	useEffect(() => {
 		if (!boardId) return;
 

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -99,6 +99,12 @@ export function App() {
 	// presentation flavor もクラウド（DB + Yjs 同期）を既定とする
 	const useCloudSync = isCloudBoard || isPresentationFlavor;
 	const { user: authUser } = useAuth();
+
+	// 最新の mode を useEffect 外部から参照するための ref。
+	// effect 依存に presentationMode を入れてしまうと切替のたびに app インスタンスが
+	// 作り直され、undo 履歴や WebSocket が吹き飛ぶ（Copilot 指摘）。
+	const modeRef = useRef<"edit" | "present">(presentationMode);
+	modeRef.current = presentationMode;
 	const [app, setApp] = useState<AppInstance | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [wsStatus, setWsStatus] = useState<WsConnectionStatus | null>(null);
@@ -135,7 +141,8 @@ export function App() {
 
 		if (flavor === "presentation") {
 			// プレゼン flavor は最小構成: presentation プラグイン + 協調プレゼン向けの3種
-			extraPlugins.push(createPresentationPlugin({ mode: presentationMode }));
+			// mode は URL で動的に変わるので ref 経由で渡す（再レンダリングの契機は plugin が popstate で受ける）
+			extraPlugins.push(createPresentationPlugin({ getMode: () => modeRef.current }));
 			if (wsProvider) {
 				extraPlugins.push(createLaserPlugin(wsProvider));
 				extraPlugins.push(createSpotlightPlugin(wsProvider));
@@ -224,7 +231,9 @@ export function App() {
 			delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
 			setApp(null);
 		};
-	}, [boardId, isCloudBoard, flavor, presentationMode, useCloudSync]);
+		// NOTE: presentationMode は依存に入れない。mode 切替では app を再作成せず、
+		// plugin 側が modeRef 経由で最新値を読む（undo 履歴・WebSocket を残すため）。
+	}, [boardId, isCloudBoard, flavor, useCloudSync]);
 
 	// ページ離脱時にビューポート位置を保存（ゴーストアバター用）
 	useEffect(() => {

--- a/apps/web/src/components/toolbar/toolbar.tsx
+++ b/apps/web/src/components/toolbar/toolbar.tsx
@@ -99,6 +99,15 @@ export function Toolbar({
 						<Divider />
 						<CopilotToggle />
 						<VoiceButton />
+						{boardId && (
+							<a
+								href={`/presentation/${boardId}?mode=edit`}
+								title="プレゼンテーション編集モードを開く"
+								style={{ ...actionBtnStyle, textDecoration: "none", fontSize: 14 }}
+							>
+								▶
+							</a>
+						)}
 					</>
 				)}
 			</div>

--- a/apps/web/src/components/toolbar/toolbar.tsx
+++ b/apps/web/src/components/toolbar/toolbar.tsx
@@ -104,7 +104,7 @@ export function Toolbar({
 						{boardId && (
 							<button
 								type="button"
-								onClick={() => navigate(`/presentation/${boardId}?mode=edit`)}
+								onClick={() => navigate(`/boards/${boardId}?present=1`)}
 								title="プレゼンテーション編集モードを開く"
 								aria-label="プレゼンテーション編集モードを開く"
 								style={{ ...actionBtnStyle, fontSize: 14 }}

--- a/apps/web/src/components/toolbar/toolbar.tsx
+++ b/apps/web/src/components/toolbar/toolbar.tsx
@@ -103,6 +103,7 @@ export function Toolbar({
 							<a
 								href={`/presentation/${boardId}?mode=edit`}
 								title="プレゼンテーション編集モードを開く"
+								aria-label="プレゼンテーション編集モードを開く"
 								style={{ ...actionBtnStyle, textDecoration: "none", fontSize: 14 }}
 							>
 								▶

--- a/apps/web/src/components/toolbar/toolbar.tsx
+++ b/apps/web/src/components/toolbar/toolbar.tsx
@@ -1,5 +1,6 @@
 import { useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import { actionBtnStyle, dividerStyle } from "../../lib/styles.js";
 import { ShareDialog } from "../share-dialog.js";
 import { StylePanel } from "../style-panel/index.js";
@@ -30,6 +31,7 @@ export function Toolbar({
 	const activeToolId = useStoreSubscribe(app.store, (s) => s.getActiveToolId());
 	const tools = app.tools.getOrdered();
 	const [showShare, setShowShare] = useState(false);
+	const navigate = useNavigate();
 
 	return (
 		<>
@@ -100,14 +102,15 @@ export function Toolbar({
 						<CopilotToggle />
 						<VoiceButton />
 						{boardId && (
-							<a
-								href={`/presentation/${boardId}?mode=edit`}
+							<button
+								type="button"
+								onClick={() => navigate(`/presentation/${boardId}?mode=edit`)}
 								title="プレゼンテーション編集モードを開く"
 								aria-label="プレゼンテーション編集モードを開く"
-								style={{ ...actionBtnStyle, textDecoration: "none", fontSize: 14 }}
+								style={{ ...actionBtnStyle, fontSize: 14 }}
 							>
 								▶
-							</a>
+							</button>
 						)}
 					</>
 				)}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -26,6 +26,7 @@ if (root) {
 						<Route path="/benchmark" element={<BenchmarkPage />} />
 						<Route path="/boards/:boardId" element={<App />} />
 						<Route path="/local/:boardId" element={<App />} />
+						<Route path="/presentation/:boardId" element={<App />} />
 						<Route path="/dashboard" element={<DashboardPage />} />
 						<Route path="/community/:slug" element={<CommunityPage />} />
 						<Route path="/community" element={<WorldMapPage />} />

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -26,7 +26,6 @@ if (root) {
 						<Route path="/benchmark" element={<BenchmarkPage />} />
 						<Route path="/boards/:boardId" element={<App />} />
 						<Route path="/local/:boardId" element={<App />} />
-						<Route path="/presentation/:boardId" element={<App />} />
 						<Route path="/dashboard" element={<DashboardPage />} />
 						<Route path="/community/:slug" element={<CommunityPage />} />
 						<Route path="/community" element={<WorldMapPage />} />

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -237,6 +237,16 @@ export interface BoardStore {
 	setViewport(viewport: Viewport): void;
 	panBy(dx: number, dy: number): void;
 	zoomTo(zoom: number, center: Point): void;
+	/**
+	 * Center the viewport so that `bounds` fits within a rectangle of
+	 * `viewportSize` (in CSS pixels), leaving `padding` pixels on each side.
+	 * `bounds` is in world coordinates.
+	 */
+	fitToBounds(
+		bounds: BoundingBox,
+		viewportSize: { width: number; height: number },
+		padding?: number,
+	): void;
 
 	getStyleSettings(): ShapeStyle;
 	setStyleSettings(style: Partial<ShapeStyle>): void;

--- a/packages/store/src/__tests__/board-store.test.ts
+++ b/packages/store/src/__tests__/board-store.test.ts
@@ -171,6 +171,66 @@ describe("BoardStore", () => {
 			store.zoomTo(100, { x: 0, y: 0 });
 			expect(store.getViewport().zoom).toBe(10);
 		});
+
+		describe("fitToBounds", () => {
+			it("centers viewport on bounds and fits with padding", () => {
+				const store = createBoardStore();
+				// 100x100 の領域を 1000x1000 のビューポートに padding=40 でフィット
+				store.fitToBounds(
+					{ x: 200, y: 300, width: 100, height: 100 },
+					{ width: 1000, height: 1000 },
+					40,
+				);
+				const vp = store.getViewport();
+				// 利用可能領域 = 1000 - 80 = 920 → zoom = 920 / 100 = 9.2
+				expect(vp.zoom).toBeCloseTo(9.2, 5);
+				// bounds の中心 (250, 350) がビューポートの中心 (500, 500) に来る
+				// → x = 500 - 250 * 9.2 = 500 - 2300 = -1800
+				expect(vp.x).toBeCloseTo(500 - 250 * 9.2, 5);
+				expect(vp.y).toBeCloseTo(500 - 350 * 9.2, 5);
+			});
+
+			it("clamps zoom to [0.1, 10]", () => {
+				const store = createBoardStore();
+				// very small bounds in large viewport → zoom would exceed 10
+				store.fitToBounds({ x: 0, y: 0, width: 1, height: 1 }, { width: 1000, height: 1000 }, 0);
+				expect(store.getViewport().zoom).toBe(10);
+
+				// huge bounds → zoom would drop below 0.1
+				store.fitToBounds(
+					{ x: 0, y: 0, width: 1_000_000, height: 1_000_000 },
+					{ width: 100, height: 100 },
+					0,
+				);
+				expect(store.getViewport().zoom).toBe(0.1);
+			});
+
+			it("no-ops for non-positive bounds or viewport size", () => {
+				const store = createBoardStore();
+				const before = store.getViewport();
+				store.fitToBounds({ x: 0, y: 0, width: 0, height: 100 }, { width: 800, height: 600 });
+				store.fitToBounds({ x: 0, y: 0, width: 100, height: -5 }, { width: 800, height: 600 });
+				store.fitToBounds({ x: 0, y: 0, width: 100, height: 100 }, { width: 0, height: 600 });
+				expect(store.getViewport()).toEqual(before);
+			});
+
+			it("defaults padding to 40 when omitted", () => {
+				const store = createBoardStore();
+				store.fitToBounds({ x: 0, y: 0, width: 100, height: 100 }, { width: 1000, height: 1000 });
+				// zoom = (1000 - 80) / 100 = 9.2
+				expect(store.getViewport().zoom).toBeCloseTo(9.2, 5);
+			});
+
+			it("emits viewport:changed mutation", () => {
+				const store = createBoardStore();
+				const listener = vi.fn();
+				store.onMutation(listener);
+				store.fitToBounds({ x: 0, y: 0, width: 100, height: 100 }, { width: 1000, height: 1000 });
+				expect(listener).toHaveBeenCalledWith(
+					expect.objectContaining({ type: "viewport:changed" }),
+				);
+			});
+		});
 	});
 
 	describe("Tool", () => {

--- a/packages/store/src/board-store.ts
+++ b/packages/store/src/board-store.ts
@@ -268,6 +268,28 @@ export function createBoardStore(): BoardStore {
 			notifyMutation("viewport:changed");
 		},
 
+		fitToBounds(
+			bounds: BoundingBox,
+			viewportSize: { width: number; height: number },
+			padding = 40,
+		) {
+			if (bounds.width <= 0 || bounds.height <= 0) return;
+			if (viewportSize.width <= 0 || viewportSize.height <= 0) return;
+			const availW = Math.max(1, viewportSize.width - padding * 2);
+			const availH = Math.max(1, viewportSize.height - padding * 2);
+			const rawZoom = Math.min(availW / bounds.width, availH / bounds.height);
+			const zoom = Math.min(Math.max(rawZoom, 0.1), 10);
+			const cx = bounds.x + bounds.width / 2;
+			const cy = bounds.y + bounds.height / 2;
+			state.viewport = {
+				x: viewportSize.width / 2 - cx * zoom,
+				y: viewportSize.height / 2 - cy * zoom,
+				zoom,
+			};
+			notify();
+			notifyMutation("viewport:changed");
+		},
+
 		getStyleSettings: () => state.styleSettings,
 
 		setStyleSettings(style: Partial<ShapeStyle>) {

--- a/plugins/usketch-plugin-presentation/package.json
+++ b/plugins/usketch-plugin-presentation/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "@edv4h/usketch-plugin-presentation",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shared": "workspace:*"
+	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.14",
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	}
+}

--- a/plugins/usketch-plugin-presentation/package.json
+++ b/plugins/usketch-plugin-presentation/package.json
@@ -19,7 +19,8 @@
 		"clean": "rm -rf dist"
 	},
 	"dependencies": {
-		"@edv4h/usketch-shared": "workspace:*"
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*"
 	},
 	"peerDependencies": {
 		"react": ">=19"

--- a/plugins/usketch-plugin-presentation/src/index.ts
+++ b/plugins/usketch-plugin-presentation/src/index.ts
@@ -1,0 +1,3 @@
+export type { PresentationMode, PresentationPluginOptions } from "./plugin.js";
+export { createPresentationPlugin } from "./plugin.js";
+export { SlideNavigator } from "./slide-navigator.js";

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -1,0 +1,71 @@
+import type { LayerRenderContext, PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import { PresentModeOverlay } from "./present-mode-overlay.js";
+import { SlideNavigator } from "./slide-navigator.js";
+import { SlideOutlinePanel } from "./slide-outline-panel.js";
+
+export type PresentationMode = "edit" | "present";
+
+export interface PresentationPluginOptions {
+	mode: PresentationMode;
+}
+
+function getWindowSize(): { width: number; height: number } {
+	return { width: window.innerWidth, height: window.innerHeight };
+}
+
+export function createPresentationPlugin(opts: PresentationPluginOptions): UsketchPlugin {
+	const mode = opts.mode;
+	let nav: SlideNavigator | null = null;
+	const unregisters: Array<() => void> = [];
+
+	return {
+		id: "presentation",
+		name: "Presentation",
+		setup(ctx: PluginContext) {
+			nav = new SlideNavigator(ctx.store, getWindowSize);
+
+			if (mode === "present") {
+				const navRef = nav;
+				unregisters.push(ctx.shortcuts.register("ArrowRight", () => navRef.next()));
+				unregisters.push(ctx.shortcuts.register("ArrowLeft", () => navRef.prev()));
+				unregisters.push(ctx.shortcuts.register("Space", () => navRef.next()));
+				unregisters.push(ctx.shortcuts.register("Home", () => navRef.first()));
+				unregisters.push(ctx.shortcuts.register("End", () => navRef.last()));
+				unregisters.push(
+					ctx.shortcuts.register("Escape", () => {
+						const url = new URL(window.location.href);
+						url.searchParams.set("mode", "edit");
+						window.history.replaceState(null, "", url.toString());
+						// replaceState は popstate を発火させないので明示的に通知する
+						window.dispatchEvent(new PopStateEvent("popstate"));
+					}),
+				);
+
+				// 初期表示: 最初のスライドに寄せる
+				nav.first();
+			}
+
+			const layerId = "presentation-overlay";
+			ctx.layers.register({
+				id: layerId,
+				order: mode === "present" ? 200 : 90,
+				fixed: true,
+				render: (renderCtx: LayerRenderContext) => {
+					if (!nav) return null;
+					return mode === "present" ? (
+						<PresentModeOverlay nav={nav} />
+					) : (
+						<SlideOutlinePanel nav={nav} store={ctx.store} renderCtx={renderCtx} />
+					);
+				},
+			});
+			unregisters.push(() => ctx.layers.unregister(layerId));
+		},
+		teardown() {
+			for (const u of unregisters) u();
+			unregisters.length = 0;
+			nav?.destroy();
+			nav = null;
+		},
+	};
+}

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -1,4 +1,9 @@
-import type { LayerRenderContext, PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import type {
+	CommandRegistry,
+	LayerRenderContext,
+	PluginContext,
+	UsketchPlugin,
+} from "@edv4h/usketch-shared";
 import { PresentModeOverlay } from "./present-mode-overlay.js";
 import { SlideNavigator } from "./slide-navigator.js";
 import { SlideOutlinePanel } from "./slide-outline-panel.js";
@@ -28,7 +33,6 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 				const navRef = nav;
 				unregisters.push(ctx.shortcuts.register("ArrowRight", () => navRef.next()));
 				unregisters.push(ctx.shortcuts.register("ArrowLeft", () => navRef.prev()));
-				unregisters.push(ctx.shortcuts.register("Space", () => navRef.next()));
 				unregisters.push(ctx.shortcuts.register("Home", () => navRef.first()));
 				unregisters.push(ctx.shortcuts.register("End", () => navRef.last()));
 				unregisters.push(
@@ -41,11 +45,30 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 					}),
 				);
 
+				// Space キーは shortcut-registry のキー名正規化（trim）で扱えないため、
+				// window 経由で直接ハンドリングする。PageDown / PageUp も同様に発表向けで受ける。
+				const onKeyDown = (e: KeyboardEvent) => {
+					const target = e.target as HTMLElement | null;
+					if (target && (target.isContentEditable || /input|textarea/i.test(target.tagName)))
+						return;
+					if (e.ctrlKey || e.metaKey || e.altKey) return;
+					if (e.key === " " || e.key === "PageDown") {
+						e.preventDefault();
+						navRef.next();
+					} else if (e.key === "PageUp") {
+						e.preventDefault();
+						navRef.prev();
+					}
+				};
+				window.addEventListener("keydown", onKeyDown);
+				unregisters.push(() => window.removeEventListener("keydown", onKeyDown));
+
 				// 初期表示: 最初のスライドに寄せる
 				nav.first();
 			}
 
 			const layerId = "presentation-overlay";
+			const commandsRef: CommandRegistry = ctx.commands;
 			ctx.layers.register({
 				id: layerId,
 				order: mode === "present" ? 200 : 90,
@@ -55,7 +78,12 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 					return mode === "present" ? (
 						<PresentModeOverlay nav={nav} />
 					) : (
-						<SlideOutlinePanel nav={nav} store={ctx.store} renderCtx={renderCtx} />
+						<SlideOutlinePanel
+							nav={nav}
+							store={ctx.store}
+							commands={commandsRef}
+							renderCtx={renderCtx}
+						/>
 					);
 				},
 			});

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -21,6 +21,11 @@ export interface PresentationPluginOptions {
 	 * モード変化を監視したいとき用の購読 API。省略時は window の popstate を使う。
 	 */
 	subscribeMode?: (listener: () => void) => () => void;
+	/**
+	 * 通常のホワイトボード（/boards/:boardId）へ戻るためのナビゲーション。
+	 * apps/web 側で react-router の navigate を渡す。省略時は window.location.assign。
+	 */
+	navigateToBoard?: () => void;
 }
 
 function getWindowSize(): { width: number; height: number } {
@@ -32,9 +37,16 @@ function defaultSubscribeMode(listener: () => void): () => void {
 	return () => window.removeEventListener("popstate", listener);
 }
 
+function defaultNavigateToBoard(): void {
+	// plugin 単独での最終手段。apps/web からは navigateToBoard を注入してフル遷移を回避する。
+	const match = window.location.pathname.match(/^\/presentation\/([^/]+)/);
+	if (match) window.location.assign(`/boards/${match[1]}`);
+}
+
 export function createPresentationPlugin(opts: PresentationPluginOptions): UsketchPlugin {
 	const getMode = opts.getMode;
 	const subscribeMode = opts.subscribeMode ?? defaultSubscribeMode;
+	const navigateToBoard = opts.navigateToBoard ?? defaultNavigateToBoard;
 	let nav: SlideNavigator | null = null;
 	const unregisters: Array<() => void> = [];
 
@@ -136,6 +148,7 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 							renderCtx={renderCtx}
 							getMode={getMode}
 							subscribeMode={subscribeMode}
+							navigateToBoard={navigateToBoard}
 						/>
 					);
 				},
@@ -162,6 +175,7 @@ interface PresentationLayerProps {
 	renderCtx: LayerRenderContext;
 	getMode: () => PresentationMode;
 	subscribeMode: (listener: () => void) => () => void;
+	navigateToBoard: () => void;
 }
 
 function PresentationLayer({
@@ -171,6 +185,7 @@ function PresentationLayer({
 	renderCtx,
 	getMode,
 	subscribeMode,
+	navigateToBoard,
 }: PresentationLayerProps) {
 	const [mode, setMode] = usePresentationMode(getMode, subscribeMode);
 	if (mode === "present") {
@@ -178,7 +193,15 @@ function PresentationLayer({
 	}
 	// _setMode は使わないが、useState 戻り値として形式的に受ける
 	void setMode;
-	return <SlideOutlinePanel nav={nav} store={store} commands={commands} renderCtx={renderCtx} />;
+	return (
+		<SlideOutlinePanel
+			nav={nav}
+			store={store}
+			commands={commands}
+			renderCtx={renderCtx}
+			navigateToBoard={navigateToBoard}
+		/>
+	);
 }
 
 function usePresentationMode(

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -4,6 +4,7 @@ import type {
 	PluginContext,
 	UsketchPlugin,
 } from "@edv4h/usketch-shared";
+import { useEffect, useState } from "react";
 import { PresentModeOverlay } from "./present-mode-overlay.js";
 import { SlideNavigator } from "./slide-navigator.js";
 import { SlideOutlinePanel } from "./slide-outline-panel.js";
@@ -11,15 +12,29 @@ import { SlideOutlinePanel } from "./slide-outline-panel.js";
 export type PresentationMode = "edit" | "present";
 
 export interface PresentationPluginOptions {
-	mode: PresentationMode;
+	/**
+	 * 現在のモードを返す関数。URL から動的に読む前提。
+	 * mode 切替時に app 全体を再生成しないために、getter で渡す。
+	 */
+	getMode: () => PresentationMode;
+	/**
+	 * モード変化を監視したいとき用の購読 API。省略時は window の popstate を使う。
+	 */
+	subscribeMode?: (listener: () => void) => () => void;
 }
 
 function getWindowSize(): { width: number; height: number } {
 	return { width: window.innerWidth, height: window.innerHeight };
 }
 
+function defaultSubscribeMode(listener: () => void): () => void {
+	window.addEventListener("popstate", listener);
+	return () => window.removeEventListener("popstate", listener);
+}
+
 export function createPresentationPlugin(opts: PresentationPluginOptions): UsketchPlugin {
-	const mode = opts.mode;
+	const getMode = opts.getMode;
+	const subscribeMode = opts.subscribeMode ?? defaultSubscribeMode;
 	let nav: SlideNavigator | null = null;
 	const unregisters: Array<() => void> = [];
 
@@ -28,61 +43,99 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 		name: "Presentation",
 		setup(ctx: PluginContext) {
 			nav = new SlideNavigator(ctx.store, getWindowSize);
+			const navRef = nav;
 
-			if (mode === "present") {
-				const navRef = nav;
-				unregisters.push(ctx.shortcuts.register("ArrowRight", () => navRef.next()));
-				unregisters.push(ctx.shortcuts.register("ArrowLeft", () => navRef.prev()));
-				unregisters.push(ctx.shortcuts.register("Home", () => navRef.first()));
-				unregisters.push(ctx.shortcuts.register("End", () => navRef.last()));
-				unregisters.push(
-					ctx.shortcuts.register("Escape", () => {
+			// 発表モード中のみ動くショートカット群（mode を実行時に毎回評価する）
+			const ifPresent = (fn: () => void) => () => {
+				if (getMode() === "present") fn();
+			};
+			unregisters.push(
+				ctx.shortcuts.register(
+					"ArrowRight",
+					ifPresent(() => navRef.next()),
+				),
+			);
+			unregisters.push(
+				ctx.shortcuts.register(
+					"ArrowLeft",
+					ifPresent(() => navRef.prev()),
+				),
+			);
+			unregisters.push(
+				ctx.shortcuts.register(
+					"Home",
+					ifPresent(() => navRef.first()),
+				),
+			);
+			unregisters.push(
+				ctx.shortcuts.register(
+					"End",
+					ifPresent(() => navRef.last()),
+				),
+			);
+			unregisters.push(
+				ctx.shortcuts.register(
+					"Escape",
+					ifPresent(() => {
 						const url = new URL(window.location.href);
 						url.searchParams.set("mode", "edit");
 						window.history.replaceState(null, "", url.toString());
 						// replaceState は popstate を発火させないので明示的に通知する
 						window.dispatchEvent(new PopStateEvent("popstate"));
 					}),
-				);
+				),
+			);
 
-				// Space キーは shortcut-registry のキー名正規化（trim）で扱えないため、
-				// window 経由で直接ハンドリングする。PageDown / PageUp も同様に発表向けで受ける。
-				const onKeyDown = (e: KeyboardEvent) => {
-					const target = e.target as HTMLElement | null;
-					if (target && (target.isContentEditable || /input|textarea/i.test(target.tagName)))
-						return;
-					if (e.ctrlKey || e.metaKey || e.altKey) return;
-					if (e.key === " " || e.key === "PageDown") {
-						e.preventDefault();
-						navRef.next();
-					} else if (e.key === "PageUp") {
-						e.preventDefault();
-						navRef.prev();
-					}
-				};
-				window.addEventListener("keydown", onKeyDown);
-				unregisters.push(() => window.removeEventListener("keydown", onKeyDown));
+			// Space キーは shortcut-registry のキー名正規化（trim）で扱えないため、
+			// window 経由で直接ハンドリングする。PageDown / PageUp も同様に発表向けで受ける。
+			const onKeyDown = (e: KeyboardEvent) => {
+				if (getMode() !== "present") return;
+				const target = e.target as HTMLElement | null;
+				if (target && (target.isContentEditable || /input|textarea/i.test(target.tagName))) return;
+				if (e.ctrlKey || e.metaKey || e.altKey) return;
+				if (e.key === " " || e.key === "PageDown") {
+					e.preventDefault();
+					navRef.next();
+				} else if (e.key === "PageUp") {
+					e.preventDefault();
+					navRef.prev();
+				}
+			};
+			window.addEventListener("keydown", onKeyDown);
+			unregisters.push(() => window.removeEventListener("keydown", onKeyDown));
 
-				// 初期表示: 最初のスライドに寄せる
-				nav.first();
-			}
+			// 発表モードに入ったら最初のスライドに寄せる。
+			let prevMode = getMode();
+			const syncOnModeChange = () => {
+				const current = getMode();
+				if (current !== prevMode) {
+					prevMode = current;
+					if (current === "present") navRef.first();
+				}
+			};
+			unregisters.push(subscribeMode(syncOnModeChange));
+			// 初期表示
+			if (prevMode === "present") navRef.first();
 
+			// レイヤー: mode に応じて edit (パネル) / present (オーバーレイ) を出し分ける。
+			// react 側で LayerRenderContext を経由して再 render されるので、子コンポーネント
+			// が mode を内部状態で購読する。
 			const layerId = "presentation-overlay";
 			const commandsRef: CommandRegistry = ctx.commands;
 			ctx.layers.register({
 				id: layerId,
-				order: mode === "present" ? 200 : 90,
+				order: 200,
 				fixed: true,
 				render: (renderCtx: LayerRenderContext) => {
 					if (!nav) return null;
-					return mode === "present" ? (
-						<PresentModeOverlay nav={nav} />
-					) : (
-						<SlideOutlinePanel
+					return (
+						<PresentationLayer
 							nav={nav}
 							store={ctx.store}
 							commands={commandsRef}
 							renderCtx={renderCtx}
+							getMode={getMode}
+							subscribeMode={subscribeMode}
 						/>
 					);
 				},
@@ -96,4 +149,47 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 			nav = null;
 		},
 	};
+}
+
+/**
+ * モード変化に応じて edit / present の UI を切り替えるラッパ。
+ * plugin 本体の teardown を起こさないため、URL の mode クエリをここで購読する。
+ */
+interface PresentationLayerProps {
+	nav: SlideNavigator;
+	store: PluginContext["store"];
+	commands: CommandRegistry;
+	renderCtx: LayerRenderContext;
+	getMode: () => PresentationMode;
+	subscribeMode: (listener: () => void) => () => void;
+}
+
+function PresentationLayer({
+	nav,
+	store,
+	commands,
+	renderCtx,
+	getMode,
+	subscribeMode,
+}: PresentationLayerProps) {
+	const [mode, setMode] = usePresentationMode(getMode, subscribeMode);
+	if (mode === "present") {
+		return <PresentModeOverlay nav={nav} />;
+	}
+	// _setMode は使わないが、useState 戻り値として形式的に受ける
+	void setMode;
+	return <SlideOutlinePanel nav={nav} store={store} commands={commands} renderCtx={renderCtx} />;
+}
+
+function usePresentationMode(
+	getMode: () => PresentationMode,
+	subscribeMode: (listener: () => void) => () => void,
+): [PresentationMode, (m: PresentationMode) => void] {
+	const [mode, setMode] = useState<PresentationMode>(getMode);
+	useEffect(() => {
+		const update = () => setMode(getMode());
+		update();
+		return subscribeMode(update);
+	}, [getMode, subscribeMode]);
+	return [mode, setMode];
 }

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -9,7 +9,8 @@ import { PresentModeOverlay } from "./present-mode-overlay.js";
 import { SlideNavigator } from "./slide-navigator.js";
 import { SlideOutlinePanel } from "./slide-outline-panel.js";
 
-export type PresentationMode = "edit" | "present";
+/** "off" = プレゼン UI 非表示（通常のホワイトボード扱い） */
+export type PresentationMode = "off" | "edit" | "present";
 
 export interface PresentationPluginOptions {
 	/**
@@ -38,9 +39,13 @@ function defaultSubscribeMode(listener: () => void): () => void {
 }
 
 function defaultNavigateToBoard(): void {
-	// plugin 単独での最終手段。apps/web からは navigateToBoard を注入してフル遷移を回避する。
-	const match = window.location.pathname.match(/^\/presentation\/([^/]+)/);
-	if (match) window.location.assign(`/boards/${match[1]}`);
+	// plugin 単独での最終手段。apps/web からは navigateToBoard を注入して SPA 遷移を使う。
+	// ?present / ?mode クエリを落として通常ホワイトボードに戻す。
+	const url = new URL(window.location.href);
+	url.searchParams.delete("present");
+	url.searchParams.delete("mode");
+	window.history.replaceState(null, "", url.toString());
+	window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
 export function createPresentationPlugin(opts: PresentationPluginOptions): UsketchPlugin {
@@ -90,6 +95,7 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 					"Escape",
 					ifPresent(() => {
 						const url = new URL(window.location.href);
+						url.searchParams.set("present", "1");
 						url.searchParams.set("mode", "edit");
 						window.history.replaceState(null, "", url.toString());
 						// replaceState は popstate を発火させないので明示的に通知する
@@ -188,11 +194,9 @@ function PresentationLayer({
 	navigateToBoard,
 }: PresentationLayerProps) {
 	const [mode, setMode] = usePresentationMode(getMode, subscribeMode);
-	if (mode === "present") {
-		return <PresentModeOverlay nav={nav} />;
-	}
-	// _setMode は使わないが、useState 戻り値として形式的に受ける
 	void setMode;
+	if (mode === "off") return null;
+	if (mode === "present") return <PresentModeOverlay nav={nav} />;
 	return (
 		<SlideOutlinePanel
 			nav={nav}

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from "react";
+import type { SlideNavigator } from "./slide-navigator.js";
+
+interface Props {
+	nav: SlideNavigator;
+}
+
+export function PresentModeOverlay({ nav }: Props) {
+	const [index, setIndex] = useState(nav.getCurrentIndex());
+	const [total, setTotal] = useState(nav.getSlides().length);
+	const [visible, setVisible] = useState(true);
+
+	useEffect(() => {
+		const unsub = nav.onChange((i) => {
+			setIndex(i);
+			setTotal(nav.getSlides().length);
+		});
+		return unsub;
+	}, [nav]);
+
+	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout> | null = null;
+		const showAndSchedule = () => {
+			setVisible(true);
+			if (timer) clearTimeout(timer);
+			timer = setTimeout(() => setVisible(false), 3000);
+		};
+		showAndSchedule();
+		window.addEventListener("mousemove", showAndSchedule);
+		window.addEventListener("keydown", showAndSchedule);
+		return () => {
+			if (timer) clearTimeout(timer);
+			window.removeEventListener("mousemove", showAndSchedule);
+			window.removeEventListener("keydown", showAndSchedule);
+		};
+	}, []);
+
+	if (total === 0) {
+		return (
+			<div
+				style={{
+					position: "fixed",
+					inset: 0,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					pointerEvents: "none",
+					color: "rgba(255,255,255,0.7)",
+					background: "rgba(0,0,0,0.3)",
+					font: "14px system-ui",
+				}}
+			>
+				スライド（Frame）がありません。編集モードでフレームを追加してください。
+			</div>
+		);
+	}
+
+	const progress = total > 1 ? index / (total - 1) : 1;
+
+	const exitPresent = () => {
+		const url = new URL(window.location.href);
+		url.searchParams.set("mode", "edit");
+		window.history.replaceState(null, "", url.toString());
+		window.dispatchEvent(new PopStateEvent("popstate"));
+	};
+
+	return (
+		<div
+			style={{
+				position: "fixed",
+				inset: 0,
+				pointerEvents: "none",
+				opacity: visible ? 1 : 0,
+				transition: "opacity 0.3s",
+			}}
+		>
+			<button
+				type="button"
+				onClick={exitPresent}
+				title="編集モードに戻る (Esc)"
+				style={{
+					position: "absolute",
+					top: 16,
+					right: 16,
+					appearance: "none",
+					background: "rgba(0,0,0,0.6)",
+					border: "none",
+					color: "white",
+					cursor: "pointer",
+					width: 36,
+					height: 36,
+					borderRadius: "50%",
+					fontSize: 18,
+					lineHeight: 1,
+					pointerEvents: "auto",
+				}}
+			>
+				✕
+			</button>
+			<div
+				style={{
+					position: "absolute",
+					top: 0,
+					left: 0,
+					right: 0,
+					height: 3,
+					background: "rgba(255,255,255,0.1)",
+				}}
+			>
+				<div
+					style={{
+						height: "100%",
+						width: `${progress * 100}%`,
+						background: "#4f9dff",
+						transition: "width 0.3s",
+					}}
+				/>
+			</div>
+
+			<div
+				style={{
+					position: "absolute",
+					bottom: 24,
+					left: "50%",
+					transform: "translateX(-50%)",
+					display: "flex",
+					alignItems: "center",
+					gap: 12,
+					padding: "8px 16px",
+					background: "rgba(0,0,0,0.6)",
+					color: "white",
+					borderRadius: 999,
+					font: "14px system-ui",
+					pointerEvents: "auto",
+				}}
+			>
+				<button
+					type="button"
+					onClick={() => nav.prev()}
+					disabled={index === 0}
+					style={buttonStyle(index === 0)}
+					aria-label="前のスライド"
+				>
+					‹
+				</button>
+				<span style={{ minWidth: 48, textAlign: "center" }}>
+					{index + 1} / {total}
+				</span>
+				<button
+					type="button"
+					onClick={() => nav.next()}
+					disabled={index >= total - 1}
+					style={buttonStyle(index >= total - 1)}
+					aria-label="次のスライド"
+				>
+					›
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function buttonStyle(disabled: boolean): React.CSSProperties {
+	return {
+		appearance: "none",
+		border: "none",
+		background: "transparent",
+		color: "white",
+		cursor: disabled ? "default" : "pointer",
+		opacity: disabled ? 0.3 : 1,
+		fontSize: 20,
+		width: 28,
+		height: 28,
+		borderRadius: 4,
+	};
+}

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -78,6 +78,7 @@ export function PresentModeOverlay({ nav }: Props) {
 				type="button"
 				onClick={exitPresent}
 				title="編集モードに戻る (Esc)"
+				aria-label="編集モードに戻る"
 				style={{
 					position: "absolute",
 					top: 16,

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -59,6 +59,7 @@ export function PresentModeOverlay({ nav }: Props) {
 
 	const exitPresent = () => {
 		const url = new URL(window.location.href);
+		url.searchParams.set("present", "1");
 		url.searchParams.set("mode", "edit");
 		window.history.replaceState(null, "", url.toString());
 		window.dispatchEvent(new PopStateEvent("popstate"));

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -9,19 +9,24 @@ export class SlideNavigator {
 	private readonly changeListeners = new Set<(index: number) => void>();
 	private readonly unsubscribeStore: () => void;
 	private getViewportSize: () => { width: number; height: number };
+	/** 現在 Frame として扱っている shape id。`shape:removed` で id が消えたかどうかの判定に使う。 */
+	private frameIds: Set<string>;
 
 	constructor(
 		private readonly store: BoardStore,
 		getViewportSize: () => { width: number; height: number },
 	) {
 		this.getViewportSize = getViewportSize;
+		this.frameIds = new Set(this.getSlides().map((s) => s.id));
 		// スライド構成（＝フレーム追加/削除/並び替え）に関係するミューテーションだけを聞く。
 		// store.subscribe は viewport 変更でも発火するので、それを契機にリスナーを呼ぶと
 		// gotoIndex 中の fitToBounds で余計な onChange が一度走ってしまう。
 		this.unsubscribeStore = store.onMutation((event) => {
 			if (!this.isSlideRelatedMutation(event.type, event.payload)) return;
+			// frame セットを更新
+			this.frameIds = new Set(this.getSlides().map((s) => s.id));
 			// スライド数が減って currentIndex が範囲外になっていれば clamp する。
-			const slideCount = this.getSlides().length;
+			const slideCount = this.frameIds.size;
 			if (slideCount === 0) {
 				this.currentIndex = 0;
 			} else if (this.currentIndex >= slideCount) {
@@ -33,12 +38,18 @@ export class SlideNavigator {
 
 	/**
 	 * mutation がスライド一覧に影響するか判定する。
-	 * 非フレームの shape:updated（ドラッグ中の位置更新やテキスト編集など）は無視する。
+	 * - shape:added / shape:updated → 対象 shape が frame のときだけ影響（非フレームのドラッグ等は無視）
+	 * - shape:removed → 削除された id が現在の frame セットにあったときだけ影響
+	 * - shapes:z-index-initialized → 常に影響
 	 */
 	private isSlideRelatedMutation(type: string, payload: unknown): boolean {
-		if (type === "shape:removed" || type === "shapes:z-index-initialized") return true;
-		if (type !== "shape:added" && type !== "shape:updated") return false;
+		if (type === "shapes:z-index-initialized") return true;
 		const id = (payload as { id?: unknown } | null | undefined)?.id;
+		if (type === "shape:removed") {
+			if (typeof id !== "string") return true;
+			return this.frameIds.has(id);
+		}
+		if (type !== "shape:added" && type !== "shape:updated") return false;
 		if (typeof id !== "string") {
 			// id が取れない想定外形式は安全側で通す
 			return true;

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -15,8 +15,18 @@ export class SlideNavigator {
 		getViewportSize: () => { width: number; height: number },
 	) {
 		this.getViewportSize = getViewportSize;
-		this.unsubscribeStore = store.subscribe(() => {
-			for (const l of this.changeListeners) l(this.currentIndex);
+		// スライド構成（＝フレーム追加/削除/並び替え）に関係するミューテーションだけを聞く。
+		// store.subscribe は viewport 変更でも発火するので、それを契機にリスナーを呼ぶと
+		// gotoIndex 中の fitToBounds で余計な onChange が一度走ってしまう。
+		this.unsubscribeStore = store.onMutation((event) => {
+			if (
+				event.type === "shape:added" ||
+				event.type === "shape:removed" ||
+				event.type === "shape:updated" ||
+				event.type === "shapes:z-index-initialized"
+			) {
+				for (const l of this.changeListeners) l(this.currentIndex);
+			}
 		});
 	}
 
@@ -32,6 +42,10 @@ export class SlideNavigator {
 		const slides = this.getSlides();
 		if (slides.length === 0) return;
 		const clamped = Math.max(0, Math.min(index, slides.length - 1));
+		// currentIndex を fitToBounds より先に更新して、後続の通知が
+		// 「古い index で発火し、その直後に新しい index で発火する」という
+		// 二段階発火を避ける。
+		this.currentIndex = clamped;
 		const target = slides[clamped];
 		if (target) {
 			const bounds: BoundingBox = {
@@ -42,7 +56,6 @@ export class SlideNavigator {
 			};
 			this.store.fitToBounds(bounds, this.getViewportSize());
 		}
-		this.currentIndex = clamped;
 		for (const l of this.changeListeners) l(clamped);
 	}
 

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -6,6 +6,12 @@ import type { BoardStore, BoundingBox, ShapeData } from "@edv4h/usketch-shared";
  */
 export class SlideNavigator {
 	private currentIndex = 0;
+	/**
+	 * 現在選択中のスライド（Frame）の shape id。
+	 * 並び替えや追加で index だけ覚えていると指す Frame が変わってしまうので、
+	 * 可能な限り id で追跡し、mutation 後に新しい slides 配列から index を再導出する。
+	 */
+	private currentFrameId: string | null = null;
 	private readonly changeListeners = new Set<(index: number) => void>();
 	private readonly unsubscribeStore: () => void;
 	private getViewportSize: () => { width: number; height: number };
@@ -17,20 +23,31 @@ export class SlideNavigator {
 		getViewportSize: () => { width: number; height: number },
 	) {
 		this.getViewportSize = getViewportSize;
-		this.frameIds = new Set(this.getSlides().map((s) => s.id));
+		const initialSlides = this.getSlides();
+		this.frameIds = new Set(initialSlides.map((s) => s.id));
+		this.currentFrameId = initialSlides[0]?.id ?? null;
 		// スライド構成（＝フレーム追加/削除/並び替え）に関係するミューテーションだけを聞く。
 		// store.subscribe は viewport 変更でも発火するので、それを契機にリスナーを呼ぶと
 		// gotoIndex 中の fitToBounds で余計な onChange が一度走ってしまう。
 		this.unsubscribeStore = store.onMutation((event) => {
 			if (!this.isSlideRelatedMutation(event.type, event.payload)) return;
-			// frame セットを更新
-			this.frameIds = new Set(this.getSlides().map((s) => s.id));
-			// スライド数が減って currentIndex が範囲外になっていれば clamp する。
-			const slideCount = this.frameIds.size;
-			if (slideCount === 0) {
+			// frame セットと現在の index を再構築する（並び替え時も currentFrameId を基準に再導出）
+			const slides = this.getSlides();
+			this.frameIds = new Set(slides.map((s) => s.id));
+			if (slides.length === 0) {
+				this.currentFrameId = null;
 				this.currentIndex = 0;
-			} else if (this.currentIndex >= slideCount) {
-				this.currentIndex = slideCount - 1;
+			} else {
+				// id が残っていればその新 index に、無ければ旧 index を slides 数に clamp
+				const foundIdx = this.currentFrameId
+					? slides.findIndex((s) => s.id === this.currentFrameId)
+					: -1;
+				if (foundIdx >= 0) {
+					this.currentIndex = foundIdx;
+				} else {
+					this.currentIndex = Math.min(this.currentIndex, slides.length - 1);
+					this.currentFrameId = slides[this.currentIndex]?.id ?? null;
+				}
 			}
 			for (const l of this.changeListeners) l(this.currentIndex);
 		});
@@ -70,11 +87,12 @@ export class SlideNavigator {
 		const slides = this.getSlides();
 		if (slides.length === 0) return;
 		const clamped = Math.max(0, Math.min(index, slides.length - 1));
-		// currentIndex を fitToBounds より先に更新して、後続の通知が
+		// currentIndex / currentFrameId を fitToBounds より先に更新して、後続の通知が
 		// 「古い index で発火し、その直後に新しい index で発火する」という
 		// 二段階発火を避ける。
 		this.currentIndex = clamped;
 		const target = slides[clamped];
+		this.currentFrameId = target?.id ?? null;
 		if (target) {
 			const bounds: BoundingBox = {
 				x: target.x,

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -1,0 +1,76 @@
+import type { BoardStore, BoundingBox, ShapeData } from "@edv4h/usketch-shared";
+
+/**
+ * Frame シェイプを表示順（zIndex 昇順）で並べたものを「スライド」と解釈する。
+ * 新しいドメイン概念を Frame に持ち込まないのがポイント。
+ */
+export class SlideNavigator {
+	private currentIndex = 0;
+	private readonly changeListeners = new Set<(index: number) => void>();
+	private readonly unsubscribeStore: () => void;
+	private getViewportSize: () => { width: number; height: number };
+
+	constructor(
+		private readonly store: BoardStore,
+		getViewportSize: () => { width: number; height: number },
+	) {
+		this.getViewportSize = getViewportSize;
+		this.unsubscribeStore = store.subscribe(() => {
+			for (const l of this.changeListeners) l(this.currentIndex);
+		});
+	}
+
+	getSlides(): ShapeData[] {
+		return this.store.getShapesSorted().filter((s) => s.type === "frame");
+	}
+
+	getCurrentIndex(): number {
+		return this.currentIndex;
+	}
+
+	gotoIndex(index: number): void {
+		const slides = this.getSlides();
+		if (slides.length === 0) return;
+		const clamped = Math.max(0, Math.min(index, slides.length - 1));
+		const target = slides[clamped];
+		if (target) {
+			const bounds: BoundingBox = {
+				x: target.x,
+				y: target.y,
+				width: target.width,
+				height: target.height,
+			};
+			this.store.fitToBounds(bounds, this.getViewportSize());
+		}
+		this.currentIndex = clamped;
+		for (const l of this.changeListeners) l(clamped);
+	}
+
+	next(): void {
+		this.gotoIndex(this.currentIndex + 1);
+	}
+
+	prev(): void {
+		this.gotoIndex(this.currentIndex - 1);
+	}
+
+	first(): void {
+		this.gotoIndex(0);
+	}
+
+	last(): void {
+		this.gotoIndex(this.getSlides().length - 1);
+	}
+
+	onChange(listener: (index: number) => void): () => void {
+		this.changeListeners.add(listener);
+		return () => {
+			this.changeListeners.delete(listener);
+		};
+	}
+
+	destroy(): void {
+		this.unsubscribeStore();
+		this.changeListeners.clear();
+	}
+}

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -19,15 +19,32 @@ export class SlideNavigator {
 		// store.subscribe は viewport 変更でも発火するので、それを契機にリスナーを呼ぶと
 		// gotoIndex 中の fitToBounds で余計な onChange が一度走ってしまう。
 		this.unsubscribeStore = store.onMutation((event) => {
-			if (
-				event.type === "shape:added" ||
-				event.type === "shape:removed" ||
-				event.type === "shape:updated" ||
-				event.type === "shapes:z-index-initialized"
-			) {
-				for (const l of this.changeListeners) l(this.currentIndex);
+			if (!this.isSlideRelatedMutation(event.type, event.payload)) return;
+			// スライド数が減って currentIndex が範囲外になっていれば clamp する。
+			const slideCount = this.getSlides().length;
+			if (slideCount === 0) {
+				this.currentIndex = 0;
+			} else if (this.currentIndex >= slideCount) {
+				this.currentIndex = slideCount - 1;
 			}
+			for (const l of this.changeListeners) l(this.currentIndex);
 		});
+	}
+
+	/**
+	 * mutation がスライド一覧に影響するか判定する。
+	 * 非フレームの shape:updated（ドラッグ中の位置更新やテキスト編集など）は無視する。
+	 */
+	private isSlideRelatedMutation(type: string, payload: unknown): boolean {
+		if (type === "shape:removed" || type === "shapes:z-index-initialized") return true;
+		if (type !== "shape:added" && type !== "shape:updated") return false;
+		const id = (payload as { id?: unknown } | null | undefined)?.id;
+		if (typeof id !== "string") {
+			// id が取れない想定外形式は安全側で通す
+			return true;
+		}
+		const shape = this.store.getShape(id);
+		return shape?.type === "frame";
 	}
 
 	getSlides(): ShapeData[] {

--- a/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
+++ b/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
@@ -1,0 +1,241 @@
+import type { BoardStore, LayerRenderContext, ShapeData } from "@edv4h/usketch-shared";
+import { useEffect, useState } from "react";
+import type { SlideNavigator } from "./slide-navigator.js";
+
+interface Props {
+	nav: SlideNavigator;
+	store: BoardStore;
+	renderCtx: LayerRenderContext;
+}
+
+export function SlideOutlinePanel({ nav, store, renderCtx: _renderCtx }: Props) {
+	const [slides, setSlides] = useState<ShapeData[]>(nav.getSlides());
+	const [current, setCurrent] = useState(nav.getCurrentIndex());
+
+	useEffect(() => {
+		const unsub = nav.onChange((i) => {
+			setSlides(nav.getSlides());
+			setCurrent(i);
+		});
+		return unsub;
+	}, [nav]);
+
+	const startPresent = () => {
+		const url = new URL(window.location.href);
+		url.searchParams.set("mode", "present");
+		window.history.replaceState(null, "", url.toString());
+		window.dispatchEvent(new PopStateEvent("popstate"));
+	};
+
+	const exitToBoard = () => {
+		// /presentation/:boardId?... → /boards/:boardId
+		const match = window.location.pathname.match(/^\/presentation\/([^/]+)/);
+		if (match) {
+			window.location.assign(`/boards/${match[1]}`);
+		}
+	};
+
+	return (
+		<div
+			style={{
+				position: "fixed",
+				top: 80,
+				left: 8,
+				width: 140,
+				maxHeight: "calc(100vh - 120px)",
+				overflowY: "auto",
+				background: "rgba(20,20,24,0.85)",
+				color: "white",
+				borderRadius: 8,
+				padding: 8,
+				font: "12px system-ui",
+				pointerEvents: "auto",
+				zIndex: 100,
+				display: "flex",
+				flexDirection: "column",
+				gap: 6,
+			}}
+		>
+			<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+				<button
+					type="button"
+					onClick={exitToBoard}
+					style={{
+						appearance: "none",
+						border: "1px solid rgba(255,255,255,0.3)",
+						background: "transparent",
+						color: "white",
+						cursor: "pointer",
+						padding: "2px 6px",
+						borderRadius: 4,
+						fontSize: 11,
+					}}
+					title="通常のホワイトボードに戻る"
+				>
+					← ボード
+				</button>
+				<button
+					type="button"
+					onClick={startPresent}
+					disabled={slides.length === 0}
+					style={{
+						appearance: "none",
+						border: "1px solid rgba(255,255,255,0.3)",
+						background: "transparent",
+						color: "white",
+						cursor: slides.length === 0 ? "default" : "pointer",
+						opacity: slides.length === 0 ? 0.4 : 1,
+						padding: "2px 8px",
+						borderRadius: 4,
+						fontSize: 11,
+					}}
+					title="発表モードに切替"
+				>
+					▶
+				</button>
+			</div>
+			<div style={{ fontWeight: 600, marginTop: 4 }}>スライド</div>
+
+			{slides.length === 0 ? (
+				<div style={{ color: "rgba(255,255,255,0.5)", padding: "8px 0" }}>
+					Frame を追加するとスライドになります
+				</div>
+			) : (
+				slides.map((slide, i) => (
+					<SlideThumbnail
+						key={slide.id}
+						slide={slide}
+						label={i + 1}
+						active={i === current}
+						onClick={() => nav.gotoIndex(i)}
+						onMoveUp={i > 0 ? () => moveSlide(store, slide, slides, -1) : undefined}
+						onMoveDown={
+							i < slides.length - 1 ? () => moveSlide(store, slide, slides, +1) : undefined
+						}
+					/>
+				))
+			)}
+		</div>
+	);
+}
+
+interface ThumbnailProps {
+	slide: ShapeData;
+	label: number;
+	active: boolean;
+	onClick: () => void;
+	onMoveUp?: () => void;
+	onMoveDown?: () => void;
+}
+
+function SlideThumbnail({ slide, label, active, onClick, onMoveUp, onMoveDown }: ThumbnailProps) {
+	return (
+		<div
+			style={{
+				position: "relative",
+				border: active ? "2px solid #4f9dff" : "1px solid rgba(255,255,255,0.2)",
+				borderRadius: 4,
+				background: "rgba(255,255,255,0.05)",
+				padding: "4px 6px",
+			}}
+		>
+			<button
+				type="button"
+				onClick={onClick}
+				style={{
+					appearance: "none",
+					background: "transparent",
+					border: "none",
+					color: "white",
+					cursor: "pointer",
+					width: "100%",
+					textAlign: "left",
+					padding: 0,
+					font: "inherit",
+				}}
+			>
+				<div style={{ fontSize: 11, color: "rgba(255,255,255,0.6)" }}>#{label}</div>
+				<div
+					style={{
+						fontSize: 12,
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+					}}
+					title={getFrameLabel(slide)}
+				>
+					{getFrameLabel(slide)}
+				</div>
+			</button>
+			<div style={{ display: "flex", gap: 4, marginTop: 4 }}>
+				<button
+					type="button"
+					disabled={!onMoveUp}
+					onClick={onMoveUp}
+					style={miniButtonStyle(!onMoveUp)}
+					title="前へ"
+				>
+					↑
+				</button>
+				<button
+					type="button"
+					disabled={!onMoveDown}
+					onClick={onMoveDown}
+					style={miniButtonStyle(!onMoveDown)}
+					title="後へ"
+				>
+					↓
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function getFrameLabel(shape: ShapeData): string {
+	const name = (shape as unknown as { name?: string }).name;
+	if (typeof name === "string" && name.trim()) return name;
+	return "(無題)";
+}
+
+function miniButtonStyle(disabled: boolean): React.CSSProperties {
+	return {
+		appearance: "none",
+		flex: 1,
+		border: "1px solid rgba(255,255,255,0.2)",
+		background: "rgba(255,255,255,0.05)",
+		color: "white",
+		cursor: disabled ? "default" : "pointer",
+		opacity: disabled ? 0.3 : 1,
+		padding: "1px 0",
+		fontSize: 10,
+		borderRadius: 3,
+	};
+}
+
+/**
+ * スライドを1つ上/下に移動する。
+ * z-index は fractional string key なので、隣接スライドのキーから新キーを生成する。
+ *
+ * NOTE: zIndexBetween のロジックは store の createBringForward/SendBackward と同じだが、
+ *       store 側のユーティリティは Command 経由のみ公開されているため、ここでは直接
+ *       updateShape を呼んで順序入替を行う。
+ */
+function moveSlide(
+	store: BoardStore,
+	slide: ShapeData,
+	slides: ShapeData[],
+	direction: -1 | 1,
+): void {
+	const index = slides.findIndex((s) => s.id === slide.id);
+	if (index < 0) return;
+	const newIndex = index + direction;
+	if (newIndex < 0 || newIndex >= slides.length) return;
+
+	// 隣接と入れ替える: 2つの zIndex を swap するだけで全体順序は保たれる
+	const a = slides[index];
+	const b = slides[newIndex];
+	if (!a || !b || typeof a.zIndex !== "string" || typeof b.zIndex !== "string") return;
+
+	store.updateShape(a.id, { zIndex: b.zIndex });
+	store.updateShape(b.id, { zIndex: a.zIndex });
+}

--- a/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
+++ b/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
@@ -37,6 +37,7 @@ export function SlideOutlinePanel({
 
 	const startPresent = () => {
 		const url = new URL(window.location.href);
+		url.searchParams.set("present", "1");
 		url.searchParams.set("mode", "present");
 		window.history.replaceState(null, "", url.toString());
 		window.dispatchEvent(new PopStateEvent("popstate"));

--- a/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
+++ b/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
@@ -1,10 +1,11 @@
 import type {
 	BoardStore,
+	Command,
 	CommandRegistry,
 	LayerRenderContext,
 	ShapeData,
 } from "@edv4h/usketch-shared";
-import { createBringForwardCommand, createSendBackwardCommand } from "@edv4h/usketch-store";
+import { zIndexBetween } from "@edv4h/usketch-shared";
 import { useEffect, useState } from "react";
 import type { SlideNavigator } from "./slide-navigator.js";
 
@@ -228,8 +229,15 @@ function miniButtonStyle(disabled: boolean): React.CSSProperties {
 
 /**
  * スライドを1つ上/下に移動する。
- * 既存の createBringForwardCommand / createSendBackwardCommand を使って
- * atomic かつ undoable に順序を入れ替える。
+ *
+ * 注意: store の createBringForwardCommand / createSendBackwardCommand は
+ * 「同じ親を持つ shape 全体（非フレーム含む）」の中で隣接 shape と入れ替える。
+ * そのためトップレベルに非フレーム shape（ラフ描画など）が混ざっていると
+ * 1 クリックでスライド順が動かなかったり、非スライドの描画順まで変わってしまう。
+ *
+ * ここではスライドとして扱う Frame の一覧（nav.getSlides）の中で前後の Frame の
+ * zIndex を参照し、その隙間に zIndexBetween で新キーを差し込む。これにより
+ * 非フレーム shape の順序には影響せず、常に 1 クリック = 1 位置の移動になる。
  */
 function moveSlide(
 	store: BoardStore,
@@ -237,9 +245,50 @@ function moveSlide(
 	shapeId: string,
 	direction: -1 | 1,
 ): void {
-	const command =
-		direction === -1
-			? createSendBackwardCommand(store, shapeId)
-			: createBringForwardCommand(store, shapeId);
+	const slides = store.getShapesSorted().filter((s) => s.type === "frame");
+	const index = slides.findIndex((s) => s.id === shapeId);
+	if (index < 0) return;
+	const newIndex = index + direction;
+	if (newIndex < 0 || newIndex >= slides.length) return;
+
+	const current = slides[index];
+	if (!current || typeof current.zIndex !== "string") return;
+
+	// 新しい位置での前後 Frame の zIndex を取得して、その間に挟むキーを生成
+	let lower: string | null;
+	let upper: string | null;
+	if (direction === 1) {
+		// 一つ後ろへ: newIndex の Frame と newIndex+1 の Frame の間に入る
+		const after = slides[newIndex];
+		const afterNext = slides[newIndex + 1];
+		if (!after || typeof after.zIndex !== "string") return;
+		lower = after.zIndex;
+		upper =
+			afterNext && typeof afterNext.zIndex === "string" && afterNext.id !== shapeId
+				? afterNext.zIndex
+				: null;
+	} else {
+		// 一つ前へ: newIndex-1 の Frame と newIndex の Frame の間に入る
+		const before = slides[newIndex];
+		const beforePrev = slides[newIndex - 1];
+		if (!before || typeof before.zIndex !== "string") return;
+		lower =
+			beforePrev && typeof beforePrev.zIndex === "string" && beforePrev.id !== shapeId
+				? beforePrev.zIndex
+				: null;
+		upper = before.zIndex;
+	}
+
+	const nextKey = zIndexBetween(lower, upper);
+	const prevKey = current.zIndex;
+
+	const command: Command = {
+		execute() {
+			store.updateShape(shapeId, { zIndex: nextKey });
+		},
+		undo() {
+			store.updateShape(shapeId, { zIndex: prevKey });
+		},
+	};
 	commands.execute(command);
 }

--- a/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
+++ b/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
@@ -1,14 +1,21 @@
-import type { BoardStore, LayerRenderContext, ShapeData } from "@edv4h/usketch-shared";
+import type {
+	BoardStore,
+	CommandRegistry,
+	LayerRenderContext,
+	ShapeData,
+} from "@edv4h/usketch-shared";
+import { createBringForwardCommand, createSendBackwardCommand } from "@edv4h/usketch-store";
 import { useEffect, useState } from "react";
 import type { SlideNavigator } from "./slide-navigator.js";
 
 interface Props {
 	nav: SlideNavigator;
 	store: BoardStore;
+	commands: CommandRegistry;
 	renderCtx: LayerRenderContext;
 }
 
-export function SlideOutlinePanel({ nav, store, renderCtx: _renderCtx }: Props) {
+export function SlideOutlinePanel({ nav, store, commands, renderCtx: _renderCtx }: Props) {
 	const [slides, setSlides] = useState<ShapeData[]>(nav.getSlides());
 	const [current, setCurrent] = useState(nav.getCurrentIndex());
 
@@ -108,9 +115,9 @@ export function SlideOutlinePanel({ nav, store, renderCtx: _renderCtx }: Props) 
 						label={i + 1}
 						active={i === current}
 						onClick={() => nav.gotoIndex(i)}
-						onMoveUp={i > 0 ? () => moveSlide(store, slide, slides, -1) : undefined}
+						onMoveUp={i > 0 ? () => moveSlide(store, commands, slide.id, -1) : undefined}
 						onMoveDown={
-							i < slides.length - 1 ? () => moveSlide(store, slide, slides, +1) : undefined
+							i < slides.length - 1 ? () => moveSlide(store, commands, slide.id, +1) : undefined
 						}
 					/>
 				))
@@ -192,7 +199,11 @@ function SlideThumbnail({ slide, label, active, onClick, onMoveUp, onMoveDown }:
 }
 
 function getFrameLabel(shape: ShapeData): string {
-	const name = (shape as unknown as { name?: string }).name;
+	// shape-frame プラグインは `frameTitle` にタイトルを保持する。
+	// 念のため `name` にもフォールバックする（他のフレーム系プラグインとの互換）。
+	const frameTitle = (shape as unknown as { frameTitle?: unknown }).frameTitle;
+	if (typeof frameTitle === "string" && frameTitle.trim()) return frameTitle;
+	const name = (shape as unknown as { name?: unknown }).name;
 	if (typeof name === "string" && name.trim()) return name;
 	return "(無題)";
 }
@@ -214,28 +225,18 @@ function miniButtonStyle(disabled: boolean): React.CSSProperties {
 
 /**
  * スライドを1つ上/下に移動する。
- * z-index は fractional string key なので、隣接スライドのキーから新キーを生成する。
- *
- * NOTE: zIndexBetween のロジックは store の createBringForward/SendBackward と同じだが、
- *       store 側のユーティリティは Command 経由のみ公開されているため、ここでは直接
- *       updateShape を呼んで順序入替を行う。
+ * 既存の createBringForwardCommand / createSendBackwardCommand を使って
+ * atomic かつ undoable に順序を入れ替える。
  */
 function moveSlide(
 	store: BoardStore,
-	slide: ShapeData,
-	slides: ShapeData[],
+	commands: CommandRegistry,
+	shapeId: string,
 	direction: -1 | 1,
 ): void {
-	const index = slides.findIndex((s) => s.id === slide.id);
-	if (index < 0) return;
-	const newIndex = index + direction;
-	if (newIndex < 0 || newIndex >= slides.length) return;
-
-	// 隣接と入れ替える: 2つの zIndex を swap するだけで全体順序は保たれる
-	const a = slides[index];
-	const b = slides[newIndex];
-	if (!a || !b || typeof a.zIndex !== "string" || typeof b.zIndex !== "string") return;
-
-	store.updateShape(a.id, { zIndex: b.zIndex });
-	store.updateShape(b.id, { zIndex: a.zIndex });
+	const command =
+		direction === -1
+			? createSendBackwardCommand(store, shapeId)
+			: createBringForwardCommand(store, shapeId);
+	commands.execute(command);
 }

--- a/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
+++ b/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
@@ -14,9 +14,16 @@ interface Props {
 	store: BoardStore;
 	commands: CommandRegistry;
 	renderCtx: LayerRenderContext;
+	navigateToBoard: () => void;
 }
 
-export function SlideOutlinePanel({ nav, store, commands, renderCtx: _renderCtx }: Props) {
+export function SlideOutlinePanel({
+	nav,
+	store,
+	commands,
+	renderCtx: _renderCtx,
+	navigateToBoard,
+}: Props) {
 	const [slides, setSlides] = useState<ShapeData[]>(nav.getSlides());
 	const [current, setCurrent] = useState(nav.getCurrentIndex());
 
@@ -35,13 +42,7 @@ export function SlideOutlinePanel({ nav, store, commands, renderCtx: _renderCtx 
 		window.dispatchEvent(new PopStateEvent("popstate"));
 	};
 
-	const exitToBoard = () => {
-		// /presentation/:boardId?... → /boards/:boardId
-		const match = window.location.pathname.match(/^\/presentation\/([^/]+)/);
-		if (match) {
-			window.location.assign(`/boards/${match[1]}`);
-		}
-	};
+	const exitToBoard = () => navigateToBoard();
 
 	return (
 		<div

--- a/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
+++ b/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
@@ -97,6 +97,7 @@ export function SlideOutlinePanel({ nav, store, commands, renderCtx: _renderCtx 
 						fontSize: 11,
 					}}
 					title="発表モードに切替"
+					aria-label="発表モードに切替"
 				>
 					▶
 				</button>
@@ -181,6 +182,7 @@ function SlideThumbnail({ slide, label, active, onClick, onMoveUp, onMoveDown }:
 					onClick={onMoveUp}
 					style={miniButtonStyle(!onMoveUp)}
 					title="前へ"
+					aria-label="スライドを前に移動"
 				>
 					↑
 				</button>
@@ -190,6 +192,7 @@ function SlideThumbnail({ slide, label, active, onClick, onMoveUp, onMoveDown }:
 					onClick={onMoveDown}
 					style={miniButtonStyle(!onMoveDown)}
 					title="後へ"
+					aria-label="スライドを後に移動"
 				>
 					↓
 				</button>

--- a/plugins/usketch-plugin-presentation/tsconfig.json
+++ b/plugins/usketch-plugin-presentation/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@edv4h/usketch-plugin-presence-enhanced':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-presence-enhanced
+      '@edv4h/usketch-plugin-presentation':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-presentation
       '@edv4h/usketch-plugin-reactions':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-reactions
@@ -1002,6 +1005,25 @@ importers:
       react:
         specifier: '>=19'
         version: 19.1.0
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.12.0)(tsx@4.21.0)
+
+  plugins/usketch-plugin-presentation:
+    dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      react:
+        specifier: '>=19'
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -3126,13 +3148,13 @@ packages:
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/chai@5.2.3':
-    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==, tarball: https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
   '@types/deep-eql@4.0.2':
-    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==, tarball: https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -3167,7 +3189,7 @@ packages:
       '@types/react': ^19.2.0
 
   '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==, tarball: https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -3197,10 +3219,10 @@ packages:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==, tarball: https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz}
 
   '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==, tarball: https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -3211,19 +3233,19 @@ packages:
         optional: true
 
   '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==, tarball: https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz}
 
   '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==, tarball: https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz}
 
   '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==, tarball: https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz}
 
   '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==, tarball: https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz}
 
   '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==, tarball: https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz}
 
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
@@ -3304,7 +3326,7 @@ packages:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
   assertion-error@2.0.1:
-    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==, tarball: https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz}
     engines: {node: '>=12'}
 
   astring@1.9.0:
@@ -3468,7 +3490,7 @@ packages:
     engines: {node: '>= 0.8'}
 
   cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==, tarball: https://registry.npmjs.org/cac/-/cac-6.7.14.tgz}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
@@ -3493,7 +3515,7 @@ packages:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==, tarball: https://registry.npmjs.org/chai/-/chai-5.3.3.tgz}
     engines: {node: '>=18'}
 
   chalk@5.6.2:
@@ -3513,7 +3535,7 @@ packages:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==, tarball: https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz}
     engines: {node: '>= 16'}
 
   chokidar@5.0.0:
@@ -3642,7 +3664,7 @@ packages:
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
   csstype@3.2.3:
-    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==, tarball: https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -3657,7 +3679,7 @@ packages:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==, tarball: https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz}
     engines: {node: '>=6'}
 
   default-browser-id@5.0.1:
@@ -3965,7 +3987,7 @@ packages:
     engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
-    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==, tarball: https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz}
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.1:
@@ -4273,7 +4295,7 @@ packages:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -4323,7 +4345,7 @@ packages:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==, tarball: https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz}
 
   lru-cache@11.2.7:
     resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
@@ -4718,10 +4740,10 @@ packages:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==, tarball: https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz}
 
   pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==, tarball: https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz}
     engines: {node: '>= 14.16'}
 
   piccolore@0.1.3:
@@ -5030,7 +5052,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==, tarball: https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -5066,14 +5088,14 @@ packages:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==, tarball: https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz}
 
   stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==, tarball: https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==, tarball: https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -5101,7 +5123,7 @@ packages:
     engines: {node: '>=12'}
 
   strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==, tarball: https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -5122,10 +5144,10 @@ packages:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==, tarball: https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz}
 
   tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==, tarball: https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz}
 
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
@@ -5136,15 +5158,15 @@ packages:
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==, tarball: https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz}
     engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==, tarball: https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==, tarball: https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz}
     engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
@@ -5196,7 +5218,7 @@ packages:
     engines: {node: '>= 0.6'}
 
   typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==, tarball: https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5347,7 +5369,7 @@ packages:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==, tarball: https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -5440,7 +5462,7 @@ packages:
         optional: true
 
   vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==, tarball: https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -5491,7 +5513,7 @@ packages:
     hasBin: true
 
   why-is-node-running@2.3.0:
-    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==, tarball: https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz}
     engines: {node: '>=8'}
     hasBin: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1021,6 +1021,9 @@ importers:
       '@edv4h/usketch-shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
       react:
         specifier: '>=19'
         version: 19.2.4


### PR DESCRIPTION
## Summary

- **新プラグイン `@edv4h/usketch-plugin-presentation`**: ホワイトボードの Frame を「スライド」として解釈するプレゼンテーション flavor を実装
- **ドメイン分離**: shape-frame には 0 行の変更。スライド順は既存の z-index（fractional indexing）を昇順に読むだけで実現し、汎用プラグインにプレゼン固有概念を持ち込まない
- **最小構成**: `/presentation/:boardId` 経由で grid/dots/snap/AI/comments を外した軽量セットがロードされる。発表モード時はツールバーも非表示

## What's changed

### Core API
- `BoardStore.fitToBounds(bounds, viewportSize, padding?)` を追加 — 指定矩形が画面に収まるよう viewport をセンターリング + ズーム

### New plugin: `usketch-plugin-presentation`
- `SlideNavigator`: Frame を z-index 昇順で列挙する薄いラッパ
- `PresentModeOverlay`: ページ番号・プログレスバー・前後矢印・3 秒無操作で自動フェード・右上に「✕」編集戻りボタン
- `SlideOutlinePanel`: サムネイル一覧・↑↓ で並び替え（z-index swap）・「← ボード」「▶」ボタン
- ショートカット: → / Space で次、← で前、Home / End で先頭末尾、Escape で編集モードへ

### apps/web integration
- `/presentation/:boardId` ルート追加
- `flavor` (whiteboard / presentation) と `mode` (edit / present) を URL から判定
- `buildBasePlugins(flavor)`: プレゼンでは背景とスナップを除外
- クラウドボードのツールバーに「▶」を追加（プレゼン編集モードへの導線）

## Test plan

- [x] `pnpm typecheck` が通る
- [x] `pnpm build` が通る
- [x] 新規ファイルの lint エラーゼロ
- [x] `shape-frame` に 0 行の変更（ドメイン分離維持）
- [x] dev ボードにサンプルスライド 5 枚を作成し、編集 / 発表両モードの挙動を手動確認
- [ ] 発表モードで Arrow / Space / Esc の動作確認
- [ ] 編集モードで ↑↓ による並び替えが z-index に反映されることの確認
- [ ] 「← ボード」「✕」ボタンでモード解除できることの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)