### PR TITLE
💄 feat(presentation+community): プレゼンモード再設計 + コミュニティ shape 刷新

### DIFF
--- a/apps/web/e2e/board.spec.ts
+++ b/apps/web/e2e/board.spec.ts
@@ -16,19 +16,19 @@ test.describe("Board", () => {
 		await page.goto("/dashboard");
 		await expect(page.locator("h1")).toContainText("uSketch");
 		// 新 UI の CTA は日本語
-		await expect(page.locator("text=新規ローカルボード")).toBeVisible();
+		await expect(page.getByRole("button", { name: "新規ローカルボード" })).toBeVisible();
 	});
 
 	test("local board can be created and opened", async ({ page }) => {
 		await page.goto("/dashboard");
-		await page.click("text=新規ローカルボード");
+		await page.getByRole("button", { name: "新規ローカルボード" }).click();
 		await page.waitForURL(/\/local\//);
 		await expect(page.locator("[style*='touch-action: none']")).toBeVisible();
 	});
 
 	test("toolbar and export button visible on board page", async ({ page }) => {
 		await page.goto("/dashboard");
-		await page.click("text=新規ローカルボード");
+		await page.getByRole("button", { name: "新規ローカルボード" }).click();
 		await page.waitForURL(/\/local\//);
 		// 新レイアウト: Toolbar は画面下中央の data-testid="toolbar" で特定
 		await expect(page.locator('[data-testid="toolbar"]')).toBeVisible();
@@ -40,7 +40,7 @@ test.describe("Board", () => {
 
 	test("command palette opens with Cmd+K and closes with Esc", async ({ page }) => {
 		await page.goto("/dashboard");
-		await page.click("text=新規ローカルボード");
+		await page.getByRole("button", { name: "新規ローカルボード" }).click();
 		await page.waitForURL(/\/local\//);
 
 		// Toolbar のレンダリング完了を待つ
@@ -52,9 +52,9 @@ test.describe("Board", () => {
 		const palette = page.locator('[role="dialog"][aria-label="コマンドパレット"]');
 		await expect(palette).toBeVisible();
 
-		// グループが出ている
-		await expect(palette.locator("text=アクション")).toBeVisible();
-		await expect(palette.locator("text=テーマ")).toBeVisible();
+		// グループが出ている (複数の候補テキストが紛れ込むので最初の 1 件で特定)
+		await expect(palette.getByText("アクション", { exact: true })).toBeVisible();
+		await expect(palette.getByText("テーマ", { exact: true })).toBeVisible();
 
 		// Esc で閉じる
 		await page.keyboard.press("Escape");
@@ -63,7 +63,7 @@ test.describe("Board", () => {
 
 	test("command palette executes a theme command", async ({ page }) => {
 		await page.goto("/dashboard");
-		await page.click("text=新規ローカルボード");
+		await page.getByRole("button", { name: "新規ローカルボード" }).click();
 		await page.waitForURL(/\/local\//);
 		await expect(page.locator('[data-testid="toolbar"]')).toBeVisible();
 

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -419,6 +419,8 @@ export function App() {
 
 	// 発表モード中だけ通常のツールバーを隠す（presentation overlay のみ表示）
 	const hideToolbar = presentationMode === "present";
+	// プレゼン編集モード中はスライド編集に関係ない UI を隠す
+	const isPresentEdit = presentationMode === "edit";
 
 	return (
 		<AppProvider app={app}>
@@ -467,22 +469,25 @@ export function App() {
 								isCloudBoard={isCloudBoard}
 								connectionStatus={wsStatus ?? undefined}
 							/>
-							<TopRightCluster
-								boardId={boardId}
-								isCloudBoard={isCloudBoard}
-								wsProvider={wsProviderRef.current}
-								connectionStatus={wsStatus ?? undefined}
-							/>
+							{!isPresentEdit && (
+								<TopRightCluster
+									boardId={boardId}
+									isCloudBoard={isCloudBoard}
+									wsProvider={wsProviderRef.current}
+									connectionStatus={wsStatus ?? undefined}
+								/>
+							)}
 							<Toolbar
 								boardId={boardId}
 								isCloudBoard={isCloudBoard}
 								wsProvider={wsProviderRef.current}
 								onOpenCommandPalette={openPalette}
+								compact={isPresentEdit}
 							/>
-							<ZoomControls />
-							<CommunityLink />
-							{isCloudBoard && <SidePanelToggles app={app} />}
-							{isCloudBoard && <CopilotPill onOpenCommandPalette={openPalette} />}
+							{!isPresentEdit && <ZoomControls />}
+							{!isPresentEdit && <CommunityLink />}
+							{isCloudBoard && !isPresentEdit && <SidePanelToggles app={app} />}
+							{isCloudBoard && !isPresentEdit && <CopilotPill onOpenCommandPalette={openPalette} />}
 						</>
 					)}
 				</div>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -215,27 +215,29 @@ export function App() {
 			extraPlugins.push(createAiRecognizePlugin({ boardId }));
 			extraPlugins.push(createWhistlePlugin(wsProvider));
 			extraPlugins.push(createActivityFeedPlugin({ wsProvider, boardId, apiUrl }));
-
-			// プレゼンテーション: 常にロードし、`?present=1` が付いた時だけ UI を出す。
-			// ルート切替せず URL クエリで切替える設計なので、アプリ再生成は起きない。
-			extraPlugins.push(
-				createPresentationPlugin({
-					getMode: () => modeRef.current,
-					navigateToBoard: () => {
-						if (boardId) navigate(`/boards/${boardId}`);
-					},
-					getViewportSize: () => {
-						const stage = stageRectRef.current;
-						if (stage) return { width: stage.width, height: stage.height };
-						return { width: window.innerWidth, height: window.innerHeight };
-					},
-				}),
-			);
 		} else {
 			extraPlugins.push(laserPlugin);
 			extraPlugins.push(spotlightPlugin);
 			extraPlugins.push(whistlePlugin);
 		}
+
+		// プレゼンテーション: ローカル/Cloud 共通で常にロードし、`?present=1` が付いた時だけ UI を出す。
+		// ルート切替せず URL クエリで切替える設計なので、アプリ再生成は起きない。
+		extraPlugins.push(
+			createPresentationPlugin({
+				getMode: () => modeRef.current,
+				navigateToBoard: () => {
+					if (boardId) {
+						navigate(isCloudBoard ? `/boards/${boardId}` : `/local/${boardId}`);
+					}
+				},
+				getViewportSize: () => {
+					const stage = stageRectRef.current;
+					if (stage) return { width: stage.width, height: stage.height };
+					return { width: window.innerWidth, height: window.innerHeight };
+				},
+			}),
+		);
 
 		syncHandle.whenSynced
 			.then(() => {
@@ -353,7 +355,7 @@ export function App() {
 	}, [authUserId, authUserName]);
 
 	// キーボードショートカット
-	useKeyboardShortcuts(app);
+	useKeyboardShortcuts(app, presentationMode === "present");
 
 	// Info タブを SidePanel に登録（Cloud ボードのみ）
 	useEffect(() => {
@@ -421,6 +423,8 @@ export function App() {
 	const hideToolbar = presentationMode === "present";
 	// プレゼン編集モード中はスライド編集に関係ない UI を隠す
 	const isPresentEdit = presentationMode === "edit";
+	// 発表中は Canvas を readonly (シェイプ選択/ドラッグ/描画を全てオフ)
+	const isPresenting = presentationMode === "present";
 
 	return (
 		<AppProvider app={app}>
@@ -458,6 +462,8 @@ export function App() {
 							: {
 									position: "absolute",
 									inset: 0,
+									// 発表モード中は Canvas への全入力をブロックして readonly 化
+									pointerEvents: isPresenting ? "none" : undefined,
 								}
 					}
 				>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -431,6 +431,12 @@ export function App() {
 					background: "var(--bg-canvas-2, #0a0a0b)",
 				}}
 			>
+				{/*
+					エディタ全体 (Canvas + Toolbar + BoardIdentity 等) をひとつの div で包む。
+					プレゼン編集モード中は stage 矩形に縮め、外側を発表 UI が取り囲む形にする。
+					transform を当てると内側の position: fixed 要素の containing block が
+					この div になるため、Toolbar 等を書き換えずに相対化できる (CSS spec)。
+				*/}
 				<div
 					style={
 						stageRect
@@ -442,6 +448,7 @@ export function App() {
 									height: stageRect.height,
 									borderRadius: 8,
 									overflow: "hidden",
+									transform: "translate(0, 0)",
 									boxShadow:
 										"0 0 0 1.5px var(--brand-violet), 0 0 0 6px color-mix(in oklab, var(--brand-violet) 18%, transparent), 0 20px 60px rgba(139,92,246,.35), 0 0 80px rgba(236,72,153,.2)",
 									transition:
@@ -454,32 +461,33 @@ export function App() {
 					}
 				>
 					<Canvas />
+					{!hideToolbar && (
+						<>
+							<BoardIdentity
+								boardName={boardName ?? undefined}
+								isCloudBoard={isCloudBoard}
+								connectionStatus={wsStatus ?? undefined}
+							/>
+							<TopRightCluster
+								boardId={boardId}
+								isCloudBoard={isCloudBoard}
+								wsProvider={wsProviderRef.current}
+								connectionStatus={wsStatus ?? undefined}
+							/>
+							<Toolbar
+								boardId={boardId}
+								isCloudBoard={isCloudBoard}
+								wsProvider={wsProviderRef.current}
+								onOpenCommandPalette={openPalette}
+							/>
+							<ZoomControls />
+							<CommunityLink />
+							{isCloudBoard && <SidePanelToggles app={app} />}
+							{isCloudBoard && <CopilotPill onOpenCommandPalette={openPalette} />}
+						</>
+					)}
 				</div>
-				{!hideToolbar && (
-					<>
-						<BoardIdentity
-							boardName={boardName ?? undefined}
-							isCloudBoard={isCloudBoard}
-							connectionStatus={wsStatus ?? undefined}
-						/>
-						<TopRightCluster
-							boardId={boardId}
-							isCloudBoard={isCloudBoard}
-							wsProvider={wsProviderRef.current}
-							connectionStatus={wsStatus ?? undefined}
-						/>
-						<Toolbar
-							boardId={boardId}
-							isCloudBoard={isCloudBoard}
-							wsProvider={wsProviderRef.current}
-							onOpenCommandPalette={openPalette}
-						/>
-						<ZoomControls />
-						<CommunityLink />
-						{isCloudBoard && <SidePanelToggles app={app} />}
-						{isCloudBoard && <CopilotPill onOpenCommandPalette={openPalette} />}
-					</>
-				)}
+				{/* 閉じタグ: エディタ全体ラッパーの終わり */}
 				<CommandPalette
 					open={paletteOpen}
 					onClose={() => setPaletteOpen(false)}

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -462,12 +462,42 @@ export function App() {
 							: {
 									position: "absolute",
 									inset: 0,
-									// 発表モード中は Canvas への全入力をブロックして readonly 化
-									pointerEvents: isPresenting ? "none" : undefined,
 								}
 					}
 				>
 					<Canvas />
+					{isPresenting && (
+						// Canvas の前面を完全に覆うガード層。pointer event 全てを吸って
+						// シェイプ選択・ドラッグ・パンを無効化する。zIndex は Canvas 内部の
+						// 最上位 layer (order 200 級) より上に置く必要があるため大きめに。
+						<div
+							aria-hidden="true"
+							style={{
+								position: "absolute",
+								inset: 0,
+								zIndex: 9999,
+								cursor: "default",
+								background: "transparent",
+							}}
+							onPointerDown={(e) => {
+								e.stopPropagation();
+								e.preventDefault();
+							}}
+							onPointerMove={(e) => {
+								e.stopPropagation();
+							}}
+							onPointerUp={(e) => {
+								e.stopPropagation();
+							}}
+							onWheel={(e) => {
+								e.stopPropagation();
+							}}
+							onContextMenu={(e) => {
+								e.stopPropagation();
+								e.preventDefault();
+							}}
+						/>
+					)}
 					{!hideToolbar && (
 						<>
 							<BoardIdentity

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -468,14 +468,16 @@ export function App() {
 					<Canvas />
 					{isPresenting && (
 						// Canvas の前面を完全に覆うガード層。pointer event 全てを吸って
-						// シェイプ選択・ドラッグ・パンを無効化する。zIndex は Canvas 内部の
-						// 最上位 layer (order 200 級) より上に置く必要があるため大きめに。
+						// シェイプ選択・ドラッグ・パンを無効化する。
+						// PresentModeOverlay は createPortal で document.body 直下にあり
+						// zIndex: 500 で配置されているので、ガード層はそれより下 (= Canvas
+						// 内部 layer より上の 400 台) に置く必要がある。
 						<div
 							aria-hidden="true"
 							style={{
 								position: "absolute",
 								inset: 0,
-								zIndex: 9999,
+								zIndex: 400,
 								cursor: "default",
 								background: "transparent",
 							}}

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -449,8 +449,7 @@ export function App() {
 									borderRadius: 8,
 									overflow: "hidden",
 									transform: "translate(0, 0)",
-									boxShadow:
-										"0 0 0 1.5px var(--brand-violet), 0 0 0 6px color-mix(in oklab, var(--brand-violet) 18%, transparent), 0 20px 60px rgba(139,92,246,.35), 0 0 80px rgba(236,72,153,.2)",
+									boxShadow: "0 30px 60px rgba(0,0,0,.5), 0 0 0 1px rgba(255,255,255,.06)",
 									transition:
 										"left 180ms var(--ease-out, ease-out), top 180ms var(--ease-out, ease-out), width 180ms var(--ease-out, ease-out), height 180ms var(--ease-out, ease-out)",
 								}

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -60,6 +60,7 @@ import { Toolbar } from "./components/toolbar/index.js";
 import { getDevUser } from "./lib/dev-auth.js";
 import { getErrorMessage } from "./lib/errors.js";
 import { localBoards } from "./lib/local-boards.js";
+import { computePresentStage, type StageRect } from "./lib/present-stage.js";
 import { useAuth } from "./lib/use-auth.js";
 import { useKeyboardShortcuts } from "./lib/use-keyboard-shortcuts.js";
 
@@ -135,6 +136,15 @@ export function App() {
 	const [wsStatus, setWsStatus] = useState<WsConnectionStatus | null>(null);
 	const [boardName, setBoardName] = useState<string | null>(null);
 	const wsProviderRef = useRef<WsProviderHandle | null>(null);
+
+	// プレゼン編集モードの stage 矩形 (Canvas を縮退させて配置する)。
+	// app 生成 useEffect で presentation plugin に getViewportSize として渡すため、
+	// ref でも保持する (stage 変更時に app を再生成しない)。
+	const stageRectRef = useRef<StageRect | null>(
+		presentationMode === "edit"
+			? computePresentStage({ width: window.innerWidth, height: window.innerHeight })
+			: null,
+	);
 
 	// ボード初期化（boardId / isCloudBoard に依存）。
 	// presentationMode は依存に入れない（presentation plugin が popstate で modeRef を読み直す）。
@@ -213,6 +223,11 @@ export function App() {
 					getMode: () => modeRef.current,
 					navigateToBoard: () => {
 						if (boardId) navigate(`/boards/${boardId}`);
+					},
+					getViewportSize: () => {
+						const stage = stageRectRef.current;
+						if (stage) return { width: stage.width, height: stage.height };
+						return { width: window.innerWidth, height: window.innerHeight };
 					},
 				}),
 			);
@@ -377,6 +392,20 @@ export function App() {
 	const openPalette = useCallback(() => setPaletteOpen(true), []);
 	useCommandPaletteShortcut(openPalette);
 
+	const [stageRect, setStageRect] = useState<StageRect | null>(stageRectRef.current);
+	stageRectRef.current = stageRect;
+	useEffect(() => {
+		if (presentationMode !== "edit") {
+			setStageRect(null);
+			return;
+		}
+		const update = () =>
+			setStageRect(computePresentStage({ width: window.innerWidth, height: window.innerHeight }));
+		update();
+		window.addEventListener("resize", update);
+		return () => window.removeEventListener("resize", update);
+	}, [presentationMode]);
+
 	if (error) {
 		return (
 			<div style={{ padding: "24px", fontFamily: "system-ui, sans-serif", color: "#c33" }}>
@@ -393,8 +422,39 @@ export function App() {
 
 	return (
 		<AppProvider app={app}>
-			<div style={{ width: "100%", height: "100%", overflow: "hidden" }}>
-				<Canvas />
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					overflow: "hidden",
+					position: "relative",
+					background: "var(--bg-canvas-2, #0a0a0b)",
+				}}
+			>
+				<div
+					style={
+						stageRect
+							? {
+									position: "absolute",
+									left: stageRect.left,
+									top: stageRect.top,
+									width: stageRect.width,
+									height: stageRect.height,
+									borderRadius: 8,
+									overflow: "hidden",
+									boxShadow:
+										"0 0 0 1.5px var(--brand-violet), 0 0 0 6px color-mix(in oklab, var(--brand-violet) 18%, transparent), 0 20px 60px rgba(139,92,246,.35), 0 0 80px rgba(236,72,153,.2)",
+									transition:
+										"left 180ms var(--ease-out, ease-out), top 180ms var(--ease-out, ease-out), width 180ms var(--ease-out, ease-out), height 180ms var(--ease-out, ease-out)",
+								}
+							: {
+									position: "absolute",
+									inset: 0,
+								}
+					}
+				>
+					<Canvas />
+				</div>
 				{!hideToolbar && (
 					<>
 						<BoardIdentity

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -49,6 +49,7 @@ import { useLocation, useNavigate, useParams } from "react-router";
 import {
 	BoardIdentity,
 	CommunityLink,
+	CopilotPill,
 	TopRightCluster,
 	ZoomControls,
 } from "./components/board-frame/index.js";
@@ -284,10 +285,9 @@ export function App() {
 			.then((r) => (r.ok ? r.json() : null))
 			.then((b) => {
 				if (cancelled) return;
+				const t = b as { title?: unknown; name?: unknown } | null;
 				const name =
-					b && typeof (b as { name?: unknown }).name === "string"
-						? (b as { name: string }).name
-						: null;
+					typeof t?.title === "string" ? t.title : typeof t?.name === "string" ? t.name : null;
 				setBoardName(name);
 			})
 			.catch(() => {});
@@ -402,7 +402,12 @@ export function App() {
 							isCloudBoard={isCloudBoard}
 							connectionStatus={wsStatus ?? undefined}
 						/>
-						<TopRightCluster boardId={boardId} isCloudBoard={isCloudBoard} />
+						<TopRightCluster
+							boardId={boardId}
+							isCloudBoard={isCloudBoard}
+							wsProvider={wsProviderRef.current}
+							connectionStatus={wsStatus ?? undefined}
+						/>
 						<Toolbar
 							boardId={boardId}
 							isCloudBoard={isCloudBoard}
@@ -412,6 +417,7 @@ export function App() {
 						<ZoomControls />
 						<CommunityLink />
 						{isCloudBoard && <SidePanelToggles app={app} />}
+						{isCloudBoard && <CopilotPill onOpenCommandPalette={openPalette} />}
 					</>
 				)}
 				<CommandPalette

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -45,6 +45,7 @@ import {
 	type WsProviderHandle,
 } from "@edv4h/usketch-sync";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useLocation, useNavigate, useParams } from "react-router";
 import {
 	BoardIdentity,
@@ -466,40 +467,6 @@ export function App() {
 					}
 				>
 					<Canvas />
-					{isPresenting && (
-						// Canvas の前面を完全に覆うガード層。pointer event 全てを吸って
-						// シェイプ選択・ドラッグ・パンを無効化する。
-						// PresentModeOverlay は createPortal で document.body 直下にあり
-						// zIndex: 500 で配置されているので、ガード層はそれより下 (= Canvas
-						// 内部 layer より上の 400 台) に置く必要がある。
-						<div
-							aria-hidden="true"
-							style={{
-								position: "absolute",
-								inset: 0,
-								zIndex: 400,
-								cursor: "default",
-								background: "transparent",
-							}}
-							onPointerDown={(e) => {
-								e.stopPropagation();
-								e.preventDefault();
-							}}
-							onPointerMove={(e) => {
-								e.stopPropagation();
-							}}
-							onPointerUp={(e) => {
-								e.stopPropagation();
-							}}
-							onWheel={(e) => {
-								e.stopPropagation();
-							}}
-							onContextMenu={(e) => {
-								e.stopPropagation();
-								e.preventDefault();
-							}}
-						/>
-					)}
 					{!hideToolbar && (
 						<>
 							<BoardIdentity
@@ -576,6 +543,31 @@ export function App() {
 					</div>
 				)}
 			</div>
+			{isPresenting &&
+				createPortal(
+					<div
+						aria-hidden="true"
+						style={{
+							position: "fixed",
+							inset: 0,
+							zIndex: 300,
+							cursor: "default",
+							background: "transparent",
+						}}
+						onPointerDown={(e) => {
+							e.stopPropagation();
+							e.preventDefault();
+						}}
+						onPointerMove={(e) => e.stopPropagation()}
+						onPointerUp={(e) => e.stopPropagation()}
+						onWheel={(e) => e.stopPropagation()}
+						onContextMenu={(e) => {
+							e.stopPropagation();
+							e.preventDefault();
+						}}
+					/>,
+					document.body,
+				)}
 		</AppProvider>
 	);
 }

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -121,6 +121,14 @@ export function App() {
 	// popstate で ref を読み直す設計。
 	const modeRef = useRef<PresentationMode>(presentationMode);
 	modeRef.current = presentationMode;
+
+	// react-router の navigate() は pushState ベースで popstate を発火しない。
+	// presentation plugin は popstate で modeRef を再読込する設計なので、
+	// ?present= の変化を検出したら明示的に popstate を dispatch する。
+	// biome-ignore lint/correctness/useExhaustiveDependencies: presentationMode の変化をトリガーとして使用
+	useEffect(() => {
+		window.dispatchEvent(new PopStateEvent("popstate"));
+	}, [presentationMode]);
 	const [app, setApp] = useState<AppInstance | null>(null);
 	const [error, setError] = useState<string | null>(null);
 	const [wsStatus, setWsStatus] = useState<WsConnectionStatus | null>(null);

--- a/apps/web/src/components/board-frame/copilot-pill.tsx
+++ b/apps/web/src/components/board-frame/copilot-pill.tsx
@@ -1,0 +1,136 @@
+import { useApp } from "@edv4h/usketch-canvas-engine";
+import { useEffect, useState } from "react";
+import { I } from "../ui/index.js";
+
+interface Props {
+	onOpenCommandPalette: () => void;
+}
+
+/**
+ * 画面下中央の Toolbar 上に浮かぶ AI Copilot 通知 pill。
+ * Copilot が ON で、最新の提案テキストがあるときだけ表示。
+ */
+export function CopilotPill({ onOpenCommandPalette }: Props) {
+	const app = useApp();
+	const [enabled, setEnabled] = useState(false);
+	const [message, setMessage] = useState<string | null>(null);
+	const [sidePanelOpen, setSidePanelOpen] = useState(false);
+
+	useEffect(() => {
+		const unsubs: (() => void)[] = [];
+		unsubs.push(
+			app.events.on<{ enabled: boolean }>("copilot:toggle", (ev) => {
+				setEnabled(ev.enabled);
+				if (!ev.enabled) setMessage(null);
+			}),
+		);
+		unsubs.push(
+			app.events.on<{ text: string }>("copilot:notice", (ev) => {
+				setMessage(ev.text);
+			}),
+		);
+		unsubs.push(app.events.on("side-panel:open", () => setSidePanelOpen(true)));
+		unsubs.push(app.events.on("side-panel:close", () => setSidePanelOpen(false)));
+		return () => {
+			for (const u of unsubs) u();
+		};
+	}, [app]);
+
+	if (!enabled || !message) return null;
+
+	return (
+		<div
+			style={{
+				position: "fixed",
+				bottom: 70,
+				left: `calc(50% - ${sidePanelOpen ? 150 : 0}px)`,
+				transform: "translateX(-50%)",
+				zIndex: 90,
+				maxWidth: "calc(100vw - 40px)",
+				pointerEvents: "none",
+			}}
+		>
+			<div
+				className="u-surface u-anim-in"
+				style={{
+					padding: "6px 8px 6px 7px",
+					display: "flex",
+					alignItems: "center",
+					gap: 10,
+					borderRadius: 999,
+					background: "var(--bg-surface-raised)",
+					border: "1px solid var(--brand-ring, rgba(139,92,246,.4))",
+					boxShadow: "0 0 30px rgba(139, 92, 246, 0.25)",
+					whiteSpace: "nowrap",
+					pointerEvents: "auto",
+					fontFamily: "var(--font-sans, system-ui)",
+				}}
+			>
+				<div
+					style={{
+						width: 22,
+						height: 22,
+						borderRadius: 99,
+						background: "var(--brand-gradient)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						color: "white",
+						animation: "u-pulse 2s infinite",
+					}}
+				>
+					<I.sparkles size={11} />
+				</div>
+				<div style={{ fontSize: 11.5, color: "var(--fg-primary)" }}>
+					<span style={{ fontWeight: 500 }}>Copilot</span>
+					<span style={{ color: "var(--fg-tertiary)" }}>: {message}</span>
+				</div>
+				<div style={{ display: "flex", gap: 4 }}>
+					<button type="button" style={copilotBtn(true)}>
+						受け入れる
+					</button>
+					<button type="button" style={copilotBtn(false)} onClick={() => setMessage(null)}>
+						却下
+					</button>
+				</div>
+				<button
+					type="button"
+					onClick={onOpenCommandPalette}
+					style={{
+						marginLeft: 2,
+						display: "flex",
+						alignItems: "center",
+						gap: 5,
+						padding: "4px 8px",
+						background: "var(--bg-input)",
+						border: "1px solid var(--border-subtle)",
+						borderRadius: 6,
+						color: "var(--fg-secondary)",
+						fontSize: 11,
+						cursor: "pointer",
+						fontFamily: "inherit",
+					}}
+				>
+					<I.search size={10} />
+					<span style={{ fontFamily: "var(--font-mono, monospace)", fontSize: 10 }}>⌘K</span>
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function copilotBtn(primary: boolean): React.CSSProperties {
+	return {
+		padding: "4px 10px",
+		background: primary ? "var(--brand-gradient)" : "transparent",
+		color: primary ? "white" : "var(--fg-secondary)",
+		border: primary ? "none" : "1px solid var(--border-subtle)",
+		borderRadius: 6,
+		cursor: "pointer",
+		fontSize: 11,
+		fontWeight: 500,
+		fontFamily: "inherit",
+		whiteSpace: "nowrap",
+		flexShrink: 0,
+	};
+}

--- a/apps/web/src/components/board-frame/index.ts
+++ b/apps/web/src/components/board-frame/index.ts
@@ -1,4 +1,6 @@
 export { BoardIdentity } from "./board-identity.js";
 export { CommunityLink } from "./community-link.js";
+export { CopilotPill } from "./copilot-pill.js";
+export { PresencePill } from "./presence-pill.js";
 export { TopRightCluster } from "./top-right-cluster.js";
 export { ZoomControls } from "./zoom-controls.js";

--- a/apps/web/src/components/board-frame/presence-pill.tsx
+++ b/apps/web/src/components/board-frame/presence-pill.tsx
@@ -1,0 +1,149 @@
+import type { WsConnectionStatus } from "@edv4h/usketch-sync";
+import { useEffect, useState } from "react";
+
+type WsProvider = {
+	awareness: {
+		getStates: () => Map<number, Record<string, unknown>>;
+		doc: { clientID: number };
+		on?: (event: "change", cb: () => void) => void;
+		off?: (event: "change", cb: () => void) => void;
+	};
+};
+
+interface Member {
+	clientId: number;
+	name: string;
+	color: string;
+	status?: string;
+}
+
+const USER_COLORS = [
+	"var(--u-1)",
+	"var(--u-2)",
+	"var(--u-3)",
+	"var(--u-4)",
+	"var(--u-5)",
+	"var(--u-6)",
+];
+
+function pickColor(clientId: number): string {
+	return USER_COLORS[clientId % USER_COLORS.length] ?? "var(--u-1)";
+}
+
+function initial(name: string): string {
+	return name?.[0]?.toUpperCase() ?? "?";
+}
+
+interface Props {
+	wsProvider: WsProvider | null;
+	connectionStatus?: WsConnectionStatus;
+}
+
+/** 右上の presence + 同期状態 pill（モック StatusBar の再現）。 */
+export function PresencePill({ wsProvider, connectionStatus }: Props) {
+	const [members, setMembers] = useState<Member[]>([]);
+
+	useEffect(() => {
+		if (!wsProvider) return;
+		const awareness = wsProvider.awareness;
+		const read = () => {
+			const states = awareness.getStates();
+			const list: Member[] = [];
+			for (const [clientId, state] of states) {
+				if (clientId === awareness.doc.clientID) continue;
+				const user = state.user as { name?: string; status?: string } | undefined;
+				list.push({
+					clientId,
+					name: user?.name ?? "Guest",
+					color: pickColor(clientId),
+					status: user?.status,
+				});
+			}
+			setMembers(list);
+		};
+		read();
+		awareness.on?.("change", read);
+		return () => {
+			awareness.off?.("change", read);
+		};
+	}, [wsProvider]);
+
+	const connected = connectionStatus === "connected";
+	const visible = members.slice(0, 3);
+	const overflow = members.length - visible.length;
+
+	return (
+		<div
+			className="u-surface"
+			style={{
+				display: "inline-flex",
+				alignItems: "center",
+				gap: 10,
+				padding: "6px 10px",
+				borderRadius: 999,
+				fontSize: 11.5,
+				fontFamily: "var(--font-sans, system-ui)",
+			}}
+		>
+			<div style={{ display: "flex", alignItems: "center", gap: 5 }}>
+				<div
+					style={{
+						width: 7,
+						height: 7,
+						borderRadius: 99,
+						background: connected ? "var(--success)" : "var(--warning)",
+						boxShadow: connected ? "0 0 6px var(--success)" : "none",
+					}}
+				/>
+				<span style={{ color: "var(--fg-secondary)" }}>
+					{connected ? "同期中" : connectionStatus === "connecting" ? "接続中…" : "再接続中…"}
+				</span>
+			</div>
+			{members.length > 0 && (
+				<>
+					<div style={{ width: 1, height: 10, background: "var(--border-default)" }} />
+					<div style={{ display: "flex" }}>
+						{visible.map((m, i) => (
+							<div
+								key={m.clientId}
+								title={m.name}
+								style={{
+									width: 20,
+									height: 20,
+									borderRadius: 99,
+									background: m.color,
+									color: "white",
+									display: "flex",
+									alignItems: "center",
+									justifyContent: "center",
+									fontSize: 9.5,
+									fontWeight: 600,
+									border: "2px solid var(--bg-surface-solid)",
+									marginLeft: i ? -6 : 0,
+									position: "relative",
+								}}
+							>
+								{initial(m.name)}
+								{m.status === "busy" && (
+									<div
+										style={{
+											position: "absolute",
+											right: -1,
+											bottom: -1,
+											width: 7,
+											height: 7,
+											borderRadius: 99,
+											background: "var(--danger)",
+											border: "1.5px solid var(--bg-surface-solid)",
+										}}
+									/>
+								)}
+							</div>
+						))}
+					</div>
+					{overflow > 0 && <span style={{ color: "var(--fg-tertiary)" }}>+ {overflow}</span>}
+				</>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/components/board-frame/top-right-cluster.tsx
+++ b/apps/web/src/components/board-frame/top-right-cluster.tsx
@@ -1,15 +1,29 @@
+import type { WsConnectionStatus } from "@edv4h/usketch-sync";
 import { useState } from "react";
 import { ShareDialog } from "../share-dialog.js";
 import { ExportMenu } from "../toolbar/export-menu.js";
-import { I } from "../ui/index.js";
+import { I, IconBtn } from "../ui/index.js";
+import { PresencePill } from "./presence-pill.js";
+
+type WsProvider = {
+	awareness: {
+		getStates: () => Map<number, Record<string, unknown>>;
+		doc: { clientID: number };
+	};
+};
 
 interface Props {
 	boardId?: string;
 	isCloudBoard: boolean;
+	wsProvider?: WsProvider | null;
+	connectionStatus?: WsConnectionStatus;
 }
 
-/** 画面右上: Share CTA + エクスポート。Cloud ボード時のみ Share ボタンが出る。 */
-export function TopRightCluster({ boardId, isCloudBoard }: Props) {
+/**
+ * 画面右上: Presence pill + Share CTA + エクスポート/通知/オーバーフロー。
+ * Cloud ボード時のみ Presence pill と Share ボタンが出る。
+ */
+export function TopRightCluster({ boardId, isCloudBoard, wsProvider, connectionStatus }: Props) {
 	const [showShare, setShowShare] = useState(false);
 
 	return (
@@ -25,6 +39,9 @@ export function TopRightCluster({ boardId, isCloudBoard }: Props) {
 					alignItems: "center",
 				}}
 			>
+				{isCloudBoard && wsProvider && (
+					<PresencePill wsProvider={wsProvider} connectionStatus={connectionStatus} />
+				)}
 				{isCloudBoard && boardId && (
 					<button
 						type="button"
@@ -49,7 +66,23 @@ export function TopRightCluster({ boardId, isCloudBoard }: Props) {
 						共有
 					</button>
 				)}
-				<ExportMenu isCloudBoard={isCloudBoard} boardId={boardId} />
+				<div
+					className="u-surface"
+					style={{
+						display: "inline-flex",
+						padding: 3,
+						borderRadius: 10,
+						gap: 1,
+					}}
+				>
+					<ExportMenu isCloudBoard={isCloudBoard} boardId={boardId} />
+					{isCloudBoard && (
+						<>
+							<IconBtn icon={I.bell} label="通知" onClick={() => {}} />
+							<IconBtn icon={I.more} label="その他" onClick={() => {}} />
+						</>
+					)}
+				</div>
 			</div>
 			{showShare && boardId && (
 				<ShareDialog boardId={boardId} onClose={() => setShowShare(false)} />

--- a/apps/web/src/components/toolbar/export-menu.tsx
+++ b/apps/web/src/components/toolbar/export-menu.tsx
@@ -53,17 +53,25 @@ export function ExportMenu({ isCloudBoard, boardId, standalone = false }: Props)
 			}
 		: { position: "relative", display: "inline-flex" };
 
+	const trigger = (
+		<IconBtn
+			icon={I.download}
+			label="エクスポート"
+			onClick={() => setShowMenu((v) => !v)}
+			active={showMenu}
+			disabled={exporting}
+		/>
+	);
+
 	return (
 		<div style={wrapperStyle}>
-			<div className="u-surface" style={{ display: "flex", padding: 3, borderRadius: 10 }}>
-				<IconBtn
-					icon={I.download}
-					label="エクスポート"
-					onClick={() => setShowMenu((v) => !v)}
-					active={showMenu}
-					disabled={exporting}
-				/>
-			</div>
+			{standalone ? (
+				<div className="u-surface" style={{ display: "flex", padding: 3, borderRadius: 10 }}>
+					{trigger}
+				</div>
+			) : (
+				trigger
+			)}
 			{showMenu && (
 				<div
 					className="u-surface"

--- a/apps/web/src/components/toolbar/toolbar.tsx
+++ b/apps/web/src/components/toolbar/toolbar.tsx
@@ -20,6 +20,8 @@ interface Props {
 		};
 	} | null;
 	onOpenCommandPalette: () => void;
+	/** プレゼン編集モード中は Cloud 限定ボタン群 (Copilot / Voice / Present / StatusBar) を隠す */
+	compact?: boolean;
 }
 
 /**
@@ -29,7 +31,13 @@ interface Props {
  * - 右: Cloud 専用（Copilot / Voice / Present）
  * - 上付き pill: Cmd+K ハンドル
  */
-export function Toolbar({ boardId, isCloudBoard, wsProvider, onOpenCommandPalette }: Props) {
+export function Toolbar({
+	boardId,
+	isCloudBoard,
+	wsProvider,
+	onOpenCommandPalette,
+	compact,
+}: Props) {
 	const app = useApp();
 	const activeToolId = useStoreSubscribe(app.store, (s) => s.getActiveToolId());
 	const tools = app.tools.getOrdered();
@@ -81,7 +89,7 @@ export function Toolbar({ boardId, isCloudBoard, wsProvider, onOpenCommandPalett
 					<ThemeToggle />
 				</div>
 
-				{isCloudBoard && (
+				{isCloudBoard && !compact && (
 					<>
 						<Divider vertical />
 						<CopilotToggle />
@@ -106,7 +114,7 @@ export function Toolbar({ boardId, isCloudBoard, wsProvider, onOpenCommandPalett
 				/>
 			</div>
 
-			{isCloudBoard && wsProvider && <StatusBar wsProvider={wsProvider} />}
+			{isCloudBoard && wsProvider && !compact && <StatusBar wsProvider={wsProvider} />}
 
 			<StylePanel />
 		</>

--- a/apps/web/src/lib/present-stage.ts
+++ b/apps/web/src/lib/present-stage.ts
@@ -14,10 +14,11 @@ export const STAGE_SIDEBAR_WIDTH = 220;
 /** サイドバーは画面左端にぴったり貼り付ける (モックに合わせる) */
 export const STAGE_SIDEBAR_MARGIN = 0;
 export const STAGE_SIDEBAR_RESERVED = STAGE_SIDEBAR_WIDTH + STAGE_SIDEBAR_MARGIN * 2;
-export const STAGE_TOP_RESERVED = 64;
-export const STAGE_BOTTOM_RESERVED = 120;
-export const STAGE_SIDE_PADDING = 30;
-export const STAGE_MAX_WIDTH = 1100;
+export const STAGE_TOP_RESERVED = 56;
+export const STAGE_BOTTOM_RESERVED = 70;
+export const STAGE_SIDE_PADDING = 16;
+/** ステージ最大幅: ウィンドウに追従させるため上限を廃止 */
+export const STAGE_MAX_WIDTH = Number.POSITIVE_INFINITY;
 export const STAGE_ASPECT = 9 / 16;
 
 export interface StageRect {

--- a/apps/web/src/lib/present-stage.ts
+++ b/apps/web/src/lib/present-stage.ts
@@ -15,7 +15,8 @@ export const STAGE_SIDEBAR_WIDTH = 220;
 export const STAGE_SIDEBAR_MARGIN = 0;
 export const STAGE_SIDEBAR_RESERVED = STAGE_SIDEBAR_WIDTH + STAGE_SIDEBAR_MARGIN * 2;
 export const STAGE_TOP_RESERVED = 56;
-export const STAGE_BOTTOM_RESERVED = 70;
+/** Stage 下: ページャー pill (約 42px + margin) 分を確保 */
+export const STAGE_BOTTOM_RESERVED = 72;
 export const STAGE_SIDE_PADDING = 16;
 /** ステージ最大幅: ウィンドウに追従させるため上限を廃止 */
 export const STAGE_MAX_WIDTH = Number.POSITIVE_INFINITY;

--- a/apps/web/src/lib/present-stage.ts
+++ b/apps/web/src/lib/present-stage.ts
@@ -11,7 +11,8 @@
  */
 
 export const STAGE_SIDEBAR_WIDTH = 220;
-export const STAGE_SIDEBAR_MARGIN = 12;
+/** サイドバーは画面左端にぴったり貼り付ける (モックに合わせる) */
+export const STAGE_SIDEBAR_MARGIN = 0;
 export const STAGE_SIDEBAR_RESERVED = STAGE_SIDEBAR_WIDTH + STAGE_SIDEBAR_MARGIN * 2;
 export const STAGE_TOP_RESERVED = 64;
 export const STAGE_BOTTOM_RESERVED = 120;

--- a/apps/web/src/lib/present-stage.ts
+++ b/apps/web/src/lib/present-stage.ts
@@ -1,0 +1,46 @@
+/**
+ * プレゼン編集モードのステージ矩形を計算する。
+ *
+ * - 左: サイドバー (220 + 12*2 = 244px)
+ * - 上: モード pill (64px)
+ * - 下: ページャー + Toolbar 用の余白 (120px)
+ * - 最大横幅 1100px、16:9 aspect
+ *
+ * Canvas コンテナサイズに適用することで、Canvas 自体が縮退する。
+ * SlideNavigator 側の viewport fit もこの矩形に対して行う。
+ */
+
+export const STAGE_SIDEBAR_WIDTH = 220;
+export const STAGE_SIDEBAR_MARGIN = 12;
+export const STAGE_SIDEBAR_RESERVED = STAGE_SIDEBAR_WIDTH + STAGE_SIDEBAR_MARGIN * 2;
+export const STAGE_TOP_RESERVED = 64;
+export const STAGE_BOTTOM_RESERVED = 120;
+export const STAGE_SIDE_PADDING = 30;
+export const STAGE_MAX_WIDTH = 1100;
+export const STAGE_ASPECT = 9 / 16;
+
+export interface StageRect {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+}
+
+export function computePresentStage(win: { width: number; height: number }): StageRect {
+	const available = {
+		width: Math.max(100, win.width - STAGE_SIDEBAR_RESERVED - STAGE_SIDE_PADDING * 2),
+		height: Math.max(
+			100,
+			win.height - STAGE_TOP_RESERVED - STAGE_SIDE_PADDING - STAGE_BOTTOM_RESERVED,
+		),
+	};
+	let width = Math.min(available.width, STAGE_MAX_WIDTH);
+	let height = width * STAGE_ASPECT;
+	if (height > available.height) {
+		height = available.height;
+		width = height / STAGE_ASPECT;
+	}
+	const left = STAGE_SIDEBAR_RESERVED + STAGE_SIDE_PADDING + (available.width - width) / 2;
+	const top = STAGE_TOP_RESERVED + STAGE_SIDE_PADDING + (available.height - height) / 2;
+	return { left, top, width, height };
+}

--- a/apps/web/src/lib/use-keyboard-shortcuts.ts
+++ b/apps/web/src/lib/use-keyboard-shortcuts.ts
@@ -4,10 +4,11 @@ import { useEffect } from "react";
 /**
  * ツールショートカットとキーボードショートカットのハンドリングを統一するhook。
  * app.tsx と community.tsx で共通利用。
+ * `disabled=true` でショートカット全般を停止 (例: 発表モード中)。
  */
-export function useKeyboardShortcuts(app: AppInstance | null) {
+export function useKeyboardShortcuts(app: AppInstance | null, disabled = false) {
 	useEffect(() => {
-		if (!app) return;
+		if (!app || disabled) return;
 
 		const handleKeyDown = (e: KeyboardEvent) => {
 			const tag = (e.target as HTMLElement)?.tagName;
@@ -43,5 +44,5 @@ export function useKeyboardShortcuts(app: AppInstance | null) {
 
 		window.addEventListener("keydown", handleKeyDown);
 		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, [app]);
+	}, [app, disabled]);
 }

--- a/apps/web/src/pages/world-map.tsx
+++ b/apps/web/src/pages/world-map.tsx
@@ -25,7 +25,7 @@ interface CommunityRegionData {
 const GRID_SPACING_X = 280;
 const GRID_SPACING_Y = 220;
 const CARD_WIDTH = 200;
-const CARD_HEIGHT = 160;
+const CARD_HEIGHT = 180;
 const FIT_PADDING = 0.8;
 
 // API 取得失敗時のフォールバック

--- a/plugins/usketch-plugin-ai-copilot/src/plugin.tsx
+++ b/plugins/usketch-plugin-ai-copilot/src/plugin.tsx
@@ -236,6 +236,13 @@ export function createAiCopilotPlugin(options: CopilotOptions): UsketchPlugin {
 						createdAt: Date.now(),
 					});
 				}
+				if (shapes.length > 0) {
+					const first = shapes[0];
+					const text = first?.text
+						? `"${first.text}" を追加しませんか？`
+						: `${shapes.length} 件のシェイプを提案`;
+					ctx.events.emit("copilot:notice", { text });
+				}
 			}
 
 			// Debounced trigger

--- a/plugins/usketch-plugin-community-chat/src/chat-tab.tsx
+++ b/plugins/usketch-plugin-community-chat/src/chat-tab.tsx
@@ -1,7 +1,8 @@
+import type { EventBus } from "@edv4h/usketch-shared";
 import type { WsProviderHandle } from "@edv4h/usketch-sync";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatClient } from "./chat-client.js";
-import type { ChatMessage } from "./types.js";
+import type { ChatMessage, ChatNewMessageEvent } from "./types.js";
 
 export interface ChatTabProps {
 	client: ChatClient;
@@ -9,11 +10,13 @@ export interface ChatTabProps {
 	userId: string;
 	userName: string;
 	threadId: string;
+	/** chat-widget シェイプの最終メッセージ表示を更新するため、送受信時に emit する */
+	events?: EventBus;
 }
 
 const LOAD_LIMIT = 50;
 
-export function ChatTab({ client, wsProvider, userId, userName, threadId }: ChatTabProps) {
+export function ChatTab({ client, wsProvider, userId, userName, threadId, events }: ChatTabProps) {
 	const [messages, setMessages] = useState<ChatMessage[]>([]);
 	const [input, setInput] = useState("");
 	const [isComposing, setIsComposing] = useState(false);
@@ -58,12 +61,18 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 		return wsProvider.onBroadcast((msg) => {
 			if (msg.kind !== "chat-message") return;
 			const chatMsg = msg as unknown as { kind: string; message: ChatMessage };
-			if (chatMsg.message.threadId !== threadId) return;
 			if (chatMsg.message.authorId === userId) return;
-			setMessages((prev) => [...prev, chatMsg.message]);
-			scrollToBottom();
+			// アクティブタブで見ているスレッドのみ表示に追加（他スレッドも shape 更新イベントは出す）
+			if (chatMsg.message.threadId === threadId) {
+				setMessages((prev) => [...prev, chatMsg.message]);
+				scrollToBottom();
+			}
+			events?.emit<ChatNewMessageEvent>("chat-widget:new-message", {
+				message: chatMsg.message,
+				fromActiveTab: chatMsg.message.threadId === threadId,
+			});
 		});
-	}, [wsProvider, userId, threadId, scrollToBottom]);
+	}, [wsProvider, userId, threadId, scrollToBottom, events]);
 
 	// 上スクロールで過去メッセージ読み込み
 	const handleScroll = useCallback(() => {
@@ -101,9 +110,14 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 			setMessages((prev) => [...prev, saved]);
 			scrollToBottom();
 			wsProvider?.broadcast({ kind: "chat-message", message: saved });
+			// 自分の送信は wsProvider.broadcast では自分に届かない想定なので明示的に emit
+			events?.emit<ChatNewMessageEvent>("chat-widget:new-message", {
+				message: saved,
+				fromActiveTab: true,
+			});
 		}
 		setIsSending(false);
-	}, [input, isSending, client, threadId, userName, wsProvider, scrollToBottom]);
+	}, [input, isSending, client, threadId, userName, wsProvider, scrollToBottom, events]);
 
 	return (
 		<div

--- a/plugins/usketch-plugin-community-chat/src/chat-tab.tsx
+++ b/plugins/usketch-plugin-community-chat/src/chat-tab.tsx
@@ -106,7 +106,15 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 	}, [input, isSending, client, threadId, userName, wsProvider, scrollToBottom]);
 
 	return (
-		<div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 300 }}>
+		<div
+			style={{
+				display: "flex",
+				flexDirection: "column",
+				height: "100%",
+				minHeight: 300,
+				color: "var(--fg-primary)",
+			}}
+		>
 			{/* メッセージ一覧 */}
 			<div
 				ref={scrollRef}
@@ -114,13 +122,27 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 				style={{ flex: 1, overflowY: "auto", padding: "12px 16px" }}
 			>
 				{isLoadingMore && (
-					<div style={{ textAlign: "center", color: "#999", fontSize: 12, padding: "8px 0" }}>
-						Loading...
+					<div
+						style={{
+							textAlign: "center",
+							color: "var(--fg-tertiary)",
+							fontSize: 12,
+							padding: "8px 0",
+						}}
+					>
+						読み込み中…
 					</div>
 				)}
 				{messages.length === 0 && !isInitialLoad.current && (
-					<div style={{ textAlign: "center", color: "#999", fontSize: 13, padding: "24px 0" }}>
-						No messages yet. Start the conversation!
+					<div
+						style={{
+							textAlign: "center",
+							color: "var(--fg-tertiary)",
+							fontSize: 13,
+							padding: "24px 0",
+						}}
+					>
+						まだメッセージはありません。会話を始めましょう。
 					</div>
 				)}
 				{messages.map((msg) => {
@@ -136,7 +158,14 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 							}}
 						>
 							{!isOwn && (
-								<div style={{ fontSize: 11, color: "#888", marginBottom: 2, padding: "0 4px" }}>
+								<div
+									style={{
+										fontSize: 11,
+										color: "var(--fg-tertiary)",
+										marginBottom: 2,
+										padding: "0 4px",
+									}}
+								>
 									{msg.authorName}
 								</div>
 							)}
@@ -145,8 +174,8 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 									maxWidth: "85%",
 									padding: "8px 12px",
 									borderRadius: isOwn ? "12px 12px 4px 12px" : "12px 12px 12px 4px",
-									background: isOwn ? "#1e1e1e" : "#f0f0f0",
-									color: isOwn ? "#fff" : "#333",
+									background: isOwn ? "var(--brand-gradient)" : "var(--bg-input)",
+									color: isOwn ? "white" : "var(--fg-primary)",
 									fontSize: 13,
 									lineHeight: 1.5,
 									wordBreak: "break-word",
@@ -154,7 +183,14 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 							>
 								{msg.text}
 							</div>
-							<div style={{ fontSize: 10, color: "#bbb", marginTop: 2, padding: "0 4px" }}>
+							<div
+								style={{
+									fontSize: 10,
+									color: "var(--fg-tertiary)",
+									marginTop: 2,
+									padding: "0 4px",
+								}}
+							>
 								{new Date(msg.createdAt).toLocaleTimeString([], {
 									hour: "2-digit",
 									minute: "2-digit",
@@ -168,7 +204,7 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 			{/* 入力欄 */}
 			<div
 				style={{
-					borderTop: "1px solid #eee",
+					borderTop: "1px solid var(--border-subtle)",
 					padding: "10px 12px",
 					display: "flex",
 					gap: 8,
@@ -184,11 +220,13 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 						e.stopPropagation();
 						if (e.key === "Enter" && !isComposing && !isSending) handleSend();
 					}}
-					placeholder="Type a message..."
+					placeholder="メッセージを入力…"
 					disabled={isSending}
 					style={{
 						flex: 1,
-						border: "1px solid #e5e5e5",
+						border: "1px solid var(--border-default)",
+						background: "var(--bg-input)",
+						color: "var(--fg-primary)",
 						borderRadius: 8,
 						padding: "8px 12px",
 						fontSize: 13,
@@ -202,16 +240,18 @@ export function ChatTab({ client, wsProvider, userId, userName, threadId }: Chat
 					disabled={isSending || !input.trim()}
 					style={{
 						border: "none",
-						background: isSending || !input.trim() ? "#ccc" : "#1e1e1e",
-						color: "#fff",
+						background: isSending || !input.trim() ? "var(--bg-input)" : "var(--brand-gradient)",
+						color: isSending || !input.trim() ? "var(--fg-tertiary)" : "white",
 						borderRadius: 8,
 						padding: "8px 14px",
 						fontSize: 13,
+						fontWeight: 500,
 						cursor: isSending || !input.trim() ? "default" : "pointer",
 						flexShrink: 0,
+						fontFamily: "inherit",
 					}}
 				>
-					Send
+					送信
 				</button>
 			</div>
 		</div>

--- a/plugins/usketch-plugin-community-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-community-chat/src/plugin.tsx
@@ -13,6 +13,7 @@ import {
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import type { WsProviderHandle } from "@edv4h/usketch-sync";
 import { createChatClient } from "./chat-client.js";
+import type { ChatNewMessageEvent } from "./types.js";
 
 export interface CommunityChatOptions {
 	apiUrl: string;
@@ -39,16 +40,34 @@ function threadHue(id: string): number {
 	return THREAD_HUES[Math.abs(hash) % THREAD_HUES.length] ?? 265;
 }
 
+function formatRelativeTime(iso: string): string {
+	const then = new Date(iso).getTime();
+	if (!Number.isFinite(then)) return "";
+	const diff = Date.now() - then;
+	if (diff < 0) return "今";
+	const sec = Math.floor(diff / 1000);
+	if (sec < 60) return "今";
+	const min = Math.floor(sec / 60);
+	if (min < 60) return `${min}分前`;
+	const hr = Math.floor(min / 60);
+	if (hr < 24) return `${hr}時間前`;
+	const day = Math.floor(hr / 24);
+	if (day < 7) return `${day}日前`;
+	return new Date(iso).toLocaleDateString();
+}
+
 // ── ピン描画 ──
 
 function renderChatPin(data: ShapeData) {
 	const label = (data.chatLabel as string) || "Chat";
 	const lastMessage = (data.lastMessage as string) || "";
 	const lastAuthor = (data.lastAuthor as string) || "";
+	const lastMessageAt = (data.lastMessageAt as string) || "";
 	const unread = Number(data.unread ?? 0);
 	const hue = threadHue((data.threadId as string) || data.id);
 	const accentColor = `hsl(${hue}, 70%, 60%)`;
 	const softColor = `hsl(${hue}, 70%, 85%)`;
+	const relTime = lastMessageAt ? formatRelativeTime(lastMessageAt) : "";
 
 	// tail を含めるため、外側ラッパーは overflow: visible で、
 	// 内部の pill だけに overflow: hidden をかける。
@@ -144,16 +163,39 @@ function renderChatPin(data: ShapeData) {
 				<div style={{ minWidth: 0, lineHeight: 1.25, flex: 1 }}>
 					<div
 						style={{
-							fontSize: 12,
-							fontWeight: 600,
-							color: "var(--fg-primary)",
-							whiteSpace: "nowrap",
-							overflow: "hidden",
-							textOverflow: "ellipsis",
+							display: "flex",
+							alignItems: "baseline",
+							gap: 6,
+							minWidth: 0,
 						}}
-						title={label}
 					>
-						{label}
+						<div
+							style={{
+								fontSize: 12,
+								fontWeight: 600,
+								color: "var(--fg-primary)",
+								whiteSpace: "nowrap",
+								overflow: "hidden",
+								textOverflow: "ellipsis",
+								flex: 1,
+								minWidth: 0,
+							}}
+							title={label}
+						>
+							{label}
+						</div>
+						{relTime && (
+							<div
+								style={{
+									fontSize: 9.5,
+									color: "var(--fg-tertiary)",
+									fontFamily: "var(--font-mono)",
+									flexShrink: 0,
+								}}
+							>
+								{relTime}
+							</div>
+						)}
 					</div>
 					{lastMessage && (
 						<div
@@ -368,6 +410,7 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 							userId={options.userId}
 							userName={options.userName}
 							threadId={activeThreadId}
+							events={ctx.events}
 						/>
 					),
 				},
@@ -382,6 +425,77 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 				createDefault,
 				renderTarget: "html",
 				minSize: { width: MIN_W, height: MIN_W * ASPECT },
+			});
+
+			// chat-widget シェイプの最終メッセージ / unread を更新するイベント購読
+			const unsubNewMessage = ctx.events.on<ChatNewMessageEvent>(
+				"chat-widget:new-message",
+				({ message, fromActiveTab }) => {
+					const shapes = ctx.store.getShapes();
+					for (const [id, shape] of shapes) {
+						if (shape.type !== "chat-widget") continue;
+						if ((shape.threadId as string) !== message.threadId) continue;
+						const prevUnread = Number(shape.unread ?? 0);
+						const nextUnread = fromActiveTab ? 0 : prevUnread + 1;
+						ctx.store.updateShape(id, {
+							lastMessage: message.text,
+							lastAuthor: message.authorName,
+							lastAuthorId: message.authorId,
+							lastMessageAt: message.createdAt,
+							unread: nextUnread,
+						});
+					}
+				},
+			);
+
+			// アクティブスレッド切替時 / タブを開いた時、そのスレッドの unread をリセット
+			const clearUnreadForThread = (threadId: string) => {
+				const shapes = ctx.store.getShapes();
+				for (const [id, shape] of shapes) {
+					if (shape.type !== "chat-widget") continue;
+					if ((shape.threadId as string) !== threadId) continue;
+					if (Number(shape.unread ?? 0) === 0) continue;
+					ctx.store.updateShape(id, { unread: 0 });
+				}
+			};
+
+			// 初期ロード時: 画面にある chat-widget シェイプ全ての最新メッセージを fetch して反映
+			// （新規 shape が後から増えたときのためにも、追加時に再 fetch する）
+			const refreshShapeMetadata = async (shapeId: string, threadId: string) => {
+				const msgs = await client.list(threadId, 1);
+				const last = msgs[msgs.length - 1];
+				if (!last) return;
+				const shape = ctx.store.getShape(shapeId);
+				if (!shape || shape.type !== "chat-widget") return;
+				if (shape.lastMessageAt === last.createdAt) return; // 変更なし
+				ctx.store.updateShape(shapeId, {
+					lastMessage: last.text,
+					lastAuthor: last.authorName,
+					lastAuthorId: last.authorId,
+					lastMessageAt: last.createdAt,
+				});
+			};
+
+			// 初期同期: 現在ある chat-widget シェイプ全てを 1 回 fetch
+			setTimeout(() => {
+				const shapes = ctx.store.getShapes();
+				for (const [id, shape] of shapes) {
+					if (shape.type !== "chat-widget") continue;
+					const threadId = (shape.threadId as string) || "";
+					if (threadId) refreshShapeMetadata(id, threadId);
+				}
+			}, 0);
+
+			// 新規 chat-widget が追加されたら fetch
+			const unsubShapeAdd = ctx.store.onMutation((event) => {
+				if (event.type !== "shape:added") return;
+				const payload = event.payload as { id?: string } | null | undefined;
+				const shapeId = payload?.id;
+				if (typeof shapeId !== "string") return;
+				const shape = ctx.store.getShape(shapeId);
+				if (!shape || shape.type !== "chat-widget") return;
+				const threadId = (shape.threadId as string) || "";
+				if (threadId) refreshShapeMetadata(shapeId, threadId);
 			});
 
 			// チャットピン選択時 → そのスレッドをサイドパネルで開く
@@ -403,6 +517,7 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 				if (shapeId !== prevSelectedChatId) {
 					prevSelectedChatId = shapeId;
 					activeThreadId = threadId;
+					clearUnreadForThread(threadId);
 					// タブを再登録してスレッドを切り替え
 					ctx.events.emit("side-panel:unregister-tab", { tabId: "community-chat" });
 					ctx.events.emit("side-panel:register-tab", {
@@ -418,6 +533,7 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 									userId={options.userId}
 									userName={options.userName}
 									threadId={activeThreadId}
+									events={ctx.events}
 								/>
 							),
 						},
@@ -448,6 +564,8 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 
 			cleanup = () => {
 				unsubMutation();
+				unsubNewMessage();
+				unsubShapeAdd();
 				ctx.events.emit("side-panel:unregister-tab", { tabId: "community-chat" });
 			};
 		},

--- a/plugins/usketch-plugin-community-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-community-chat/src/plugin.tsx
@@ -23,42 +23,32 @@ export interface CommunityChatOptions {
 }
 
 // ── ピン定数 ──
-
-const PIN_W = 64;
-const PIN_H = 80;
+// モックの ChatThreadPin (expanded 状態) 相当: 横長の pill 型
+const PIN_W = 280;
+const PIN_H = 60;
 const ASPECT = PIN_H / PIN_W;
-const MIN_W = 40;
-const PIN_HUE = 200;
+const MIN_W = 180;
+
+// threadId をハッシュしてアバター色を決める
+const THREAD_HUES = [265, 330, 195, 150, 20, 210, 0, 175, 240, 35];
+function threadHue(id: string): number {
+	let hash = 0;
+	for (let i = 0; i < id.length; i++) {
+		hash = (hash * 31 + id.charCodeAt(i)) | 0;
+	}
+	return THREAD_HUES[Math.abs(hash) % THREAD_HUES.length] ?? 265;
+}
 
 // ── ピン描画 ──
 
-function pinPath(cx: number, cy: number, r: number, tipY: number): string {
-	const angle = Math.PI / 5;
-	const sinA = Math.sin(angle);
-	const cosA = Math.cos(angle);
-	const tx = cx + r * sinA;
-	const ty = cy + r * cosA;
-	const lx = cx - r * sinA;
-	const ly = ty;
-	return [`M${cx} ${tipY}`, `L${tx} ${ty}`, `A${r} ${r} 0 1 0 ${lx} ${ly}`, "Z"].join(" ");
-}
-
 function renderChatPin(data: ShapeData) {
 	const label = (data.chatLabel as string) || "Chat";
-	const w = data.width;
-	const h = data.height;
-
-	const labelH = h * 0.25;
-	const pinH = h - labelH;
-	const r = w * 0.4;
-	const cx = w / 2;
-	const cy = h * 0.02 + r;
-	const tipY = pinH - h * 0.01;
-
-	const uid = `chat-pin-${data.id}`;
-	const lightColor = `hsl(${PIN_HUE}, 70%, 68%)`;
-	const darkColor = `hsl(${PIN_HUE}, 60%, 38%)`;
-	const iconColor = `hsl(${PIN_HUE}, 55%, 45%)`;
+	const lastMessage = (data.lastMessage as string) || "";
+	const lastAuthor = (data.lastAuthor as string) || "";
+	const unread = Number(data.unread ?? 0);
+	const hue = threadHue((data.threadId as string) || data.id);
+	const accentColor = `hsl(${hue}, 70%, 60%)`;
+	const softColor = `hsl(${hue}, 70%, 85%)`;
 
 	return (
 		<div
@@ -68,93 +58,121 @@ function renderChatPin(data: ShapeData) {
 				position: "relative",
 				pointerEvents: "none",
 				userSelect: "none",
+				boxSizing: "border-box",
+				display: "flex",
+				alignItems: "center",
+				gap: 10,
+				padding: "8px 14px 8px 8px",
+				background: "var(--bg-surface-raised)",
+				border: `1.5px solid ${accentColor}`,
+				borderRadius: 99,
+				boxShadow: `0 6px 16px color-mix(in oklab, ${accentColor} 28%, transparent)`,
+				backdropFilter: "blur(20px) saturate(1.4)",
+				WebkitBackdropFilter: "blur(20px) saturate(1.4)",
+				fontFamily: "var(--font-sans, system-ui, sans-serif)",
 				overflow: "hidden",
 			}}
 		>
-			<svg
-				width={w}
-				height={pinH}
-				viewBox={`0 0 ${w} ${pinH}`}
-				style={{ position: "absolute", top: 0, left: 0 }}
-			>
-				<title>{label}</title>
-				<defs>
-					<linearGradient id={`${uid}-grad`} x1="0" y1="0" x2="0.3" y2="1">
-						<stop offset="0%" stopColor={lightColor} />
-						<stop offset="100%" stopColor={darkColor} />
-					</linearGradient>
-					<radialGradient id={`${uid}-hl`} cx="0.4" cy="0.35" r="0.6">
-						<stop offset="0%" stopColor="rgba(255,255,255,0.35)" />
-						<stop offset="100%" stopColor="rgba(255,255,255,0)" />
-					</radialGradient>
-				</defs>
-				<ellipse cx={cx} cy={tipY + 1} rx={r * 0.3} ry={2} fill="rgba(0,0,0,0.1)" />
-				<path d={pinPath(cx, cy, r, tipY)} fill={`url(#${uid}-grad)`} />
-				<circle cx={cx} cy={cy} r={r} fill={`url(#${uid}-hl)`} />
-				<circle cx={cx} cy={cy} r={r * 0.58} fill="#fff" />
-				<g transform={`translate(${cx - r * 0.32}, ${cy - r * 0.3}) scale(${(r * 0.64) / 20})`}>
-					<path
-						d="M4 3h12a2 2 0 012 2v7a2 2 0 01-2 2H8l-4 3v-3H4a2 2 0 01-2-2V5a2 2 0 012-2z"
-						fill="none"
-						stroke={iconColor}
-						strokeWidth="1.8"
-						strokeLinejoin="round"
-					/>
-					<line
-						x1="7"
-						y1="7"
-						x2="13"
-						y2="7"
-						stroke={iconColor}
-						strokeWidth="1.4"
-						strokeLinecap="round"
-					/>
-					<line
-						x1="7"
-						y1="10"
-						x2="11"
-						y2="10"
-						stroke={iconColor}
-						strokeWidth="1.4"
-						strokeLinecap="round"
-					/>
-				</g>
-				<circle cx={cx - r * 0.28} cy={cy - r * 0.28} r={r * 0.08} fill="rgba(255,255,255,0.5)" />
-			</svg>
+			{/* アバター (comment icon) */}
 			<div
 				style={{
-					position: "absolute",
-					bottom: 0,
-					left: 0,
-					width: w,
-					height: labelH,
+					width: 32,
+					height: 32,
+					borderRadius: 99,
+					flexShrink: 0,
+					background: `linear-gradient(135deg, ${accentColor}, ${softColor})`,
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "center",
+					position: "relative",
 				}}
 			>
-				<span
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 16 16"
+					fill="none"
+					stroke="white"
+					strokeWidth="1.8"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M2.5 7.5c0-2.8 2.5-5 5.5-5s5.5 2.2 5.5 5-2.5 5-5.5 5c-.7 0-1.4-.1-2-.3L3 13.5l.8-2.4a4.8 4.8 0 0 1-1.3-3.6Z" />
+				</svg>
+				{unread > 0 && (
+					<div
+						style={{
+							position: "absolute",
+							top: -3,
+							right: -3,
+							minWidth: 16,
+							height: 16,
+							padding: "0 4px",
+							borderRadius: 99,
+							background: "var(--danger)",
+							color: "white",
+							fontSize: 9.5,
+							fontWeight: 700,
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							border: "2px solid var(--bg-canvas)",
+						}}
+					>
+						{unread > 99 ? "99+" : unread}
+					</div>
+				)}
+			</div>
+
+			{/* タイトル + 最終メッセージ */}
+			<div style={{ minWidth: 0, lineHeight: 1.25, flex: 1 }}>
+				<div
 					style={{
-						fontSize: Math.max(9, Math.min(13, h * 0.11)),
+						fontSize: 12,
 						fontWeight: 600,
-						color: "#334155",
-						fontFamily: "system-ui, sans-serif",
-						background: "rgba(255,255,255,0.88)",
-						padding: "2px 6px",
-						borderRadius: 8,
-						maxWidth: "100%",
+						color: "var(--fg-primary)",
+						whiteSpace: "nowrap",
 						overflow: "hidden",
-						display: "-webkit-box",
-						WebkitLineClamp: 2,
-						WebkitBoxOrient: "vertical",
-						textAlign: "center",
-						lineHeight: 1.25,
-						wordBreak: "break-word",
+						textOverflow: "ellipsis",
 					}}
+					title={label}
 				>
 					{label}
-				</span>
+				</div>
+				{lastMessage && (
+					<div
+						style={{
+							fontSize: 10.5,
+							color: "var(--fg-tertiary)",
+							whiteSpace: "nowrap",
+							overflow: "hidden",
+							textOverflow: "ellipsis",
+						}}
+					>
+						{lastAuthor && (
+							<span style={{ color: accentColor, fontWeight: 500 }}>{lastAuthor}: </span>
+						)}
+						{lastMessage}
+					</div>
+				)}
 			</div>
+
+			{/* pin tail — 下に小さな三角 */}
+			<div
+				aria-hidden="true"
+				style={{
+					position: "absolute",
+					bottom: -5,
+					left: 20,
+					width: 8,
+					height: 8,
+					background: "var(--bg-surface-raised)",
+					borderRight: `1.5px solid ${accentColor}`,
+					borderBottom: `1.5px solid ${accentColor}`,
+					transform: "rotate(45deg)",
+				}}
+			/>
 		</div>
 	);
 }
@@ -243,9 +261,10 @@ function createDefault(params: { id: string; x: number; y: number }): ShapeData 
 		y: params.y,
 		width: PIN_W,
 		height: PIN_H,
-		style: { ...DEFAULT_STYLE, fill: "#ffffff", stroke: "#e2e8f0" },
+		style: { ...DEFAULT_STYLE, fill: "transparent", stroke: "transparent", strokeWidth: 0 },
 		chatLabel: "Chat",
 		threadId: generateId(),
+		unread: 0,
 	};
 }
 

--- a/plugins/usketch-plugin-community-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-community-chat/src/plugin.tsx
@@ -50,6 +50,13 @@ function renderChatPin(data: ShapeData) {
 	const accentColor = `hsl(${hue}, 70%, 60%)`;
 	const softColor = `hsl(${hue}, 70%, 85%)`;
 
+	// tail を含めるため、外側ラッパーは overflow: visible で、
+	// 内部の pill だけに overflow: hidden をかける。
+	// tail は pill の下辺から張り出す SVG で描画し、pill 背景と border を一筆で継承する。
+	const TAIL_W = 14;
+	const TAIL_H = 8;
+	const TAIL_OFFSET_LEFT = 24; // アバター中心の少し右下から生やす
+
 	return (
 		<div
 			style={{
@@ -59,104 +66,146 @@ function renderChatPin(data: ShapeData) {
 				pointerEvents: "none",
 				userSelect: "none",
 				boxSizing: "border-box",
-				display: "flex",
-				alignItems: "center",
-				gap: 10,
-				padding: "8px 14px 8px 8px",
-				background: "var(--bg-surface-raised)",
-				border: `1.5px solid ${accentColor}`,
-				borderRadius: 99,
-				boxShadow: `0 6px 16px color-mix(in oklab, ${accentColor} 28%, transparent)`,
-				backdropFilter: "blur(20px) saturate(1.4)",
-				WebkitBackdropFilter: "blur(20px) saturate(1.4)",
 				fontFamily: "var(--font-sans, system-ui, sans-serif)",
-				overflow: "hidden",
+				filter: `drop-shadow(0 6px 14px color-mix(in oklab, ${accentColor} 28%, transparent))`,
 			}}
 		>
-			{/* アバター (comment icon) */}
+			{/* pill 本体 */}
 			<div
 				style={{
-					width: 32,
-					height: 32,
-					borderRadius: 99,
-					flexShrink: 0,
-					background: `linear-gradient(135deg, ${accentColor}, ${softColor})`,
+					position: "absolute",
+					inset: 0,
 					display: "flex",
 					alignItems: "center",
-					justifyContent: "center",
-					position: "relative",
+					gap: 10,
+					padding: "8px 14px 8px 8px",
+					background: "var(--bg-surface-raised)",
+					border: `1.5px solid ${accentColor}`,
+					borderRadius: 99,
+					backdropFilter: "blur(20px) saturate(1.4)",
+					WebkitBackdropFilter: "blur(20px) saturate(1.4)",
+					overflow: "hidden",
+					boxSizing: "border-box",
 				}}
 			>
-				<svg
-					width="14"
-					height="14"
-					viewBox="0 0 16 16"
-					fill="none"
-					stroke="white"
-					strokeWidth="1.8"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					aria-hidden="true"
-				>
-					<path d="M2.5 7.5c0-2.8 2.5-5 5.5-5s5.5 2.2 5.5 5-2.5 5-5.5 5c-.7 0-1.4-.1-2-.3L3 13.5l.8-2.4a4.8 4.8 0 0 1-1.3-3.6Z" />
-				</svg>
-				{unread > 0 && (
-					<div
-						style={{
-							position: "absolute",
-							top: -3,
-							right: -3,
-							minWidth: 16,
-							height: 16,
-							padding: "0 4px",
-							borderRadius: 99,
-							background: "var(--danger)",
-							color: "white",
-							fontSize: 9.5,
-							fontWeight: 700,
-							display: "flex",
-							alignItems: "center",
-							justifyContent: "center",
-							border: "2px solid var(--bg-canvas)",
-						}}
-					>
-						{unread > 99 ? "99+" : unread}
-					</div>
-				)}
-			</div>
-
-			{/* タイトル + 最終メッセージ */}
-			<div style={{ minWidth: 0, lineHeight: 1.25, flex: 1 }}>
+				{/* アバター (comment icon) */}
 				<div
 					style={{
-						fontSize: 12,
-						fontWeight: 600,
-						color: "var(--fg-primary)",
-						whiteSpace: "nowrap",
-						overflow: "hidden",
-						textOverflow: "ellipsis",
+						width: 32,
+						height: 32,
+						borderRadius: 99,
+						flexShrink: 0,
+						background: `linear-gradient(135deg, ${accentColor}, ${softColor})`,
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						position: "relative",
 					}}
-					title={label}
 				>
-					{label}
+					<svg
+						width="14"
+						height="14"
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="white"
+						strokeWidth="1.8"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						aria-hidden="true"
+					>
+						<path d="M2.5 7.5c0-2.8 2.5-5 5.5-5s5.5 2.2 5.5 5-2.5 5-5.5 5c-.7 0-1.4-.1-2-.3L3 13.5l.8-2.4a4.8 4.8 0 0 1-1.3-3.6Z" />
+					</svg>
+					{unread > 0 && (
+						<div
+							style={{
+								position: "absolute",
+								top: -3,
+								right: -3,
+								minWidth: 16,
+								height: 16,
+								padding: "0 4px",
+								borderRadius: 99,
+								background: "var(--danger)",
+								color: "white",
+								fontSize: 9.5,
+								fontWeight: 700,
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								border: "2px solid var(--bg-canvas)",
+							}}
+						>
+							{unread > 99 ? "99+" : unread}
+						</div>
+					)}
 				</div>
-				{lastMessage && (
+
+				{/* タイトル + 最終メッセージ */}
+				<div style={{ minWidth: 0, lineHeight: 1.25, flex: 1 }}>
 					<div
 						style={{
-							fontSize: 10.5,
-							color: "var(--fg-tertiary)",
+							fontSize: 12,
+							fontWeight: 600,
+							color: "var(--fg-primary)",
 							whiteSpace: "nowrap",
 							overflow: "hidden",
 							textOverflow: "ellipsis",
 						}}
+						title={label}
 					>
-						{lastAuthor && (
-							<span style={{ color: accentColor, fontWeight: 500 }}>{lastAuthor}: </span>
-						)}
-						{lastMessage}
+						{label}
 					</div>
-				)}
+					{lastMessage && (
+						<div
+							style={{
+								fontSize: 10.5,
+								color: "var(--fg-tertiary)",
+								whiteSpace: "nowrap",
+								overflow: "hidden",
+								textOverflow: "ellipsis",
+							}}
+						>
+							{lastAuthor && (
+								<span style={{ color: accentColor, fontWeight: 500 }}>{lastAuthor}: </span>
+							)}
+							{lastMessage}
+						</div>
+					)}
+				</div>
 			</div>
+
+			{/* tail — pill の下辺に張り出す三角 (SVG) */}
+			<svg
+				aria-hidden="true"
+				width={TAIL_W}
+				height={TAIL_H + 2}
+				viewBox={`0 0 ${TAIL_W} ${TAIL_H + 2}`}
+				style={{
+					position: "absolute",
+					left: TAIL_OFFSET_LEFT,
+					// pill の下端線にちょうど重ねる。pill の border 1.5px の外側に出すため少し上から。
+					bottom: -(TAIL_H + 1),
+					pointerEvents: "none",
+				}}
+			>
+				{/* pill の border と同色のアウトライン三角 (下向き ▼) */}
+				<path
+					d={`M0 0 L${TAIL_W} 0 L${TAIL_W / 2} ${TAIL_H} Z`}
+					fill="var(--bg-surface-raised)"
+					stroke={accentColor}
+					strokeWidth="1.5"
+					strokeLinejoin="round"
+				/>
+				{/* pill の底辺 border と tail の上端を重ねて、接地部分の 2 重線を隠す */}
+				<line
+					x1="1"
+					y1="0"
+					x2={TAIL_W - 1}
+					y2="0"
+					stroke="var(--bg-surface-raised)"
+					strokeWidth="2"
+				/>
+			</svg>
 		</div>
 	);
 }

--- a/plugins/usketch-plugin-community-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-community-chat/src/plugin.tsx
@@ -157,22 +157,6 @@ function renderChatPin(data: ShapeData) {
 					</div>
 				)}
 			</div>
-
-			{/* pin tail — 下に小さな三角 */}
-			<div
-				aria-hidden="true"
-				style={{
-					position: "absolute",
-					bottom: -5,
-					left: 20,
-					width: 8,
-					height: 8,
-					background: "var(--bg-surface-raised)",
-					borderRight: `1.5px solid ${accentColor}`,
-					borderBottom: `1.5px solid ${accentColor}`,
-					transform: "rotate(45deg)",
-				}}
-			/>
 		</div>
 	);
 }

--- a/plugins/usketch-plugin-community-chat/src/types.ts
+++ b/plugins/usketch-plugin-community-chat/src/types.ts
@@ -7,3 +7,10 @@ export interface ChatMessage {
 	text: string;
 	createdAt: string;
 }
+
+/** chat-widget シェイプが subscribe する新着メッセージイベント */
+export interface ChatNewMessageEvent {
+	message: ChatMessage;
+	/** このイベントは「現在アクティブなタブで受信/送信された」= unread に計上しない */
+	fromActiveTab: boolean;
+}

--- a/plugins/usketch-plugin-presentation/package.json
+++ b/plugins/usketch-plugin-presentation/package.json
@@ -23,10 +23,13 @@
 		"@edv4h/usketch-store": "workspace:*"
 	},
 	"peerDependencies": {
-		"react": ">=19"
+		"react": ">=19",
+		"react-dom": ">=19"
 	},
 	"devDependencies": {
 		"@types/react": "19.2.14",
+		"@types/react-dom": "19.2.3",
+		"react-dom": "19.2.4",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
 	}

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -5,9 +5,9 @@ import type {
 	UsketchPlugin,
 } from "@edv4h/usketch-shared";
 import { useEffect, useState } from "react";
+import { PresentEditOverlay } from "./present-edit-overlay.js";
 import { PresentModeOverlay } from "./present-mode-overlay.js";
 import { SlideNavigator } from "./slide-navigator.js";
-import { SlideOutlinePanel } from "./slide-outline-panel.js";
 
 /** "off" = プレゼン UI 非表示（通常のホワイトボード扱い） */
 export type PresentationMode = "off" | "edit" | "present";
@@ -197,12 +197,12 @@ function PresentationLayer({
 	void setMode;
 	if (mode === "off") return null;
 	if (mode === "present") return <PresentModeOverlay nav={nav} />;
+	void renderCtx;
 	return (
-		<SlideOutlinePanel
+		<PresentEditOverlay
 			nav={nav}
 			store={store}
 			commands={commands}
-			renderCtx={renderCtx}
 			navigateToBoard={navigateToBoard}
 		/>
 	);

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -129,18 +129,18 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 			window.addEventListener("keydown", onKeyDown);
 			unregisters.push(() => window.removeEventListener("keydown", onKeyDown));
 
-			// 発表モードに入ったら最初のスライドに寄せる。
+			// 発表モード突入時の初回 fit は PresentModeOverlay の useEffect (mount 後) に委ねる。
+			// plugin レイヤーで即座に fit すると、Canvas コンテナの縮退解除より前の
+			// 古いサイズで計算されてズームがずれる。ここではモード変化の購読だけ行い、
+			// navRef の fit は呼ばない。
 			let prevMode = getMode();
 			const syncOnModeChange = () => {
 				const current = getMode();
 				if (current !== prevMode) {
 					prevMode = current;
-					if (current === "present") navRef.first();
 				}
 			};
 			unregisters.push(subscribeMode(syncOnModeChange));
-			// 初期表示
-			if (prevMode === "present") navRef.first();
 
 			// レイヤー: mode に応じて edit (パネル) / present (オーバーレイ) を出し分ける。
 			// react 側で LayerRenderContext を経由して再 render されるので、子コンポーネント

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -27,9 +27,15 @@ export interface PresentationPluginOptions {
 	 * apps/web 側で react-router の navigate を渡す。省略時は window.location.assign。
 	 */
 	navigateToBoard?: () => void;
+	/**
+	 * SlideNavigator.fitToBounds で使う viewport サイズを返す。
+	 * 編集モード時は Canvas が stage 矩形に縮退するため、ウィンドウ全体ではなく
+	 * stage のサイズを返したい。省略時は window.innerWidth/Height を使う。
+	 */
+	getViewportSize?: () => { width: number; height: number };
 }
 
-function getWindowSize(): { width: number; height: number } {
+function defaultGetViewportSize(): { width: number; height: number } {
 	return { width: window.innerWidth, height: window.innerHeight };
 }
 
@@ -52,6 +58,7 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 	const getMode = opts.getMode;
 	const subscribeMode = opts.subscribeMode ?? defaultSubscribeMode;
 	const navigateToBoard = opts.navigateToBoard ?? defaultNavigateToBoard;
+	const getViewportSize = opts.getViewportSize ?? defaultGetViewportSize;
 	let nav: SlideNavigator | null = null;
 	const unregisters: Array<() => void> = [];
 
@@ -59,7 +66,7 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 		id: "presentation",
 		name: "Presentation",
 		setup(ctx: PluginContext) {
-			nav = new SlideNavigator(ctx.store, getWindowSize);
+			nav = new SlideNavigator(ctx.store, getViewportSize);
 			const navRef = nav;
 
 			// 発表モード中のみ動くショートカット群（mode を実行時に毎回評価する）

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -20,14 +20,6 @@ const TOP_BAR_HEIGHT = 64;
 const BOTTOM_RESERVED = 120;
 const SIDEBAR_RESERVED = SIDEBAR_WIDTH + SIDEBAR_LEFT_MARGIN * 2;
 const ASPECT = 9 / 16;
-const SLIDE_USER_COLORS = [
-	"var(--u-1)",
-	"var(--u-2)",
-	"var(--u-3)",
-	"var(--u-4)",
-	"var(--u-5)",
-	"var(--u-6)",
-];
 
 interface StageRect {
 	left: number;
@@ -406,8 +398,6 @@ const THUMB_H = 112; // 16:9
  * shape を minimap 矩形に畳んで SVG 化する。空スライドはグラデ背景にフォールバック。
  */
 function SlideThumb({ slide, index, active, onClick, store, storeRev }: ThumbProps) {
-	const colorA = SLIDE_USER_COLORS[index % SLIDE_USER_COLORS.length];
-	const colorB = SLIDE_USER_COLORS[(index + 2) % SLIDE_USER_COLORS.length];
 	const title = getFrameLabel(slide);
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: storeRev 経由で shape mutation に追随する
@@ -468,7 +458,7 @@ function SlideThumb({ slide, index, active, onClick, store, storeRev }: ThumbPro
 					style={{
 						aspectRatio: "16 / 9",
 						position: "relative",
-						background: isEmpty ? `linear-gradient(135deg, ${colorA}, ${colorB})` : "#ffffff",
+						background: "#ffffff",
 						overflow: "hidden",
 					}}
 				>
@@ -504,9 +494,9 @@ function SlideThumb({ slide, index, active, onClick, store, storeRev }: ThumbPro
 							left: 6,
 							top: 4,
 							fontSize: 9,
-							color: isEmpty ? "rgba(255,255,255,.7)" : "var(--fg-tertiary)",
+							color: "var(--fg-tertiary)",
 							fontFamily: "var(--font-mono, monospace)",
-							mixBlendMode: isEmpty ? "normal" : "multiply",
+							mixBlendMode: "multiply",
 						}}
 					>
 						{String(index + 1).padStart(2, "0")}

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -134,21 +134,6 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				fontFamily: "var(--font-sans, system-ui)",
 			}}
 		>
-			{/* ステージ枠: Canvas がそのまま透けて見える。violet 枠で場所だけ示す。 */}
-			<div
-				style={{
-					position: "absolute",
-					left: stage.left - 1,
-					top: stage.top - 1,
-					width: stage.width + 2,
-					height: stage.height + 2,
-					borderRadius: 8,
-					border: "1.5px solid var(--brand-violet)",
-					boxShadow: "0 0 0 4px color-mix(in oklab, var(--brand-violet) 15%, transparent)",
-					pointerEvents: "none",
-				}}
-			/>
-
 			{/* サイドバー */}
 			<aside
 				className="u-surface"

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -1,6 +1,7 @@
 import type { BoardStore, Command, CommandRegistry, ShapeData } from "@edv4h/usketch-shared";
 import { zIndexBetween } from "@edv4h/usketch-shared";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { SlideNavigator } from "./slide-navigator.js";
 
 interface Props {
@@ -109,7 +110,11 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 
 	const total = slides.length;
 
-	return (
+	// Canvas layer として render されるが、apps/web 側で Canvas コンテナを
+	// プレゼン編集の stage 矩形に縮退させているため、Canvas 内に描画されると
+	// overlay 自体も縮小されてしまう。Portal で document.body 直下に逃がし、
+	// ウィンドウ全体を基準とした配置に保つ。
+	return createPortal(
 		<div
 			style={{
 				position: "fixed",
@@ -328,7 +333,8 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 					Frame を追加するとスライドになります
 				</div>
 			)}
-		</div>
+		</div>,
+		document.body,
 	);
 }
 

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -86,31 +86,16 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 		return () => window.removeEventListener("resize", onResize);
 	}, []);
 
-	// ステージサイズに合わせて、現在のスライドを再フィット。
-	// nav は getViewportSize 経由で画面全体サイズを返す前提だが、ここではステージ外に
-	// canvas がはみ出しても overlay で隠れるので、敢えて fitToBounds を直接呼ぶ。
+	// Canvas 自体が stage 矩形に縮退しているので、SlideNavigator の fitToBounds が
+	// そのまま正しく動く。mode 突入時や stage リサイズ時にだけ nav 経由で再フィットする。
 	useEffect(() => {
 		const slide = slides[current];
 		if (!slide) return;
-		const key = `${slide.id}:${Math.round(stage.width)}x${Math.round(stage.height)}:${Math.round(stage.left)}x${Math.round(stage.top)}`;
+		const key = `${slide.id}:${Math.round(stage.width)}x${Math.round(stage.height)}`;
 		if (lastFitRef.current === key) return;
 		lastFitRef.current = key;
-		// stage の world-to-screen 比率に合わせて viewport を手動で組む。
-		// fitToBounds はビューポート中心基準なので、ステージ中心 = 画面中心に
-		// なるよう left/top をオフセット補正する。
-		const winW = window.innerWidth;
-		const winH = window.innerHeight;
-		const stageCenterX = stage.left + stage.width / 2;
-		const stageCenterY = stage.top + stage.height / 2;
-		const screenCenterX = winW / 2;
-		const screenCenterY = winH / 2;
-		const zoom = Math.min(stage.width / slide.width, stage.height / slide.height);
-		const viewportX =
-			screenCenterX - (slide.x + slide.width / 2) * zoom + (stageCenterX - screenCenterX);
-		const viewportY =
-			screenCenterY - (slide.y + slide.height / 2) * zoom + (stageCenterY - screenCenterY);
-		store.setViewport({ x: viewportX, y: viewportY, zoom });
-	}, [slides, current, stage, store]);
+		nav.gotoIndex(current);
+	}, [slides, current, stage, nav]);
 
 	const startPresent = () => {
 		const url = new URL(window.location.href);
@@ -134,23 +119,8 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				fontFamily: "var(--font-sans, system-ui)",
 			}}
 		>
-			{/* ステージ枠: Canvas を violet のリング + 外側オーラで囲む。
-			    内側は塗らず Canvas を透過。outline + box-shadow のみで構成。 */}
-			<div
-				style={{
-					position: "absolute",
-					left: stage.left,
-					top: stage.top,
-					width: stage.width,
-					height: stage.height,
-					borderRadius: 8,
-					pointerEvents: "none",
-					outline: "2.5px solid var(--brand-violet)",
-					outlineOffset: 2,
-					boxShadow:
-						"0 0 0 6px color-mix(in oklab, var(--brand-violet) 18%, transparent), 0 20px 60px rgba(139,92,246,.35), 0 0 80px rgba(236,72,153,.2)",
-				}}
-			/>
+			{/* ステージ枠は apps/web 側で Canvas 本体に box-shadow を当てて描画。
+			    ここではサイドバー / 上部 pill / ページャーのみを重ねる。 */}
 
 			{/* サイドバー */}
 			<aside

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -259,7 +259,7 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				</div>
 			</div>
 
-			{/* ページネーション pill: 画面最下部に固定 (stage 下の余白内) */}
+			{/* ページネーション pill: 画面最下部に固定 (発表モードと同じデザイン) */}
 			<div
 				style={{
 					position: "absolute",
@@ -272,47 +272,45 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				}}
 			>
 				<div
-					className="u-surface"
 					style={{
 						display: "flex",
 						alignItems: "center",
 						gap: 2,
 						padding: 4,
 						borderRadius: 999,
+						background: "rgba(20,20,25,0.85)",
+						backdropFilter: "blur(20px)",
+						WebkitBackdropFilter: "blur(20px)",
+						border: "1px solid rgba(255,255,255,0.1)",
+						boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
 						pointerEvents: "auto",
 					}}
 				>
-					<button
-						type="button"
-						onClick={() => nav.prev()}
+					<PagerChevron
 						disabled={current === 0}
-						style={navBtn(current === 0)}
-						aria-label="前のスライド"
-					>
-						‹
-					</button>
+						onClick={() => nav.prev()}
+						ariaLabel="前のスライド"
+						direction="prev"
+					/>
 					<div
 						style={{
 							padding: "0 12px",
 							fontSize: 13,
-							color: "var(--fg-primary)",
 							fontFamily: "var(--font-mono, monospace)",
+							letterSpacing: 0,
 							minWidth: 60,
 							textAlign: "center",
 						}}
 					>
-						<span style={{ fontWeight: 600 }}>{total === 0 ? 0 : current + 1}</span>
-						<span style={{ color: "var(--fg-tertiary)" }}> / {total}</span>
+						<span style={{ color: "white", fontWeight: 600 }}>{total === 0 ? 0 : current + 1}</span>
+						<span style={{ color: "rgba(255,255,255,0.5)" }}> / {total}</span>
 					</div>
-					<button
-						type="button"
-						onClick={() => nav.next()}
+					<PagerChevron
 						disabled={current >= total - 1}
-						style={navBtn(current >= total - 1)}
-						aria-label="次のスライド"
-					>
-						›
-					</button>
+						onClick={() => nav.next()}
+						ariaLabel="次のスライド"
+						direction="next"
+					/>
 				</div>
 			</div>
 
@@ -360,24 +358,55 @@ function pillBtn(active: boolean): React.CSSProperties {
 	};
 }
 
-function navBtn(disabled: boolean): React.CSSProperties {
-	return {
-		appearance: "none",
-		width: 34,
-		height: 34,
-		borderRadius: 999,
-		background: "transparent",
-		border: "none",
-		color: "white",
-		cursor: disabled ? "default" : "pointer",
-		opacity: disabled ? 0.3 : 1,
-		fontSize: 18,
-		fontFamily: "inherit",
-		display: "inline-flex",
-		alignItems: "center",
-		justifyContent: "center",
-		padding: 0,
-	};
+function PagerChevron({
+	disabled,
+	onClick,
+	ariaLabel,
+	direction,
+}: {
+	disabled: boolean;
+	onClick: () => void;
+	ariaLabel: string;
+	direction: "prev" | "next";
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled}
+			aria-label={ariaLabel}
+			style={{
+				appearance: "none",
+				border: "none",
+				background: "transparent",
+				color: "white",
+				cursor: disabled ? "default" : "pointer",
+				opacity: disabled ? 0.3 : 1,
+				width: 34,
+				height: 34,
+				borderRadius: 999,
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: 0,
+				transition: "background var(--dur-fast)",
+			}}
+		>
+			<svg
+				width="14"
+				height="14"
+				viewBox="0 0 16 16"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				{direction === "prev" ? <path d="m10 4-4 4 4 4" /> : <path d="m6 4 4 4-4 4" />}
+			</svg>
+		</button>
+	);
 }
 
 interface ThumbProps {

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -1,0 +1,641 @@
+import type { BoardStore, Command, CommandRegistry, ShapeData } from "@edv4h/usketch-shared";
+import { zIndexBetween } from "@edv4h/usketch-shared";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import type { SlideNavigator } from "./slide-navigator.js";
+
+interface Props {
+	nav: SlideNavigator;
+	store: BoardStore;
+	commands: CommandRegistry;
+	navigateToBoard: () => void;
+}
+
+const SIDEBAR_WIDTH = 220;
+const STAGE_MAX_WIDTH = 1100;
+const STAGE_PADDING = 30;
+const TOP_BAR_HEIGHT = 64;
+const ASPECT = 9 / 16;
+const SLIDE_USER_COLORS = [
+	"var(--u-1)",
+	"var(--u-2)",
+	"var(--u-3)",
+	"var(--u-4)",
+	"var(--u-5)",
+	"var(--u-6)",
+];
+
+interface StageRect {
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+}
+
+function computeStageRect(win: { width: number; height: number }): StageRect {
+	const available = {
+		width: Math.max(100, win.width - SIDEBAR_WIDTH - STAGE_PADDING * 2),
+		height: Math.max(100, win.height - TOP_BAR_HEIGHT - STAGE_PADDING * 2 - 80),
+	};
+	let width = Math.min(available.width, STAGE_MAX_WIDTH);
+	let height = width * ASPECT;
+	if (height > available.height) {
+		height = available.height;
+		width = height / ASPECT;
+	}
+	const left = SIDEBAR_WIDTH + STAGE_PADDING + (available.width - width) / 2;
+	const top = TOP_BAR_HEIGHT + STAGE_PADDING + (available.height - height) / 2;
+	return { left, top, width, height };
+}
+
+/**
+ * プレゼン編集モードの全画面オーバーレイ。
+ * Canvas 自体はそのまま背面で動作しており、この overlay は
+ *  - 左サイドバー (スライド一覧)
+ *  - 上部 pill (モード切替)
+ *  - 下部ナビ
+ *  - ステージ穴を囲む 4 方向の黒ベール
+ * を重ねるだけ。ステージ中央は pointer-events を通すので、
+ * 通常のボード編集操作 (シェイプ選択・追加・移動) がそのまま使える。
+ */
+export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Props) {
+	const [slides, setSlides] = useState<ShapeData[]>(nav.getSlides());
+	const [current, setCurrent] = useState(nav.getCurrentIndex());
+	const [stage, setStage] = useState<StageRect>(() =>
+		computeStageRect({ width: window.innerWidth, height: window.innerHeight }),
+	);
+	const lastFitRef = useRef<string>("");
+
+	useEffect(() => {
+		const unsub = nav.onChange((i) => {
+			setSlides(nav.getSlides());
+			setCurrent(i);
+		});
+		return unsub;
+	}, [nav]);
+
+	// リサイズに追随
+	useLayoutEffect(() => {
+		const onResize = () => {
+			setStage(computeStageRect({ width: window.innerWidth, height: window.innerHeight }));
+		};
+		window.addEventListener("resize", onResize);
+		return () => window.removeEventListener("resize", onResize);
+	}, []);
+
+	// ステージサイズに合わせて、現在のスライドを再フィット。
+	// nav は getViewportSize 経由で画面全体サイズを返す前提だが、ここではステージ外に
+	// canvas がはみ出しても overlay で隠れるので、敢えて fitToBounds を直接呼ぶ。
+	useEffect(() => {
+		const slide = slides[current];
+		if (!slide) return;
+		const key = `${slide.id}:${Math.round(stage.width)}x${Math.round(stage.height)}:${Math.round(stage.left)}x${Math.round(stage.top)}`;
+		if (lastFitRef.current === key) return;
+		lastFitRef.current = key;
+		// stage の world-to-screen 比率に合わせて viewport を手動で組む。
+		// fitToBounds はビューポート中心基準なので、ステージ中心 = 画面中心に
+		// なるよう left/top をオフセット補正する。
+		const winW = window.innerWidth;
+		const winH = window.innerHeight;
+		const stageCenterX = stage.left + stage.width / 2;
+		const stageCenterY = stage.top + stage.height / 2;
+		const screenCenterX = winW / 2;
+		const screenCenterY = winH / 2;
+		const zoom = Math.min(stage.width / slide.width, stage.height / slide.height);
+		const viewportX =
+			screenCenterX - (slide.x + slide.width / 2) * zoom + (stageCenterX - screenCenterX);
+		const viewportY =
+			screenCenterY - (slide.y + slide.height / 2) * zoom + (stageCenterY - screenCenterY);
+		store.setViewport({ x: viewportX, y: viewportY, zoom });
+	}, [slides, current, stage, store]);
+
+	const startPresent = () => {
+		const url = new URL(window.location.href);
+		url.searchParams.set("present", "1");
+		url.searchParams.set("mode", "present");
+		window.history.replaceState(null, "", url.toString());
+		window.dispatchEvent(new PopStateEvent("popstate"));
+	};
+
+	const exitToBoard = () => navigateToBoard();
+
+	const total = slides.length;
+
+	return (
+		<div
+			style={{
+				position: "fixed",
+				inset: 0,
+				zIndex: 500,
+				pointerEvents: "none",
+				fontFamily: "var(--font-sans, system-ui)",
+			}}
+		>
+			{/* Veil: 上 */}
+			<div style={veilStyle(0, 0, "100%", stage.top)} />
+			{/* Veil: 下 */}
+			<div
+				style={veilStyle(
+					0,
+					stage.top + stage.height,
+					"100%",
+					`calc(100% - ${stage.top + stage.height}px)`,
+				)}
+			/>
+			{/* Veil: 左 (サイドバー含む) */}
+			<div style={veilStyle(0, stage.top, stage.left, stage.height)} />
+			{/* Veil: 右 */}
+			<div
+				style={veilStyle(
+					stage.left + stage.width,
+					stage.top,
+					`calc(100% - ${stage.left + stage.width}px)`,
+					stage.height,
+				)}
+			/>
+
+			{/* ステージ枠の視覚的な影 (透過穴の強調) */}
+			<div
+				style={{
+					position: "absolute",
+					left: stage.left - 1,
+					top: stage.top - 1,
+					width: stage.width + 2,
+					height: stage.height + 2,
+					borderRadius: 8,
+					boxShadow: "0 30px 60px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.05)",
+					pointerEvents: "none",
+				}}
+			/>
+
+			{/* サイドバー */}
+			<aside
+				style={{
+					position: "absolute",
+					left: 0,
+					top: 0,
+					bottom: 0,
+					width: SIDEBAR_WIDTH,
+					background: "var(--bg-canvas-2)",
+					borderRight: "1px solid var(--border-subtle)",
+					display: "flex",
+					flexDirection: "column",
+					pointerEvents: "auto",
+					color: "var(--fg-primary)",
+				}}
+			>
+				<div
+					style={{
+						padding: "14px 16px",
+						borderBottom: "1px solid var(--border-subtle)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "space-between",
+					}}
+				>
+					<div style={{ fontSize: 12, fontWeight: 600 }}>スライド</div>
+					<div
+						style={{
+							fontSize: 11,
+							color: "var(--fg-tertiary)",
+							fontFamily: "var(--font-mono, monospace)",
+						}}
+					>
+						{total}
+					</div>
+				</div>
+				<div
+					style={{
+						flex: 1,
+						overflow: "auto",
+						padding: 10,
+						display: "flex",
+						flexDirection: "column",
+						gap: 8,
+					}}
+				>
+					{slides.map((s, i) => (
+						<SlideThumb
+							key={s.id}
+							slide={s}
+							index={i}
+							active={i === current}
+							onClick={() => nav.gotoIndex(i)}
+							onMoveUp={i > 0 ? () => moveSlide(store, commands, s.id, -1) : undefined}
+							onMoveDown={
+								i < slides.length - 1 ? () => moveSlide(store, commands, s.id, +1) : undefined
+							}
+						/>
+					))}
+					<button
+						type="button"
+						onClick={() => addSlide(store, commands)}
+						style={{
+							padding: 8,
+							background: "var(--bg-input)",
+							border: "1px dashed var(--border-default)",
+							borderRadius: 8,
+							color: "var(--fg-tertiary)",
+							cursor: "pointer",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							gap: 5,
+							fontSize: 12,
+							fontFamily: "inherit",
+						}}
+					>
+						+ スライド追加
+					</button>
+				</div>
+			</aside>
+
+			{/* 上部 pill: モード切替 */}
+			<div
+				style={{
+					position: "absolute",
+					top: 12,
+					left: SIDEBAR_WIDTH,
+					right: 0,
+					display: "flex",
+					justifyContent: "center",
+					pointerEvents: "none",
+				}}
+			>
+				<div
+					className="u-surface"
+					style={{
+						display: "flex",
+						padding: 4,
+						gap: 2,
+						borderRadius: 10,
+						pointerEvents: "auto",
+					}}
+				>
+					<button type="button" onClick={exitToBoard} style={pillBtn(false)}>
+						← ボード
+					</button>
+					<div style={{ width: 1, background: "var(--border-default)", margin: "4px 2px" }} />
+					<button type="button" style={pillBtn(true)}>
+						編集
+					</button>
+					<button
+						type="button"
+						onClick={startPresent}
+						disabled={total === 0}
+						style={{
+							...pillBtn(false),
+							background: total === 0 ? "var(--bg-input)" : "var(--brand-gradient)",
+							color: total === 0 ? "var(--fg-tertiary)" : "white",
+							opacity: total === 0 ? 0.6 : 1,
+						}}
+					>
+						▶ 発表開始
+					</button>
+				</div>
+			</div>
+
+			{/* 下部ナビ pill */}
+			<div
+				style={{
+					position: "absolute",
+					bottom: 30,
+					left: SIDEBAR_WIDTH,
+					right: 0,
+					display: "flex",
+					justifyContent: "center",
+					pointerEvents: "none",
+				}}
+			>
+				<div
+					className="u-surface"
+					style={{
+						display: "flex",
+						alignItems: "center",
+						gap: 2,
+						padding: 4,
+						borderRadius: 999,
+						pointerEvents: "auto",
+					}}
+				>
+					<button
+						type="button"
+						onClick={() => nav.prev()}
+						disabled={current === 0}
+						style={navBtn(current === 0)}
+						aria-label="前のスライド"
+					>
+						‹
+					</button>
+					<div
+						style={{
+							padding: "0 12px",
+							fontSize: 13,
+							color: "var(--fg-primary)",
+							fontFamily: "var(--font-mono, monospace)",
+							minWidth: 60,
+							textAlign: "center",
+						}}
+					>
+						<span style={{ fontWeight: 600 }}>{total === 0 ? 0 : current + 1}</span>
+						<span style={{ color: "var(--fg-tertiary)" }}> / {total}</span>
+					</div>
+					<button
+						type="button"
+						onClick={() => nav.next()}
+						disabled={current >= total - 1}
+						style={navBtn(current >= total - 1)}
+						aria-label="次のスライド"
+					>
+						›
+					</button>
+				</div>
+			</div>
+
+			{total === 0 && (
+				<div
+					style={{
+						position: "absolute",
+						left: stage.left,
+						top: stage.top,
+						width: stage.width,
+						height: stage.height,
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						color: "var(--fg-tertiary)",
+						fontSize: 13,
+						background: "var(--bg-canvas)",
+						borderRadius: 8,
+						pointerEvents: "none",
+					}}
+				>
+					Frame を追加するとスライドになります
+				</div>
+			)}
+		</div>
+	);
+}
+
+function veilStyle(
+	left: number | string,
+	top: number | string,
+	width: number | string,
+	height: number | string,
+): React.CSSProperties {
+	return {
+		position: "absolute",
+		left,
+		top,
+		width,
+		height,
+		background: "#0a0a0b",
+		pointerEvents: "auto",
+	};
+}
+
+function pillBtn(active: boolean): React.CSSProperties {
+	return {
+		appearance: "none",
+		border: "none",
+		background: active ? "var(--bg-active)" : "transparent",
+		color: active ? "var(--brand-violet)" : "var(--fg-secondary)",
+		cursor: "pointer",
+		padding: "6px 12px",
+		borderRadius: 6,
+		fontSize: 12,
+		fontWeight: 500,
+		fontFamily: "inherit",
+		display: "inline-flex",
+		alignItems: "center",
+		gap: 5,
+	};
+}
+
+function navBtn(disabled: boolean): React.CSSProperties {
+	return {
+		appearance: "none",
+		width: 34,
+		height: 34,
+		borderRadius: 999,
+		background: "transparent",
+		border: "none",
+		color: "white",
+		cursor: disabled ? "default" : "pointer",
+		opacity: disabled ? 0.3 : 1,
+		fontSize: 18,
+		fontFamily: "inherit",
+		display: "inline-flex",
+		alignItems: "center",
+		justifyContent: "center",
+		padding: 0,
+	};
+}
+
+interface ThumbProps {
+	slide: ShapeData;
+	index: number;
+	active: boolean;
+	onClick: () => void;
+	onMoveUp?: () => void;
+	onMoveDown?: () => void;
+}
+
+function SlideThumb({ slide, index, active, onClick, onMoveUp, onMoveDown }: ThumbProps) {
+	const colorA = SLIDE_USER_COLORS[index % SLIDE_USER_COLORS.length];
+	const colorB = SLIDE_USER_COLORS[(index + 2) % SLIDE_USER_COLORS.length];
+	const title = getFrameLabel(slide);
+	return (
+		<div
+			style={{
+				cursor: "pointer",
+				borderRadius: 8,
+				overflow: "hidden",
+				border: active ? "2px solid var(--brand-violet)" : "1px solid var(--border-subtle)",
+				background: "var(--bg-canvas)",
+			}}
+		>
+			<button
+				type="button"
+				onClick={onClick}
+				style={{
+					appearance: "none",
+					border: "none",
+					background: "transparent",
+					cursor: "pointer",
+					padding: 0,
+					width: "100%",
+					textAlign: "left",
+					color: "inherit",
+					fontFamily: "inherit",
+				}}
+			>
+				<div
+					style={{
+						aspectRatio: "16 / 9",
+						background: `linear-gradient(135deg, ${colorA}, ${colorB})`,
+						position: "relative",
+					}}
+				>
+					<div
+						style={{
+							position: "absolute",
+							left: 6,
+							top: 4,
+							fontSize: 9,
+							color: "rgba(255,255,255,.7)",
+							fontFamily: "var(--font-mono, monospace)",
+						}}
+					>
+						{String(index + 1).padStart(2, "0")}
+					</div>
+				</div>
+				<div
+					style={{
+						padding: "6px 8px",
+						fontSize: 11,
+						color: "var(--fg-primary)",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+					}}
+					title={title}
+				>
+					{title}
+				</div>
+			</button>
+			{(onMoveUp || onMoveDown) && (
+				<div style={{ display: "flex", gap: 4, padding: "0 6px 6px" }}>
+					<button
+						type="button"
+						disabled={!onMoveUp}
+						onClick={onMoveUp}
+						style={miniBtn(!onMoveUp)}
+						aria-label="スライドを前に移動"
+					>
+						↑
+					</button>
+					<button
+						type="button"
+						disabled={!onMoveDown}
+						onClick={onMoveDown}
+						style={miniBtn(!onMoveDown)}
+						aria-label="スライドを後に移動"
+					>
+						↓
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function miniBtn(disabled: boolean): React.CSSProperties {
+	return {
+		appearance: "none",
+		flex: 1,
+		border: "1px solid var(--border-subtle)",
+		background: "transparent",
+		color: "var(--fg-secondary)",
+		cursor: disabled ? "default" : "pointer",
+		opacity: disabled ? 0.3 : 1,
+		padding: "2px 0",
+		fontSize: 10,
+		borderRadius: 4,
+		fontFamily: "inherit",
+	};
+}
+
+function getFrameLabel(shape: ShapeData): string {
+	const frameTitle = (shape as unknown as { frameTitle?: unknown }).frameTitle;
+	if (typeof frameTitle === "string" && frameTitle.trim()) return frameTitle;
+	const name = (shape as unknown as { name?: unknown }).name;
+	if (typeof name === "string" && name.trim()) return name;
+	return "(無題)";
+}
+
+/**
+ * 新しいスライド (Frame) を追加する。
+ * 位置は現在最後のスライドの横に並べ、サイズは 1280x720 (16:9)。
+ */
+function addSlide(store: BoardStore, commands: CommandRegistry): void {
+	const existing = store.getShapesSorted().filter((s) => s.type === "frame");
+	const width = 1280;
+	const height = 720;
+	let x = 0;
+	let y = 0;
+	const last = existing[existing.length - 1];
+	if (last) {
+		x = last.x + last.width + 80;
+		y = last.y;
+	}
+	const id = `frame-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+	const lastZ = last && typeof last.zIndex === "string" ? last.zIndex : null;
+	const newZ = zIndexBetween(lastZ, null);
+	const snapshot: ShapeData = {
+		id,
+		type: "frame",
+		x,
+		y,
+		width,
+		height,
+		style: { fill: "#ffffff", stroke: "#1e1e1e", strokeWidth: 1, opacity: 1 },
+		zIndex: newZ,
+		frameTitle: `スライド ${existing.length + 1}`,
+	} as ShapeData;
+	const command: Command = {
+		execute() {
+			store.addShape(snapshot);
+		},
+		undo() {
+			store.deleteShape(id);
+		},
+	};
+	commands.execute(command);
+}
+
+function moveSlide(
+	store: BoardStore,
+	commands: CommandRegistry,
+	shapeId: string,
+	direction: -1 | 1,
+): void {
+	const slides = store.getShapesSorted().filter((s) => s.type === "frame");
+	const index = slides.findIndex((s) => s.id === shapeId);
+	if (index < 0) return;
+	const newIndex = index + direction;
+	if (newIndex < 0 || newIndex >= slides.length) return;
+	const current = slides[index];
+	if (!current || typeof current.zIndex !== "string") return;
+	let lower: string | null;
+	let upper: string | null;
+	if (direction === 1) {
+		const after = slides[newIndex];
+		const afterNext = slides[newIndex + 1];
+		if (!after || typeof after.zIndex !== "string") return;
+		lower = after.zIndex;
+		upper =
+			afterNext && typeof afterNext.zIndex === "string" && afterNext.id !== shapeId
+				? afterNext.zIndex
+				: null;
+	} else {
+		const before = slides[newIndex];
+		const beforePrev = slides[newIndex - 1];
+		if (!before || typeof before.zIndex !== "string") return;
+		lower =
+			beforePrev && typeof beforePrev.zIndex === "string" && beforePrev.id !== shapeId
+				? beforePrev.zIndex
+				: null;
+		upper = before.zIndex;
+	}
+	const nextKey = zIndexBetween(lower, upper);
+	const prevKey = current.zIndex;
+	const command: Command = {
+		execute() {
+			store.updateShape(shapeId, { zIndex: nextKey });
+		},
+		undo() {
+			store.updateShape(shapeId, { zIndex: prevKey });
+		},
+	};
+	commands.execute(command);
+}

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -240,9 +240,6 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 						← ボード
 					</button>
 					<div style={{ width: 1, background: "var(--border-default)", margin: "4px 2px" }} />
-					<button type="button" style={pillBtn(true)}>
-						編集
-					</button>
 					<button
 						type="button"
 						onClick={startPresent}

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -127,16 +127,16 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 			{/* ステージ枠は apps/web 側で Canvas 本体に box-shadow を当てて描画。
 			    ここではサイドバー / 上部 pill / ページャーのみを重ねる。 */}
 
-			{/* サイドバー */}
+			{/* サイドバー (画面左端に貼り付け、モック準拠で不透明 bg-canvas-2) */}
 			<aside
-				className="u-surface"
 				style={{
 					position: "absolute",
-					left: 12,
-					top: 70,
-					bottom: 80,
+					left: 0,
+					top: 0,
+					bottom: 0,
 					width: SIDEBAR_WIDTH,
-					borderRadius: 12,
+					background: "var(--bg-canvas-2)",
+					borderRight: "1px solid var(--border-subtle)",
 					display: "flex",
 					flexDirection: "column",
 					pointerEvents: "auto",
@@ -181,10 +181,6 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 							index={i}
 							active={i === current}
 							onClick={() => nav.gotoIndex(i)}
-							onMoveUp={i > 0 ? () => moveSlide(store, commands, s.id, -1) : undefined}
-							onMoveDown={
-								i < slides.length - 1 ? () => moveSlide(store, commands, s.id, +1) : undefined
-							}
 						/>
 					))}
 					<button
@@ -381,11 +377,9 @@ interface ThumbProps {
 	index: number;
 	active: boolean;
 	onClick: () => void;
-	onMoveUp?: () => void;
-	onMoveDown?: () => void;
 }
 
-function SlideThumb({ slide, index, active, onClick, onMoveUp, onMoveDown }: ThumbProps) {
+function SlideThumb({ slide, index, active, onClick }: ThumbProps) {
 	const colorA = SLIDE_USER_COLORS[index % SLIDE_USER_COLORS.length];
 	const colorB = SLIDE_USER_COLORS[(index + 2) % SLIDE_USER_COLORS.length];
 	const title = getFrameLabel(slide);
@@ -448,46 +442,8 @@ function SlideThumb({ slide, index, active, onClick, onMoveUp, onMoveDown }: Thu
 					{title}
 				</div>
 			</button>
-			{(onMoveUp || onMoveDown) && (
-				<div style={{ display: "flex", gap: 4, padding: "0 6px 6px" }}>
-					<button
-						type="button"
-						disabled={!onMoveUp}
-						onClick={onMoveUp}
-						style={miniBtn(!onMoveUp)}
-						aria-label="スライドを前に移動"
-					>
-						↑
-					</button>
-					<button
-						type="button"
-						disabled={!onMoveDown}
-						onClick={onMoveDown}
-						style={miniBtn(!onMoveDown)}
-						aria-label="スライドを後に移動"
-					>
-						↓
-					</button>
-				</div>
-			)}
 		</div>
 	);
-}
-
-function miniBtn(disabled: boolean): React.CSSProperties {
-	return {
-		appearance: "none",
-		flex: 1,
-		border: "1px solid var(--border-subtle)",
-		background: "transparent",
-		color: "var(--fg-secondary)",
-		cursor: disabled ? "default" : "pointer",
-		opacity: disabled ? 0.3 : 1,
-		padding: "2px 0",
-		fontSize: 10,
-		borderRadius: 4,
-		fontFamily: "inherit",
-	};
 }
 
 function getFrameLabel(shape: ShapeData): string {
@@ -533,53 +489,6 @@ function addSlide(store: BoardStore, commands: CommandRegistry): void {
 		},
 		undo() {
 			store.deleteShape(id);
-		},
-	};
-	commands.execute(command);
-}
-
-function moveSlide(
-	store: BoardStore,
-	commands: CommandRegistry,
-	shapeId: string,
-	direction: -1 | 1,
-): void {
-	const slides = store.getShapesSorted().filter((s) => s.type === "frame");
-	const index = slides.findIndex((s) => s.id === shapeId);
-	if (index < 0) return;
-	const newIndex = index + direction;
-	if (newIndex < 0 || newIndex >= slides.length) return;
-	const current = slides[index];
-	if (!current || typeof current.zIndex !== "string") return;
-	let lower: string | null;
-	let upper: string | null;
-	if (direction === 1) {
-		const after = slides[newIndex];
-		const afterNext = slides[newIndex + 1];
-		if (!after || typeof after.zIndex !== "string") return;
-		lower = after.zIndex;
-		upper =
-			afterNext && typeof afterNext.zIndex === "string" && afterNext.id !== shapeId
-				? afterNext.zIndex
-				: null;
-	} else {
-		const before = slides[newIndex];
-		const beforePrev = slides[newIndex - 1];
-		if (!before || typeof before.zIndex !== "string") return;
-		lower =
-			beforePrev && typeof beforePrev.zIndex === "string" && beforePrev.id !== shapeId
-				? beforePrev.zIndex
-				: null;
-		upper = before.zIndex;
-	}
-	const nextKey = zIndexBetween(lower, upper);
-	const prevKey = current.zIndex;
-	const command: Command = {
-		execute() {
-			store.updateShape(shapeId, { zIndex: nextKey });
-		},
-		undo() {
-			store.updateShape(shapeId, { zIndex: prevKey });
 		},
 	};
 	commands.execute(command);

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -1,6 +1,6 @@
 import type { BoardStore, Command, CommandRegistry, ShapeData } from "@edv4h/usketch-shared";
-import { zIndexBetween } from "@edv4h/usketch-shared";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { computeMinimap, zIndexBetween } from "@edv4h/usketch-shared";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { SlideNavigator } from "./slide-navigator.js";
 
@@ -69,6 +69,20 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 		computeStageRect({ width: window.innerWidth, height: window.innerHeight }),
 	);
 	const lastFitRef = useRef<string>("");
+	// サムネ再描画用のリビジョン。shape が追加/更新/削除されたら bump。
+	const [storeRev, setStoreRev] = useState(0);
+	useEffect(() => {
+		let scheduled = false;
+		const unsub = store.onMutation(() => {
+			if (scheduled) return;
+			scheduled = true;
+			requestAnimationFrame(() => {
+				scheduled = false;
+				setStoreRev((r) => r + 1);
+			});
+		});
+		return unsub;
+	}, [store]);
 
 	useEffect(() => {
 		const unsub = nav.onChange((i) => {
@@ -181,6 +195,8 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 							index={i}
 							active={i === current}
 							onClick={() => nav.gotoIndex(i)}
+							store={store}
+							storeRev={storeRev}
 						/>
 					))}
 					<button
@@ -377,12 +393,52 @@ interface ThumbProps {
 	index: number;
 	active: boolean;
 	onClick: () => void;
+	store: BoardStore;
+	storeRev: number;
 }
 
-function SlideThumb({ slide, index, active, onClick }: ThumbProps) {
+const THUMB_W = 200;
+const THUMB_H = 112; // 16:9
+
+/**
+ * スライド frame の中身を縮小してサムネに描画する。
+ * `computeMinimap` でボード全体と同じ pipeline を共有し、frame bbox 内の
+ * shape を minimap 矩形に畳んで SVG 化する。空スライドはグラデ背景にフォールバック。
+ */
+function SlideThumb({ slide, index, active, onClick, store, storeRev }: ThumbProps) {
 	const colorA = SLIDE_USER_COLORS[index % SLIDE_USER_COLORS.length];
 	const colorB = SLIDE_USER_COLORS[(index + 2) % SLIDE_USER_COLORS.length];
 	const title = getFrameLabel(slide);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: storeRev 経由で shape mutation に追随する
+	const thumb = useMemo(() => {
+		const frameBounds = {
+			x: slide.x,
+			y: slide.y,
+			width: slide.width,
+			height: slide.height,
+		};
+		// storeRev を参照するだけで mutation 後に再計算されるようにする (実体は store から読む)
+		void storeRev;
+		const all = store.getShapesSorted();
+		const inside: ShapeData[] = [];
+		for (const s of all) {
+			if (s.id === slide.id) continue;
+			if (s.type === "frame") continue;
+			if (rectsIntersect(s, frameBounds)) inside.push(s);
+		}
+		return computeMinimap({
+			shapes: inside,
+			viewportWorld: frameBounds,
+			mapWidth: THUMB_W,
+			mapHeight: THUMB_H,
+			padding: 0,
+			minSize: 1.5,
+		});
+	}, [slide.id, slide.x, slide.y, slide.width, slide.height, store, storeRev]);
+
+	const isEmpty = thumb.rects.length === 0;
+
 	return (
 		<div
 			style={{
@@ -411,18 +467,46 @@ function SlideThumb({ slide, index, active, onClick }: ThumbProps) {
 				<div
 					style={{
 						aspectRatio: "16 / 9",
-						background: `linear-gradient(135deg, ${colorA}, ${colorB})`,
 						position: "relative",
+						background: isEmpty ? `linear-gradient(135deg, ${colorA}, ${colorB})` : "#ffffff",
+						overflow: "hidden",
 					}}
 				>
+					{!isEmpty && (
+						<svg
+							width="100%"
+							height="100%"
+							viewBox={`0 0 ${THUMB_W} ${THUMB_H}`}
+							preserveAspectRatio="xMidYMid meet"
+							aria-hidden="true"
+							style={{ display: "block" }}
+						>
+							<title>{title}</title>
+							{thumb.rects.map((r) => (
+								<rect
+									key={r.id}
+									x={r.x}
+									y={r.y}
+									width={r.width}
+									height={r.height}
+									fill={r.fill}
+									stroke="rgba(0,0,0,0.25)"
+									strokeWidth={0.6}
+									opacity={0.92}
+									rx={1}
+								/>
+							))}
+						</svg>
+					)}
 					<div
 						style={{
 							position: "absolute",
 							left: 6,
 							top: 4,
 							fontSize: 9,
-							color: "rgba(255,255,255,.7)",
+							color: isEmpty ? "rgba(255,255,255,.7)" : "var(--fg-tertiary)",
 							fontFamily: "var(--font-mono, monospace)",
+							mixBlendMode: isEmpty ? "normal" : "multiply",
 						}}
 					>
 						{String(index + 1).padStart(2, "0")}
@@ -443,6 +527,18 @@ function SlideThumb({ slide, index, active, onClick }: ThumbProps) {
 				</div>
 			</button>
 		</div>
+	);
+}
+
+function rectsIntersect(
+	a: { x: number; y: number; width: number; height: number },
+	b: { x: number; y: number; width: number; height: number },
+): boolean {
+	return !(
+		a.x + a.width <= b.x ||
+		b.x + b.width <= a.x ||
+		a.y + a.height <= b.y ||
+		b.y + b.height <= a.y
 	);
 }
 

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -15,6 +15,8 @@ const SIDEBAR_LEFT_MARGIN = 12;
 const STAGE_MAX_WIDTH = 1100;
 const STAGE_PADDING = 30;
 const TOP_BAR_HEIGHT = 64;
+/** Toolbar (bottom: 12, 高さ約 44) + ページャー pill (高さ約 42 + 12 gap) 分の予約 */
+const BOTTOM_RESERVED = 120;
 const SIDEBAR_RESERVED = SIDEBAR_WIDTH + SIDEBAR_LEFT_MARGIN * 2;
 const ASPECT = 9 / 16;
 const SLIDE_USER_COLORS = [
@@ -36,7 +38,7 @@ interface StageRect {
 function computeStageRect(win: { width: number; height: number }): StageRect {
 	const available = {
 		width: Math.max(100, win.width - SIDEBAR_RESERVED - STAGE_PADDING * 2),
-		height: Math.max(100, win.height - TOP_BAR_HEIGHT - STAGE_PADDING * 2 - 80),
+		height: Math.max(100, win.height - TOP_BAR_HEIGHT - STAGE_PADDING - BOTTOM_RESERVED),
 	};
 	let width = Math.min(available.width, STAGE_MAX_WIDTH);
 	let height = width * ASPECT;
@@ -275,13 +277,13 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				</div>
 			</div>
 
-			{/* 下部ナビ pill */}
+			{/* ステージ直下のページネーション pill (Toolbar と重ならないよう stage 下に追従) */}
 			<div
 				style={{
 					position: "absolute",
-					bottom: 30,
-					left: SIDEBAR_RESERVED,
-					right: 0,
+					left: stage.left + stage.width / 2,
+					top: stage.top + stage.height + 12,
+					transform: "translateX(-50%)",
 					display: "flex",
 					justifyContent: "center",
 					pointerEvents: "none",

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -251,12 +251,12 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				</div>
 			</div>
 
-			{/* ステージ直下のページネーション pill (Toolbar と重ならないよう stage 下に追従) */}
+			{/* ページネーション pill: 画面最下部に固定 (stage 下の余白内) */}
 			<div
 				style={{
 					position: "absolute",
-					left: stage.left + stage.width / 2,
-					top: stage.top + stage.height + 12,
+					left: SIDEBAR_RESERVED + (window.innerWidth - SIDEBAR_RESERVED) / 2,
+					bottom: 14,
 					transform: "translateX(-50%)",
 					display: "flex",
 					justifyContent: "center",

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -134,6 +134,24 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				fontFamily: "var(--font-sans, system-ui)",
 			}}
 		>
+			{/* ステージ枠: Canvas を violet のリング + 外側オーラで囲む。
+			    内側は塗らず Canvas を透過。outline + box-shadow のみで構成。 */}
+			<div
+				style={{
+					position: "absolute",
+					left: stage.left,
+					top: stage.top,
+					width: stage.width,
+					height: stage.height,
+					borderRadius: 8,
+					pointerEvents: "none",
+					outline: "2.5px solid var(--brand-violet)",
+					outlineOffset: 2,
+					boxShadow:
+						"0 0 0 6px color-mix(in oklab, var(--brand-violet) 18%, transparent), 0 20px 60px rgba(139,92,246,.35), 0 0 80px rgba(236,72,153,.2)",
+				}}
+			/>
+
 			{/* サイドバー */}
 			<aside
 				className="u-surface"

--- a/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-edit-overlay.tsx
@@ -11,9 +11,11 @@ interface Props {
 }
 
 const SIDEBAR_WIDTH = 220;
+const SIDEBAR_LEFT_MARGIN = 12;
 const STAGE_MAX_WIDTH = 1100;
 const STAGE_PADDING = 30;
 const TOP_BAR_HEIGHT = 64;
+const SIDEBAR_RESERVED = SIDEBAR_WIDTH + SIDEBAR_LEFT_MARGIN * 2;
 const ASPECT = 9 / 16;
 const SLIDE_USER_COLORS = [
 	"var(--u-1)",
@@ -33,7 +35,7 @@ interface StageRect {
 
 function computeStageRect(win: { width: number; height: number }): StageRect {
 	const available = {
-		width: Math.max(100, win.width - SIDEBAR_WIDTH - STAGE_PADDING * 2),
+		width: Math.max(100, win.width - SIDEBAR_RESERVED - STAGE_PADDING * 2),
 		height: Math.max(100, win.height - TOP_BAR_HEIGHT - STAGE_PADDING * 2 - 80),
 	};
 	let width = Math.min(available.width, STAGE_MAX_WIDTH);
@@ -42,7 +44,7 @@ function computeStageRect(win: { width: number; height: number }): StageRect {
 		height = available.height;
 		width = height / ASPECT;
 	}
-	const left = SIDEBAR_WIDTH + STAGE_PADDING + (available.width - width) / 2;
+	const left = SIDEBAR_RESERVED + STAGE_PADDING + (available.width - width) / 2;
 	const top = TOP_BAR_HEIGHT + STAGE_PADDING + (available.height - height) / 2;
 	return { left, top, width, height };
 }
@@ -130,30 +132,7 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				fontFamily: "var(--font-sans, system-ui)",
 			}}
 		>
-			{/* Veil: 上 */}
-			<div style={veilStyle(0, 0, "100%", stage.top)} />
-			{/* Veil: 下 */}
-			<div
-				style={veilStyle(
-					0,
-					stage.top + stage.height,
-					"100%",
-					`calc(100% - ${stage.top + stage.height}px)`,
-				)}
-			/>
-			{/* Veil: 左 (サイドバー含む) */}
-			<div style={veilStyle(0, stage.top, stage.left, stage.height)} />
-			{/* Veil: 右 */}
-			<div
-				style={veilStyle(
-					stage.left + stage.width,
-					stage.top,
-					`calc(100% - ${stage.left + stage.width}px)`,
-					stage.height,
-				)}
-			/>
-
-			{/* ステージ枠の視覚的な影 (透過穴の強調) */}
+			{/* ステージ枠: Canvas がそのまま透けて見える。violet 枠で場所だけ示す。 */}
 			<div
 				style={{
 					position: "absolute",
@@ -162,25 +141,27 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 					width: stage.width + 2,
 					height: stage.height + 2,
 					borderRadius: 8,
-					boxShadow: "0 30px 60px rgba(0,0,0,.6), 0 0 0 1px rgba(255,255,255,.05)",
+					border: "1.5px solid var(--brand-violet)",
+					boxShadow: "0 0 0 4px color-mix(in oklab, var(--brand-violet) 15%, transparent)",
 					pointerEvents: "none",
 				}}
 			/>
 
 			{/* サイドバー */}
 			<aside
+				className="u-surface"
 				style={{
 					position: "absolute",
-					left: 0,
-					top: 0,
-					bottom: 0,
+					left: 12,
+					top: 70,
+					bottom: 80,
 					width: SIDEBAR_WIDTH,
-					background: "var(--bg-canvas-2)",
-					borderRight: "1px solid var(--border-subtle)",
+					borderRadius: 12,
 					display: "flex",
 					flexDirection: "column",
 					pointerEvents: "auto",
 					color: "var(--fg-primary)",
+					overflow: "hidden",
 				}}
 			>
 				<div
@@ -254,7 +235,7 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				style={{
 					position: "absolute",
 					top: 12,
-					left: SIDEBAR_WIDTH,
+					left: SIDEBAR_RESERVED,
 					right: 0,
 					display: "flex",
 					justifyContent: "center",
@@ -299,7 +280,7 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 				style={{
 					position: "absolute",
 					bottom: 30,
-					left: SIDEBAR_WIDTH,
+					left: SIDEBAR_RESERVED,
 					right: 0,
 					display: "flex",
 					justifyContent: "center",
@@ -374,23 +355,6 @@ export function PresentEditOverlay({ nav, store, commands, navigateToBoard }: Pr
 			)}
 		</div>
 	);
-}
-
-function veilStyle(
-	left: number | string,
-	top: number | string,
-	width: number | string,
-	height: number | string,
-): React.CSSProperties {
-	return {
-		position: "absolute",
-		left,
-		top,
-		width,
-		height,
-		background: "#0a0a0b",
-		pointerEvents: "auto",
-	};
 }
 
 function pillBtn(active: boolean): React.CSSProperties {

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import type { SlideNavigator } from "./slide-navigator.js";
 
 interface Props {
@@ -52,11 +53,12 @@ export function PresentModeOverlay({ nav }: Props) {
 	}, []);
 
 	if (total === 0) {
-		return (
+		return createPortal(
 			<div
 				style={{
 					position: "fixed",
 					inset: 0,
+					zIndex: 500,
 					display: "flex",
 					alignItems: "center",
 					justifyContent: "center",
@@ -79,7 +81,8 @@ export function PresentModeOverlay({ nav }: Props) {
 				>
 					スライド（Frame）がありません。編集モードでフレームを追加してください。
 				</div>
-			</div>
+			</div>,
+			document.body,
 		);
 	}
 
@@ -93,11 +96,12 @@ export function PresentModeOverlay({ nav }: Props) {
 		window.dispatchEvent(new PopStateEvent("popstate"));
 	};
 
-	return (
+	return createPortal(
 		<div
 			style={{
 				position: "fixed",
 				inset: 0,
+				zIndex: 500,
 				pointerEvents: "none",
 				opacity: visible ? 1 : 0,
 				transition: "opacity 0.3s",
@@ -243,7 +247,8 @@ export function PresentModeOverlay({ nav }: Props) {
 					終了
 				</button>
 			</div>
-		</div>
+		</div>,
+		document.body,
 	);
 }
 

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -236,24 +236,10 @@ export function PresentModeOverlay({ nav }: Props) {
 						borderRadius: 999,
 						display: "flex",
 						alignItems: "center",
-						gap: 6,
 						fontSize: 12,
 						fontFamily: "inherit",
 					}}
 				>
-					<svg
-						width="12"
-						height="12"
-						viewBox="0 0 16 16"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="1.5"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						aria-hidden="true"
-					>
-						<path d="m3.5 3.5 9 9M12.5 3.5l-9 9" />
-					</svg>
 					終了
 				</button>
 			</div>

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -45,12 +45,24 @@ export function PresentModeOverlay({ nav }: Props) {
 					alignItems: "center",
 					justifyContent: "center",
 					pointerEvents: "none",
-					color: "rgba(255,255,255,0.7)",
+					color: "var(--fg-secondary)",
 					background: "rgba(0,0,0,0.3)",
-					font: "14px system-ui",
+					backdropFilter: "blur(4px)",
+					WebkitBackdropFilter: "blur(4px)",
+					fontFamily: "var(--font-sans, system-ui)",
+					fontSize: 14,
 				}}
 			>
-				スライド（Frame）がありません。編集モードでフレームを追加してください。
+				<div
+					className="u-surface"
+					style={{
+						padding: "16px 24px",
+						borderRadius: 12,
+						background: "var(--bg-surface-raised)",
+					}}
+				>
+					スライド（Frame）がありません。編集モードでフレームを追加してください。
+				</div>
 			</div>
 		);
 	}
@@ -73,8 +85,10 @@ export function PresentModeOverlay({ nav }: Props) {
 				pointerEvents: "none",
 				opacity: visible ? 1 : 0,
 				transition: "opacity 0.3s",
+				fontFamily: "var(--font-sans, system-ui)",
 			}}
 		>
+			{/* 閉じるボタン (右上) */}
 			<button
 				type="button"
 				onClick={exitPresent}
@@ -85,20 +99,38 @@ export function PresentModeOverlay({ nav }: Props) {
 					top: 16,
 					right: 16,
 					appearance: "none",
-					background: "rgba(0,0,0,0.6)",
-					border: "none",
+					background: "rgba(255,255,255,0.1)",
+					backdropFilter: "blur(16px)",
+					WebkitBackdropFilter: "blur(16px)",
+					border: "1px solid rgba(255,255,255,0.1)",
 					color: "white",
 					cursor: "pointer",
 					width: 36,
 					height: 36,
-					borderRadius: "50%",
-					fontSize: 18,
-					lineHeight: 1,
+					borderRadius: 10,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
 					pointerEvents: "auto",
+					padding: 0,
 				}}
 			>
-				✕
+				<svg
+					width="14"
+					height="14"
+					viewBox="0 0 16 16"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<path d="m3.5 3.5 9 9M12.5 3.5l-9 9" />
+				</svg>
 			</button>
+
+			{/* 上部プログレスバー */}
 			<div
 				style={{
 					position: "absolute",
@@ -119,6 +151,7 @@ export function PresentModeOverlay({ nav }: Props) {
 				/>
 			</div>
 
+			{/* 下部ナビ pill */}
 			<div
 				style={{
 					position: "absolute",
@@ -127,52 +160,94 @@ export function PresentModeOverlay({ nav }: Props) {
 					transform: "translateX(-50%)",
 					display: "flex",
 					alignItems: "center",
-					gap: 12,
-					padding: "8px 16px",
-					background: "rgba(0,0,0,0.6)",
-					color: "white",
+					gap: 2,
+					padding: 4,
 					borderRadius: 999,
-					font: "14px system-ui",
+					background: "rgba(20,20,25,0.85)",
+					backdropFilter: "blur(20px)",
+					WebkitBackdropFilter: "blur(20px)",
+					border: "1px solid rgba(255,255,255,0.1)",
 					pointerEvents: "auto",
+					boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
 				}}
 			>
-				<button
-					type="button"
-					onClick={() => nav.prev()}
+				<NavButton
 					disabled={index === 0}
-					style={buttonStyle(index === 0)}
-					aria-label="前のスライド"
+					onClick={() => nav.prev()}
+					ariaLabel="前のスライド"
+					direction="prev"
+				/>
+				<div
+					style={{
+						padding: "0 12px",
+						fontSize: 13,
+						fontFamily: "var(--font-mono)",
+						letterSpacing: 0,
+						minWidth: 60,
+						textAlign: "center",
+					}}
 				>
-					‹
-				</button>
-				<span style={{ minWidth: 48, textAlign: "center" }}>
-					{index + 1} / {total}
-				</span>
-				<button
-					type="button"
-					onClick={() => nav.next()}
+					<span style={{ color: "white", fontWeight: 600 }}>{index + 1}</span>
+					<span style={{ color: "rgba(255,255,255,0.5)" }}> / {total}</span>
+				</div>
+				<NavButton
 					disabled={index >= total - 1}
-					style={buttonStyle(index >= total - 1)}
-					aria-label="次のスライド"
-				>
-					›
-				</button>
+					onClick={() => nav.next()}
+					ariaLabel="次のスライド"
+					direction="next"
+				/>
 			</div>
 		</div>
 	);
 }
 
-function buttonStyle(disabled: boolean): React.CSSProperties {
-	return {
-		appearance: "none",
-		border: "none",
-		background: "transparent",
-		color: "white",
-		cursor: disabled ? "default" : "pointer",
-		opacity: disabled ? 0.3 : 1,
-		fontSize: 20,
-		width: 28,
-		height: 28,
-		borderRadius: 4,
-	};
+function NavButton({
+	disabled,
+	onClick,
+	ariaLabel,
+	direction,
+}: {
+	disabled: boolean;
+	onClick: () => void;
+	ariaLabel: string;
+	direction: "prev" | "next";
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled}
+			aria-label={ariaLabel}
+			style={{
+				appearance: "none",
+				border: "none",
+				background: "transparent",
+				color: "white",
+				cursor: disabled ? "default" : "pointer",
+				opacity: disabled ? 0.3 : 1,
+				width: 34,
+				height: 34,
+				borderRadius: 999,
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: 0,
+				transition: "background var(--dur-fast)",
+			}}
+		>
+			<svg
+				width="14"
+				height="14"
+				viewBox="0 0 16 16"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+				aria-hidden="true"
+			>
+				{direction === "prev" ? <path d="m10 4-4 4 4 4" /> : <path d="m6 4 4 4-4 4" />}
+			</svg>
+		</button>
+	);
 }

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -18,6 +18,22 @@ export function PresentModeOverlay({ nav }: Props) {
 		return unsub;
 	}, [nav]);
 
+	// 発表モードに入った直後は Canvas コンテナサイズが edit → 画面全体に切り替わる
+	// 途中でもあり得る。React のレイアウト確定 (double rAF) を待って先頭スライドに fit する。
+	useEffect(() => {
+		let raf1: number;
+		let raf2 = 0;
+		raf1 = requestAnimationFrame(() => {
+			raf2 = requestAnimationFrame(() => {
+				nav.first();
+			});
+		});
+		return () => {
+			cancelAnimationFrame(raf1);
+			if (raf2) cancelAnimationFrame(raf2);
+		};
+	}, [nav]);
+
 	useEffect(() => {
 		let timer: ReturnType<typeof setTimeout> | null = null;
 		const showAndSchedule = () => {

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -212,6 +212,50 @@ export function PresentModeOverlay({ nav }: Props) {
 					ariaLabel="次のスライド"
 					direction="next"
 				/>
+				<div
+					style={{
+						width: 1,
+						height: 20,
+						background: "rgba(255,255,255,0.15)",
+						margin: "0 4px",
+					}}
+				/>
+				<button
+					type="button"
+					onClick={exitPresent}
+					title="発表を終了 (Esc)"
+					aria-label="発表を終了"
+					style={{
+						appearance: "none",
+						border: "none",
+						background: "transparent",
+						color: "white",
+						cursor: "pointer",
+						height: 34,
+						padding: "0 12px",
+						borderRadius: 999,
+						display: "flex",
+						alignItems: "center",
+						gap: 6,
+						fontSize: 12,
+						fontFamily: "inherit",
+					}}
+				>
+					<svg
+						width="12"
+						height="12"
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="1.5"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						aria-hidden="true"
+					>
+						<path d="m3.5 3.5 9 9M12.5 3.5l-9 9" />
+					</svg>
+					終了
+				</button>
 			</div>
 		</div>
 	);

--- a/plugins/usketch-plugin-shape-board-portal/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-board-portal/src/plugin.tsx
@@ -12,9 +12,9 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 
-const PORTAL_WIDTH = 64;
-const PORTAL_HEIGHT = 80;
-const MIN_PIN_W = 40;
+const PORTAL_WIDTH = 200;
+const PORTAL_HEIGHT = 120;
+const MIN_PORTAL_W = 140;
 
 /**
  * HSL ベースのカラーパレット — 彩度・明度を揃えて統一感を出す
@@ -26,44 +26,15 @@ function pinHue(boardId: string): number {
 	for (let i = 0; i < boardId.length; i++) {
 		hash = (hash * 31 + boardId.charCodeAt(i)) | 0;
 	}
-	return PIN_HUES[Math.abs(hash) % PIN_HUES.length];
-}
-
-/**
- * Google Maps 風ドロップピンの SVG path を生成。
- * cx, cy: 円の中心。r: 円の半径。tipY: 先端の Y 座標。
- */
-function pinPath(cx: number, cy: number, r: number, tipY: number): string {
-	const angle = Math.PI / 5;
-	const sinA = Math.sin(angle);
-	const cosA = Math.cos(angle);
-	const tx = cx + r * sinA;
-	const ty = cy + r * cosA;
-	const lx = cx - r * sinA;
-	const ly = ty;
-	return [`M${cx} ${tipY}`, `L${tx} ${ty}`, `A${r} ${r} 0 1 0 ${lx} ${ly}`, "Z"].join(" ");
+	return PIN_HUES[Math.abs(hash) % PIN_HUES.length] ?? 210;
 }
 
 function renderContent(data: ShapeData) {
 	const title = (data.boardTitle as string) || "Untitled";
 	const isPublic = data.isPublic !== false;
 	const hue = pinHue((data.boardId as string) || data.id);
-	const w = data.width;
-	const h = data.height;
-
-	// すべて比率ベースでレイアウト（サイズ変更で崩れない）
-	const labelH = h * 0.25; // 下25%がラベル（2行分）
-	const pinH = h - labelH;
-
-	const r = w * 0.4; // 円の半径 = 幅の40%
-	const cx = w / 2;
-	const cy = h * 0.02 + r; // 円の中心（上端2% + r）
-	const tipY = pinH - h * 0.01; // 先端
-
-	const uid = `pin-${data.id}`;
-	const lightColor = `hsl(${hue}, 70%, 68%)`;
-	const darkColor = `hsl(${hue}, 60%, 38%)`;
-	const iconColor = `hsl(${hue}, 55%, 45%)`;
+	// themeColor は HSL から生成 — tokens.css の var は SVG/color-mix で使う
+	const accentColor = `hsl(${hue}, 65%, 58%)`;
 
 	return (
 		<div
@@ -74,135 +45,130 @@ function renderContent(data: ShapeData) {
 				pointerEvents: "none",
 				userSelect: "none",
 				overflow: "hidden",
+				borderRadius: 16,
+				// モックの isPortal 背景: themeColor 20% × bg-input のグラデーション
+				background: `linear-gradient(135deg, color-mix(in oklab, ${accentColor} 20%, var(--bg-input)), var(--bg-input))`,
+				border: `1.5px dashed color-mix(in oklab, ${accentColor} 40%, transparent)`,
+				padding: 14,
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				boxSizing: "border-box",
+				fontFamily: "var(--font-sans, system-ui, sans-serif)",
+				boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
 			}}
 		>
-			<svg
-				width={w}
-				height={pinH}
-				viewBox={`0 0 ${w} ${pinH}`}
-				style={{ position: "absolute", top: 0, left: 0 }}
-			>
-				<title>{title}</title>
-				<defs>
-					<linearGradient id={`${uid}-grad`} x1="0" y1="0" x2="0.3" y2="1">
-						<stop offset="0%" stopColor={lightColor} />
-						<stop offset="100%" stopColor={darkColor} />
-					</linearGradient>
-					<radialGradient id={`${uid}-hl`} cx="0.4" cy="0.35" r="0.6">
-						<stop offset="0%" stopColor="rgba(255,255,255,0.35)" />
-						<stop offset="100%" stopColor="rgba(255,255,255,0)" />
-					</radialGradient>
-				</defs>
-
-				{/* 地面の影 */}
-				<ellipse cx={cx} cy={tipY + 1} rx={r * 0.3} ry={2} fill="rgba(0,0,0,0.1)" />
-
-				{/* ピン本体 */}
-				<path d={pinPath(cx, cy, r, tipY)} fill={`url(#${uid}-grad)`} />
-
-				{/* ハイライト */}
-				<circle cx={cx} cy={cy} r={r} fill={`url(#${uid}-hl)`} />
-
-				{/* 白い内円 */}
-				<circle cx={cx} cy={cy} r={r * 0.58} fill="#fff" />
-
-				{/* アイコン: ホワイトボード (Public) / ロック (Private) */}
-				{isPublic ? (
-					<g transform={`translate(${cx - r * 0.32}, ${cy - r * 0.32}) scale(${(r * 0.64) / 24})`}>
-						{/* ボード外枠 */}
-						<rect
-							x="1"
-							y="3"
-							width="22"
-							height="16"
-							rx="2.5"
-							fill="none"
-							stroke={iconColor}
-							strokeWidth="2"
-						/>
-						{/* 付箋1 */}
-						<rect x="4" y="6" width="6" height="5" rx="0.8" fill={`hsl(${hue}, 60%, 75%)`} />
-						{/* 付箋2 */}
-						<rect
-							x="12"
-							y="6"
-							width="8"
-							height="4"
-							rx="0.8"
-							fill={`hsl(${(hue + 40) % 360}, 55%, 72%)`}
-						/>
-						{/* テキスト行 */}
-						<line
-							x1="12"
-							y1="13"
-							x2="20"
-							y2="13"
-							stroke={iconColor}
-							strokeWidth="1.5"
-							strokeLinecap="round"
-						/>
-						<line
-							x1="4"
-							y1="15"
-							x2="10"
-							y2="15"
-							stroke={iconColor}
-							strokeWidth="1.2"
-							strokeLinecap="round"
-							opacity="0.5"
-						/>
-					</g>
-				) : (
-					<g transform={`translate(${cx - r * 0.25}, ${cy - r * 0.32}) scale(${(r * 0.5) / 16})`}>
-						<rect x="2" y="7" width="12" height="9" rx="2" fill={iconColor} />
-						<path
-							d="M5 7V5a3 3 0 016 0v2"
-							fill="none"
-							stroke={iconColor}
-							strokeWidth="2"
-							strokeLinecap="round"
-						/>
-					</g>
-				)}
-
-				{/* キャッチライト */}
-				<circle cx={cx - r * 0.28} cy={cy - r * 0.28} r={r * 0.08} fill="rgba(255,255,255,0.5)" />
-			</svg>
-
-			{/* タイトルラベル — bounds 内下部に配置 */}
-			<div
-				style={{
-					position: "absolute",
-					bottom: 0,
-					left: 0,
-					width: w,
-					height: labelH,
-					display: "flex",
-					alignItems: "center",
-					justifyContent: "center",
-				}}
-			>
-				<span
+			<div>
+				<div
 					style={{
-						fontSize: Math.max(9, Math.min(13, h * 0.11)),
+						display: "flex",
+						alignItems: "center",
+						gap: 7,
+						marginBottom: 6,
+					}}
+				>
+					<div
+						style={{
+							width: 22,
+							height: 22,
+							borderRadius: 6,
+							background: `color-mix(in oklab, ${accentColor} 25%, transparent)`,
+							color: accentColor,
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+						}}
+					>
+						{isPublic ? (
+							<svg
+								width="11"
+								height="11"
+								viewBox="0 0 16 16"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="1.5"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<path d="M7 9a2.5 2.5 0 0 0 3.5 0l2-2a2.5 2.5 0 0 0-3.5-3.5l-1 1" />
+								<path d="M9 7a2.5 2.5 0 0 0-3.5 0l-2 2A2.5 2.5 0 0 0 7 12.5l1-1" />
+							</svg>
+						) : (
+							<svg
+								width="11"
+								height="11"
+								viewBox="0 0 16 16"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="1.5"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+								aria-hidden="true"
+							>
+								<rect x="3.5" y="7" width="9" height="6.5" rx="1" />
+								<path d="M5 7V5a3 3 0 0 1 6 0v2" />
+							</svg>
+						)}
+					</div>
+					<div
+						style={{
+							fontSize: 9.5,
+							fontWeight: 700,
+							color: accentColor,
+							letterSpacing: 1,
+							textTransform: "uppercase",
+						}}
+					>
+						{isPublic ? "Portal" : "Private"}
+					</div>
+				</div>
+				<div
+					style={{
+						fontSize: 14,
 						fontWeight: 600,
-						color: "#334155",
-						fontFamily: "system-ui, sans-serif",
-						background: "rgba(255,255,255,0.88)",
-						padding: "2px 6px",
-						borderRadius: 8,
-						maxWidth: "100%",
+						color: "var(--fg-primary)",
+						letterSpacing: "-0.01em",
 						overflow: "hidden",
 						display: "-webkit-box",
 						WebkitLineClamp: 2,
 						WebkitBoxOrient: "vertical",
-						textAlign: "center",
 						lineHeight: 1.25,
 						wordBreak: "break-word",
 					}}
 				>
 					{title}
-				</span>
+				</div>
+			</div>
+
+			<div
+				style={{
+					display: "inline-flex",
+					alignItems: "center",
+					gap: 5,
+					alignSelf: "flex-start",
+					padding: "4px 10px",
+					borderRadius: 6,
+					background: `color-mix(in oklab, ${accentColor} 25%, transparent)`,
+					color: accentColor,
+					fontSize: 11,
+					fontWeight: 600,
+				}}
+			>
+				開く
+				<svg
+					width="11"
+					height="11"
+					viewBox="0 0 16 16"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="1.5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+				>
+					<path d="M2.5 8h11M10 4.5 13.5 8 10 11.5" />
+				</svg>
 			</div>
 		</div>
 	);
@@ -221,7 +187,7 @@ function hitTest(data: ShapeData, point: Point): boolean {
 	);
 }
 
-const ASPECT = PORTAL_HEIGHT / PORTAL_WIDTH; // 1.25
+const ASPECT = PORTAL_HEIGHT / PORTAL_WIDTH; // 0.6 (横長カード)
 
 function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
 	let { x, y, width, height } = data;
@@ -276,7 +242,7 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 			x = data.x + (data.width - width) / 2;
 			break;
 	}
-	const minW = MIN_PIN_W;
+	const minW = MIN_PORTAL_W;
 	const minH = minW * ASPECT;
 	if (width < minW) {
 		// clamp してから x/y を再計算（アンカー辺がジャンプしないように）
@@ -368,7 +334,7 @@ export function createBoardPortalPlugin(options?: BoardPortalPluginOptions): Usk
 				resize,
 				createDefault,
 				renderTarget: "html",
-				minSize: { width: MIN_PIN_W, height: MIN_PIN_W * ASPECT },
+				minSize: { width: MIN_PORTAL_W, height: MIN_PORTAL_W * ASPECT },
 			});
 
 			// ポータル作成ツール

--- a/plugins/usketch-plugin-shape-board-portal/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-board-portal/src/plugin.tsx
@@ -48,7 +48,7 @@ function renderContent(data: ShapeData) {
 				borderRadius: 16,
 				// モックの isPortal 背景: themeColor 20% × bg-input のグラデーション
 				background: `linear-gradient(135deg, color-mix(in oklab, ${accentColor} 20%, var(--bg-input)), var(--bg-input))`,
-				border: `1.5px dashed color-mix(in oklab, ${accentColor} 40%, transparent)`,
+				border: `1.5px solid color-mix(in oklab, ${accentColor} 40%, transparent)`,
 				padding: 14,
 				display: "flex",
 				flexDirection: "column",

--- a/plugins/usketch-plugin-shape-community-region/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-community-region/src/plugin.tsx
@@ -8,19 +8,31 @@ import {
 } from "@edv4h/usketch-shared";
 
 const CARD_WIDTH = 200;
-const CARD_HEIGHT = 160;
+const CARD_HEIGHT = 180;
 
 export interface CommunityRegionPluginOptions {
 	onRegionClick?: (slug: string) => void;
 }
 
-function renderContent(data: ShapeData) {
+/**
+ * themeColor と背景 (bg-input) を混ぜた soft な tint を生成。
+ * color-mix(in oklab) を使い、非対応ブラウザには CSS のフォールバック値で劣化表示。
+ */
+function softTint(color: string, pct: number): string {
+	return `color-mix(in oklab, ${color} ${pct}%, var(--bg-input))`;
+}
+
+function softBorder(color: string, pct: number): string {
+	return `color-mix(in oklab, ${color} ${pct}%, transparent)`;
+}
+
+function RegionCard({ data }: { data: ShapeData }) {
 	const displayName = (data.displayName as string) || "Region";
 	const themeColor = (data.themeColor as string) || "#6366f1";
 	const icon = (data.icon as string) || "🏠";
 	const onlineCount = (data.onlineCount as number) || 0;
-	const w = data.width;
-	const h = data.height;
+	const memberCount = (data.memberCount as number) ?? onlineCount;
+	const isActive = Boolean(data.active);
 
 	return (
 		<div
@@ -31,47 +43,66 @@ function renderContent(data: ShapeData) {
 				pointerEvents: "auto",
 				userSelect: "none",
 				cursor: "pointer",
+				borderRadius: 16,
+				background: softTint(themeColor, 16),
+				border: `1.5px solid ${softBorder(themeColor, 40)}`,
+				padding: 16,
+				overflow: "hidden",
+				transition: "box-shadow 200ms, transform 200ms",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				boxSizing: "border-box",
 			}}
 		>
+			{/* 大きな薄いグリフ（右上背面） */}
 			<div
+				aria-hidden="true"
 				style={{
-					width: "100%",
-					height: "100%",
-					borderRadius: 16,
-					background: `linear-gradient(135deg, ${themeColor}, ${themeColor}dd)`,
-					boxShadow: "0 4px 16px rgba(0,0,0,0.15)",
-					display: "flex",
-					flexDirection: "column",
-					alignItems: "center",
-					justifyContent: "center",
-					gap: h * 0.04,
-					overflow: "hidden",
-					transition: "box-shadow 0.2s, transform 0.2s",
+					position: "absolute",
+					top: -8,
+					right: -8,
+					fontSize: 96,
+					opacity: 0.12,
+					color: themeColor,
+					pointerEvents: "none",
+					lineHeight: 1,
+					filter: `drop-shadow(0 4px 12px ${softBorder(themeColor, 30)})`,
 				}}
 			>
-				{/* Icon */}
-				<div
-					style={{
-						fontSize: Math.max(24, Math.min(48, w * 0.22)),
-						lineHeight: 1,
-						filter: "drop-shadow(0 2px 4px rgba(0,0,0,0.2))",
-					}}
-				>
-					{icon}
-				</div>
+				{icon}
+			</div>
 
-				{/* Region name */}
+			<div style={{ position: "relative", zIndex: 1 }}>
+				<div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+					<div
+						style={{
+							width: 8,
+							height: 8,
+							borderRadius: 99,
+							background: themeColor,
+							boxShadow: `0 0 8px ${themeColor}`,
+						}}
+					/>
+					{isActive && (
+						<div
+							style={{
+								fontSize: 9,
+								fontWeight: 700,
+								color: themeColor,
+								letterSpacing: 0.5,
+							}}
+						>
+							LIVE
+						</div>
+					)}
+				</div>
 				<div
 					style={{
-						color: "#fff",
-						fontSize: Math.max(12, Math.min(20, w * 0.09)),
-						fontWeight: 700,
-						fontFamily: "system-ui, sans-serif",
-						textAlign: "center",
-						textShadow: "0 1px 3px rgba(0,0,0,0.3)",
-						padding: "0 8px",
-						lineHeight: 1.2,
-						maxWidth: "100%",
+						fontSize: 18,
+						fontWeight: 600,
+						color: "var(--fg-primary)",
+						letterSpacing: "-0.01em",
 						overflow: "hidden",
 						textOverflow: "ellipsis",
 						whiteSpace: "nowrap",
@@ -79,35 +110,58 @@ function renderContent(data: ShapeData) {
 				>
 					{displayName}
 				</div>
-
-				{/* Online count badge */}
-				{onlineCount > 0 && (
+				{memberCount > 0 && (
 					<div
 						style={{
-							background: "rgba(255,255,255,0.25)",
-							color: "#fff",
-							fontSize: Math.max(10, Math.min(13, w * 0.06)),
-							fontWeight: 600,
-							fontFamily: "system-ui, sans-serif",
-							padding: "2px 10px",
-							borderRadius: 12,
-							display: "flex",
-							alignItems: "center",
-							gap: 4,
+							fontSize: 11.5,
+							color: "var(--fg-tertiary)",
+							marginTop: 2,
+							fontFamily: "var(--font-mono)",
 						}}
 					>
-						<span
-							style={{
-								width: 6,
-								height: 6,
-								borderRadius: "50%",
-								background: "#4ade80",
-								display: "inline-block",
-							}}
-						/>
-						{onlineCount}
+						{memberCount} members
 					</div>
 				)}
+			</div>
+
+			<div
+				style={{
+					position: "relative",
+					zIndex: 1,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+				}}
+			>
+				<div style={{ display: "flex" }}>
+					{memberCount > 0
+						? Array.from({
+								length: Math.min(4, Math.max(1, Math.ceil(memberCount / 40))),
+							}).map((_, i) => (
+								<div
+									// biome-ignore lint/suspicious/noArrayIndexKey: decorative avatars don't reorder
+									key={i}
+									aria-hidden="true"
+									style={{
+										width: 18,
+										height: 18,
+										borderRadius: 99,
+										background: `var(--u-${(i % 6) + 1})`,
+										border: "2px solid var(--bg-input)",
+										marginLeft: i ? -5 : 0,
+									}}
+								/>
+							))
+						: null}
+				</div>
+				<div
+					style={{
+						fontSize: 10,
+						color: "var(--fg-tertiary)",
+					}}
+				>
+					参加 →
+				</div>
 			</div>
 		</div>
 	);
@@ -134,7 +188,7 @@ export function createCommunityRegionPlugin(options?: CommunityRegionPluginOptio
 					style: { fill: "transparent", stroke: "transparent", strokeWidth: 0, opacity: 1 },
 				}),
 
-				render: (data) => renderContent(data),
+				render: (data) => <RegionCard data={data} />,
 
 				getBounds: (data): BoundingBox => ({
 					x: data.x,
@@ -172,7 +226,7 @@ export function createCommunityRegionPlugin(options?: CommunityRegionPluginOptio
 
 					// 新しく選択されたシェイプがあるかチェック
 					const [shapeId] = selection;
-					if (prevSelection.has(shapeId)) {
+					if (!shapeId || prevSelection.has(shapeId)) {
 						prevSelection = new Set(selection);
 						return;
 					}

--- a/plugins/usketch-plugin-spatial-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-spatial-chat/src/plugin.tsx
@@ -14,7 +14,8 @@ const INPUT_ID = "chat-input-active";
 function ChatBubble({ obj }: { obj: TransientObject }) {
 	const text = (obj.data.text as string) || "";
 	const name = (obj.data.name as string) || "";
-	const color = (obj.data.color as string) || "#333";
+	const color = (obj.data.color as string) || "var(--brand-violet)";
+	const initial = name ? name.charAt(0).toUpperCase() : "?";
 
 	return (
 		<div
@@ -27,25 +28,66 @@ function ChatBubble({ obj }: { obj: TransientObject }) {
 			}}
 		>
 			<div
+				className="u-surface u-anim-in"
 				style={{
-					background: "#fff",
-					border: `2px solid ${color}`,
-					borderRadius: 12,
-					padding: "6px 10px",
-					fontSize: 13,
-					fontFamily: "system-ui, sans-serif",
-					color: "#333",
-					maxWidth: 200,
-					wordBreak: "break-word",
-					boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
-					whiteSpace: "pre-wrap",
+					padding: "8px 12px",
+					borderRadius: 14,
+					width: "max-content",
+					maxWidth: 240,
+					background: "var(--bg-surface-raised)",
+					borderLeft: `3px solid ${color}`,
+					color: "var(--fg-primary)",
+					fontFamily: "var(--font-sans, system-ui, sans-serif)",
 				}}
 			>
-				{text}
+				{name && (
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 6,
+							marginBottom: 3,
+						}}
+					>
+						<div
+							style={{
+								width: 14,
+								height: 14,
+								borderRadius: 99,
+								background: color,
+								color: "white",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								fontSize: 8,
+								fontWeight: 700,
+							}}
+						>
+							{initial}
+						</div>
+						<div
+							style={{
+								fontSize: 10.5,
+								fontWeight: 500,
+								color: "var(--fg-secondary)",
+							}}
+						>
+							{name}
+						</div>
+					</div>
+				)}
+				<div
+					style={{
+						fontSize: 12.5,
+						lineHeight: 1.4,
+						overflowWrap: "break-word",
+						wordBreak: "break-word",
+						whiteSpace: "pre-wrap",
+					}}
+				>
+					{text}
+				</div>
 			</div>
-			{name && (
-				<div style={{ fontSize: 10, color: "#999", textAlign: "center", marginTop: 2 }}>{name}</div>
-			)}
 		</div>
 	);
 }
@@ -118,18 +160,18 @@ function ChatInput({
 			}}
 		>
 			<div
+				className="u-surface"
 				style={{
-					background: "#fff",
+					background: "var(--bg-surface-raised)",
 					borderRadius: 10,
 					padding: "6px 10px",
-					border: "1px solid #ddd",
-					minWidth: 180,
+					minWidth: 200,
 				}}
 			>
 				<input
 					ref={inputRef}
 					type="text"
-					placeholder="Type and Enter..."
+					placeholder="入力して Enter…"
 					maxLength={200}
 					style={{
 						width: "100%",
@@ -137,7 +179,8 @@ function ChatInput({
 						fontSize: 13,
 						border: "none",
 						outline: "none",
-						fontFamily: "system-ui, sans-serif",
+						fontFamily: "var(--font-sans, system-ui, sans-serif)",
+						color: "var(--fg-primary)",
 						boxSizing: "border-box",
 						background: "transparent",
 					}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1031,6 +1031,12 @@ importers:
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      react-dom:
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -3187,7 +3193,7 @@ packages:
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
   '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==, tarball: https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz}
     peerDependencies:
       '@types/react': ^19.2.0
 
@@ -4844,7 +4850,7 @@ packages:
       react: ^19.1.0
 
   react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==, tarball: https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz}
     peerDependencies:
       react: ^19.2.4
 
@@ -4995,7 +5001,7 @@ packages:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
   scheduler@0.27.0:
-    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}


### PR DESCRIPTION
## Summary

PR #563 (Phase A-F) のフォローアップ。プレゼンテーションモードを Canvas flavor として再設計し、コミュニティ系 shape の見た目をモックに寄せる。

- **プレゼンテーション機能の再設計**: 編集モード で Canvas 全体を stage 矩形に縮退、外側に発表編集 UI を配置する flavor 構造へ。発表中は Canvas readonly。
- **コミュニティ shape リデザイン**: CommunityRegion / BoardPortal / SpatialChat / CommunityChat Pin のカードデザインをモック準拠に。

## 変更の柱

### プレゼンテーション (新 flavor 構造)

- `?present=1` の編集モードで、エディタ全体 (Canvas + Toolbar + BoardIdentity 等) を画面中央の stage 矩形に縮退させ、外側に発表編集 UI (サイドバー + 上部 pill + ページャー) を portal で重ねる構造に
- `SlideNavigator.fitToBounds` が stage サイズ基準で動くよう `PresentationPluginOptions.getViewportSize` を追加
- スライドサムネを **`computeMinimap`** で frame 内の shape から実際にレンダリング (空スライドは白のまま)
- 発表モード中は Canvas 前面に portal ガード層を被せて shape 選択・ドラッグ・ショートカットを全て無効化 (readonly)
- 発表ナビの下部ページャーに「終了」ボタンを統合、編集モード側のページャーとデザインを揃える
- プレゼン編集中は無関係な UI (共有/Presence/Export/Zoom/Community/Copilot 等) を自動的に隠す

### コミュニティ shape

- `usketch-plugin-shape-community-region`: タイルデザインをモック Territory 風に刷新
- `usketch-plugin-shape-board-portal`: ピン型からタイルカードへ、outline を solid に
- `usketch-plugin-spatial-chat`: ChatBubble をモック準拠の glass card + アバターへ
- `usketch-plugin-community-chat`: ChatWidget を ChatThreadPin 風 pill へ刷新、最終メッセージ/時刻/未読数を表示、SVG tail を復活

### apps/web 側

- `PresencePill`: 右上に Cloud ボードの presence (同期中 + avatars) を表示
- `CopilotPill`: Toolbar 上に浮かぶ AI 提案 pill を新設、ai-copilot plugin から `copilot:notice` を発火
- `BoardIdentity`: API が返す `title` フィールドを読むよう修正
- プレゼンテーション plugin を cloud/local 共通でロード

## Test plan

- [x] `pnpm typecheck` 全パッケージ pass
- [x] プレゼン編集モード → 発表モード → 終了の往復が動作
- [x] 発表中 readonly (shape 操作・ショートカット不能) + 発表ナビのみ操作可能
- [x] スライド追加・サムネ縮小レンダリングが動作
- [x] コミュニティ shape (Region / Portal / SpatialChat / CommunityChat) の見た目を目視確認
- [ ] Cloud ボードでの PresencePill / CopilotPill 動作 (要手動確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)