### PR TITLE
💄 feat(web): モック準拠のデザイン適用 (Phase A-F)

### DIFF
--- a/apps/web/e2e/board.spec.ts
+++ b/apps/web/e2e/board.spec.ts
@@ -37,4 +37,46 @@ test.describe("Board", () => {
 		// エクスポートボタン（aria-label）
 		await expect(page.locator('button[aria-label="エクスポート"]')).toBeVisible();
 	});
+
+	test("command palette opens with Cmd+K and closes with Esc", async ({ page }) => {
+		await page.goto("/dashboard");
+		await page.click("text=新規ローカルボード");
+		await page.waitForURL(/\/local\//);
+
+		// Toolbar のレンダリング完了を待つ
+		await expect(page.locator('[data-testid="toolbar"]')).toBeVisible();
+
+		// Cmd+K / Ctrl+K 両方を試す（macOS は Meta、他は Control）
+		await page.keyboard.press("ControlOrMeta+k");
+
+		const palette = page.locator('[role="dialog"][aria-label="コマンドパレット"]');
+		await expect(palette).toBeVisible();
+
+		// グループが出ている
+		await expect(palette.locator("text=アクション")).toBeVisible();
+		await expect(palette.locator("text=テーマ")).toBeVisible();
+
+		// Esc で閉じる
+		await page.keyboard.press("Escape");
+		await expect(palette).not.toBeVisible();
+	});
+
+	test("command palette executes a theme command", async ({ page }) => {
+		await page.goto("/dashboard");
+		await page.click("text=新規ローカルボード");
+		await page.waitForURL(/\/local\//);
+		await expect(page.locator('[data-testid="toolbar"]')).toBeVisible();
+
+		await page.keyboard.press("ControlOrMeta+k");
+
+		const palette = page.locator('[role="dialog"][aria-label="コマンドパレット"]');
+		await expect(palette).toBeVisible();
+
+		// 「テーマ切替: ライト」コマンドをクリックして実行
+		await palette.locator("text=テーマ切替: ライト").click();
+
+		// パレットが閉じ、data-theme が light に
+		await expect(palette).not.toBeVisible();
+		await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+	});
 });

--- a/apps/web/e2e/board.spec.ts
+++ b/apps/web/e2e/board.spec.ts
@@ -15,19 +15,20 @@ test.describe("Board", () => {
 	test("dashboard loads with local board button", async ({ page }) => {
 		await page.goto("/dashboard");
 		await expect(page.locator("h1")).toContainText("uSketch");
-		await expect(page.locator("text=New Local Board")).toBeVisible();
+		// 新 UI の CTA は日本語
+		await expect(page.locator("text=新規ローカルボード")).toBeVisible();
 	});
 
 	test("local board can be created and opened", async ({ page }) => {
 		await page.goto("/dashboard");
-		await page.click("text=New Local Board");
+		await page.click("text=新規ローカルボード");
 		await page.waitForURL(/\/local\//);
 		await expect(page.locator("[style*='touch-action: none']")).toBeVisible();
 	});
 
 	test("toolbar and export button visible on board page", async ({ page }) => {
 		await page.goto("/dashboard");
-		await page.click("text=New Local Board");
+		await page.click("text=新規ローカルボード");
 		await page.waitForURL(/\/local\//);
 		// 新レイアウト: Toolbar は画面下中央の data-testid="toolbar" で特定
 		await expect(page.locator('[data-testid="toolbar"]')).toBeVisible();

--- a/apps/web/e2e/board.spec.ts
+++ b/apps/web/e2e/board.spec.ts
@@ -29,9 +29,11 @@ test.describe("Board", () => {
 		await page.goto("/dashboard");
 		await page.click("text=New Local Board");
 		await page.waitForURL(/\/local\//);
-		// ツールバーのUndoボタン（titleで特定）
-		await expect(page.locator('button[title*="Undo"]')).toBeVisible();
-		// Exportボタン
-		await expect(page.locator("button", { hasText: "Export" })).toBeVisible();
+		// 新レイアウト: Toolbar は画面下中央の data-testid="toolbar" で特定
+		await expect(page.locator('[data-testid="toolbar"]')).toBeVisible();
+		// Undo ボタン（aria-label）
+		await expect(page.locator('button[aria-label="元に戻す"]')).toBeVisible();
+		// エクスポートボタン（aria-label）
+		await expect(page.locator('button[aria-label="エクスポート"]')).toBeVisible();
 	});
 });

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,31 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>uSketch</title>
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=IBM+Plex+Sans+JP:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap"
+			rel="stylesheet"
+		/>
+		<script>
+			// 初回 flash 防止: React 起動前に data-theme を設定しておく。
+			// localStorage > prefers-color-scheme の順で決定。
+			(function () {
+				try {
+					var stored = localStorage.getItem("usketch-theme");
+					var theme = stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+					var resolved =
+						theme === "system"
+							? window.matchMedia("(prefers-color-scheme: dark)").matches
+								? "dark"
+								: "light"
+							: theme;
+					document.documentElement.dataset.theme = resolved;
+				} catch (_) {
+					document.documentElement.dataset.theme = "dark";
+				}
+			})();
+		</script>
 		<style>
 			html, body, #root {
 				margin: 0;
@@ -11,6 +36,12 @@
 				overflow: hidden;
 				width: 100%;
 				height: 100%;
+			}
+			body {
+				font-family: var(--font-sans, system-ui, sans-serif);
+				background: var(--bg-canvas, #0a0a0b);
+				color: var(--fg-primary, #ededf0);
+				-webkit-font-smoothing: antialiased;
 			}
 		</style>
 	</head>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -58,6 +58,7 @@ import { SidePanelToggles } from "./components/side-panel/side-panel-toggles.js"
 import { Toolbar } from "./components/toolbar/index.js";
 import { getDevUser } from "./lib/dev-auth.js";
 import { getErrorMessage } from "./lib/errors.js";
+import { localBoards } from "./lib/local-boards.js";
 import { useAuth } from "./lib/use-auth.js";
 import { useKeyboardShortcuts } from "./lib/use-keyboard-shortcuts.js";
 
@@ -123,6 +124,7 @@ export function App() {
 	const [app, setApp] = useState<AppInstance | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [wsStatus, setWsStatus] = useState<WsConnectionStatus | null>(null);
+	const [boardName, setBoardName] = useState<string | null>(null);
 	const wsProviderRef = useRef<WsProviderHandle | null>(null);
 
 	// ボード初期化（boardId / isCloudBoard に依存）。
@@ -252,6 +254,40 @@ export function App() {
 		// presentation plugin が modeRef 経由で最新値を読む（undo 履歴・WebSocket を残すため）。
 	}, [boardId, isCloudBoard, navigate]);
 
+	// Cloud ボードのタイトル取得（BoardIdentity 表示用）
+	useEffect(() => {
+		if (!boardId) {
+			setBoardName(null);
+			return;
+		}
+		if (!isCloudBoard) {
+			const local = localBoards.list().find((b) => b.id === boardId);
+			setBoardName(local?.title ?? null);
+			return;
+		}
+		let cancelled = false;
+		const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
+		const headers: Record<string, string> = {};
+		if (import.meta.env.DEV) {
+			const devUser = getDevUser();
+			if (devUser) headers["X-User-Id"] = devUser.id;
+		}
+		fetch(`${apiUrl}/api/boards/${boardId}`, { credentials: "include", headers })
+			.then((r) => (r.ok ? r.json() : null))
+			.then((b) => {
+				if (cancelled) return;
+				const name =
+					b && typeof (b as { name?: unknown }).name === "string"
+						? (b as { name: string }).name
+						: null;
+				setBoardName(name);
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, [boardId, isCloudBoard]);
+
 	// ページ離脱時にビューポート位置を保存（ゴーストアバター用）
 	useEffect(() => {
 		if (!isCloudBoard || !boardId) return;
@@ -354,7 +390,7 @@ export function App() {
 				{!hideToolbar && (
 					<>
 						<BoardIdentity
-							boardName={boardId}
+							boardName={boardName ?? undefined}
 							isCloudBoard={isCloudBoard}
 							connectionStatus={wsStatus ?? undefined}
 						/>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -43,8 +43,15 @@ import {
 	type WsConnectionStatus,
 	type WsProviderHandle,
 } from "@edv4h/usketch-sync";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router";
+import {
+	BoardIdentity,
+	CommunityLink,
+	TopRightCluster,
+	ZoomControls,
+} from "./components/board-frame/index.js";
+import { CommandPalette, useCommandPaletteShortcut } from "./components/command-palette.js";
 import { Toolbar } from "./components/toolbar/index.js";
 import { getDevUser } from "./lib/dev-auth.js";
 import { getErrorMessage } from "./lib/errors.js";
@@ -175,7 +182,8 @@ export function App() {
 
 			// AI プラグイン
 			extraPlugins.push(createAiAgentPlugin({ apiUrl, extraHeaders: aiHeaders }));
-			extraPlugins.push(createAiChatPlugin({ boardId }));
+			// Cmd+K の UI は apps/web 側の CommandPalette が担当するため無効化
+			extraPlugins.push(createAiChatPlugin({ boardId, enableCommandPalette: false }));
 			extraPlugins.push(createAiActionsPlugin({ boardId }));
 			extraPlugins.push(createAiCopilotPlugin({ apiUrl, boardId, extraHeaders: aiHeaders }));
 			extraPlugins.push(createAiVoicePlugin({ boardId }));
@@ -284,6 +292,10 @@ export function App() {
 	// キーボードショートカット
 	useKeyboardShortcuts(app);
 
+	const [paletteOpen, setPaletteOpen] = useState(false);
+	const openPalette = useCallback(() => setPaletteOpen(true), []);
+	useCommandPaletteShortcut(openPalette);
+
 	if (error) {
 		return (
 			<div style={{ padding: "24px", fontFamily: "system-ui, sans-serif", color: "#c33" }}>
@@ -302,45 +314,67 @@ export function App() {
 		<AppProvider app={app}>
 			<div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
 				<Canvas />
-				{!hideToolbar && <Toolbar boardId={boardId} isCloudBoard={isCloudBoard} />}
+				{!hideToolbar && (
+					<>
+						<BoardIdentity
+							boardName={boardId}
+							isCloudBoard={isCloudBoard}
+							connectionStatus={wsStatus ?? undefined}
+						/>
+						<TopRightCluster boardId={boardId} isCloudBoard={isCloudBoard} />
+						<Toolbar
+							boardId={boardId}
+							isCloudBoard={isCloudBoard}
+							wsProvider={wsProviderRef.current}
+							onOpenCommandPalette={openPalette}
+						/>
+						<ZoomControls />
+						<CommunityLink />
+					</>
+				)}
+				<CommandPalette
+					open={paletteOpen}
+					onClose={() => setPaletteOpen(false)}
+					app={app}
+					boardId={boardId}
+					isCloudBoard={isCloudBoard}
+				/>
 				{isCloudBoard && wsStatus === "failed" && (
 					<div
+						className="u-surface"
 						style={{
 							position: "fixed",
-							bottom: 16,
+							bottom: 60,
 							left: "50%",
 							transform: "translateX(-50%)",
-							background: "#c33",
-							color: "#fff",
+							background: "var(--danger)",
+							color: "white",
 							padding: "8px 20px",
-							borderRadius: 8,
+							borderRadius: 10,
 							fontSize: 13,
-							fontFamily: "system-ui, sans-serif",
-							boxShadow: "0 2px 12px rgba(0,0,0,0.2)",
 							zIndex: 200,
 						}}
 					>
-						Unable to connect — you may not have access to this board
+						接続できません — このボードへのアクセス権限がない可能性があります
 					</div>
 				)}
 				{isCloudBoard && wsStatus === "connecting" && (
 					<div
+						className="u-surface"
 						style={{
 							position: "fixed",
-							bottom: 16,
+							bottom: 60,
 							left: "50%",
 							transform: "translateX(-50%)",
-							background: "#f90",
-							color: "#fff",
+							background: "var(--warning)",
+							color: "white",
 							padding: "8px 20px",
-							borderRadius: 8,
+							borderRadius: 10,
 							fontSize: 13,
-							fontFamily: "system-ui, sans-serif",
-							boxShadow: "0 2px 12px rgba(0,0,0,0.2)",
 							zIndex: 200,
 						}}
 					>
-						Connecting...
+						接続中…
 					</div>
 				)}
 			</div>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -2,6 +2,7 @@ import { AppProvider, Canvas, TransientLayer } from "@edv4h/usketch-canvas-engin
 import { type AppInstance, createApp } from "@edv4h/usketch-core";
 import { createDomRendererPlugin } from "@edv4h/usketch-dom-renderer";
 import { createGpuRendererPlugin } from "@edv4h/usketch-gpu-renderer";
+import { createActivityFeedPlugin } from "@edv4h/usketch-plugin-activity-feed";
 import { createAiActionsPlugin } from "@edv4h/usketch-plugin-ai-actions";
 import { createAiAgentPlugin } from "@edv4h/usketch-plugin-ai-agent";
 import { createAiChatPlugin } from "@edv4h/usketch-plugin-ai-chat";
@@ -52,6 +53,8 @@ import {
 	ZoomControls,
 } from "./components/board-frame/index.js";
 import { CommandPalette, useCommandPaletteShortcut } from "./components/command-palette.js";
+import { InfoTab } from "./components/side-panel/info-tab.js";
+import { SidePanelToggles } from "./components/side-panel/side-panel-toggles.js";
 import { Toolbar } from "./components/toolbar/index.js";
 import { getDevUser } from "./lib/dev-auth.js";
 import { getErrorMessage } from "./lib/errors.js";
@@ -190,6 +193,7 @@ export function App() {
 			extraPlugins.push(createAiImagePlugin({ boardId }));
 			extraPlugins.push(createAiRecognizePlugin({ boardId }));
 			extraPlugins.push(createWhistlePlugin(wsProvider));
+			extraPlugins.push(createActivityFeedPlugin({ wsProvider, boardId, apiUrl }));
 
 			// プレゼンテーション: 常にロードし、`?present=1` が付いた時だけ UI を出す。
 			// ルート切替せず URL クエリで切替える設計なので、アプリ再生成は起きない。
@@ -292,6 +296,39 @@ export function App() {
 	// キーボードショートカット
 	useKeyboardShortcuts(app);
 
+	// Info タブを SidePanel に登録（Cloud ボードのみ）
+	useEffect(() => {
+		if (!app || !isCloudBoard || !boardId) return;
+		const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
+		app.events.emit("side-panel:register-tab", {
+			tab: {
+				id: "info",
+				label: "情報",
+				icon: "📋",
+				iconComponent: () => (
+					<svg
+						width={13}
+						height={13}
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="1.5"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M2 4a1 1 0 0 1 1-1h3l1.5 1.5H13a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4Z" />
+					</svg>
+				),
+				order: 30,
+				render: () => <InfoTab boardId={boardId} apiUrl={apiUrl} />,
+			},
+		});
+		return () => {
+			app.events.emit("side-panel:unregister-tab", { tabId: "info" });
+		};
+	}, [app, boardId, isCloudBoard]);
+
 	const [paletteOpen, setPaletteOpen] = useState(false);
 	const openPalette = useCallback(() => setPaletteOpen(true), []);
 	useCommandPaletteShortcut(openPalette);
@@ -330,6 +367,7 @@ export function App() {
 						/>
 						<ZoomControls />
 						<CommunityLink />
+						{isCloudBoard && <SidePanelToggles app={app} />}
 					</>
 				)}
 				<CommandPalette

--- a/apps/web/src/components/board-frame/board-identity.tsx
+++ b/apps/web/src/components/board-frame/board-identity.tsx
@@ -1,0 +1,120 @@
+import type { WsConnectionStatus } from "@edv4h/usketch-sync";
+import { useNavigate } from "react-router";
+
+interface BoardIdentityProps {
+	boardName?: string;
+	isCloudBoard: boolean;
+	connectionStatus?: WsConnectionStatus;
+}
+
+/** 画面左上: ロゴ (ダッシュボードへ戻る) + ボード名 + 保存ステータス。 */
+export function BoardIdentity({ boardName, isCloudBoard, connectionStatus }: BoardIdentityProps) {
+	const navigate = useNavigate();
+	const status = renderStatus(isCloudBoard, connectionStatus);
+
+	return (
+		<div
+			style={{
+				position: "fixed",
+				top: 12,
+				left: 12,
+				display: "flex",
+				gap: 8,
+				zIndex: 30,
+				alignItems: "center",
+			}}
+		>
+			<button
+				type="button"
+				onClick={() => navigate("/dashboard")}
+				className="u-surface"
+				title="ダッシュボードへ戻る"
+				aria-label="ダッシュボードへ戻る"
+				style={{
+					padding: "6px 10px 6px 7px",
+					display: "inline-flex",
+					alignItems: "center",
+					gap: 8,
+					border: "none",
+					color: "var(--fg-primary)",
+					borderRadius: 10,
+					cursor: "pointer",
+					fontFamily: "inherit",
+				}}
+			>
+				<div
+					style={{
+						width: 22,
+						height: 22,
+						borderRadius: 6,
+						background: "var(--brand-gradient)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						color: "white",
+						fontWeight: 700,
+						fontSize: 12,
+						letterSpacing: -0.5,
+					}}
+				>
+					u
+				</div>
+			</button>
+			{boardName && (
+				<div
+					className="u-surface"
+					style={{
+						padding: "6px 12px",
+						borderRadius: 10,
+						display: "flex",
+						flexDirection: "column",
+						lineHeight: 1.15,
+					}}
+				>
+					<div style={{ fontSize: 12.5, fontWeight: 600, color: "var(--fg-primary)" }}>
+						{boardName}
+					</div>
+					{status && (
+						<div
+							style={{
+								fontSize: 10.5,
+								color: "var(--fg-tertiary)",
+								display: "flex",
+								alignItems: "center",
+								gap: 5,
+							}}
+						>
+							<div
+								style={{
+									width: 6,
+									height: 6,
+									borderRadius: 99,
+									background: status.color,
+								}}
+							/>
+							{status.text}
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function renderStatus(
+	isCloudBoard: boolean,
+	connectionStatus?: WsConnectionStatus,
+): { color: string; text: string } | null {
+	if (!isCloudBoard) return { color: "var(--fg-tertiary)", text: "ローカル保存" };
+	switch (connectionStatus) {
+		case "connected":
+			return { color: "var(--success)", text: "自動保存済み" };
+		case "connecting":
+			return { color: "var(--warning)", text: "接続中…" };
+		case "failed":
+		case "disconnected":
+			return { color: "var(--danger)", text: "オフライン" };
+		default:
+			return null;
+	}
+}

--- a/apps/web/src/components/board-frame/community-link.tsx
+++ b/apps/web/src/components/board-frame/community-link.tsx
@@ -1,0 +1,33 @@
+import { useNavigate } from "react-router";
+import { I } from "../ui/index.js";
+
+/** 画面左下（StatusBar の隣）: コミュニティマップへのリンク。 */
+export function CommunityLink() {
+	const navigate = useNavigate();
+	return (
+		<button
+			type="button"
+			onClick={() => navigate("/community")}
+			className="u-surface"
+			style={{
+				position: "fixed",
+				bottom: 12,
+				left: 172,
+				zIndex: 25,
+				padding: "7px 11px",
+				display: "inline-flex",
+				alignItems: "center",
+				gap: 6,
+				border: "none",
+				color: "var(--fg-secondary)",
+				fontSize: 11.5,
+				fontWeight: 500,
+				borderRadius: 10,
+				cursor: "pointer",
+				fontFamily: "inherit",
+			}}
+		>
+			<I.community size={12} /> コミュニティ
+		</button>
+	);
+}

--- a/apps/web/src/components/board-frame/index.ts
+++ b/apps/web/src/components/board-frame/index.ts
@@ -1,0 +1,4 @@
+export { BoardIdentity } from "./board-identity.js";
+export { CommunityLink } from "./community-link.js";
+export { TopRightCluster } from "./top-right-cluster.js";
+export { ZoomControls } from "./zoom-controls.js";

--- a/apps/web/src/components/board-frame/top-right-cluster.tsx
+++ b/apps/web/src/components/board-frame/top-right-cluster.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { ShareDialog } from "../share-dialog.js";
+import { ExportMenu } from "../toolbar/export-menu.js";
+import { I } from "../ui/index.js";
+
+interface Props {
+	boardId?: string;
+	isCloudBoard: boolean;
+}
+
+/** 画面右上: Share CTA + エクスポート。Cloud ボード時のみ Share ボタンが出る。 */
+export function TopRightCluster({ boardId, isCloudBoard }: Props) {
+	const [showShare, setShowShare] = useState(false);
+
+	return (
+		<>
+			<div
+				style={{
+					position: "fixed",
+					top: 12,
+					right: 12,
+					display: "flex",
+					gap: 8,
+					zIndex: 30,
+					alignItems: "center",
+				}}
+			>
+				{isCloudBoard && boardId && (
+					<button
+						type="button"
+						onClick={() => setShowShare(true)}
+						style={{
+							padding: "7px 14px",
+							display: "inline-flex",
+							alignItems: "center",
+							gap: 6,
+							background: "var(--brand-gradient)",
+							border: "none",
+							color: "white",
+							fontSize: 12.5,
+							fontWeight: 600,
+							borderRadius: 10,
+							cursor: "pointer",
+							boxShadow: "0 4px 14px rgba(139, 92, 246, 0.25)",
+							fontFamily: "inherit",
+						}}
+					>
+						<I.share size={12} />
+						共有
+					</button>
+				)}
+				<ExportMenu isCloudBoard={isCloudBoard} boardId={boardId} />
+			</div>
+			{showShare && boardId && (
+				<ShareDialog boardId={boardId} onClose={() => setShowShare(false)} />
+			)}
+		</>
+	);
+}

--- a/apps/web/src/components/board-frame/zoom-controls.tsx
+++ b/apps/web/src/components/board-frame/zoom-controls.tsx
@@ -1,0 +1,58 @@
+import { useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
+import { I, IconBtn } from "../ui/index.js";
+
+/** 画面右下: ズームイン / アウト / パーセンテージ / リセット。 */
+export function ZoomControls() {
+	const app = useApp();
+	const viewport = useStoreSubscribe(app.store, (s) => s.getViewport());
+
+	const zoomAt = (factor: number) => {
+		const cx = window.innerWidth / 2;
+		const cy = window.innerHeight / 2;
+		app.store.zoomTo(viewport.zoom * factor, { x: cx, y: cy });
+	};
+
+	const reset = () => {
+		app.store.setViewport({ x: 0, y: 0, zoom: 1 });
+	};
+
+	return (
+		<div
+			className="u-surface"
+			style={{
+				position: "fixed",
+				bottom: 12,
+				right: 12,
+				zIndex: 20,
+				padding: 3,
+				borderRadius: 10,
+				display: "flex",
+				alignItems: "center",
+				gap: 1,
+			}}
+		>
+			<IconBtn icon={I.zoomOut} label="ズームアウト" onClick={() => zoomAt(0.8)} size={30} />
+			<button
+				type="button"
+				onClick={reset}
+				title="100% にリセット"
+				style={{
+					minWidth: 48,
+					height: 30,
+					padding: "0 6px",
+					background: "transparent",
+					border: "none",
+					color: "var(--fg-secondary)",
+					cursor: "pointer",
+					fontSize: 11.5,
+					fontWeight: 500,
+					fontFamily: "var(--font-mono)",
+					borderRadius: 6,
+				}}
+			>
+				{Math.round(viewport.zoom * 100)}%
+			</button>
+			<IconBtn icon={I.zoomIn} label="ズームイン" onClick={() => zoomAt(1.25)} size={30} />
+		</div>
+	);
+}

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -1,0 +1,425 @@
+import type { AppInstance } from "@edv4h/usketch-core";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { setTheme } from "../lib/theme.js";
+import { I, type IconComponent, Kbd } from "./ui/index.js";
+
+interface CommandItem {
+	id: string;
+	group: string;
+	label: string;
+	icon: IconComponent;
+	shortcut?: string;
+	hint?: string;
+	run: () => void;
+}
+
+interface CommandPaletteProps {
+	open: boolean;
+	onClose: () => void;
+	app: AppInstance;
+	boardId?: string;
+	isCloudBoard: boolean;
+}
+
+export function CommandPalette({ open, onClose, app, boardId, isCloudBoard }: CommandPaletteProps) {
+	const [query, setQuery] = useState("");
+	const [activeIndex, setActiveIndex] = useState(0);
+	const navigate = useNavigate();
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	const commands = useMemo<CommandItem[]>(() => {
+		const list: CommandItem[] = [];
+
+		if (isCloudBoard) {
+			list.push(
+				{
+					id: "ai.summarize",
+					group: "AI",
+					label: "このボードを要約",
+					icon: I.sparkles,
+					hint: "AI",
+					run: () => app.events.emit("ai:request", { prompt: "このボードの内容を要約して" }),
+				},
+				{
+					id: "ai.align",
+					group: "AI",
+					label: "フローチャートを整列する",
+					icon: I.wand,
+					hint: "AI",
+					run: () => app.events.emit("ai:request", { prompt: "フローチャートを整列して" }),
+				},
+				{
+					id: "ai.translate",
+					group: "AI",
+					label: "選択を英語に翻訳",
+					icon: I.translate,
+					hint: "AI",
+					run: () => app.events.emit("ai:request", { prompt: "選択を英語に翻訳して" }),
+				},
+				{
+					id: "ai.image",
+					group: "AI",
+					label: "画像を生成…",
+					icon: I.image,
+					hint: "AI",
+					run: () => app.events.emit("ai:image:open", {}),
+				},
+			);
+		}
+
+		list.push(
+			{
+				id: "action.frame",
+				group: "アクション",
+				label: "フレームを追加",
+				icon: I.frame,
+				shortcut: "F",
+				run: () => app.store.setActiveToolId("frame"),
+			},
+			{
+				id: "action.undo",
+				group: "アクション",
+				label: "元に戻す",
+				icon: I.undo,
+				shortcut: "⌘Z",
+				run: () => app.commands.undo(),
+			},
+			{
+				id: "action.redo",
+				group: "アクション",
+				label: "やり直す",
+				icon: I.redo,
+				shortcut: "⌘⇧Z",
+				run: () => app.commands.redo(),
+			},
+		);
+
+		if (isCloudBoard && boardId) {
+			list.push({
+				id: "action.present",
+				group: "アクション",
+				label: "プレゼンテーションを開始",
+				icon: I.present,
+				shortcut: "⌘⇧P",
+				run: () => navigate(`/boards/${boardId}?present=1`),
+			});
+		}
+
+		list.push(
+			{
+				id: "theme.light",
+				group: "テーマ",
+				label: "テーマ切替: ライト",
+				icon: I.sun,
+				run: () => setTheme("light"),
+			},
+			{
+				id: "theme.dark",
+				group: "テーマ",
+				label: "テーマ切替: ダーク",
+				icon: I.moon,
+				run: () => setTheme("dark"),
+			},
+			{
+				id: "theme.system",
+				group: "テーマ",
+				label: "テーマ切替: システム",
+				icon: I.monitor,
+				run: () => setTheme("system"),
+			},
+		);
+
+		list.push(
+			{
+				id: "nav.dashboard",
+				group: "移動",
+				label: "ダッシュボードへ戻る",
+				icon: I.home,
+				run: () => navigate("/dashboard"),
+			},
+			{
+				id: "nav.community",
+				group: "移動",
+				label: "コミュニティマップ",
+				icon: I.community,
+				run: () => navigate("/community"),
+			},
+		);
+
+		return list;
+	}, [app, boardId, isCloudBoard, navigate]);
+
+	const filtered = useMemo(() => {
+		if (!query) return commands;
+		const q = query.toLowerCase();
+		return commands.filter((c) => c.label.toLowerCase().includes(q));
+	}, [commands, query]);
+
+	const grouped = useMemo(() => {
+		const map = new Map<string, CommandItem[]>();
+		for (const c of filtered) {
+			const g = map.get(c.group) ?? [];
+			g.push(c);
+			map.set(c.group, g);
+		}
+		return Array.from(map.entries());
+	}, [filtered]);
+
+	useEffect(() => {
+		if (open) {
+			setQuery("");
+			setActiveIndex(0);
+			// 次のフレームで focus（animation 開始前に focus が外れるのを防ぐ）
+			requestAnimationFrame(() => inputRef.current?.focus());
+		}
+	}, [open]);
+
+	useEffect(() => {
+		setActiveIndex(0);
+	}, []);
+
+	const runAt = useCallback(
+		(idx: number) => {
+			const item = filtered[idx];
+			if (!item) return;
+			onClose();
+			item.run();
+		},
+		[filtered, onClose],
+	);
+
+	const onKeyDown = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "ArrowDown") {
+				e.preventDefault();
+				setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+			} else if (e.key === "ArrowUp") {
+				e.preventDefault();
+				setActiveIndex((i) => Math.max(i - 1, 0));
+			} else if (e.key === "Enter") {
+				e.preventDefault();
+				runAt(activeIndex);
+			} else if (e.key === "Escape") {
+				e.preventDefault();
+				onClose();
+			}
+		},
+		[activeIndex, filtered.length, runAt, onClose],
+	);
+
+	if (!open) return null;
+
+	let globalIndex = 0;
+	const groupBlocks: ReactNode[] = grouped.map(([group, items]) => (
+		<div key={group}>
+			<div
+				style={{
+					padding: "10px 16px 4px",
+					fontSize: 10.5,
+					fontWeight: 600,
+					color: "var(--fg-tertiary)",
+					textTransform: "uppercase",
+					letterSpacing: 0.4,
+				}}
+			>
+				{group}
+			</div>
+			{items.map((c) => {
+				const idx = globalIndex++;
+				const active = idx === activeIndex;
+				return (
+					<button
+						key={c.id}
+						type="button"
+						onClick={() => runAt(idx)}
+						onMouseEnter={() => setActiveIndex(idx)}
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 10,
+							padding: "8px 16px",
+							background: active ? "var(--bg-hover)" : "transparent",
+							cursor: "pointer",
+							width: "100%",
+							border: "none",
+							color: "var(--fg-primary)",
+							textAlign: "left",
+							fontFamily: "inherit",
+							fontSize: "inherit",
+						}}
+					>
+						<div
+							style={{
+								width: 26,
+								height: 26,
+								borderRadius: 6,
+								background: "var(--bg-input)",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								color: c.group === "AI" ? "var(--brand-violet)" : "var(--fg-secondary)",
+							}}
+						>
+							<c.icon size={14} />
+						</div>
+						<div style={{ flex: 1, fontSize: 13 }}>{c.label}</div>
+						{c.hint && (
+							<span
+								style={{
+									fontSize: 10,
+									color: "var(--brand-violet)",
+									background: "var(--bg-active)",
+									padding: "2px 6px",
+									borderRadius: 4,
+									fontWeight: 600,
+								}}
+							>
+								{c.hint}
+							</span>
+						)}
+						{c.shortcut && <Kbd>{c.shortcut}</Kbd>}
+					</button>
+				);
+			})}
+		</div>
+	));
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: 背景クリックで閉じる標準的なモーダルパターン
+		<div
+			onClick={onClose}
+			onKeyDown={onKeyDown}
+			style={{
+				position: "fixed",
+				inset: 0,
+				background: "rgba(0, 0, 0, 0.5)",
+				backdropFilter: "blur(8px)",
+				WebkitBackdropFilter: "blur(8px)",
+				zIndex: 1000,
+				display: "flex",
+				alignItems: "flex-start",
+				justifyContent: "center",
+			}}
+		>
+			{/* biome-ignore lint/a11y/useKeyWithClickEvents: キーボード操作は親 div の onKeyDown で処理 */}
+			<div
+				role="dialog"
+				aria-label="コマンドパレット"
+				aria-modal="true"
+				onClick={(e) => e.stopPropagation()}
+				className="u-surface u-anim-in"
+				style={{
+					width: 580,
+					maxHeight: "70vh",
+					marginTop: "10vh",
+					borderRadius: 14,
+					display: "flex",
+					flexDirection: "column",
+					overflow: "hidden",
+					background: "var(--bg-surface-raised)",
+					boxShadow: "var(--shadow-3), var(--shadow-glow)",
+				}}
+			>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: 10,
+						padding: "14px 16px",
+						borderBottom: "1px solid var(--border-subtle)",
+					}}
+				>
+					<div
+						style={{
+							width: 22,
+							height: 22,
+							borderRadius: 6,
+							background: "var(--brand-gradient)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							color: "white",
+						}}
+					>
+						<I.sparkles size={13} />
+					</div>
+					<input
+						ref={inputRef}
+						value={query}
+						onChange={(e) => {
+							setQuery(e.target.value);
+							setActiveIndex(0);
+						}}
+						placeholder="何をしますか？"
+						style={{
+							flex: 1,
+							background: "transparent",
+							border: "none",
+							color: "var(--fg-primary)",
+							fontSize: 15,
+							outline: "none",
+							fontFamily: "inherit",
+							padding: "4px 0",
+							letterSpacing: "-0.01em",
+						}}
+					/>
+					<Kbd>esc</Kbd>
+				</div>
+				<div style={{ flex: 1, overflow: "auto", padding: "8px 0" }}>
+					{groupBlocks}
+					{filtered.length === 0 && (
+						<div
+							style={{
+								padding: "30px 20px",
+								textAlign: "center",
+								color: "var(--fg-tertiary)",
+								fontSize: 13,
+							}}
+						>
+							コマンドが見つかりません
+						</div>
+					)}
+				</div>
+				<div
+					style={{
+						padding: "8px 16px",
+						borderTop: "1px solid var(--border-subtle)",
+						display: "flex",
+						gap: 14,
+						fontSize: 11,
+						color: "var(--fg-tertiary)",
+						background: "var(--bg-canvas-2)",
+					}}
+				>
+					<span>
+						<Kbd>↑↓</Kbd> 移動
+					</span>
+					<span>
+						<Kbd>↵</Kbd> 実行
+					</span>
+					<span>
+						<Kbd>esc</Kbd> 閉じる
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Cmd+K / Ctrl+K のグローバルキーハンドラを登録するフック。
+ * CommandPalette を親コンポーネントで open 制御してから onOpen で呼ばれる。
+ */
+export function useCommandPaletteShortcut(onOpen: () => void): void {
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+				e.preventDefault();
+				onOpen();
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [onOpen]);
+}

--- a/apps/web/src/components/side-panel/info-tab.tsx
+++ b/apps/web/src/components/side-panel/info-tab.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useState } from "react";
+import { getDevUser } from "../../lib/dev-auth.js";
+import { I } from "../ui/index.js";
+
+interface BoardInfo {
+	id: string;
+	name: string;
+	isPublic: number;
+	ownerId: string;
+}
+
+interface Member {
+	userId: string;
+	role: string;
+	name?: string | null;
+}
+
+interface Props {
+	boardId: string;
+	apiUrl: string;
+}
+
+function buildHeaders(): HeadersInit {
+	const headers: Record<string, string> = {};
+	if (import.meta.env.DEV) {
+		const devUser = getDevUser();
+		if (devUser) headers["X-User-Id"] = devUser.id;
+	}
+	return headers;
+}
+
+export function InfoTab({ boardId, apiUrl }: Props) {
+	const [board, setBoard] = useState<BoardInfo | null>(null);
+	const [members, setMembers] = useState<Member[]>([]);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		let cancelled = false;
+		setLoading(true);
+
+		const headers = buildHeaders();
+
+		Promise.all([
+			fetch(`${apiUrl}/api/boards/${boardId}`, { credentials: "include", headers })
+				.then((r) => (r.ok ? r.json() : null))
+				.catch(() => null),
+			fetch(`${apiUrl}/api/boards/${boardId}/members`, { credentials: "include", headers })
+				.then((r) => (r.ok ? r.json() : []))
+				.catch(() => [] as Member[]),
+		]).then(([b, m]) => {
+			if (cancelled) return;
+			setBoard(b as BoardInfo | null);
+			setMembers(m as Member[]);
+			setLoading(false);
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [boardId, apiUrl]);
+
+	if (loading) {
+		return <div style={placeholderStyle}>読み込み中…</div>;
+	}
+
+	if (!board) {
+		return <div style={placeholderStyle}>ボード情報を取得できませんでした</div>;
+	}
+
+	return (
+		<div style={{ padding: 14, display: "flex", flexDirection: "column", gap: 16 }}>
+			<Section title="ボード">
+				<Row label="名前" value={board.name} />
+				<Row label="ID" value={board.id} mono />
+				<Row
+					label="公開範囲"
+					value={
+						<span
+							style={{
+								display: "inline-flex",
+								alignItems: "center",
+								gap: 5,
+								color: board.isPublic ? "var(--success)" : "var(--fg-secondary)",
+							}}
+						>
+							{board.isPublic ? <I.globe size={12} /> : <I.lock size={12} />}
+							{board.isPublic ? "公開" : "非公開"}
+						</span>
+					}
+				/>
+			</Section>
+
+			<Section title={`メンバー (${members.length})`}>
+				{members.length === 0 ? (
+					<div style={{ fontSize: 12, color: "var(--fg-tertiary)" }}>メンバーはいません</div>
+				) : (
+					members.map((m) => (
+						<div
+							key={m.userId}
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: 8,
+								padding: "6px 0",
+								borderBottom: "1px solid var(--border-subtle)",
+							}}
+						>
+							<div
+								style={{
+									width: 24,
+									height: 24,
+									borderRadius: "50%",
+									background: "var(--brand-gradient)",
+									color: "white",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+									fontSize: 11,
+									fontWeight: 600,
+									flexShrink: 0,
+								}}
+							>
+								{(m.name ?? m.userId).charAt(0).toUpperCase()}
+							</div>
+							<div style={{ flex: 1, minWidth: 0 }}>
+								<div
+									style={{
+										fontSize: 12,
+										fontWeight: 500,
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+										whiteSpace: "nowrap",
+										color: "var(--fg-primary)",
+									}}
+								>
+									{m.name ?? m.userId}
+								</div>
+								<div
+									style={{
+										fontSize: 10.5,
+										color: "var(--fg-tertiary)",
+										fontFamily: "var(--font-mono)",
+									}}
+								>
+									{m.role}
+								</div>
+							</div>
+						</div>
+					))
+				)}
+			</Section>
+		</div>
+	);
+}
+
+const placeholderStyle: React.CSSProperties = {
+	padding: 20,
+	textAlign: "center",
+	color: "var(--fg-tertiary)",
+	fontSize: 12,
+};
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+	return (
+		<div>
+			<div
+				style={{
+					fontSize: 10.5,
+					fontWeight: 600,
+					color: "var(--fg-tertiary)",
+					textTransform: "uppercase",
+					letterSpacing: 0.4,
+					marginBottom: 8,
+				}}
+			>
+				{title}
+			</div>
+			<div style={{ display: "flex", flexDirection: "column", gap: 2 }}>{children}</div>
+		</div>
+	);
+}
+
+function Row({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
+	return (
+		<div
+			style={{
+				display: "flex",
+				justifyContent: "space-between",
+				alignItems: "center",
+				padding: "6px 0",
+				borderBottom: "1px solid var(--border-subtle)",
+				gap: 8,
+			}}
+		>
+			<span style={{ fontSize: 11.5, color: "var(--fg-secondary)" }}>{label}</span>
+			<span
+				style={{
+					fontSize: 12,
+					color: "var(--fg-primary)",
+					fontFamily: mono ? "var(--font-mono)" : "inherit",
+					overflow: "hidden",
+					textOverflow: "ellipsis",
+					whiteSpace: "nowrap",
+					maxWidth: "60%",
+					textAlign: "right",
+				}}
+			>
+				{value}
+			</span>
+		</div>
+	);
+}

--- a/apps/web/src/components/side-panel/side-panel-toggles.tsx
+++ b/apps/web/src/components/side-panel/side-panel-toggles.tsx
@@ -1,0 +1,75 @@
+import type { AppInstance } from "@edv4h/usketch-core";
+import { useEffect, useState } from "react";
+import { I, IconBtn } from "../ui/index.js";
+
+interface Props {
+	app: AppInstance;
+}
+
+/**
+ * SidePanel が閉じているときに画面右端に出すトグル群。
+ * 各ボタンを押すと `side-panel:open` イベントで該当タブを開く。
+ */
+export function SidePanelToggles({ app }: Props) {
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		const unsubs: (() => void)[] = [];
+		unsubs.push(app.events.on("side-panel:open", () => setOpen(true)));
+		unsubs.push(app.events.on("side-panel:close", () => setOpen(false)));
+		unsubs.push(
+			app.events.on("side-panel:toggle", () => {
+				setOpen((v) => !v);
+			}),
+		);
+		return () => {
+			for (const u of unsubs) u();
+		};
+	}, [app]);
+
+	if (open) return null;
+
+	const openTab = (tabId: string) => app.events.emit("side-panel:open", { tabId });
+
+	return (
+		<div
+			className="u-surface"
+			style={{
+				position: "fixed",
+				top: 70,
+				right: 12,
+				zIndex: 140,
+				padding: 3,
+				borderRadius: 10,
+				display: "flex",
+				flexDirection: "column",
+				gap: 1,
+			}}
+		>
+			<IconBtn
+				icon={I.comment}
+				label="コメント"
+				tooltipPlacement="left"
+				onClick={() => openTab("comments")}
+			/>
+			<IconBtn
+				icon={I.sparkles}
+				label="AI"
+				tooltipPlacement="left"
+				onClick={() => openTab("ai-chat")}
+			/>
+			<IconBtn
+				icon={I.folder}
+				label="情報"
+				tooltipPlacement="left"
+				onClick={() => openTab("info")}
+			/>
+			<IconBtn
+				icon={I.history}
+				label="履歴"
+				tooltipPlacement="left"
+				onClick={() => openTab("activity")}
+			/>
+		</div>
+	);
+}

--- a/apps/web/src/components/style-panel/compact-color-picker.tsx
+++ b/apps/web/src/components/style-panel/compact-color-picker.tsx
@@ -41,7 +41,7 @@ export function CompactColorPicker({
 
 	return (
 		<div style={{ position: "relative", display: "flex", alignItems: "center", gap: 3 }}>
-			<span style={{ color: "#666", fontSize: 10 }}>{label}</span>
+			<span style={{ color: "var(--fg-secondary)", fontSize: 10 }}>{label}</span>
 			<input
 				type="color"
 				value={pickerValue}
@@ -51,7 +51,7 @@ export function CompactColorPicker({
 				style={{
 					width: 20,
 					height: 20,
-					border: "1px solid #e0e0e0",
+					border: "1px solid var(--border-default)",
 					borderRadius: 4,
 					padding: 0,
 					cursor: "pointer",
@@ -69,29 +69,28 @@ export function CompactColorPicker({
 					cursor: "pointer",
 					padding: 0,
 					fontSize: 8,
-					color: "#999",
+					color: "var(--fg-tertiary)",
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "center",
 				}}
-				title="Color palette"
+				title="カラーパレット"
+				aria-label="カラーパレットを開く"
 			>
 				▼
 			</button>
 			{showPalette && (
 				<div
+					className="u-surface"
 					style={{
 						position: "absolute",
 						top: 28,
 						left: 0,
-						background: "#fff",
-						border: "1px solid #e0e0e0",
-						borderRadius: 8,
+						background: "var(--bg-surface-raised)",
 						padding: 6,
 						display: "grid",
 						gridTemplateColumns: "repeat(6, 1fr)",
 						gap: 3,
-						boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
 						zIndex: 200,
 					}}
 				>
@@ -106,12 +105,14 @@ export function CompactColorPicker({
 									onSwatchClick(color);
 									setShowPalette(false);
 								}}
-								title={isTrans ? "Transparent" : color}
+								title={isTrans ? "透明" : color}
 								style={{
 									width: 18,
 									height: 18,
 									borderRadius: 3,
-									border: isActive ? "2px solid #3b82f6" : "1px solid #e0e0e0",
+									border: isActive
+										? "2px solid var(--brand-violet)"
+										: "1px solid var(--border-default)",
 									background: isTrans ? CHECKER_BG : color,
 									cursor: "pointer",
 									padding: 0,
@@ -127,7 +128,7 @@ export function CompactColorPicker({
 											left: -2,
 											width: "130%",
 											height: 2,
-											background: "#ef4444",
+											background: "var(--danger)",
 											transform: "rotate(-45deg)",
 											transformOrigin: "center",
 											pointerEvents: "none",

--- a/apps/web/src/components/style-panel/style-panel.tsx
+++ b/apps/web/src/components/style-panel/style-panel.tsx
@@ -195,32 +195,69 @@ export function StylePanel() {
 					onBlur={handleOpacityEnd}
 					style={{ width: 48, cursor: "pointer" }}
 				/>
-				<span style={{ fontSize: 10, color: "#666", minWidth: 28, textAlign: "right" }}>
+				<span
+					style={{
+						fontSize: 10,
+						color: "var(--fg-secondary)",
+						minWidth: 28,
+						textAlign: "right",
+					}}
+				>
 					{currentStyle.opacity !== undefined ? `${Math.round(currentStyle.opacity * 100)}%` : "—"}
 				</span>
 				<div style={barSepStyle} />
 				<button
 					type="button"
 					onClick={handleSendToBack}
-					title="Send to back (Ctrl+Shift+[)"
+					title="最背面へ (Ctrl+Shift+[)"
+					aria-label="最背面へ"
 					style={zOrderButtonStyle}
 				>
 					<svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-						<title>Send to back</title>
-						<rect x="1" y="1" width="9" height="9" fill="#2680eb" stroke="#1e1e1e" />
-						<rect x="6" y="6" width="9" height="9" fill="#ffffff" stroke="#1e1e1e" />
+						<title>最背面へ</title>
+						<rect
+							x="1"
+							y="1"
+							width="9"
+							height="9"
+							fill="var(--brand-violet)"
+							stroke="var(--fg-primary)"
+						/>
+						<rect
+							x="6"
+							y="6"
+							width="9"
+							height="9"
+							fill="var(--bg-surface-solid)"
+							stroke="var(--fg-primary)"
+						/>
 					</svg>
 				</button>
 				<button
 					type="button"
 					onClick={handleBringToFront}
-					title="Bring to front (Ctrl+Shift+])"
+					title="最前面へ (Ctrl+Shift+])"
+					aria-label="最前面へ"
 					style={zOrderButtonStyle}
 				>
 					<svg width="14" height="14" viewBox="0 0 16 16" fill="none">
-						<title>Bring to front</title>
-						<rect x="1" y="1" width="9" height="9" fill="#ffffff" stroke="#1e1e1e" />
-						<rect x="6" y="6" width="9" height="9" fill="#2680eb" stroke="#1e1e1e" />
+						<title>最前面へ</title>
+						<rect
+							x="1"
+							y="1"
+							width="9"
+							height="9"
+							fill="var(--bg-surface-solid)"
+							stroke="var(--fg-primary)"
+						/>
+						<rect
+							x="6"
+							y="6"
+							width="9"
+							height="9"
+							fill="var(--brand-violet)"
+							stroke="var(--fg-primary)"
+						/>
 					</svg>
 				</button>
 			</div>
@@ -245,12 +282,16 @@ const anchoredBarStyle: React.CSSProperties = {
 	display: "flex",
 	alignItems: "center",
 	gap: 4,
-	padding: "4px 8px",
-	background: "#fff",
-	borderRadius: 8,
-	boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-	fontFamily: "system-ui, sans-serif",
+	padding: "5px 9px",
+	background: "var(--bg-surface-raised)",
+	backdropFilter: "blur(20px) saturate(1.4)",
+	WebkitBackdropFilter: "blur(20px) saturate(1.4)",
+	border: "1px solid var(--border-subtle)",
+	borderRadius: 10,
+	boxShadow: "var(--shadow-2)",
+	fontFamily: "var(--font-sans, system-ui, sans-serif)",
 	fontSize: 11,
+	color: "var(--fg-primary)",
 	whiteSpace: "nowrap",
 	pointerEvents: "auto",
 };
@@ -258,18 +299,21 @@ const anchoredBarStyle: React.CSSProperties = {
 const barSepStyle: React.CSSProperties = {
 	width: 1,
 	height: 18,
-	background: "#e0e0e0",
+	background: "var(--border-default)",
 	flexShrink: 0,
 };
 
 const compactNumberStyle: React.CSSProperties = {
 	width: 36,
 	height: 22,
-	border: "1px solid #e0e0e0",
+	border: "1px solid var(--border-default)",
+	background: "var(--bg-input)",
+	color: "var(--fg-primary)",
 	borderRadius: 4,
 	padding: "0 3px",
 	fontSize: 11,
 	textAlign: "center",
+	fontFamily: "inherit",
 };
 
 type MergedStyle = { [K in keyof ShapeStyle]: ShapeStyle[K] | undefined };

--- a/apps/web/src/components/toolbar/bg-toggle.tsx
+++ b/apps/web/src/components/toolbar/bg-toggle.tsx
@@ -1,15 +1,15 @@
 import { useApp } from "@edv4h/usketch-canvas-engine";
 import { useCallback, useState } from "react";
-import { actionBtnStyle } from "../../lib/styles.js";
+import { I, IconBtn } from "../ui/index.js";
 
 type BgType = "grid" | "dots" | "none";
 
 const CYCLE: BgType[] = ["grid", "dots", "none"];
-const LABELS: Record<BgType, string> = { grid: "#", dots: ":", none: "/" };
-const TITLES: Record<BgType, string> = {
-	grid: "Background: Grid",
-	dots: "Background: Dots",
-	none: "Background: None",
+const ICONS = { grid: I.grid, dots: I.dots, none: I.bgNone };
+const LABELS: Record<BgType, string> = {
+	grid: "背景: グリッド",
+	dots: "背景: ドット",
+	none: "背景: なし",
 };
 
 export function BgToggle() {
@@ -19,24 +19,17 @@ export function BgToggle() {
 	const toggle = useCallback(() => {
 		const idx = CYCLE.indexOf(bgType);
 		const next = CYCLE[(idx + 1) % CYCLE.length];
+		if (!next) return;
 		setBgType(next);
 		app.events.emit("bg:set", { type: next });
 	}, [bgType, app.events]);
 
 	return (
-		<button
-			type="button"
+		<IconBtn
+			icon={ICONS[bgType]}
+			label={LABELS[bgType]}
+			active={bgType !== "none"}
 			onClick={toggle}
-			title={TITLES[bgType]}
-			style={{
-				...actionBtnStyle,
-				background: bgType !== "none" ? "#f0f4ff" : "transparent",
-				color: bgType !== "none" ? "#3b82f6" : "#999",
-				fontSize: 13,
-				fontFamily: "monospace",
-			}}
-		>
-			{LABELS[bgType]}
-		</button>
+		/>
 	);
 }

--- a/apps/web/src/components/toolbar/copilot-toggle.tsx
+++ b/apps/web/src/components/toolbar/copilot-toggle.tsx
@@ -1,6 +1,6 @@
 import { useApp } from "@edv4h/usketch-canvas-engine";
 import { useCallback, useState } from "react";
-import { actionBtnStyle } from "../../lib/styles.js";
+import { I, IconBtn } from "../ui/index.js";
 
 export function CopilotToggle() {
 	const app = useApp();
@@ -13,18 +13,11 @@ export function CopilotToggle() {
 	}, [enabled, app.events]);
 
 	return (
-		<button
-			type="button"
+		<IconBtn
+			icon={I.sparkles}
+			label={`Copilot: ${enabled ? "ON" : "OFF"}`}
+			active={enabled}
 			onClick={toggle}
-			title={`Copilot: ${enabled ? "ON" : "OFF"}`}
-			style={{
-				...actionBtnStyle,
-				background: enabled ? "#e8f5e9" : "transparent",
-				color: enabled ? "#2e7d32" : "#999",
-				fontSize: 14,
-			}}
-		>
-			{enabled ? "\u2726" : "\u2727"}
-		</button>
+		/>
 	);
 }

--- a/apps/web/src/components/toolbar/export-menu.tsx
+++ b/apps/web/src/components/toolbar/export-menu.tsx
@@ -1,14 +1,18 @@
 import { useApp } from "@edv4h/usketch-canvas-engine";
 import { useCallback, useState } from "react";
-import { dropdownStyle, menuItemStyle } from "../../lib/styles.js";
+import { I, IconBtn } from "../ui/index.js";
 
-export function ExportMenu({
-	isCloudBoard,
-	boardId,
-}: {
+interface Props {
 	isCloudBoard?: boolean;
 	boardId?: string;
-}) {
+	/**
+	 * true の場合、コンポーネントを fixed で画面右上に配置する（旧挙動）。
+	 * false の場合は親要素のレイアウトに従う（新しい TopRightCluster 用）。既定は false。
+	 */
+	standalone?: boolean;
+}
+
+export function ExportMenu({ isCloudBoard, boardId, standalone = false }: Props) {
 	const app = useApp();
 	const [exporting, setExporting] = useState(false);
 	const [showMenu, setShowMenu] = useState(false);
@@ -40,45 +44,87 @@ export function ExportMenu({
 		});
 	}, [app.store]);
 
-	return (
-		<div
-			style={{
+	const wrapperStyle: React.CSSProperties = standalone
+		? {
 				position: "fixed",
 				top: 12,
 				right: isCloudBoard && boardId ? 92 : 12,
 				zIndex: 100,
-			}}
-		>
-			<button
-				type="button"
-				onClick={() => setShowMenu((v) => !v)}
-				disabled={exporting}
-				style={{
-					height: 44,
-					padding: "0 16px",
-					background: "white",
-					border: "none",
-					borderRadius: 8,
-					boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-					fontSize: 13,
-					fontWeight: 600,
-					color: "#333",
-					cursor: "pointer",
-				}}
-			>
-				{exporting ? "Exporting..." : "Export"}
-			</button>
+			}
+		: { position: "relative", display: "inline-flex" };
+
+	return (
+		<div style={wrapperStyle}>
+			<div className="u-surface" style={{ display: "flex", padding: 3, borderRadius: 10 }}>
+				<IconBtn
+					icon={I.download}
+					label="エクスポート"
+					onClick={() => setShowMenu((v) => !v)}
+					active={showMenu}
+					disabled={exporting}
+				/>
+			</div>
 			{showMenu && (
-				<div style={{ ...dropdownStyle, top: 50, right: 0, minWidth: 140 }}>
-					<button type="button" onClick={() => handleExport("png")} style={menuItemStyle}>
-						PNG
-					</button>
-					<button type="button" onClick={() => handleExport("svg")} style={menuItemStyle}>
-						SVG
-					</button>
-					<button type="button" onClick={handleExportJson} style={menuItemStyle}>
-						JSON
-					</button>
+				<div
+					className="u-surface"
+					style={{
+						position: "absolute",
+						top: "calc(100% + 6px)",
+						right: 0,
+						minWidth: 200,
+						padding: 6,
+						borderRadius: 10,
+						background: "var(--bg-surface-raised)",
+						boxShadow: "var(--shadow-3)",
+						zIndex: 100,
+						display: "flex",
+						flexDirection: "column",
+						gap: 1,
+					}}
+				>
+					{[
+						{
+							label: "PNG 形式",
+							sub: "ラスタ画像",
+							shortcut: "⌘⇧E",
+							run: () => handleExport("png"),
+						},
+						{
+							label: "SVG 形式",
+							sub: "ベクタ画像",
+							shortcut: "⌘⇧⌥E",
+							run: () => handleExport("svg"),
+						},
+						{ label: "JSON 形式", sub: "ボード完全保存", shortcut: "⌘⇧J", run: handleExportJson },
+					].map((item) => (
+						<button
+							key={item.label}
+							type="button"
+							onClick={item.run}
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: 10,
+								padding: "7px 10px",
+								background: "transparent",
+								border: "none",
+								borderRadius: 6,
+								cursor: "pointer",
+								textAlign: "left",
+								color: "var(--fg-primary)",
+								fontFamily: "inherit",
+								fontSize: 12.5,
+							}}
+						>
+							<div style={{ flex: 1 }}>
+								<div style={{ fontWeight: 500 }}>{item.label}</div>
+								<div style={{ fontSize: 10.5, color: "var(--fg-tertiary)", marginTop: 1 }}>
+									{item.sub}
+								</div>
+							</div>
+							<span className="u-kbd">{item.shortcut}</span>
+						</button>
+					))}
 				</div>
 			)}
 		</div>

--- a/apps/web/src/components/toolbar/tool-button.tsx
+++ b/apps/web/src/components/toolbar/tool-button.tsx
@@ -45,8 +45,8 @@ export function ToolButton({
 					justifyContent: "center",
 					border: "none",
 					borderRadius: 6,
-					background: isActive ? "#e3f2fd" : "transparent",
-					color: isActive ? "#1976d2" : "#333",
+					background: isActive ? "var(--bg-active)" : "transparent",
+					color: isActive ? "var(--brand-violet)" : "var(--fg-secondary)",
 					cursor: "pointer",
 				}}
 			>
@@ -88,11 +88,11 @@ function BasicShapePicker({ onSelect }: { onSelect: (type: string) => void }) {
 		<div
 			style={{
 				position: "absolute",
-				top: 44,
+				bottom: 44,
 				left: "50%",
 				transform: "translateX(-50%)",
-				background: "#fff",
-				border: "1px solid #e0e0e0",
+				background: "var(--bg-surface-raised)",
+				border: "1px solid var(--border-default)",
 				borderRadius: 10,
 				padding: 8,
 				display: "grid",
@@ -151,11 +151,11 @@ function StickyColorPicker({
 		<div
 			style={{
 				position: "absolute",
-				top: 44,
+				bottom: 44,
 				left: "50%",
 				transform: "translateX(-50%)",
-				background: "#fff",
-				border: "1px solid #e0e0e0",
+				background: "var(--bg-surface-raised)",
+				border: "1px solid var(--border-default)",
 				borderRadius: 10,
 				padding: 8,
 				display: "flex",
@@ -206,11 +206,11 @@ function WireframePicker({
 		<div
 			style={{
 				position: "absolute",
-				top: 44,
+				bottom: 44,
 				left: "50%",
 				transform: "translateX(-50%)",
-				background: "#fff",
-				border: "1px solid #e0e0e0",
+				background: "var(--bg-surface-raised)",
+				border: "1px solid var(--border-default)",
 				borderRadius: 10,
 				padding: 8,
 				boxShadow: "0 4px 16px rgba(0,0,0,0.12)",

--- a/apps/web/src/components/toolbar/toolbar.tsx
+++ b/apps/web/src/components/toolbar/toolbar.tsx
@@ -1,21 +1,14 @@
 import { useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
-import { useState } from "react";
 import { useNavigate } from "react-router";
-import { actionBtnStyle, dividerStyle } from "../../lib/styles.js";
-import { ShareDialog } from "../share-dialog.js";
 import { StylePanel } from "../style-panel/index.js";
+import { Divider, I, IconBtn, ThemeToggle } from "../ui/index.js";
 import { BgToggle } from "./bg-toggle.js";
 import { CopilotToggle } from "./copilot-toggle.js";
-import { ExportMenu } from "./export-menu.js";
 import { StatusBar } from "./status-bar.js";
 import { ToolButton } from "./tool-button.js";
 import { VoiceButton } from "./voice-button.js";
 
-export function Toolbar({
-	boardId,
-	isCloudBoard,
-	wsProvider,
-}: {
+interface Props {
 	boardId?: string;
 	isCloudBoard?: boolean;
 	wsProvider?: {
@@ -26,43 +19,40 @@ export function Toolbar({
 			doc: { clientID: number };
 		};
 	} | null;
-}) {
+	onOpenCommandPalette: () => void;
+}
+
+/**
+ * 画面下中央に固定された主ツールバー。
+ * - 左: ツール（select / pan / 各 shape 描画）
+ * - 中央: Undo/Redo + 背景切替 + テーマ切替
+ * - 右: Cloud 専用（Copilot / Voice / Present）
+ * - 上付き pill: Cmd+K ハンドル
+ */
+export function Toolbar({ boardId, isCloudBoard, wsProvider, onOpenCommandPalette }: Props) {
 	const app = useApp();
 	const activeToolId = useStoreSubscribe(app.store, (s) => s.getActiveToolId());
 	const tools = app.tools.getOrdered();
-	const [showShare, setShowShare] = useState(false);
 	const navigate = useNavigate();
 
 	return (
 		<>
 			<div
+				data-testid="toolbar"
+				className="u-surface"
 				style={{
 					position: "fixed",
-					top: 12,
+					bottom: 12,
 					left: "50%",
 					transform: "translateX(-50%)",
 					display: "flex",
-					gap: 4,
+					gap: 2,
 					padding: 4,
-					background: "white",
-					borderRadius: 8,
-					boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+					borderRadius: 12,
 					zIndex: 100,
 					alignItems: "center",
 				}}
 			>
-				{/* ホームリンク */}
-				<a
-					href="/"
-					title="Dashboard"
-					style={{ ...actionBtnStyle, textDecoration: "none", fontSize: 14 }}
-				>
-					⌂
-				</a>
-
-				<Divider />
-
-				{/* ツール */}
 				{tools.map(({ id, definition }) => (
 					<ToolButton
 						key={id}
@@ -73,90 +63,52 @@ export function Toolbar({
 					/>
 				))}
 
-				<Divider />
+				<Divider vertical />
 
-				{/* Undo/Redo */}
-				<button
-					type="button"
-					onClick={() => app.commands.undo()}
-					title="Undo (Ctrl+Z)"
-					style={actionBtnStyle}
-				>
-					↩
-				</button>
-				<button
-					type="button"
+				<IconBtn icon={I.undo} label="元に戻す" shortcut="⌘Z" onClick={() => app.commands.undo()} />
+				<IconBtn
+					icon={I.redo}
+					label="やり直す"
+					shortcut="⌘⇧Z"
 					onClick={() => app.commands.redo()}
-					title="Redo (Ctrl+Shift+Z)"
-					style={actionBtnStyle}
-				>
-					↪
-				</button>
+				/>
 
-				<Divider />
+				<Divider vertical />
+
 				<BgToggle />
+
+				<div style={{ padding: "0 2px", display: "inline-flex", alignItems: "center" }}>
+					<ThemeToggle />
+				</div>
 
 				{isCloudBoard && (
 					<>
-						<Divider />
+						<Divider vertical />
 						<CopilotToggle />
 						<VoiceButton />
 						{boardId && (
-							<button
-								type="button"
+							<IconBtn
+								icon={I.present}
+								label="プレゼンテーション"
 								onClick={() => navigate(`/boards/${boardId}?present=1`)}
-								title="プレゼンテーション編集モードを開く"
-								aria-label="プレゼンテーション編集モードを開く"
-								style={{ ...actionBtnStyle, fontSize: 14 }}
-							>
-								▶
-							</button>
+							/>
 						)}
 					</>
 				)}
+
+				<Divider vertical />
+
+				<IconBtn
+					icon={I.search}
+					label="コマンドパレット"
+					shortcut="⌘K"
+					onClick={onOpenCommandPalette}
+				/>
 			</div>
 
-			{/* ステータス + Follow（左下） */}
 			{isCloudBoard && wsProvider && <StatusBar wsProvider={wsProvider} />}
-
-			{/* エクスポート（右上、Shareの左） */}
-			<ExportMenu isCloudBoard={isCloudBoard} boardId={boardId} />
-
-			{/* 共有ボタン（右上、Cloud Boardのみ） */}
-			{isCloudBoard && boardId && (
-				<button
-					type="button"
-					onClick={() => setShowShare(true)}
-					style={{
-						position: "fixed",
-						top: 12,
-						right: 12,
-						height: 44,
-						padding: "0 16px",
-						background: "#0066ff",
-						color: "#fff",
-						border: "none",
-						borderRadius: 8,
-						fontSize: 13,
-						fontWeight: 600,
-						cursor: "pointer",
-						boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-						zIndex: 100,
-					}}
-				>
-					Share
-				</button>
-			)}
-
-			{showShare && boardId && (
-				<ShareDialog boardId={boardId} onClose={() => setShowShare(false)} />
-			)}
 
 			<StylePanel />
 		</>
 	);
-}
-
-function Divider() {
-	return <div style={dividerStyle} />;
 }

--- a/apps/web/src/components/toolbar/voice-button.tsx
+++ b/apps/web/src/components/toolbar/voice-button.tsx
@@ -1,6 +1,6 @@
 import { useApp } from "@edv4h/usketch-canvas-engine";
 import { useEffect, useState } from "react";
-import { actionBtnStyle } from "../../lib/styles.js";
+import { I, IconBtn } from "../ui/index.js";
 
 export function VoiceButton() {
 	const app = useApp();
@@ -14,19 +14,12 @@ export function VoiceButton() {
 	}, [app.events]);
 
 	return (
-		<button
-			type="button"
+		<IconBtn
+			icon={I.mic}
+			label={listening ? "音声入力（認識中）" : "音声入力"}
+			active={listening}
+			danger={listening}
 			onClick={() => app.events.emit("voice:toggle", {})}
-			title="Voice input"
-			style={{
-				...actionBtnStyle,
-				background: listening ? "#fce4ec" : "transparent",
-				color: listening ? "#c62828" : "#999",
-				fontSize: 14,
-				animation: listening ? "voice-pulse 1s infinite" : "none",
-			}}
-		>
-			🎤
-		</button>
+		/>
 	);
 }

--- a/apps/web/src/components/ui/divider.tsx
+++ b/apps/web/src/components/ui/divider.tsx
@@ -1,0 +1,17 @@
+interface DividerProps {
+	vertical?: boolean;
+}
+
+export function Divider({ vertical }: DividerProps) {
+	return (
+		<div
+			style={{
+				width: vertical ? 1 : 16,
+				height: vertical ? 16 : 1,
+				background: "var(--border-default)",
+				margin: vertical ? "0 4px" : "4px 0",
+				flexShrink: 0,
+			}}
+		/>
+	);
+}

--- a/apps/web/src/components/ui/icon-btn.tsx
+++ b/apps/web/src/components/ui/icon-btn.tsx
@@ -1,0 +1,133 @@
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import type { IconComponent } from "./icons.js";
+
+type TooltipPlacement = "top" | "bottom" | "left" | "right";
+
+interface IconBtnProps {
+	icon?: IconComponent;
+	label?: string;
+	shortcut?: string;
+	active?: boolean;
+	danger?: boolean;
+	size?: number;
+	onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+	tooltipPlacement?: TooltipPlacement;
+	disabled?: boolean;
+	"aria-label"?: string;
+	children?: ReactNode;
+	title?: string;
+}
+
+const TOOLTIP_POS: Record<TooltipPlacement, React.CSSProperties> = {
+	top: { bottom: "calc(100% + 8px)", left: "50%", transform: "translateX(-50%)" },
+	bottom: { top: "calc(100% + 8px)", left: "50%", transform: "translateX(-50%)" },
+	left: { right: "calc(100% + 8px)", top: "50%", transform: "translateY(-50%)" },
+	right: { left: "calc(100% + 8px)", top: "50%", transform: "translateY(-50%)" },
+};
+
+export function IconBtn({
+	icon: IconCmp,
+	label,
+	shortcut,
+	active,
+	danger,
+	size = 32,
+	onClick,
+	tooltipPlacement,
+	disabled,
+	"aria-label": ariaLabel,
+	children,
+	title,
+}: IconBtnProps) {
+	const [hover, setHover] = useState(false);
+	const [placement, setPlacement] = useState<TooltipPlacement>(tooltipPlacement ?? "bottom");
+	const btnRef = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (!hover || tooltipPlacement) return;
+		const el = btnRef.current;
+		if (!el) return;
+		const rect = el.getBoundingClientRect();
+		const spaceBelow = window.innerHeight - rect.bottom;
+		const spaceAbove = rect.top;
+		const spaceRight = window.innerWidth - rect.right;
+		const spaceLeft = rect.left;
+		if (spaceBelow < 60 && spaceAbove > spaceBelow) setPlacement("top");
+		else if (spaceRight < 80 && spaceLeft > spaceRight) setPlacement("left");
+		else if (spaceLeft < 80 && spaceRight > spaceLeft) setPlacement("right");
+		else setPlacement("bottom");
+	}, [hover, tooltipPlacement]);
+
+	const idleColor = danger ? "var(--danger)" : "var(--fg-secondary)";
+
+	return (
+		<button
+			ref={btnRef}
+			type="button"
+			onClick={onClick}
+			onMouseEnter={() => setHover(true)}
+			onMouseLeave={() => setHover(false)}
+			disabled={disabled}
+			aria-label={ariaLabel ?? label}
+			title={title}
+			style={{
+				position: "relative",
+				width: size,
+				height: size,
+				display: "inline-flex",
+				alignItems: "center",
+				justifyContent: "center",
+				background: active
+					? "var(--bg-active)"
+					: hover && !disabled
+						? "var(--bg-hover)"
+						: "transparent",
+				color: active
+					? "var(--brand-violet)"
+					: hover && !disabled
+						? "var(--fg-primary)"
+						: idleColor,
+				border: "none",
+				borderRadius: "var(--r-sm)",
+				cursor: disabled ? "default" : "pointer",
+				opacity: disabled ? 0.45 : 1,
+				transition:
+					"background var(--dur-fast) var(--ease-out), color var(--dur-fast) var(--ease-out)",
+				flexShrink: 0,
+				padding: 0,
+			}}
+		>
+			{IconCmp ? <IconCmp /> : null}
+			{children}
+			{hover && label && !disabled && (
+				<div
+					style={{
+						position: "absolute",
+						...TOOLTIP_POS[placement],
+						background: "var(--bg-surface-solid)",
+						color: "var(--fg-primary)",
+						padding: "5px 9px",
+						borderRadius: 6,
+						fontSize: 11.5,
+						whiteSpace: "nowrap",
+						border: "1px solid var(--border-default)",
+						boxShadow: "var(--shadow-2)",
+						zIndex: 1000,
+						pointerEvents: "none",
+						display: "flex",
+						alignItems: "center",
+						gap: 6,
+						fontWeight: 500,
+					}}
+				>
+					{label}
+					{shortcut && (
+						<span className="u-kbd" style={{ marginLeft: 2 }}>
+							{shortcut}
+						</span>
+					)}
+				</div>
+			)}
+		</button>
+	);
+}

--- a/apps/web/src/components/ui/icons.tsx
+++ b/apps/web/src/components/ui/icons.tsx
@@ -1,0 +1,475 @@
+/**
+ * Thin-line 16px icon set — モック (whiteboard-new-design/components/icons.jsx) から移植。
+ * 全アイコン stroke-width 1.5、currentColor。
+ */
+
+import type { CSSProperties, ReactNode } from "react";
+
+interface IconProps {
+	size?: number;
+	className?: string;
+	style?: CSSProperties;
+}
+
+function Icon({ children, size = 16, className, style }: IconProps & { children: ReactNode }) {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 16 16"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			style={style}
+			aria-hidden="true"
+		>
+			{children}
+		</svg>
+	);
+}
+
+export type IconComponent = (props: IconProps) => ReactNode;
+
+export const I = {
+	// Tools
+	cursor: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M3 2.5 8 13l2-4.5L14.5 7 3 2.5Z" />
+		</Icon>
+	),
+	hand: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M5 8V4a1 1 0 1 1 2 0v3" />
+			<path d="M7 7V3a1 1 0 1 1 2 0v4" />
+			<path d="M9 7V4a1 1 0 1 1 2 0v5" />
+			<path d="M11 6a1 1 0 1 1 2 0v5c0 2-2 3.5-4 3.5s-4-1-4-3L3.5 8.5a1 1 0 0 1 1.7-1L6 8.5" />
+		</Icon>
+	),
+	rect: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="2.5" y="3.5" width="11" height="9" rx="1" />
+		</Icon>
+	),
+	circle: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="8" r="5.5" />
+		</Icon>
+	),
+	triangle: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 2.5 14 13H2L8 2.5Z" />
+		</Icon>
+	),
+	diamond: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 2 14 8l-6 6-6-6 6-6Z" />
+		</Icon>
+	),
+	star: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 2.2 9.7 6l4.1.4-3.1 2.8.9 4.1L8 11.2 4.4 13.3l.9-4.1L2.2 6.4 6.3 6 8 2.2Z" />
+		</Icon>
+	),
+	arrow: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2.5 8h11M10 4.5 13.5 8 10 11.5" />
+		</Icon>
+	),
+	line: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m3 13 10-10" />
+		</Icon>
+	),
+	text: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M3 4V3h10v1M8 3v10M6 13h4" />
+		</Icon>
+	),
+	sticky: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2.5 3.5h8l3 3v7h-11v-10Z" />
+			<path d="M10.5 3.5v3h3" />
+		</Icon>
+	),
+	pen: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M11 2.5 13.5 5 5 13.5H2.5V11L11 2.5Z" />
+		</Icon>
+	),
+	image: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="2" y="3" width="12" height="10" rx="1.5" />
+			<circle cx="5.5" cy="6.5" r="1" />
+			<path d="m2.5 11.5 3-3 3 3 2-2 3 3" />
+		</Icon>
+	),
+	frame: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M4 2v12M12 2v12M2 4h12M2 12h12" />
+		</Icon>
+	),
+	connector: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="3" cy="3" r="1.2" />
+			<circle cx="13" cy="13" r="1.2" />
+			<path d="M4 4c4 0 4 8 8 8" />
+		</Icon>
+	),
+	ui: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="2" y="2.5" width="12" height="11" rx="1.5" />
+			<path d="M2 6h12M5 9.5h3M5 11.5h5" />
+		</Icon>
+	),
+
+	// Actions
+	undo: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M3 6h7a3.5 3.5 0 0 1 0 7H6M3 6l2.5-2.5M3 6l2.5 2.5" />
+		</Icon>
+	),
+	redo: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M13 6H6a3.5 3.5 0 0 0 0 7h4M13 6l-2.5-2.5M13 6l-2.5 2.5" />
+		</Icon>
+	),
+	grid: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="2.5" y="2.5" width="11" height="11" rx=".5" />
+			<path d="M6 2.5v11M10 2.5v11M2.5 6h11M2.5 10h11" />
+		</Icon>
+	),
+	dots: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="4" cy="4" r=".6" fill="currentColor" />
+			<circle cx="8" cy="4" r=".6" fill="currentColor" />
+			<circle cx="12" cy="4" r=".6" fill="currentColor" />
+			<circle cx="4" cy="8" r=".6" fill="currentColor" />
+			<circle cx="8" cy="8" r=".6" fill="currentColor" />
+			<circle cx="12" cy="8" r=".6" fill="currentColor" />
+			<circle cx="4" cy="12" r=".6" fill="currentColor" />
+			<circle cx="8" cy="12" r=".6" fill="currentColor" />
+			<circle cx="12" cy="12" r=".6" fill="currentColor" />
+		</Icon>
+	),
+	bgNone: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="8" r="5.5" />
+			<path d="m4 12 8-8" />
+		</Icon>
+	),
+	zoomIn: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="7" cy="7" r="4.5" />
+			<path d="m10.5 10.5 3 3M5 7h4M7 5v4" />
+		</Icon>
+	),
+	zoomOut: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="7" cy="7" r="4.5" />
+			<path d="m10.5 10.5 3 3M5 7h4" />
+		</Icon>
+	),
+	present: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="1.5" y="3" width="13" height="9" rx="1" />
+			<path d="M6 14h4M8 12v2" />
+		</Icon>
+	),
+	mic: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="6" y="2" width="4" height="8" rx="2" />
+			<path d="M3.5 8a4.5 4.5 0 0 0 9 0M8 12.5V14" />
+		</Icon>
+	),
+	sparkles: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 2v3M8 11v3M2 8h3M11 8h3M4.5 4.5l2 2M9.5 9.5l2 2M11.5 4.5l-2 2M6.5 9.5l-2 2" />
+		</Icon>
+	),
+	search: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="7" cy="7" r="4.5" />
+			<path d="m10.5 10.5 3 3" />
+		</Icon>
+	),
+	close: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m3.5 3.5 9 9M12.5 3.5l-9 9" />
+		</Icon>
+	),
+	plus: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 3v10M3 8h10" />
+		</Icon>
+	),
+	minus: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M3 8h10" />
+		</Icon>
+	),
+	more: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="3.5" cy="8" r=".8" fill="currentColor" />
+			<circle cx="8" cy="8" r=".8" fill="currentColor" />
+			<circle cx="12.5" cy="8" r=".8" fill="currentColor" />
+		</Icon>
+	),
+	chevDown: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m4 6 4 4 4-4" />
+		</Icon>
+	),
+	chevRight: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m6 4 4 4-4 4" />
+		</Icon>
+	),
+	chevLeft: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m10 4-4 4 4 4" />
+		</Icon>
+	),
+	chevUp: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m4 10 4-4 4 4" />
+		</Icon>
+	),
+	check: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m3 8 3.5 3.5L13 5" />
+		</Icon>
+	),
+	comment: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2.5 7.5c0-2.8 2.5-5 5.5-5s5.5 2.2 5.5 5-2.5 5-5.5 5c-.7 0-1.4-.1-2-.3L3 13.5l.8-2.4a4.8 4.8 0 0 1-1.3-3.6Z" />
+		</Icon>
+	),
+	users: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="6" cy="5.5" r="2.2" />
+			<path d="M2 13c0-2.2 1.8-4 4-4s4 1.8 4 4" />
+			<circle cx="11" cy="5" r="1.8" />
+			<path d="M10.5 9a3.5 3.5 0 0 1 3.5 3.5" />
+		</Icon>
+	),
+	share: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="3.5" cy="8" r="1.7" />
+			<circle cx="12" cy="3.5" r="1.7" />
+			<circle cx="12" cy="12.5" r="1.7" />
+			<path d="m5 7 5.5-2.8M5 9l5.5 2.8" />
+		</Icon>
+	),
+	layers: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 1.5 1.5 5 8 8.5 14.5 5 8 1.5ZM1.5 8 8 11.5 14.5 8M1.5 11 8 14.5 14.5 11" />
+		</Icon>
+	),
+	home: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2.5 7.5 8 3l5.5 4.5V13a.5.5 0 0 1-.5.5h-3V10H6v3.5H3a.5.5 0 0 1-.5-.5V7.5Z" />
+		</Icon>
+	),
+	back: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M13 8H3M7 4 3 8l4 4" />
+		</Icon>
+	),
+	download: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 2v8M4.5 7 8 10.5 11.5 7M3 13h10" />
+		</Icon>
+	),
+	lock: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="3.5" y="7" width="9" height="6.5" rx="1" />
+			<path d="M5 7V5a3 3 0 0 1 6 0v2" />
+		</Icon>
+	),
+	globe: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="8" r="5.5" />
+			<path d="M2.5 8h11M8 2.5c2 2 2 9 0 11M8 2.5c-2 2-2 9 0 11" />
+		</Icon>
+	),
+	link: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M7 9a2.5 2.5 0 0 0 3.5 0l2-2a2.5 2.5 0 0 0-3.5-3.5l-1 1" />
+			<path d="M9 7a2.5 2.5 0 0 0-3.5 0l-2 2A2.5 2.5 0 0 0 7 12.5l1-1" />
+		</Icon>
+	),
+	trash: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M3 4h10M6 4V2.5h4V4M5 4l.5 9h5L11 4M7 6.5v5M9 6.5v5" />
+		</Icon>
+	),
+	moon: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M12.5 9A5 5 0 0 1 7 3.5 5.2 5.2 0 0 0 8 13.5a5 5 0 0 0 4.5-4.5Z" />
+		</Icon>
+	),
+	sun: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="8" r="3" />
+			<path d="M8 1.5v1.5M8 13v1.5M2.5 8H1M15 8h-1.5M3.7 3.7l1 1M11.3 11.3l1 1M3.7 12.3l1-1M11.3 4.7l1-1" />
+		</Icon>
+	),
+	monitor: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="1.5" y="2.5" width="13" height="9" rx="1" />
+			<path d="M5 14h6M8 11.5V14" />
+		</Icon>
+	),
+	eye: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M1.5 8S4 3 8 3s6.5 5 6.5 5S12 13 8 13 1.5 8 1.5 8Z" />
+			<circle cx="8" cy="8" r="2" />
+		</Icon>
+	),
+	ghost: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M3 13V7a5 5 0 0 1 10 0v6l-1.5-1L10 13l-2-1-2 1-1.5-1L3 13Z" />
+			<circle cx="6.5" cy="7" r=".6" fill="currentColor" />
+			<circle cx="9.5" cy="7" r=".6" fill="currentColor" />
+		</Icon>
+	),
+	wand: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="m3 13 8-8M10 4l2 2M12.5 1.5v2M15 4h-2M2 8v1M4 8H3" />
+		</Icon>
+	),
+	play: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M4 3v10l9-5L4 3Z" />
+		</Icon>
+	),
+	settings: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="8" r="1.8" />
+			<path d="M12.5 8a4.5 4.5 0 0 0-.1-1l1-.8-1-1.7-1.3.3a4.5 4.5 0 0 0-1.7-1l-.2-1.3H7.8l-.2 1.3a4.5 4.5 0 0 0-1.7 1l-1.3-.3-1 1.7 1 .8a4.5 4.5 0 0 0 0 2l-1 .8 1 1.7 1.3-.3a4.5 4.5 0 0 0 1.7 1l.2 1.3h1.4l.2-1.3a4.5 4.5 0 0 0 1.7-1l1.3.3 1-1.7-1-.8c.1-.3.1-.7.1-1Z" />
+		</Icon>
+	),
+	bell: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M4 10.5c0-1 .5-1.5.5-4a3.5 3.5 0 0 1 7 0c0 2.5.5 3 .5 4H4Z" />
+			<path d="M6.5 12.5a1.5 1.5 0 0 0 3 0" />
+		</Icon>
+	),
+	history: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2.5 8a5.5 5.5 0 1 0 1.5-3.8" />
+			<path d="M2.5 3v3h3M8 5v3l2 1.5" />
+		</Icon>
+	),
+	palette: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 13.5A5.5 5.5 0 1 1 8 2.5c3 0 5.5 2 5.5 4.5 0 1.5-1.5 2-3 2h-1a1 1 0 0 0-.5 1.8c.4.4.5 1 .3 1.5-.2.5-.7.7-1.3.7Z" />
+			<circle cx="5" cy="6" r=".8" fill="currentColor" />
+			<circle cx="8" cy="5" r=".8" fill="currentColor" />
+			<circle cx="11" cy="6.5" r=".8" fill="currentColor" />
+		</Icon>
+	),
+	group: (p: IconProps) => (
+		<Icon {...p}>
+			<rect x="1.5" y="1.5" width="5" height="5" rx=".5" />
+			<rect x="9.5" y="1.5" width="5" height="5" rx=".5" />
+			<rect x="1.5" y="9.5" width="5" height="5" rx=".5" />
+			<rect x="9.5" y="9.5" width="5" height="5" rx=".5" />
+		</Icon>
+	),
+	align: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2 2v12M4 4h6M4 8h9M4 12h4" />
+		</Icon>
+	),
+	pin: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 1.5 6 3v4L3 9l3 .5V14l2-1.5v-3L11 9 8 7V3L8 1.5Z" />
+		</Icon>
+	),
+	map: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M1.5 3.5 5.5 2l5 2 4-1.5v10l-4 1.5-5-2-4 1.5v-10Z" />
+			<path d="M5.5 2v10M10.5 4v10" />
+		</Icon>
+	),
+	community: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="4.5" r="1.7" />
+			<circle cx="4" cy="11" r="1.5" />
+			<circle cx="12" cy="11" r="1.5" />
+			<path d="M6.5 5.5 5 9.5M9.5 5.5l1.5 4M5.5 11h5" />
+		</Icon>
+	),
+	spotlight: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.5 3.5l1.5 1.5M11 11l1.5 1.5" />
+			<circle cx="8" cy="8" r="3" />
+		</Icon>
+	),
+	laser: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M8 1v2" />
+			<path d="M8 15v-2" />
+			<circle cx="8" cy="8" r="1.8" fill="currentColor" stroke="none" />
+			<path d="M8 5v1.5M8 11v-1.5" />
+		</Icon>
+	),
+	reaction: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="8" r="5.5" />
+			<path d="M5.5 9.5c.5 1 1.4 1.5 2.5 1.5s2-.5 2.5-1.5" />
+			<circle cx="6" cy="6.5" r=".5" fill="currentColor" />
+			<circle cx="10" cy="6.5" r=".5" fill="currentColor" />
+		</Icon>
+	),
+	chat: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2.5 4.5c0-1 .8-2 2-2h7c1.2 0 2 1 2 2v5c0 1-.8 2-2 2H6.5L3.5 14v-2.5c-.6-.3-1-1-1-1.5v-5.5Z" />
+		</Icon>
+	),
+	send: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2 8 14 2l-5 12-2-5L2 8Z" />
+		</Icon>
+	),
+	folder: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2 4a1 1 0 0 1 1-1h3l1.5 1.5H13a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4Z" />
+		</Icon>
+	),
+	star2: (p: IconProps) => (
+		<Icon {...p}>
+			<path
+				d="M8 2 9.8 6l4.2.4-3.2 2.8 1 4.1L8 11.2 4.2 13.3l1-4.1L2 6.4 6.2 6 8 2Z"
+				fill="currentColor"
+				strokeWidth="0"
+			/>
+		</Icon>
+	),
+	vote: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M3 7.5 5.5 10l7-7M2.5 11.5h11v2h-11z" />
+		</Icon>
+	),
+	clock: (p: IconProps) => (
+		<Icon {...p}>
+			<circle cx="8" cy="8" r="5.5" />
+			<path d="M8 4.5V8l2 1.5" />
+		</Icon>
+	),
+	bolt: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M9 2 4 9h4l-1 5 5-7H8l1-5Z" />
+		</Icon>
+	),
+	translate: (p: IconProps) => (
+		<Icon {...p}>
+			<path d="M2 3h6M5 3v1.5c0 2-1 3.5-3 4.5M3 5.5c0 2 2 3.5 4 3.5M9 14l2.5-6 2.5 6M10 12h3" />
+		</Icon>
+	),
+} satisfies Record<string, IconComponent>;

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -1,0 +1,6 @@
+export { Divider } from "./divider.js";
+export { IconBtn } from "./icon-btn.js";
+export { I, type IconComponent } from "./icons.js";
+export { Kbd } from "./kbd.js";
+export { Surface } from "./surface.js";
+export { ThemeToggle } from "./theme-toggle.js";

--- a/apps/web/src/components/ui/kbd.tsx
+++ b/apps/web/src/components/ui/kbd.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+interface KbdProps {
+	children: ReactNode;
+}
+
+export function Kbd({ children }: KbdProps) {
+	return <span className="u-kbd">{children}</span>;
+}

--- a/apps/web/src/components/ui/surface.tsx
+++ b/apps/web/src/components/ui/surface.tsx
@@ -1,0 +1,30 @@
+import type { CSSProperties, ReactNode } from "react";
+
+interface SurfaceProps {
+	children: ReactNode;
+	className?: string;
+	style?: CSSProperties;
+	as?: "div" | "section" | "aside" | "nav";
+	role?: string;
+	"aria-label"?: string;
+}
+
+/**
+ * Glassmorphic floating surface — `className="u-surface"` を適用する薄いラッパー。
+ * 追加クラスや style は merge。
+ */
+export function Surface({
+	children,
+	className,
+	style,
+	as: Tag = "div",
+	role,
+	"aria-label": ariaLabel,
+}: SurfaceProps) {
+	const cls = className ? `u-surface ${className}` : "u-surface";
+	return (
+		<Tag className={cls} style={style} role={role} aria-label={ariaLabel}>
+			{children}
+		</Tag>
+	);
+}

--- a/apps/web/src/components/ui/theme-toggle.tsx
+++ b/apps/web/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,55 @@
+import type { Theme } from "../../lib/theme.js";
+import { useTheme } from "../../lib/use-theme.js";
+import { I } from "./icons.js";
+
+const OPTIONS: { value: Theme; label: string; Icon: typeof I.sun }[] = [
+	{ value: "light", label: "ライト", Icon: I.sun },
+	{ value: "dark", label: "ダーク", Icon: I.moon },
+	{ value: "system", label: "システム", Icon: I.monitor },
+];
+
+export function ThemeToggle() {
+	const { theme, setTheme } = useTheme();
+	return (
+		<div
+			style={{
+				display: "inline-flex",
+				gap: 2,
+				padding: 2,
+				background: "var(--bg-input)",
+				border: "1px solid var(--border-subtle)",
+				borderRadius: "var(--r-sm)",
+			}}
+		>
+			{OPTIONS.map(({ value, label, Icon }) => {
+				const active = theme === value;
+				return (
+					<button
+						key={value}
+						type="button"
+						aria-pressed={active}
+						aria-label={label}
+						title={label}
+						onClick={() => setTheme(value)}
+						style={{
+							display: "inline-flex",
+							alignItems: "center",
+							justifyContent: "center",
+							width: 26,
+							height: 22,
+							background: active ? "var(--bg-surface-raised)" : "transparent",
+							color: active ? "var(--brand-violet)" : "var(--fg-tertiary)",
+							border: "none",
+							borderRadius: 4,
+							cursor: "pointer",
+							padding: 0,
+							transition: "all var(--dur-fast) var(--ease-out)",
+						}}
+					>
+						<Icon size={13} />
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/web/src/lib/styles.ts
+++ b/apps/web/src/lib/styles.ts
@@ -1,6 +1,9 @@
 /**
  * Design tokens and reusable style objects for the demo app UI.
- * See DESIGN.md for the full design guide.
+ *
+ * NOTE: デザインモック適用の段階移行中。新規コードは `apps/web/src/styles/tokens.css`
+ * の CSS 変数（`var(--brand-gradient)` など）を優先して参照し、このファイルの
+ * 定数は既存コードの互換レイヤーとして一時的に維持している。全面移行後に削除予定。
  */
 
 // ── Colors ──

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,99 @@
+/**
+ * Theme management — light / dark / system の 3 モードを管理する。
+ *
+ * - localStorage キー `usketch-theme` に永続化
+ * - "system" モードは OS の `prefers-color-scheme` を解決して追従
+ * - `data-theme` 属性を `<html>` に書き込む（tokens.css の変数がスコープされる）
+ *
+ * 初回 flash 防止のため、HTML の `<head>` 内で同名ロジックをインライン実行して
+ * React 起動前に属性を設定する。この TS モジュールは runtime 変更・購読用。
+ */
+
+export type Theme = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "usketch-theme";
+
+const listeners = new Set<(theme: Theme, resolved: ResolvedTheme) => void>();
+let currentTheme: Theme = "system";
+let mediaQuery: MediaQueryList | null = null;
+let mediaListener: ((e: MediaQueryListEvent) => void) | null = null;
+
+function isTheme(value: unknown): value is Theme {
+	return value === "light" || value === "dark" || value === "system";
+}
+
+function readStoredTheme(): Theme {
+	try {
+		const stored = localStorage.getItem(THEME_STORAGE_KEY);
+		if (isTheme(stored)) return stored;
+	} catch {
+		// localStorage が使えない環境はフォールスルー
+	}
+	return "system";
+}
+
+function resolveSystem(): ResolvedTheme {
+	if (typeof window === "undefined") return "dark";
+	return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function resolveTheme(theme: Theme): ResolvedTheme {
+	return theme === "system" ? resolveSystem() : theme;
+}
+
+export function getInitialTheme(): Theme {
+	return readStoredTheme();
+}
+
+export function getCurrentTheme(): Theme {
+	return currentTheme;
+}
+
+function apply(theme: Theme): void {
+	const resolved = resolveTheme(theme);
+	document.documentElement.dataset.theme = resolved;
+	for (const l of listeners) l(theme, resolved);
+}
+
+function ensureSystemListener(active: boolean): void {
+	if (typeof window === "undefined") return;
+	if (active && !mediaListener) {
+		mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+		mediaListener = () => {
+			if (currentTheme === "system") apply("system");
+		};
+		mediaQuery.addEventListener("change", mediaListener);
+	} else if (!active && mediaListener && mediaQuery) {
+		mediaQuery.removeEventListener("change", mediaListener);
+		mediaListener = null;
+		mediaQuery = null;
+	}
+}
+
+export function setTheme(theme: Theme): void {
+	currentTheme = theme;
+	try {
+		localStorage.setItem(THEME_STORAGE_KEY, theme);
+	} catch {
+		// localStorage が使えない環境は無視
+	}
+	ensureSystemListener(theme === "system");
+	apply(theme);
+}
+
+export function subscribeTheme(
+	listener: (theme: Theme, resolved: ResolvedTheme) => void,
+): () => void {
+	listeners.add(listener);
+	return () => {
+		listeners.delete(listener);
+	};
+}
+
+/** アプリ起動時に 1 回だけ呼ぶ。localStorage から現在テーマを復元してリスナーを繋ぐ。 */
+export function initTheme(): void {
+	currentTheme = readStoredTheme();
+	ensureSystemListener(currentTheme === "system");
+	apply(currentTheme);
+}

--- a/apps/web/src/lib/use-theme.ts
+++ b/apps/web/src/lib/use-theme.ts
@@ -1,0 +1,23 @@
+import { useSyncExternalStore } from "react";
+import {
+	getCurrentTheme,
+	type ResolvedTheme,
+	resolveTheme,
+	setTheme,
+	subscribeTheme,
+	type Theme,
+} from "./theme.js";
+
+function subscribe(callback: () => void): () => void {
+	return subscribeTheme(callback);
+}
+
+export function useTheme(): {
+	theme: Theme;
+	resolved: ResolvedTheme;
+	setTheme: (theme: Theme) => void;
+} {
+	const theme = useSyncExternalStore(subscribe, getCurrentTheme, getCurrentTheme);
+	const resolved = resolveTheme(theme);
+	return { theme, resolved, setTheme };
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,10 +2,14 @@ import { lazy, StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router";
 import { App } from "./app.js";
+import { initTheme } from "./lib/theme.js";
 import { CommunityPage } from "./pages/community/index.js";
 import { DashboardPage } from "./pages/dashboard.js";
 import { DevicePage } from "./pages/device.js";
 import { LoginPage } from "./pages/login.js";
+import "./styles/tokens.css";
+
+initTheme();
 
 const BenchmarkPage = lazy(() =>
 	import("./pages/benchmark.js").then((m) => ({ default: m.BenchmarkPage })),

--- a/apps/web/src/pages/community/community-header.tsx
+++ b/apps/web/src/pages/community/community-header.tsx
@@ -1,5 +1,6 @@
 import { useApp } from "@edv4h/usketch-canvas-engine";
 import { useNavigate } from "react-router";
+import { I, IconBtn, ThemeToggle } from "../../components/ui/index.js";
 import { useAuth } from "../../lib/use-auth.js";
 
 export function CommunityHeader({ regionName }: { regionName: string }) {
@@ -23,29 +24,32 @@ export function CommunityHeader({ regionName }: { regionName: string }) {
 				<button
 					type="button"
 					onClick={() => navigate("/community")}
+					className="u-surface"
 					style={{
-						background: "white",
 						border: "none",
-						borderRadius: 8,
 						padding: "6px 12px",
-						boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-						fontSize: 14,
+						fontSize: 12,
 						cursor: "pointer",
-						color: "#0066ff",
-						fontFamily: "system-ui, sans-serif",
+						color: "var(--fg-secondary)",
+						fontFamily: "var(--font-sans)",
+						display: "inline-flex",
+						alignItems: "center",
+						gap: 6,
+						borderRadius: 10,
 					}}
 				>
-					World Map
+					<I.map size={12} />
+					ワールドマップ
 				</button>
 				<div
+					className="u-surface"
 					style={{
-						background: "white",
-						borderRadius: 8,
 						padding: "6px 14px",
-						boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-						fontSize: 14,
+						fontSize: 13,
 						fontWeight: 600,
-						fontFamily: "system-ui, sans-serif",
+						fontFamily: "var(--font-sans)",
+						color: "var(--fg-primary)",
+						borderRadius: 10,
 					}}
 				>
 					{regionName || "uSketch"}
@@ -57,102 +61,80 @@ export function CommunityHeader({ regionName }: { regionName: string }) {
 							logout();
 							navigate("/login");
 						}}
+						className="u-surface"
 						style={{
-							background: "white",
 							border: "none",
-							borderRadius: 8,
 							padding: "6px 12px",
-							boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-							fontSize: 12,
+							fontSize: 11.5,
 							cursor: "pointer",
-							color: "#666",
+							color: "var(--fg-tertiary)",
+							fontFamily: "var(--font-sans)",
+							borderRadius: 10,
 						}}
 					>
-						{sessionUser.name} — Sign Out
+						{sessionUser.name} — サインアウト
 					</button>
 				) : (
 					<a
 						href="/login"
+						className="u-surface"
 						style={{
-							background: "white",
-							borderRadius: 8,
 							padding: "6px 12px",
-							boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-							fontSize: 12,
+							fontSize: 11.5,
 							textDecoration: "none",
-							color: "#0066ff",
+							color: "var(--brand-violet)",
+							fontFamily: "var(--font-sans)",
+							borderRadius: 10,
 						}}
 					>
-						Sign In
+						サインイン
 					</a>
 				)}
 			</div>
-			{/* 右上: サイドパネル開閉ボタン */}
-			{sessionUser && (
-				<div
-					style={{
-						position: "fixed",
-						top: 12,
-						right: 12,
-						zIndex: 100,
-						display: "flex",
-						gap: 6,
-					}}
-				>
-					<button
-						type="button"
-						onClick={() => app.events.emit("side-panel:toggle", { tabId: "board-info" })}
+			{/* 右上: テーマ切替 + サイドパネル開閉 */}
+			<div
+				style={{
+					position: "fixed",
+					top: 12,
+					right: 12,
+					zIndex: 100,
+					display: "flex",
+					gap: 8,
+					alignItems: "center",
+				}}
+			>
+				<ThemeToggle />
+				{sessionUser && (
+					<div
+						className="u-surface"
 						style={{
-							background: "white",
-							border: "none",
-							borderRadius: 8,
-							padding: "6px 10px",
-							boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-							fontSize: 14,
-							cursor: "pointer",
-							color: "#475569",
+							padding: 3,
+							display: "flex",
+							gap: 1,
+							borderRadius: 10,
 						}}
-						title="Board Info"
 					>
-						📋
-					</button>
-					<button
-						type="button"
-						onClick={() => app.events.emit("side-panel:toggle", { tabId: "comments" })}
-						style={{
-							background: "white",
-							border: "none",
-							borderRadius: 8,
-							padding: "6px 10px",
-							boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-							fontSize: 14,
-							cursor: "pointer",
-							color: "#475569",
-						}}
-						title="Comments"
-					>
-						💬
-					</button>
-					<button
-						type="button"
-						onClick={() => app.events.emit("side-panel:toggle", { tabId: "community-chat" })}
-						style={{
-							background: "white",
-							border: "none",
-							borderRadius: 8,
-							padding: "6px 10px",
-							boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-							fontSize: 14,
-							cursor: "pointer",
-							color: "#475569",
-						}}
-						title="Chat"
-						aria-label="Chat"
-					>
-						🗨️
-					</button>
-				</div>
-			)}
+						<IconBtn
+							icon={I.folder}
+							label="ボード情報"
+							tooltipPlacement="bottom"
+							onClick={() => app.events.emit("side-panel:toggle", { tabId: "board-info" })}
+						/>
+						<IconBtn
+							icon={I.comment}
+							label="コメント"
+							tooltipPlacement="bottom"
+							onClick={() => app.events.emit("side-panel:toggle", { tabId: "comments" })}
+						/>
+						<IconBtn
+							icon={I.chat}
+							label="チャット"
+							tooltipPlacement="bottom"
+							onClick={() => app.events.emit("side-panel:toggle", { tabId: "community-chat" })}
+						/>
+					</div>
+				)}
+			</div>
 		</>
 	);
 }

--- a/apps/web/src/pages/community/community-page.tsx
+++ b/apps/web/src/pages/community/community-page.tsx
@@ -263,7 +263,15 @@ export function CommunityPage() {
 
 	if (error) {
 		return (
-			<div style={{ padding: 24, fontFamily: "system-ui, sans-serif", color: "#c33" }}>
+			<div
+				style={{
+					padding: 24,
+					fontFamily: "var(--font-sans)",
+					color: "var(--danger)",
+					background: "var(--bg-canvas)",
+					minHeight: "100vh",
+				}}
+			>
 				<p>Error: {error}</p>
 			</div>
 		);

--- a/apps/web/src/pages/community/community-page.tsx
+++ b/apps/web/src/pages/community/community-page.tsx
@@ -133,6 +133,10 @@ export function CommunityPage() {
 							userImage: authUserImage,
 						}),
 					);
+					// サイドパネル + ボード情報パネル + コメント
+					// SidePanel プラグインは `side-panel:register-tab` イベントを listen するため、
+					// タブを登録する側のプラグインより先に setup されている必要がある。
+					extraPlugins.push(createSidePanelPlugin());
 					extraPlugins.push(
 						createActivityFeedPlugin({
 							wsProvider,
@@ -140,9 +144,6 @@ export function CommunityPage() {
 							apiUrl,
 						}),
 					);
-
-					// サイドパネル + ボード情報パネル + コメント
-					extraPlugins.push(createSidePanelPlugin());
 					const infoHeaders: Record<string, string> = {};
 					if (import.meta.env.DEV) {
 						const devUser = getDevUser();

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
+import { I, ThemeToggle } from "../components/ui/index.js";
 import { api, type Board } from "../lib/api.js";
 import { getErrorMessage } from "../lib/errors.js";
 import { type LocalBoard, localBoards } from "../lib/local-boards.js";
 import { useAuth } from "../lib/use-auth.js";
+
+type Filter = "all" | "cloud" | "local";
 
 export function DashboardPage() {
 	const navigate = useNavigate();
@@ -11,8 +14,8 @@ export function DashboardPage() {
 	const [boards, setBoards] = useState<Board[]>([]);
 	const [locals, setLocals] = useState<LocalBoard[]>([]);
 	const [loading, setLoading] = useState(true);
-
 	const [error, setError] = useState("");
+	const [filter, setFilter] = useState<Filter>("all");
 
 	const loadBoards = useCallback(async () => {
 		setLocals(localBoards.list());
@@ -69,22 +72,17 @@ export function DashboardPage() {
 		setLocals(localBoards.list());
 	};
 
-	const cardStyle = {
-		display: "flex",
-		justifyContent: "space-between",
-		alignItems: "center",
-		padding: "12px 16px",
-		border: "1px solid #eee",
-		borderRadius: "8px",
-	};
+	const showLocals = filter === "all" || filter === "local";
+	const showCloud = filter === "all" || filter === "cloud";
 
 	return (
 		<div
 			style={{
-				maxWidth: "800px",
-				margin: "0 auto",
-				padding: "24px",
-				fontFamily: "system-ui, sans-serif",
+				minHeight: "100vh",
+				overflow: "auto",
+				background: "var(--bg-canvas)",
+				color: "var(--fg-primary)",
+				fontFamily: "var(--font-sans)",
 			}}
 		>
 			<header
@@ -92,200 +90,398 @@ export function DashboardPage() {
 					display: "flex",
 					justifyContent: "space-between",
 					alignItems: "center",
-					marginBottom: "24px",
+					padding: "16px 28px",
+					borderBottom: "1px solid var(--border-subtle)",
 				}}
 			>
-				<h1 style={{ fontSize: "1.5rem", margin: 0 }}>uSketch</h1>
-				<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
-					{sessionUser && (
-						<span style={{ fontSize: "14px", color: "#666" }}>{sessionUser.name}</span>
-					)}
+				<div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+					<div
+						style={{
+							width: 28,
+							height: 28,
+							borderRadius: 8,
+							background: "var(--brand-gradient)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							color: "white",
+							fontWeight: 700,
+							letterSpacing: -0.5,
+						}}
+					>
+						u
+					</div>
+					<h1 style={{ fontSize: 15, margin: 0, fontWeight: 600 }}>uSketch</h1>
+				</div>
+				<div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+					<ThemeToggle />
+					<button type="button" onClick={() => navigate("/community")} style={secondaryBtn}>
+						<I.community size={12} /> コミュニティ
+					</button>
 					{sessionUser ? (
-						<button
-							type="button"
-							onClick={() => {
-								logout();
-								navigate("/login");
-							}}
-							style={{
-								padding: "6px 12px",
-								fontSize: "12px",
-								cursor: "pointer",
-								border: "1px solid #ddd",
-								borderRadius: "4px",
-								background: "#fff",
-							}}
-						>
-							Sign Out
-						</button>
+						<>
+							<span style={{ fontSize: 12, color: "var(--fg-secondary)" }}>{sessionUser.name}</span>
+							<button
+								type="button"
+								onClick={() => {
+									logout();
+									navigate("/login");
+								}}
+								style={secondaryBtn}
+							>
+								サインアウト
+							</button>
+						</>
 					) : (
-						<a
-							href="/login"
-							style={{
-								padding: "6px 12px",
-								fontSize: "12px",
-								textDecoration: "none",
-								border: "1px solid #ddd",
-								borderRadius: "4px",
-								color: "#333",
-							}}
-						>
-							Sign In
-						</a>
+						<button type="button" onClick={() => navigate("/login")} style={secondaryBtn}>
+							サインイン
+						</button>
 					)}
 				</div>
 			</header>
 
-			{/* Local Boards */}
 			<div
 				style={{
+					maxWidth: 960,
+					margin: "0 auto",
+					padding: "28px 28px 60px",
 					display: "flex",
-					justifyContent: "space-between",
-					alignItems: "center",
-					marginBottom: "16px",
+					flexDirection: "column",
+					gap: 20,
 				}}
 			>
-				<h2 style={{ fontSize: "1.1rem", margin: 0 }}>Local Boards</h2>
-				<button
-					type="button"
-					onClick={handleCreateLocal}
+				<div
 					style={{
-						padding: "8px 16px",
-						fontSize: "14px",
-						cursor: "pointer",
-						border: "1px solid #0066ff",
-						borderRadius: "6px",
-						background: "#fff",
-						color: "#0066ff",
+						display: "flex",
+						justifyContent: "space-between",
+						alignItems: "center",
+						gap: 12,
+						flexWrap: "wrap",
 					}}
 				>
-					New Local Board
-				</button>
-			</div>
-
-			{locals.length === 0 ? (
-				<p style={{ color: "#999", marginBottom: "24px" }}>
-					No local boards. These are saved in your browser only.
-				</p>
-			) : (
-				<div style={{ display: "grid", gap: "8px", marginBottom: "24px" }}>
-					{locals.map((board) => (
-						<div key={board.id} style={cardStyle}>
-							<a
-								href={`/local/${board.id}`}
-								style={{ textDecoration: "none", color: "#333", fontWeight: 500 }}
-							>
-								{board.title}
-							</a>
-							<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
-								<span
-									style={{
-										fontSize: "11px",
-										color: "#999",
-										background: "#f5f5f5",
-										padding: "2px 6px",
-										borderRadius: "3px",
-									}}
-								>
-									local
-								</span>
-								<span style={{ fontSize: "12px", color: "#999" }}>
-									{new Date(board.updatedAt).toLocaleDateString()}
-								</span>
-								<button
-									type="button"
-									onClick={() => handleDeleteLocal(board.id)}
-									style={{
-										padding: "4px 8px",
-										fontSize: "11px",
-										cursor: "pointer",
-										border: "1px solid #fcc",
-										borderRadius: "4px",
-										background: "#fff",
-										color: "#c33",
-									}}
-								>
-									Delete
-								</button>
-							</div>
-						</div>
-					))}
+					<div>
+						<h2 style={{ fontSize: 20, margin: 0, fontWeight: 600 }}>ボード一覧</h2>
+						<p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-tertiary)" }}>
+							作業中のボードを開く、または新しく作成します
+						</p>
+					</div>
+					<div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+						<button type="button" onClick={handleCreateLocal} style={ctaOutlineBtn}>
+							<I.plus size={12} /> 新規ローカルボード
+						</button>
+						{sessionUser && (
+							<button type="button" onClick={handleCreate} style={ctaPrimaryBtn}>
+								<I.plus size={12} /> 新規クラウドボード
+							</button>
+						)}
+					</div>
 				</div>
-			)}
 
-			{/* Cloud Boards */}
-			{sessionUser && (
-				<>
+				{/* フィルターチップ */}
+				<div
+					style={{
+						display: "flex",
+						gap: 6,
+						padding: 4,
+						background: "var(--bg-input)",
+						border: "1px solid var(--border-subtle)",
+						borderRadius: 8,
+						alignSelf: "flex-start",
+					}}
+				>
+					{(
+						[
+							{ v: "all", label: "すべて" },
+							{ v: "cloud", label: "クラウド" },
+							{ v: "local", label: "ローカル" },
+						] as { v: Filter; label: string }[]
+					).map((chip) => {
+						const active = filter === chip.v;
+						return (
+							<button
+								key={chip.v}
+								type="button"
+								aria-pressed={active}
+								onClick={() => setFilter(chip.v)}
+								style={{
+									padding: "5px 12px",
+									background: active ? "var(--bg-surface-raised)" : "transparent",
+									color: active ? "var(--fg-primary)" : "var(--fg-tertiary)",
+									border: "none",
+									borderRadius: 5,
+									fontSize: 11.5,
+									fontWeight: 500,
+									cursor: "pointer",
+									fontFamily: "inherit",
+								}}
+							>
+								{chip.label}
+							</button>
+						);
+					})}
+				</div>
+
+				{error && (
 					<div
 						style={{
-							display: "flex",
-							justifyContent: "space-between",
-							alignItems: "center",
-							marginBottom: "16px",
+							padding: 12,
+							borderRadius: 8,
+							background: "rgba(239, 68, 68, 0.08)",
+							border: "1px solid var(--danger)",
+							color: "var(--danger)",
+							fontSize: 12.5,
 						}}
 					>
-						<h2 style={{ fontSize: "1.1rem", margin: 0 }}>Cloud Boards</h2>
-						<button
-							type="button"
-							onClick={handleCreate}
-							style={{
-								padding: "8px 16px",
-								fontSize: "14px",
-								cursor: "pointer",
-								border: "none",
-								borderRadius: "6px",
-								background: "#0066ff",
-								color: "#fff",
-							}}
-						>
-							New Cloud Board
-						</button>
+						{error}
 					</div>
+				)}
 
-					{error ? (
-						<p style={{ color: "#c33" }}>{error}</p>
-					) : loading ? (
-						<p style={{ color: "#999" }}>Loading...</p>
-					) : boards.length === 0 ? (
-						<p style={{ color: "#999" }}>No cloud boards yet.</p>
-					) : (
-						<div style={{ display: "grid", gap: "8px" }}>
-							{boards.map((board) => (
-								<div key={board.id} style={cardStyle}>
-									<a
-										href={`/boards/${board.id}`}
-										style={{ textDecoration: "none", color: "#333", fontWeight: 500 }}
-									>
-										{board.title}
-									</a>
-									<div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
-										<span style={{ fontSize: "12px", color: "#999" }}>
-											{new Date(board.updatedAt).toLocaleDateString()}
-										</span>
-										{board.role === "owner" && (
-											<button
-												type="button"
-												onClick={() => handleDelete(board.id)}
-												style={{
-													padding: "4px 8px",
-													fontSize: "11px",
-													cursor: "pointer",
-													border: "1px solid #fcc",
-													borderRadius: "4px",
-													background: "#fff",
-													color: "#c33",
-												}}
-											>
-												Delete
-											</button>
-										)}
-									</div>
-								</div>
-							))}
-						</div>
-					)}
-				</>
-			)}
+				{showLocals && (
+					<Section title="ローカルボード" hint="ブラウザにのみ保存されます">
+						{locals.length === 0 ? (
+							<Empty>
+								ローカルボードはまだありません。「新規ローカルボード」から作成できます。
+							</Empty>
+						) : (
+							<div style={gridStyle}>
+								{locals.map((board) => (
+									<BoardCard
+										key={board.id}
+										title={board.title}
+										updatedAt={board.updatedAt}
+										badge={{ label: "ローカル", icon: <I.folder size={10} /> }}
+										onOpen={() => navigate(`/local/${board.id}`)}
+										onDelete={() => handleDeleteLocal(board.id)}
+									/>
+								))}
+							</div>
+						)}
+					</Section>
+				)}
+
+				{showCloud && (
+					<Section
+						title="クラウドボード"
+						hint={sessionUser ? "共有・リアルタイム編集対応" : "サインインしてアクセス"}
+					>
+						{!sessionUser ? (
+							<Empty>
+								クラウドボードを使うには{" "}
+								<a href="/login" style={linkStyle}>
+									サインイン
+								</a>{" "}
+								してください。
+							</Empty>
+						) : loading ? (
+							<Empty>読み込み中…</Empty>
+						) : boards.length === 0 ? (
+							<Empty>
+								クラウドボードはまだありません。「新規クラウドボード」から作成してください。
+							</Empty>
+						) : (
+							<div style={gridStyle}>
+								{boards.map((board) => (
+									<BoardCard
+										key={board.id}
+										title={board.title}
+										updatedAt={board.updatedAt}
+										badge={{ label: "クラウド", icon: <I.globe size={10} /> }}
+										onOpen={() => navigate(`/boards/${board.id}`)}
+										onDelete={board.role === "owner" ? () => handleDelete(board.id) : undefined}
+									/>
+								))}
+							</div>
+						)}
+					</Section>
+				)}
+			</div>
 		</div>
 	);
 }
+
+function Section({
+	title,
+	hint,
+	children,
+}: {
+	title: string;
+	hint?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<section style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+			<div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+				<h3 style={{ fontSize: 13, margin: 0, fontWeight: 600, color: "var(--fg-primary)" }}>
+					{title}
+				</h3>
+				{hint && <span style={{ fontSize: 11, color: "var(--fg-tertiary)" }}>{hint}</span>}
+			</div>
+			{children}
+		</section>
+	);
+}
+
+function Empty({ children }: { children: React.ReactNode }) {
+	return (
+		<div
+			style={{
+				padding: 20,
+				borderRadius: 10,
+				background: "var(--bg-input)",
+				border: "1px dashed var(--border-default)",
+				fontSize: 12.5,
+				color: "var(--fg-tertiary)",
+			}}
+		>
+			{children}
+		</div>
+	);
+}
+
+interface BoardCardProps {
+	title: string;
+	updatedAt: number | string;
+	badge: { label: string; icon: React.ReactNode };
+	onOpen: () => void;
+	onDelete?: () => void;
+}
+
+function BoardCard({ title, updatedAt, badge, onOpen, onDelete }: BoardCardProps) {
+	return (
+		<div
+			className="u-surface"
+			style={{
+				padding: 14,
+				display: "flex",
+				flexDirection: "column",
+				gap: 8,
+				cursor: "pointer",
+				minHeight: 120,
+				justifyContent: "space-between",
+			}}
+		>
+			<button
+				type="button"
+				onClick={onOpen}
+				style={{
+					background: "transparent",
+					border: "none",
+					textAlign: "left",
+					padding: 0,
+					cursor: "pointer",
+					color: "inherit",
+					fontFamily: "inherit",
+				}}
+			>
+				<div style={{ fontSize: 13.5, fontWeight: 600, color: "var(--fg-primary)" }}>{title}</div>
+				<div
+					style={{
+						fontSize: 10.5,
+						color: "var(--fg-tertiary)",
+						marginTop: 4,
+						fontFamily: "var(--font-mono)",
+					}}
+				>
+					{new Date(updatedAt).toLocaleDateString()}
+				</div>
+			</button>
+			<div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+				<span
+					style={{
+						display: "inline-flex",
+						alignItems: "center",
+						gap: 4,
+						fontSize: 10.5,
+						color: "var(--fg-secondary)",
+						background: "var(--bg-input)",
+						padding: "2px 6px",
+						borderRadius: 4,
+					}}
+				>
+					{badge.icon}
+					{badge.label}
+				</span>
+				{onDelete && (
+					<button
+						type="button"
+						onClick={(e) => {
+							e.stopPropagation();
+							onDelete();
+						}}
+						title="削除"
+						aria-label="削除"
+						style={{
+							padding: "3px 6px",
+							fontSize: 10.5,
+							background: "transparent",
+							color: "var(--danger)",
+							border: "1px solid var(--border-subtle)",
+							borderRadius: 4,
+							cursor: "pointer",
+							fontFamily: "inherit",
+						}}
+					>
+						削除
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+const gridStyle: React.CSSProperties = {
+	display: "grid",
+	gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+	gap: 12,
+};
+
+const secondaryBtn: React.CSSProperties = {
+	display: "inline-flex",
+	alignItems: "center",
+	gap: 6,
+	padding: "6px 12px",
+	background: "transparent",
+	border: "1px solid var(--border-default)",
+	borderRadius: 8,
+	color: "var(--fg-secondary)",
+	fontSize: 12,
+	cursor: "pointer",
+	fontFamily: "inherit",
+	textDecoration: "none",
+};
+
+const ctaOutlineBtn: React.CSSProperties = {
+	display: "inline-flex",
+	alignItems: "center",
+	gap: 6,
+	padding: "7px 14px",
+	background: "transparent",
+	border: "1px solid var(--brand-violet)",
+	borderRadius: 8,
+	color: "var(--brand-violet)",
+	fontSize: 12.5,
+	fontWeight: 500,
+	cursor: "pointer",
+	fontFamily: "inherit",
+};
+
+const ctaPrimaryBtn: React.CSSProperties = {
+	display: "inline-flex",
+	alignItems: "center",
+	gap: 6,
+	padding: "7px 14px",
+	background: "var(--brand-gradient)",
+	border: "none",
+	borderRadius: 8,
+	color: "white",
+	fontSize: 12.5,
+	fontWeight: 600,
+	cursor: "pointer",
+	fontFamily: "inherit",
+	boxShadow: "0 4px 14px rgba(139, 92, 246, 0.25)",
+};
+
+const linkStyle: React.CSSProperties = {
+	color: "var(--brand-violet)",
+	textDecoration: "underline",
+};

--- a/apps/web/src/pages/world-map.tsx
+++ b/apps/web/src/pages/world-map.tsx
@@ -193,7 +193,15 @@ export function WorldMapPage() {
 
 	if (error) {
 		return (
-			<div style={{ padding: 24, fontFamily: "system-ui, sans-serif", color: "#c33" }}>
+			<div
+				style={{
+					padding: 24,
+					fontFamily: "var(--font-sans)",
+					color: "var(--danger)",
+					background: "var(--bg-canvas)",
+					minHeight: "100vh",
+				}}
+			>
 				<p>Error: {error}</p>
 			</div>
 		);
@@ -239,14 +247,14 @@ function WorldMapHeader({
 			}}
 		>
 			<div
+				className="u-surface"
 				style={{
-					background: "white",
-					borderRadius: 8,
 					padding: "6px 14px",
-					boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-					fontSize: 14,
+					fontSize: 13,
 					fontWeight: 600,
-					fontFamily: "system-ui, sans-serif",
+					fontFamily: "var(--font-sans)",
+					color: "var(--fg-primary)",
+					borderRadius: 10,
 				}}
 			>
 				uSketch World
@@ -256,50 +264,50 @@ function WorldMapHeader({
 					<button
 						type="button"
 						onClick={() => navigate("/dashboard")}
+						className="u-surface"
 						style={{
-							background: "white",
 							border: "none",
-							borderRadius: 8,
 							padding: "6px 12px",
-							boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
 							fontSize: 12,
 							cursor: "pointer",
-							color: "#0066ff",
+							color: "var(--brand-violet)",
+							fontFamily: "var(--font-sans)",
+							borderRadius: 10,
 						}}
 					>
-						Dashboard
+						ダッシュボード
 					</button>
 					<button
 						type="button"
 						onClick={onLogout}
+						className="u-surface"
 						style={{
-							background: "white",
 							border: "none",
-							borderRadius: 8,
 							padding: "6px 12px",
-							boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-							fontSize: 12,
+							fontSize: 11.5,
 							cursor: "pointer",
-							color: "#666",
+							color: "var(--fg-tertiary)",
+							fontFamily: "var(--font-sans)",
+							borderRadius: 10,
 						}}
 					>
-						{user.name} — Sign Out
+						{user.name} — サインアウト
 					</button>
 				</>
 			) : (
 				<a
 					href="/login"
+					className="u-surface"
 					style={{
-						background: "white",
-						borderRadius: 8,
 						padding: "6px 12px",
-						boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-						fontSize: 12,
+						fontSize: 11.5,
 						textDecoration: "none",
-						color: "#0066ff",
+						color: "var(--brand-violet)",
+						fontFamily: "var(--font-sans)",
+						borderRadius: 10,
 					}}
 				>
-					Sign In
+					サインイン
 				</a>
 			)}
 		</div>

--- a/apps/web/src/pages/world-map.tsx
+++ b/apps/web/src/pages/world-map.tsx
@@ -211,7 +211,15 @@ export function WorldMapPage() {
 
 	return (
 		<AppProvider app={app}>
-			<div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					overflow: "hidden",
+					background: "var(--bg-canvas)",
+					color: "var(--fg-primary)",
+				}}
+			>
 				<Canvas />
 				<WorldMapHeader
 					user={authUser ? { name: authUser.name ?? "User" } : null}

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,0 +1,234 @@
+/* uSketch v2 — Design Tokens
+ *
+ * モックデザイン (whiteboard-new-design) から移植したデザイントークン。
+ * light / dark 両対応。`[data-theme="light"]` / `[data-theme="dark"]` で切替。
+ *
+ * NOTE: 既存の apps/web/src/lib/styles.ts は段階移行中のため並走させている。
+ */
+
+:root {
+	/* Brand — violet → pink gradient */
+	--brand-violet: #8b5cf6;
+	--brand-pink: #ec4899;
+	--brand-gradient: linear-gradient(135deg, #8b5cf6 0%, #ec4899 100%);
+	--brand-gradient-soft: linear-gradient(
+		135deg,
+		rgba(139, 92, 246, 0.18) 0%,
+		rgba(236, 72, 153, 0.18) 100%
+	);
+	--brand-ring: rgba(139, 92, 246, 0.45);
+
+	/* Typography */
+	--font-sans:
+		"Inter", "IBM Plex Sans JP", "Hiragino Kaku Gothic ProN", "Noto Sans JP", system-ui, sans-serif;
+	--font-mono: "Geist Mono", "IBM Plex Mono", "JetBrains Mono", ui-monospace, monospace;
+	--font-display: "Inter", "IBM Plex Sans JP", "Hiragino Kaku Gothic ProN", sans-serif;
+
+	/* Spacing */
+	--space-1: 4px;
+	--space-2: 8px;
+	--space-3: 12px;
+	--space-4: 16px;
+	--space-5: 20px;
+	--space-6: 24px;
+	--space-8: 32px;
+	--space-10: 40px;
+	--space-12: 48px;
+
+	/* Radius */
+	--r-xs: 4px;
+	--r-sm: 6px;
+	--r-md: 10px;
+	--r-lg: 14px;
+	--r-xl: 20px;
+	--r-pill: 999px;
+
+	/* Motion */
+	--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+	--ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+	--dur-fast: 120ms;
+	--dur-med: 220ms;
+	--dur-slow: 400ms;
+}
+
+/* DARK (default) */
+:root,
+[data-theme="dark"] {
+	--bg-canvas: #0a0a0b;
+	--bg-canvas-2: #111114;
+	--bg-surface: rgba(22, 22, 28, 0.72);
+	--bg-surface-solid: #17171c;
+	--bg-surface-raised: rgba(30, 30, 38, 0.85);
+	--bg-hover: rgba(255, 255, 255, 0.06);
+	--bg-active: rgba(139, 92, 246, 0.15);
+	--bg-input: rgba(255, 255, 255, 0.04);
+
+	--fg-primary: #ededf0;
+	--fg-secondary: #a8a8b3;
+	--fg-tertiary: #6b6b7a;
+	--fg-disabled: #45454f;
+	--fg-inverse: #0a0a0b;
+
+	--border-subtle: rgba(255, 255, 255, 0.06);
+	--border-default: rgba(255, 255, 255, 0.1);
+	--border-strong: rgba(255, 255, 255, 0.16);
+
+	--grid-color: rgba(255, 255, 255, 0.04);
+	--dot-color: rgba(255, 255, 255, 0.1);
+
+	--success: #10b981;
+	--warning: #f59e0b;
+	--danger: #ef4444;
+	--info: #3b82f6;
+
+	/* user presence colors */
+	--u-1: #8b5cf6;
+	--u-2: #ec4899;
+	--u-3: #06b6d4;
+	--u-4: #10b981;
+	--u-5: #f59e0b;
+	--u-6: #ef4444;
+
+	/* Elevation — floating UI */
+	--shadow-1: 0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.04);
+	--shadow-2: 0 4px 12px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.05);
+	--shadow-3: 0 12px 32px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(255, 255, 255, 0.06);
+	--shadow-glow: 0 0 40px rgba(139, 92, 246, 0.25);
+}
+
+[data-theme="light"] {
+	--bg-canvas: #fafafa;
+	--bg-canvas-2: #f4f4f5;
+	--bg-surface: rgba(255, 255, 255, 0.82);
+	--bg-surface-solid: #ffffff;
+	--bg-surface-raised: rgba(255, 255, 255, 0.95);
+	--bg-hover: rgba(0, 0, 0, 0.05);
+	--bg-active: rgba(139, 92, 246, 0.1);
+	--bg-input: rgba(0, 0, 0, 0.03);
+
+	--fg-primary: #0a0a0b;
+	--fg-secondary: #52525b;
+	--fg-tertiary: #8b8b95;
+	--fg-disabled: #c4c4cc;
+	--fg-inverse: #ffffff;
+
+	--border-subtle: rgba(0, 0, 0, 0.06);
+	--border-default: rgba(0, 0, 0, 0.09);
+	--border-strong: rgba(0, 0, 0, 0.14);
+
+	--grid-color: rgba(0, 0, 0, 0.05);
+	--dot-color: rgba(0, 0, 0, 0.12);
+
+	--success: #10b981;
+	--warning: #f59e0b;
+	--danger: #ef4444;
+	--info: #3b82f6;
+
+	--u-1: #8b5cf6;
+	--u-2: #ec4899;
+	--u-3: #06b6d4;
+	--u-4: #10b981;
+	--u-5: #f59e0b;
+	--u-6: #ef4444;
+
+	--shadow-1: 0 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 1px rgba(0, 0, 0, 0.04);
+	--shadow-2: 0 4px 12px rgba(0, 0, 0, 0.08), 0 0 0 1px rgba(0, 0, 0, 0.05);
+	--shadow-3: 0 12px 32px rgba(0, 0, 0, 0.14), 0 0 0 1px rgba(0, 0, 0, 0.06);
+	--shadow-glow: 0 0 40px rgba(139, 92, 246, 0.18);
+}
+
+/* Floating glass surface — 使う側は className="u-surface" */
+.u-surface {
+	background: var(--bg-surface);
+	backdrop-filter: blur(20px) saturate(1.4);
+	-webkit-backdrop-filter: blur(20px) saturate(1.4);
+	border: 1px solid var(--border-subtle);
+	border-radius: var(--r-lg);
+	box-shadow: var(--shadow-2);
+}
+
+/* Keyboard chip */
+.u-kbd {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 5px;
+	font-family: var(--font-mono);
+	font-size: 10.5px;
+	font-weight: 500;
+	color: var(--fg-secondary);
+	background: var(--bg-input);
+	border: 1px solid var(--border-subtle);
+	border-radius: 4px;
+	letter-spacing: 0;
+}
+
+/* Gradient text helper */
+.u-grad-text {
+	background: var(--brand-gradient);
+	-webkit-background-clip: text;
+	background-clip: text;
+	-webkit-text-fill-color: transparent;
+	color: transparent;
+}
+
+/* Animations */
+@keyframes u-fade-in {
+	from {
+		opacity: 0;
+		transform: translateY(4px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes u-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}
+
+@keyframes u-ripple {
+	0% {
+		transform: scale(0.5);
+		opacity: 0.8;
+	}
+	100% {
+		transform: scale(2.2);
+		opacity: 0;
+	}
+}
+
+@keyframes u-ghost-dash {
+	to {
+		stroke-dashoffset: -16;
+	}
+}
+
+@keyframes u-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+.u-anim-in {
+	animation: u-fade-in var(--dur-med) var(--ease-out) both;
+}
+
+/*
+ * E2E スクリーンショット差分対策 — `<body class="u-no-blur">` を付けると
+ * backdrop-filter を無効化。Playwright から任意で有効化できるようにしておく。
+ */
+body.u-no-blur .u-surface {
+	backdrop-filter: none;
+	-webkit-backdrop-filter: none;
+	background: var(--bg-surface-solid);
+}

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -258,7 +258,8 @@ export function Canvas() {
 				width: "100%",
 				height: "100%",
 				overflow: "hidden",
-				background: DEFAULT_THEME.canvasBackground,
+				// `data-theme` による CSS 変数がある場合はそちらが効き、無い場合は従来の既定色にフォールバック
+				background: `var(--bg-canvas, ${DEFAULT_THEME.canvasBackground})`,
 				cursor: activeTool?.cursor ?? "default",
 				touchAction: "none",
 			}}

--- a/plugins/usketch-plugin-activity-feed/src/plugin.tsx
+++ b/plugins/usketch-plugin-activity-feed/src/plugin.tsx
@@ -16,140 +16,110 @@ function formatTime(iso: string): string {
 	return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function ActivityPanel({ entries, onClose }: { entries: ActivityEntry[]; onClose: () => void }) {
+function ActivityTab({ boardId, apiUrl }: { boardId: string; apiUrl: string }) {
+	const [entries, setEntries] = useState<ActivityEntry[]>([]);
+	const [loading, setLoading] = useState(true);
+	const fetchedRef = useRef(false);
+
+	useEffect(() => {
+		if (fetchedRef.current) return;
+		fetchedRef.current = true;
+		setLoading(true);
+		fetch(`${apiUrl}/api/boards/${boardId}/activity`, { credentials: "include" })
+			.then((res) => (res.ok ? res.json() : []))
+			.then((data) => setEntries(data as ActivityEntry[]))
+			.catch(() => {})
+			.finally(() => setLoading(false));
+	}, [boardId, apiUrl]);
+
+	if (loading) {
+		return (
+			<div
+				style={{
+					padding: 20,
+					textAlign: "center",
+					color: "var(--fg-tertiary)",
+					fontSize: 12,
+				}}
+			>
+				読み込み中…
+			</div>
+		);
+	}
+
+	if (entries.length === 0) {
+		return (
+			<div
+				style={{
+					padding: 20,
+					textAlign: "center",
+					color: "var(--fg-tertiary)",
+					fontSize: 12,
+				}}
+			>
+				まだアクティビティがありません
+			</div>
+		);
+	}
+
 	return (
 		<div
 			style={{
-				position: "fixed",
-				top: 60,
-				right: 12,
-				width: 280,
-				maxHeight: "calc(100vh - 120px)",
-				background: "#fff",
-				borderRadius: 12,
-				boxShadow: "0 4px 24px rgba(0,0,0,0.15)",
-				zIndex: 150,
-				overflow: "hidden",
-				fontFamily: "system-ui, sans-serif",
+				padding: "8px 0",
 				display: "flex",
 				flexDirection: "column",
 			}}
 		>
-			<div
-				style={{
-					padding: "12px 16px",
-					borderBottom: "1px solid #eee",
-					display: "flex",
-					justifyContent: "space-between",
-					alignItems: "center",
-				}}
-			>
-				<span style={{ fontSize: 14, fontWeight: 600 }}>Activity</span>
-				<button
-					type="button"
-					onClick={onClose}
+			{entries.map((entry) => (
+				<div
+					key={entry.id}
 					style={{
-						border: "none",
-						background: "none",
-						fontSize: 16,
-						cursor: "pointer",
-						color: "#999",
+						padding: "8px 16px",
+						fontSize: 12,
+						color: "var(--fg-primary)",
+						borderBottom: "1px solid var(--border-subtle)",
+						display: "flex",
+						flexDirection: "column",
+						gap: 2,
 					}}
 				>
-					x
-				</button>
-			</div>
-			<div style={{ overflowY: "auto", flex: 1, padding: "8px 0" }}>
-				{entries.length === 0 ? (
-					<div style={{ padding: "16px", textAlign: "center", color: "#999", fontSize: 13 }}>
-						No activity yet
+					<div style={{ lineHeight: 1.4 }}>
+						<span style={{ fontWeight: 500 }}>{entry.action}</span>
+						{entry.summary && (
+							<span style={{ color: "var(--fg-tertiary)" }}> — {entry.summary}</span>
+						)}
 					</div>
-				) : (
-					entries.map((entry) => (
-						<div
-							key={entry.id}
-							style={{
-								padding: "6px 16px",
-								fontSize: 12,
-								color: "#555",
-								borderBottom: "1px solid #f5f5f5",
-							}}
-						>
-							<div>
-								<span style={{ fontWeight: 500 }}>{entry.action}</span>
-								{entry.summary && <span style={{ color: "#999" }}> — {entry.summary}</span>}
-							</div>
-							<div style={{ fontSize: 10, color: "#bbb", marginTop: 2 }}>
-								{formatTime(entry.createdAt)}
-							</div>
-						</div>
-					))
-				)}
-			</div>
+					<div
+						style={{
+							fontSize: 10.5,
+							color: "var(--fg-tertiary)",
+							fontFamily: "var(--font-mono)",
+						}}
+					>
+						{formatTime(entry.createdAt)}
+					</div>
+				</div>
+			))}
 		</div>
 	);
 }
 
-function ActivityButton({ onClick }: { onClick: () => void }) {
+function ActivityIcon() {
 	return (
-		<button
-			type="button"
-			onClick={onClick}
-			title="Activity Feed"
-			style={{
-				position: "fixed",
-				bottom: 12,
-				right: 12,
-				width: 40,
-				height: 40,
-				borderRadius: "50%",
-				border: "none",
-				background: "#fff",
-				boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-				cursor: "pointer",
-				display: "flex",
-				alignItems: "center",
-				justifyContent: "center",
-				zIndex: 100,
-				fontSize: 16,
-			}}
+		<svg
+			width={13}
+			height={13}
+			viewBox="0 0 16 16"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
 		>
-			<svg width="20" height="20" viewBox="0 0 20 20">
-				<title>Activity</title>
-				<polyline
-					points="2,14 6,10 10,12 14,6 18,8"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-				/>
-				<circle cx="18" cy="4" r="2" fill="currentColor" opacity="0.5" />
-			</svg>
-		</button>
-	);
-}
-
-function ActivityFeedUI({ boardId, apiUrl }: { boardId: string; apiUrl: string }) {
-	const [open, setOpen] = useState(false);
-	const [entries, setEntries] = useState<ActivityEntry[]>([]);
-	const fetchedRef = useRef(false);
-
-	useEffect(() => {
-		if (!open || fetchedRef.current) return;
-		fetchedRef.current = true;
-
-		fetch(`${apiUrl}/api/boards/${boardId}/activity`, { credentials: "include" })
-			.then((res) => (res.ok ? res.json() : []))
-			.then((data) => setEntries(data as ActivityEntry[]))
-			.catch(() => {});
-	}, [open, boardId, apiUrl]);
-
-	return (
-		<>
-			<ActivityButton onClick={() => setOpen((v) => !v)} />
-			{open && <ActivityPanel entries={entries} onClose={() => setOpen(false)} />}
-		</>
+			<path d="M2.5 8a5.5 5.5 0 1 0 1.5-3.8" />
+			<path d="M2.5 3v3h3M8 5v3l2 1.5" />
+		</svg>
 	);
 }
 
@@ -169,15 +139,19 @@ export function createActivityFeedPlugin(options: ActivityFeedOptions): UsketchP
 		name: "アクティビティフィード",
 
 		setup(ctx: PluginContext) {
-			ctx.layers.register({
-				id: "activity-feed",
-				order: 200,
-				fixed: true,
-				render: () => <ActivityFeedUI boardId={boardId} apiUrl={apiUrl} />,
+			ctx.events.emit("side-panel:register-tab", {
+				tab: {
+					id: "activity",
+					label: "履歴",
+					icon: "🕒",
+					iconComponent: () => <ActivityIcon />,
+					order: 40,
+					render: () => <ActivityTab boardId={boardId} apiUrl={apiUrl} />,
+				},
 			});
 
 			cleanup = () => {
-				ctx.layers.unregister("activity-feed");
+				ctx.events.emit("side-panel:unregister-tab", { tabId: "activity" });
 			};
 		},
 

--- a/plugins/usketch-plugin-ai-chat/src/ai-chat-tab.tsx
+++ b/plugins/usketch-plugin-ai-chat/src/ai-chat-tab.tsx
@@ -36,11 +36,11 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 			switch (status.status) {
 				case "thinking":
 					setIsLoading(true);
-					setStatusText("AI is thinking…");
+					setStatusText("AI が考えています…");
 					scrollToBottom();
 					break;
 				case "placing":
-					setStatusText(`Placing ${status.shapeCount ?? 0} shapes…`);
+					setStatusText(`${status.shapeCount ?? 0} 個のシェイプを配置中…`);
 					scrollToBottom();
 					break;
 				case "done":
@@ -52,8 +52,8 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 							id: nextId(),
 							role: "assistant",
 							text: status.shapeCount
-								? `Done — placed ${status.shapeCount} shapes on the canvas.`
-								: "Done!",
+								? `完了 — ${status.shapeCount} 個のシェイプを配置しました。`
+								: "完了しました。",
 							createdAt: new Date().toISOString(),
 						},
 					]);
@@ -67,7 +67,7 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 						{
 							id: nextId(),
 							role: "assistant",
-							text: `Error: ${status.message ?? "Something went wrong"}`,
+							text: `エラー: ${status.message ?? "予期しない問題が発生しました"}`,
 							createdAt: new Date().toISOString(),
 						},
 					]);
@@ -97,12 +97,27 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 	}, [input, isLoading, events, boardId, scrollToBottom]);
 
 	return (
-		<div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 300 }}>
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: "100%",
+				minHeight: 300,
+				color: "var(--fg-primary)",
+			}}
+		>
 			{/* メッセージ一覧 */}
 			<div ref={scrollRef} style={{ flex: 1, overflowY: "auto", padding: "12px 16px" }}>
 				{messages.length === 0 && !isLoading && (
-					<div style={{ textAlign: "center", color: "#999", fontSize: 13, padding: "24px 0" }}>
-						Ask AI to draw, modify, or organize shapes on the canvas.
+					<div
+						style={{
+							textAlign: "center",
+							color: "var(--fg-tertiary)",
+							fontSize: 13,
+							padding: "24px 0",
+						}}
+					>
+						AI にキャンバス上のシェイプの作成・編集・整列を依頼できます。
 					</div>
 				)}
 				{messages.map((msg) => (
@@ -120,8 +135,8 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 								maxWidth: "85%",
 								padding: "8px 12px",
 								borderRadius: msg.role === "user" ? "12px 12px 4px 12px" : "12px 12px 12px 4px",
-								background: msg.role === "user" ? "#1e1e1e" : "#f0f0f0",
-								color: msg.role === "user" ? "#fff" : "#333",
+								background: msg.role === "user" ? "var(--brand-gradient)" : "var(--bg-input)",
+								color: msg.role === "user" ? "white" : "var(--fg-primary)",
 								fontSize: 13,
 								lineHeight: 1.5,
 								wordBreak: "break-word",
@@ -129,7 +144,14 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 						>
 							{msg.text}
 						</div>
-						<div style={{ fontSize: 10, color: "#bbb", marginTop: 2, padding: "0 4px" }}>
+						<div
+							style={{
+								fontSize: 10,
+								color: "var(--fg-tertiary)",
+								marginTop: 2,
+								padding: "0 4px",
+							}}
+						>
 							{new Date(msg.createdAt).toLocaleTimeString([], {
 								hour: "2-digit",
 								minute: "2-digit",
@@ -145,15 +167,15 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 							gap: 8,
 							padding: "8px 0",
 							fontSize: 13,
-							color: "#666",
+							color: "var(--fg-secondary)",
 						}}
 					>
 						<div
 							style={{
 								width: 14,
 								height: 14,
-								border: "2px solid #ddd",
-								borderTopColor: "#666",
+								border: "2px solid var(--border-default)",
+								borderTopColor: "var(--brand-violet)",
 								borderRadius: "50%",
 								animation: "ai-chat-spin 0.6s linear infinite",
 								flexShrink: 0,
@@ -167,7 +189,7 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 			{/* 入力欄 */}
 			<div
 				style={{
-					borderTop: "1px solid #eee",
+					borderTop: "1px solid var(--border-subtle)",
 					padding: "10px 12px",
 					display: "flex",
 					gap: 8,
@@ -184,11 +206,13 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 						e.stopPropagation();
 						if (e.key === "Enter" && !isComposing && !isLoading) handleSend();
 					}}
-					placeholder="Ask AI…"
+					placeholder="AI に依頼…"
 					disabled={isLoading}
 					style={{
 						flex: 1,
-						border: "1px solid #e5e5e5",
+						border: "1px solid var(--border-default)",
+						background: "var(--bg-input)",
+						color: "var(--fg-primary)",
 						borderRadius: 8,
 						padding: "8px 12px",
 						fontSize: 13,
@@ -202,16 +226,18 @@ export function AiChatTab({ events, boardId }: AiChatTabProps) {
 					disabled={isLoading || !input.trim()}
 					style={{
 						border: "none",
-						background: isLoading || !input.trim() ? "#ccc" : "#1e1e1e",
-						color: "#fff",
+						background: isLoading || !input.trim() ? "var(--bg-input)" : "var(--brand-gradient)",
+						color: isLoading || !input.trim() ? "var(--fg-tertiary)" : "white",
 						borderRadius: 8,
 						padding: "8px 14px",
 						fontSize: 13,
+						fontWeight: 500,
 						cursor: isLoading || !input.trim() ? "default" : "pointer",
 						flexShrink: 0,
+						fontFamily: "inherit",
 					}}
 				>
-					Send
+					送信
 				</button>
 			</div>
 

--- a/plugins/usketch-plugin-ai-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-ai-chat/src/plugin.tsx
@@ -1,6 +1,24 @@
 import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
 import { createCommandPalette } from "./command-palette.js";
 
+function AiChatIcon() {
+	return (
+		<svg
+			width={13}
+			height={13}
+			viewBox="0 0 16 16"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M8 2v3M8 11v3M2 8h3M11 8h3M4.5 4.5l2 2M9.5 9.5l2 2M11.5 4.5l-2 2M6.5 9.5l-2 2" />
+		</svg>
+	);
+}
+
 export interface AiChatOptions {
 	boardId: string;
 	/**
@@ -47,9 +65,10 @@ export function createAiChatPlugin(options: AiChatOptions): UsketchPlugin {
 			ctx.events.emit("side-panel:register-tab", {
 				tab: {
 					id: "ai-chat",
-					label: "AI Chat",
+					label: "AI",
 					icon: "🤖",
-					order: 2,
+					iconComponent: () => <AiChatIcon />,
+					order: 20,
 					render: () => <AiChatTab events={ctx.events} boardId={options.boardId} />,
 				},
 			});

--- a/plugins/usketch-plugin-ai-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-ai-chat/src/plugin.tsx
@@ -3,30 +3,44 @@ import { createCommandPalette } from "./command-palette.js";
 
 export interface AiChatOptions {
 	boardId: string;
+	/**
+	 * Cmd+K で開くコマンドパレット UI をこのプラグインから登録するかどうか。
+	 * apps/web 側で独自のコマンドパレットを提供する場合は false を渡して無効化する。
+	 * 既定は true（後方互換）。
+	 */
+	enableCommandPalette?: boolean;
 }
 
 export function createAiChatPlugin(options: AiChatOptions): UsketchPlugin {
 	let cleanup: (() => void) | undefined;
+	const paletteEnabled = options.enableCommandPalette !== false;
 
 	return {
 		id: "usketch-plugin-ai-chat",
 		name: "AI Chat",
 
 		async setup(ctx: PluginContext) {
-			const palette = createCommandPalette({
-				events: ctx.events,
-				boardId: options.boardId,
-			});
+			let paletteCleanup: (() => void) | undefined;
+			if (paletteEnabled) {
+				const palette = createCommandPalette({
+					events: ctx.events,
+					boardId: options.boardId,
+				});
 
-			const handleKeyDown = (e: KeyboardEvent) => {
-				// Cmd+K (Mac) / Ctrl+K (Windows/Linux)
-				if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
-					e.preventDefault();
-					palette.open();
-				}
-			};
+				const handleKeyDown = (e: KeyboardEvent) => {
+					// Cmd+K (Mac) / Ctrl+K (Windows/Linux)
+					if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+						e.preventDefault();
+						palette.open();
+					}
+				};
 
-			window.addEventListener("keydown", handleKeyDown);
+				window.addEventListener("keydown", handleKeyDown);
+				paletteCleanup = () => {
+					window.removeEventListener("keydown", handleKeyDown);
+					palette.destroy();
+				};
+			}
 
 			// サイドパネルにAIチャットタブを登録（遅延インポートでReact依存を分離）
 			const { AiChatTab } = await import("./ai-chat-tab.js");
@@ -41,8 +55,7 @@ export function createAiChatPlugin(options: AiChatOptions): UsketchPlugin {
 			});
 
 			cleanup = () => {
-				window.removeEventListener("keydown", handleKeyDown);
-				palette.destroy();
+				paletteCleanup?.();
 				ctx.events.emit("side-panel:unregister-tab", { tabId: "ai-chat" });
 			};
 		},

--- a/plugins/usketch-plugin-comments/src/comments-tab.tsx
+++ b/plugins/usketch-plugin-comments/src/comments-tab.tsx
@@ -50,8 +50,9 @@ function ThreadItem({
 			ref={threadRef}
 			style={{
 				padding: "12px 16px",
-				borderBottom: "1px solid #f0f0f0",
-				background: isFocused ? "#f8f9ff" : "transparent",
+				borderBottom: "1px solid var(--border-subtle)",
+				background: isFocused ? "var(--bg-active)" : "transparent",
+				color: "var(--fg-primary)",
 			}}
 		>
 			{/* ヘッダー */}
@@ -63,7 +64,7 @@ function ThreadItem({
 					marginBottom: 8,
 				}}
 			>
-				<span style={{ fontSize: 11, color: "#999" }}>
+				<span style={{ fontSize: 11, color: "var(--fg-tertiary)" }}>
 					on shape {thread.anchorShapeId.slice(0, 8)}…
 				</span>
 				<div style={{ display: "flex", gap: 4 }}>
@@ -76,7 +77,7 @@ function ThreadItem({
 							background: "none",
 							cursor: "pointer",
 							fontSize: 14,
-							color: thread.resolved ? "#16a34a" : "#999",
+							color: thread.resolved ? "var(--success)" : "var(--fg-tertiary)",
 							padding: "2px 4px",
 						}}
 					>
@@ -91,7 +92,7 @@ function ThreadItem({
 							background: "none",
 							cursor: "pointer",
 							fontSize: 12,
-							color: "#ccc",
+							color: "var(--fg-disabled)",
 							padding: "2px 4px",
 						}}
 					>
@@ -103,8 +104,10 @@ function ThreadItem({
 			{/* メッセージ一覧 */}
 			{thread.messages.map((msg) => (
 				<div key={msg.id} style={{ marginBottom: 6 }}>
-					<div style={{ fontSize: 13, color: "#333", lineHeight: 1.4 }}>{msg.text}</div>
-					<div style={{ fontSize: 10, color: "#bbb", marginTop: 2 }}>
+					<div style={{ fontSize: 13, color: "var(--fg-primary)", lineHeight: 1.4 }}>
+						{msg.text}
+					</div>
+					<div style={{ fontSize: 10, color: "var(--fg-tertiary)", marginTop: 2 }}>
 						{msg.authorId.slice(0, 8)}… · {formatTime(msg.createdAt)}
 					</div>
 				</div>
@@ -127,7 +130,9 @@ function ThreadItem({
 						placeholder="Reply…"
 						style={{
 							flex: 1,
-							border: "1px solid #e5e5e5",
+							border: "1px solid var(--border-default)",
+							background: "var(--bg-input)",
+							color: "var(--fg-primary)",
 							borderRadius: 6,
 							padding: "6px 10px",
 							fontSize: 12,
@@ -140,16 +145,18 @@ function ThreadItem({
 						onClick={handleSubmit}
 						style={{
 							border: "none",
-							background: "#1e1e1e",
-							color: "#fff",
+							background: "var(--brand-gradient)",
+							color: "white",
 							borderRadius: 6,
 							padding: "6px 10px",
 							fontSize: 12,
 							cursor: "pointer",
 							flexShrink: 0,
+							fontFamily: "inherit",
+							fontWeight: 500,
 						}}
 					>
-						Send
+						送信
 					</button>
 				</div>
 			)}
@@ -181,9 +188,15 @@ function NewThreadForm({
 	}, []);
 
 	return (
-		<div style={{ padding: "12px 16px", borderBottom: "1px solid #eee", background: "#f8f9ff" }}>
-			<div style={{ fontSize: 12, color: "#666", marginBottom: 8 }}>
-				New comment on shape {prompt.anchorShapeId.slice(0, 8)}…
+		<div
+			style={{
+				padding: "12px 16px",
+				borderBottom: "1px solid var(--border-subtle)",
+				background: "var(--bg-active)",
+			}}
+		>
+			<div style={{ fontSize: 12, color: "var(--fg-secondary)", marginBottom: 8 }}>
+				新しいコメント: {prompt.anchorShapeId.slice(0, 8)}…
 			</div>
 			<div style={{ display: "flex", gap: 6 }}>
 				<input
@@ -198,10 +211,12 @@ function NewThreadForm({
 						if (e.key === "Enter" && !isComposing && text.trim()) onSubmit(text.trim());
 						if (e.key === "Escape") onCancel();
 					}}
-					placeholder="Write a comment…"
+					placeholder="コメントを書く…"
 					style={{
 						flex: 1,
-						border: "1px solid #e5e5e5",
+						border: "1px solid var(--border-default)",
+						background: "var(--bg-input)",
+						color: "var(--fg-primary)",
 						borderRadius: 6,
 						padding: "6px 10px",
 						fontSize: 12,
@@ -214,16 +229,18 @@ function NewThreadForm({
 					onClick={() => text.trim() && onSubmit(text.trim())}
 					style={{
 						border: "none",
-						background: "#1e1e1e",
-						color: "#fff",
+						background: "var(--brand-gradient)",
+						color: "white",
 						borderRadius: 6,
 						padding: "6px 10px",
 						fontSize: 12,
 						cursor: "pointer",
 						flexShrink: 0,
+						fontFamily: "inherit",
+						fontWeight: 500,
 					}}
 				>
-					Post
+					投稿
 				</button>
 			</div>
 		</div>
@@ -328,8 +345,8 @@ export function CommentsTab({ client, events, focusThreadId }: CommentsTabProps)
 
 	if (loading) {
 		return (
-			<div style={{ padding: 16, textAlign: "center", color: "#999", fontSize: 13 }}>
-				Loading comments…
+			<div style={{ padding: 16, textAlign: "center", color: "var(--fg-tertiary)", fontSize: 13 }}>
+				コメントを読み込み中…
 			</div>
 		);
 	}
@@ -344,8 +361,15 @@ export function CommentsTab({ client, events, focusThreadId }: CommentsTabProps)
 				/>
 			)}
 			{threads.length === 0 && !newThreadPrompt ? (
-				<div style={{ padding: 24, textAlign: "center", color: "#999", fontSize: 13 }}>
-					No comments yet. Select a shape and click 💬 Comment to start a thread.
+				<div
+					style={{
+						padding: 24,
+						textAlign: "center",
+						color: "var(--fg-tertiary)",
+						fontSize: 13,
+					}}
+				>
+					まだコメントはありません。シェイプを選択してスレッドを開始してください。
 				</div>
 			) : (
 				threads.map((thread) => (

--- a/plugins/usketch-plugin-comments/src/plugin.tsx
+++ b/plugins/usketch-plugin-comments/src/plugin.tsx
@@ -4,6 +4,24 @@ import { CommentBadgeLayer } from "./comment-badge-layer.js";
 import { createCommentClient } from "./comment-client.js";
 import { CommentsTabWrapper } from "./comments-tab-wrapper.js";
 
+function CommentIcon() {
+	return (
+		<svg
+			width={13}
+			height={13}
+			viewBox="0 0 16 16"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M2.5 7.5c0-2.8 2.5-5 5.5-5s5.5 2.2 5.5 5-2.5 5-5.5 5c-.7 0-1.4-.1-2-.3L3 13.5l.8-2.4a4.8 4.8 0 0 1-1.3-3.6Z" />
+		</svg>
+	);
+}
+
 export interface CommentsPluginOptions {
 	boardId: string;
 	apiUrl: string;
@@ -25,9 +43,10 @@ export function createCommentsPlugin(options: CommentsPluginOptions): UsketchPlu
 			ctx.events.emit<SidePanelRegisterEvent>("side-panel:register-tab", {
 				tab: {
 					id: "comments",
-					label: "Comments",
+					label: "コメント",
 					icon: "💬",
-					order: 1,
+					iconComponent: () => <CommentIcon />,
+					order: 10,
 					render: () => <CommentsTabWrapper client={client} events={ctx.events} />,
 				},
 			});

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -113,7 +113,7 @@ export function PresentModeOverlay({ nav }: Props) {
 					style={{
 						height: "100%",
 						width: `${progress * 100}%`,
-						background: "#4f9dff",
+						background: "var(--brand-gradient)",
 						transition: "width 0.3s",
 					}}
 				/>

--- a/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
+++ b/plugins/usketch-plugin-presentation/src/slide-outline-panel.tsx
@@ -47,18 +47,18 @@ export function SlideOutlinePanel({
 
 	return (
 		<div
+			className="u-surface u-anim-in"
 			style={{
 				position: "fixed",
 				top: 80,
 				left: 8,
-				width: 140,
+				width: 160,
 				maxHeight: "calc(100vh - 120px)",
 				overflowY: "auto",
-				background: "rgba(20,20,24,0.85)",
-				color: "white",
-				borderRadius: 8,
-				padding: 8,
-				font: "12px system-ui",
+				color: "var(--fg-primary)",
+				borderRadius: 12,
+				padding: 10,
+				font: "12px var(--font-sans, system-ui)",
 				pointerEvents: "auto",
 				zIndex: 100,
 				display: "flex",
@@ -72,13 +72,14 @@ export function SlideOutlinePanel({
 					onClick={exitToBoard}
 					style={{
 						appearance: "none",
-						border: "1px solid rgba(255,255,255,0.3)",
+						border: "1px solid var(--border-default)",
 						background: "transparent",
-						color: "white",
+						color: "var(--fg-secondary)",
 						cursor: "pointer",
-						padding: "2px 6px",
-						borderRadius: 4,
+						padding: "3px 8px",
+						borderRadius: 5,
 						fontSize: 11,
+						fontFamily: "inherit",
 					}}
 					title="通常のホワイトボードに戻る"
 				>
@@ -90,14 +91,15 @@ export function SlideOutlinePanel({
 					disabled={slides.length === 0}
 					style={{
 						appearance: "none",
-						border: "1px solid rgba(255,255,255,0.3)",
-						background: "transparent",
-						color: "white",
+						border: "none",
+						background: slides.length === 0 ? "var(--bg-input)" : "var(--brand-gradient)",
+						color: slides.length === 0 ? "var(--fg-tertiary)" : "white",
 						cursor: slides.length === 0 ? "default" : "pointer",
-						opacity: slides.length === 0 ? 0.4 : 1,
-						padding: "2px 8px",
-						borderRadius: 4,
+						padding: "3px 10px",
+						borderRadius: 5,
 						fontSize: 11,
+						fontFamily: "inherit",
+						fontWeight: 600,
 					}}
 					title="発表モードに切替"
 					aria-label="発表モードに切替"
@@ -105,10 +107,21 @@ export function SlideOutlinePanel({
 					▶
 				</button>
 			</div>
-			<div style={{ fontWeight: 600, marginTop: 4 }}>スライド</div>
+			<div
+				style={{
+					fontSize: 10.5,
+					fontWeight: 600,
+					color: "var(--fg-tertiary)",
+					textTransform: "uppercase",
+					letterSpacing: 0.4,
+					marginTop: 4,
+				}}
+			>
+				スライド
+			</div>
 
 			{slides.length === 0 ? (
-				<div style={{ color: "rgba(255,255,255,0.5)", padding: "8px 0" }}>
+				<div style={{ color: "var(--fg-tertiary)", padding: "8px 0", fontSize: 11 }}>
 					Frame を追加するとスライドになります
 				</div>
 			) : (
@@ -144,10 +157,10 @@ function SlideThumbnail({ slide, label, active, onClick, onMoveUp, onMoveDown }:
 		<div
 			style={{
 				position: "relative",
-				border: active ? "2px solid #4f9dff" : "1px solid rgba(255,255,255,0.2)",
-				borderRadius: 4,
-				background: "rgba(255,255,255,0.05)",
-				padding: "4px 6px",
+				border: active ? "2px solid var(--brand-violet)" : "1px solid var(--border-subtle)",
+				borderRadius: 6,
+				background: active ? "var(--bg-active)" : "var(--bg-input)",
+				padding: "6px 8px",
 			}}
 		>
 			<button
@@ -157,7 +170,7 @@ function SlideThumbnail({ slide, label, active, onClick, onMoveUp, onMoveDown }:
 					appearance: "none",
 					background: "transparent",
 					border: "none",
-					color: "white",
+					color: "var(--fg-primary)",
 					cursor: "pointer",
 					width: "100%",
 					textAlign: "left",
@@ -165,7 +178,15 @@ function SlideThumbnail({ slide, label, active, onClick, onMoveUp, onMoveDown }:
 					font: "inherit",
 				}}
 			>
-				<div style={{ fontSize: 11, color: "rgba(255,255,255,0.6)" }}>#{label}</div>
+				<div
+					style={{
+						fontSize: 10.5,
+						color: active ? "var(--brand-violet)" : "var(--fg-tertiary)",
+						fontWeight: 600,
+					}}
+				>
+					#{label}
+				</div>
 				<div
 					style={{
 						fontSize: 12,
@@ -218,14 +239,15 @@ function miniButtonStyle(disabled: boolean): React.CSSProperties {
 	return {
 		appearance: "none",
 		flex: 1,
-		border: "1px solid rgba(255,255,255,0.2)",
-		background: "rgba(255,255,255,0.05)",
-		color: "white",
+		border: "1px solid var(--border-subtle)",
+		background: "transparent",
+		color: "var(--fg-secondary)",
 		cursor: disabled ? "default" : "pointer",
 		opacity: disabled ? 0.3 : 1,
-		padding: "1px 0",
+		padding: "2px 0",
 		fontSize: 10,
-		borderRadius: 3,
+		borderRadius: 4,
+		fontFamily: "inherit",
 	};
 }
 

--- a/plugins/usketch-plugin-side-panel/src/plugin.tsx
+++ b/plugins/usketch-plugin-side-panel/src/plugin.tsx
@@ -3,6 +3,15 @@ import { SidePanelUI } from "./side-panel-ui.js";
 import { createTabStore } from "./tab-store.js";
 import type { SidePanelRegisterEvent, SidePanelUnregisterEvent } from "./types.js";
 
+/**
+ * NOTE: このプラグインは `side-panel:register-tab` / `side-panel:unregister-tab`
+ * イベントを setup 時に listen する。EventBus は過去の emit を replay しないため、
+ * タブを登録する側のプラグイン（ai-chat / comments / activity-feed 等）より
+ * **先に** plugin 配列に入れて setup されている必要がある。
+ *
+ * 順序を誤るとタブが表示されない（silent failure）ので、apps 側でコメントで
+ * 明示することを推奨。
+ */
 export function createSidePanelPlugin(): UsketchPlugin {
 	let cleanup: (() => void) | undefined;
 

--- a/plugins/usketch-plugin-side-panel/src/side-panel-ui.tsx
+++ b/plugins/usketch-plugin-side-panel/src/side-panel-ui.tsx
@@ -1,5 +1,5 @@
 import type { EventBus } from "@edv4h/usketch-shared";
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { type ReactNode, useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import type { TabStore } from "./tab-store.js";
 import type { SidePanelOpenEvent } from "./types.js";
 
@@ -162,7 +162,7 @@ export function SidePanelUI({ events, tabStore }: SidePanelUIProps) {
 	);
 }
 
-function TabIcon({ tab }: { tab: { icon: string; iconComponent?: () => React.ReactNode } }) {
+function TabIcon({ tab }: { tab: { icon: string; iconComponent?: () => ReactNode } }) {
 	if (tab.iconComponent) return <>{tab.iconComponent()}</>;
 	return <span style={{ fontSize: 13, lineHeight: 1 }}>{tab.icon}</span>;
 }

--- a/plugins/usketch-plugin-side-panel/src/side-panel-ui.tsx
+++ b/plugins/usketch-plugin-side-panel/src/side-panel-ui.tsx
@@ -59,6 +59,7 @@ export function SidePanelUI({ events, tabStore }: SidePanelUIProps) {
 	return (
 		<aside
 			aria-label="Side Panel"
+			className="u-surface u-anim-in"
 			onPointerDown={(e) => e.stopPropagation()}
 			onPointerUp={(e) => e.stopPropagation()}
 			onClick={(e) => e.stopPropagation()}
@@ -70,75 +71,98 @@ export function SidePanelUI({ events, tabStore }: SidePanelUIProps) {
 			onWheel={(e) => e.stopPropagation()}
 			style={{
 				position: "fixed",
-				top: 60,
+				top: 70,
 				right: 12,
-				width: 360,
-				maxHeight: "calc(100vh - 80px)",
-				background: "#fff",
-				borderRadius: 12,
-				boxShadow: "0 4px 24px rgba(0,0,0,0.15)",
+				width: 340,
+				maxHeight: "calc(100vh - 160px)",
+				borderRadius: 14,
 				zIndex: 160,
-				fontFamily: "system-ui, -apple-system, sans-serif",
 				display: "flex",
 				flexDirection: "column",
 				overflow: "hidden",
+				color: "var(--fg-primary)",
+				fontFamily: "var(--font-sans, system-ui, sans-serif)",
 			}}
 		>
-			{/* タブバー */}
 			<div
 				style={{
 					display: "flex",
-					borderBottom: "1px solid #eee",
+					padding: 6,
+					gap: 2,
+					borderBottom: "1px solid var(--border-subtle)",
 					alignItems: "center",
 				}}
 			>
-				<div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
-					{tabs.map((tab) => (
-						<button
-							key={tab.id}
-							type="button"
-							onClick={() => setActiveTabId(tab.id)}
-							style={{
-								flex: 1,
-								padding: "10px 8px",
-								border: "none",
-								background: "none",
-								cursor: "pointer",
-								fontSize: 13,
-								fontWeight: resolvedTabId === tab.id ? 600 : 400,
-								color: resolvedTabId === tab.id ? "#1e1e1e" : "#999",
-								borderBottom:
-									resolvedTabId === tab.id ? "2px solid #1e1e1e" : "2px solid transparent",
-								whiteSpace: "nowrap",
-								overflow: "hidden",
-								textOverflow: "ellipsis",
-							}}
-						>
-							{tab.icon} {tab.label}
-						</button>
-					))}
+				<div style={{ display: "flex", flex: 1, minWidth: 0 }}>
+					{tabs.map((tab) => {
+						const active = resolvedTabId === tab.id;
+						return (
+							<button
+								key={tab.id}
+								type="button"
+								onClick={() => setActiveTabId(tab.id)}
+								title={tab.label}
+								style={{
+									flex: 1,
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+									gap: 5,
+									padding: "7px 6px",
+									background: active ? "var(--bg-active)" : "transparent",
+									color: active ? "var(--brand-violet)" : "var(--fg-secondary)",
+									border: "none",
+									borderRadius: 7,
+									cursor: "pointer",
+									fontSize: 11.5,
+									fontWeight: 500,
+									fontFamily: "inherit",
+									whiteSpace: "nowrap",
+									minWidth: 0,
+									transition: "background var(--dur-fast), color var(--dur-fast)",
+								}}
+							>
+								<TabIcon tab={tab} />
+								<span
+									style={{
+										overflow: "hidden",
+										textOverflow: "ellipsis",
+									}}
+								>
+									{tab.label}
+								</span>
+							</button>
+						);
+					})}
 				</div>
 				<button
 					type="button"
 					onClick={handleClose}
+					aria-label="サイドパネルを閉じる"
 					style={{
+						padding: 7,
+						background: "transparent",
 						border: "none",
-						background: "none",
-						fontSize: 16,
+						color: "var(--fg-tertiary)",
 						cursor: "pointer",
-						color: "#999",
-						padding: "8px 12px",
+						borderRadius: 6,
+						fontSize: 14,
+						lineHeight: 1,
 						flexShrink: 0,
 					}}
 				>
-					✕
+					×
 				</button>
 			</div>
 
-			{/* タブコンテンツ */}
 			<div style={{ flex: 1, overflow: "auto", minHeight: 0 }}>
 				{activeTab ? activeTab.render() : null}
 			</div>
 		</aside>
 	);
+}
+
+function TabIcon({ tab }: { tab: { icon: string; iconComponent?: () => React.ReactNode } }) {
+	if (tab.iconComponent) return <>{tab.iconComponent()}</>;
+	return <span style={{ fontSize: 13, lineHeight: 1 }}>{tab.icon}</span>;
 }

--- a/plugins/usketch-plugin-side-panel/src/types.ts
+++ b/plugins/usketch-plugin-side-panel/src/types.ts
@@ -3,7 +3,13 @@ import type { ReactNode } from "react";
 export interface SidePanelTab {
 	id: string;
 	label: string;
+	/** 絵文字やテキストの short icon（後方互換）。iconComponent があれば優先される。 */
 	icon: string;
+	/**
+	 * React コンポーネントで icon を描画する場合に指定する。SVG アイコン等を使いたい場合はこちら。
+	 * 指定があれば icon (文字列) より優先される。
+	 */
+	iconComponent?: () => ReactNode;
 	order: number;
 	render: () => ReactNode;
 }


### PR DESCRIPTION
## Summary

デザイナーから受領したモック (`whiteboard-new-design`) を apps/web に段階的に適用。ダーク/ライト両対応、violet→pink のブランドグラデーション、glassmorphism UI を導入しつつ、既存機能は一切壊さない構成。

- Phase A: デザイントークン (tokens.css) + light/dark/system 切替 + localStorage 永続化
- Phase B: 共通 UI kit (IconBtn / Surface / Divider / Kbd / 60+ Icons / ThemeToggle)
- Phase C: ボードエディタ画面再配置 (Toolbar bottom 中央化 + BoardIdentity / TopRightCluster / ZoomControls / CommunityLink / CommandPalette)
- Phase D: SidePanel 4 タブ化 (Comments / AI / 情報 / 履歴) + activity-feed プラグインの SidePanel 統合
- Phase E: StylePanel を glass + dark 対応
- Phase F: Dashboard / Community / Presentation の見た目刷新

## コミット分割

```
074ff3a6 Phase F-3: community glass
58311054 Phase F-2: presentation plugin glass
a5e839e3 Phase F-1: dashboard glass UI
33b94d30 Phase E:   style-panel glass
612a5e57 Phase D:   side-panel 4 tabs
d451ed5b Phase C:   editor chrome (Toolbar bottom 中央)
9f96e6f7 Phase A+B: tokens.css + UI kit
```

## 主要変更点

- **テーマ切替**: `data-theme="light|dark"` + localStorage (usketch-theme) + OS 追従 (system)。Toolbar 内 ThemeToggle と Cmd+K コマンドパレットの両方で操作可能
- **Cmd+K コマンドパレット** (新規): AI / アクション / テーマ / 移動の 4 グループ、矢印キー + Enter + Esc ナビゲーション。ai-chat プラグイン側の旧 palette は `enableCommandPalette: false` で無効化
- **Toolbar**: `top: 12` → `bottom: 12` に移動し、glass 化
- **SidePanel**: `iconComponent?: () => ReactNode` を併設（既存 `icon: string` は後方互換として維持）
- **activity-feed**: 独立 Panel + 右下 floating button を廃止し、SidePanel の「履歴」タブとして統合

## スコープ外

- TweaksPanel（モック専用のライブ編集 UI）
- CommunityBoard の Poll / ChatThread / Island 新ドメイン
- Laser / Spotlight / Reactions / SpatialChat の挙動変更
- 初期 flash 対策以外のアクセシビリティ改善

## Test plan

- [x] `pnpm typecheck && pnpm build` が全パッケージで pass
- [x] `pnpm lint` は Phase 追加分クリーン（残エラーは既存 apps/docs/.astro 等、本 PR 対象外）
- [x] ローカルボードで dark/light/system 切替が動作、localStorage 永続化、初回 flash なしを目視確認
- [x] Toolbar が画面下中央、全ツール / undo/redo / bg toggle / present 起動が動作
- [x] Cmd+K でパレット開閉、AI/テーマ/移動のコマンド実行
- [x] 既存 E2E の aria-label / data-testid ベースのセレクタに合わせて更新
- [ ] Cloud ボードでの SidePanel 4 タブ動作（要手動確認）
- [ ] Presentation mode (edit/present) の見た目確認（要手動確認）
- [ ] CommunityBoard ページの header / theme 動作確認（要手動確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)