### PR TITLE
✨ feat: Changesets リリース CI 追加 + 62 パッケージ publishable 化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+env:
+  TURBO_TELEMETRY_DISABLED: 1
+  TURBO_NO_DAEMON: 1
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release PR or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm version
+          publish: pnpm release
+          title: "🎉 release: Version Packages"
+          commit: "🎉 release: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
 		"format:check": "biome check .",
 		"typecheck": "turbo run typecheck",
 		"clean": "turbo run clean",
+		"changeset": "changeset",
+		"version": "changeset version",
+		"release": "pnpm build && changeset publish",
 		"prepare": "prek install"
 	},
 	"devDependencies": {

--- a/packages/canvas-engine/package.json
+++ b/packages/canvas-engine/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-canvas-engine",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -31,5 +30,22 @@
 		"@types/react-dom": "19.2.3",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/canvas-engine"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-core",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -24,5 +23,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/core"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/dom-renderer/package.json
+++ b/packages/dom-renderer/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-dom-renderer",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react-dom": "19.2.3",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/dom-renderer"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/gpu-renderer/package.json
+++ b/packages/gpu-renderer/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-gpu-renderer",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -31,5 +30,22 @@
 		"@webgpu/types": "0.1.69",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/gpu-renderer"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/server-core/package.json
+++ b/packages/server-core/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-server-core",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"drizzle-orm": "0.45.1",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/server-core"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-shared",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 	"dependencies": {
 		"fractional-indexing": "3.2.0",
 		"xid-ts": "1.2.2"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/shared"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-store",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -25,5 +24,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/store"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-sync",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -25,5 +24,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/sync"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-ui",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -25,5 +24,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "packages/ui"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-activity-feed/package.json
+++ b/plugins/usketch-plugin-activity-feed/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-activity-feed",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-activity-feed"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-ai-actions/package.json
+++ b/plugins/usketch-plugin-ai-actions/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-ai-actions",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-ai-actions"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-ai-agent/package.json
+++ b/plugins/usketch-plugin-ai-agent/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-ai-agent",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -24,5 +23,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-ai-agent"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-ai-chat/package.json
+++ b/plugins/usketch-plugin-ai-chat/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-ai-chat",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-ai-chat"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-ai-copilot/package.json
+++ b/plugins/usketch-plugin-ai-copilot/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-ai-copilot",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-ai-copilot"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-ai-image/package.json
+++ b/plugins/usketch-plugin-ai-image/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-ai-image",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -25,5 +24,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-ai-image"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-ai-recognize/package.json
+++ b/plugins/usketch-plugin-ai-recognize/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-ai-recognize",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -25,5 +24,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-ai-recognize"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-ai-voice/package.json
+++ b/plugins/usketch-plugin-ai-voice/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-ai-voice",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -25,5 +24,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-ai-voice"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-avatar/package.json
+++ b/plugins/usketch-plugin-avatar/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-avatar",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-avatar"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-bg-dots/package.json
+++ b/plugins/usketch-plugin-bg-dots/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-bg-dots",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-bg-dots"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-bg-grid/package.json
+++ b/plugins/usketch-plugin-bg-grid/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-bg-grid",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-bg-grid"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-board-info-panel/package.json
+++ b/plugins/usketch-plugin-board-info-panel/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-board-info-panel",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-board-info-panel"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-canvas-filter/package.json
+++ b/plugins/usketch-plugin-canvas-filter/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-canvas-filter",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-canvas-filter"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-comments/package.json
+++ b/plugins/usketch-plugin-comments/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-comments",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-comments"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-community-chat/package.json
+++ b/plugins/usketch-plugin-community-chat/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-community-chat",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-community-chat"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-debug-hud/package.json
+++ b/plugins/usketch-plugin-debug-hud/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-debug-hud",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-debug-hud"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-effect-ripple/package.json
+++ b/plugins/usketch-plugin-effect-ripple/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-effect-ripple",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-effect-ripple"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-export/package.json
+++ b/plugins/usketch-plugin-export/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-export",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -31,5 +30,22 @@
 		"@types/react-dom": "19.2.3",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-export"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-follow-me/package.json
+++ b/plugins/usketch-plugin-follow-me/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-follow-me",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-follow-me"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-keyboard-shortcuts/package.json
+++ b/plugins/usketch-plugin-keyboard-shortcuts/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-keyboard-shortcuts",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-keyboard-shortcuts"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-laser/package.json
+++ b/plugins/usketch-plugin-laser/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-laser",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-laser"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-presence-cursor/package.json
+++ b/plugins/usketch-plugin-presence-cursor/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-presence-cursor",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-presence-cursor"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-presence-enhanced/package.json
+++ b/plugins/usketch-plugin-presence-enhanced/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-presence-enhanced",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-presence-enhanced"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-presentation/package.json
+++ b/plugins/usketch-plugin-presentation/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-presentation",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -32,5 +31,22 @@
 		"react-dom": "19.2.4",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-presentation"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-reactions/package.json
+++ b/plugins/usketch-plugin-reactions/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-reactions",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-reactions"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-server-ai/package.json
+++ b/plugins/usketch-plugin-server-ai/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-server-ai",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@cloudflare/workers-types": "4.20260317.1",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-server-ai"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-server-auth/package.json
+++ b/plugins/usketch-plugin-server-auth/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-server-auth",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -25,5 +24,22 @@
 		"@cloudflare/workers-types": "4.20260317.1",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-server-auth"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-server-boards/package.json
+++ b/plugins/usketch-plugin-server-boards/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-server-boards",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@cloudflare/workers-types": "4.20260317.1",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-server-boards"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-server-chat/package.json
+++ b/plugins/usketch-plugin-server-chat/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-server-chat",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@cloudflare/workers-types": "4.20260317.1",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-server-chat"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-server-comments/package.json
+++ b/plugins/usketch-plugin-server-comments/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-server-comments",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@cloudflare/workers-types": "4.20260317.1",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-server-comments"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-basic/package.json
+++ b/plugins/usketch-plugin-shape-basic/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-basic",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-basic"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-board-portal/package.json
+++ b/plugins/usketch-plugin-shape-board-portal/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-board-portal",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-board-portal"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-community-region/package.json
+++ b/plugins/usketch-plugin-shape-community-region/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-community-region",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-community-region"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-connector/package.json
+++ b/plugins/usketch-plugin-shape-connector/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-connector",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -31,5 +30,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-connector"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-counter/package.json
+++ b/plugins/usketch-plugin-shape-counter/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-counter",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-counter"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-frame/package.json
+++ b/plugins/usketch-plugin-shape-frame/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-frame",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-frame"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-freedraw/package.json
+++ b/plugins/usketch-plugin-shape-freedraw/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-freedraw",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-freedraw"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-group/package.json
+++ b/plugins/usketch-plugin-shape-group/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-group",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-group"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-image/package.json
+++ b/plugins/usketch-plugin-shape-image/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-image",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-image"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-island/package.json
+++ b/plugins/usketch-plugin-shape-island/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-island",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-island"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-sticky/package.json
+++ b/plugins/usketch-plugin-shape-sticky/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-sticky",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -32,5 +31,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-sticky"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-text/package.json
+++ b/plugins/usketch-plugin-shape-text/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-text",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -32,5 +31,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-text"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-shape-wireframe/package.json
+++ b/plugins/usketch-plugin-shape-wireframe/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-shape-wireframe",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-wireframe"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-side-panel/package.json
+++ b/plugins/usketch-plugin-side-panel/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-side-panel",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -28,5 +27,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-side-panel"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-snap/package.json
+++ b/plugins/usketch-plugin-snap/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-snap",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-snap"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-spatial-chat/package.json
+++ b/plugins/usketch-plugin-spatial-chat/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-spatial-chat",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-spatial-chat"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-spotlight/package.json
+++ b/plugins/usketch-plugin-spotlight/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-spotlight",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-spotlight"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-sync-localstorage-yjs/package.json
+++ b/plugins/usketch-plugin-sync-localstorage-yjs/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-sync-localstorage-yjs",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -27,5 +26,22 @@
 		"fake-indexeddb": "^6.0.0",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-sync-localstorage-yjs"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-tool-pan/package.json
+++ b/plugins/usketch-plugin-tool-pan/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-tool-pan",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-tool-pan"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-tool-select/package.json
+++ b/plugins/usketch-plugin-tool-select/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-tool-select",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -30,5 +29,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-tool-select"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-viewport-nav/package.json
+++ b/plugins/usketch-plugin-viewport-nav/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-viewport-nav",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -26,5 +25,22 @@
 	"devDependencies": {
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-viewport-nav"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-voting/package.json
+++ b/plugins/usketch-plugin-voting/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-voting",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-voting"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }

--- a/plugins/usketch-plugin-whistle/package.json
+++ b/plugins/usketch-plugin-whistle/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@edv4h/usketch-plugin-whistle",
 	"version": "1.0.0",
-	"private": true,
 	"type": "module",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",
@@ -29,5 +28,22 @@
 		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-whistle"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
 	}
 }


### PR DESCRIPTION
## Summary

uSketch v1.0.0 リリース完了を受けて、今後の patch / minor / major リリースを自動化するための Changesets 駆動の Release CI を導入する。

### この PR で入るもの

1. **62 パッケージを publishable 化** (0d058432)
   - `packages/*` (9) + `plugins/*` (52) + `apps/mcp-server` 相当分の private を解除
   - `publishConfig: { access: "public" }` / `files: ["dist", "README.md"]` / `repository` / `homepage` / `bugs` 追加
   - apps/\* (web / server / docs / mcp-server) は内部アプリのため private 維持

2. **`.github/workflows/release.yml` 新規作成** (84397f73)
   - main push トリガー
   - `changesets/action@v1` を使用:
     - 未消化 changeset があれば "Version Packages" PR を自動作成（バージョン bump + CHANGELOG 反映）
     - Version PR が merge されると `pnpm release` (= `pnpm build && changeset publish`) が走り、npm 公開 + GitHub Release tag 自動発行
   - 必要な permission: `contents: write` / `pull-requests: write` / `id-token: write`

3. **ルート package.json に release scripts 追加**
   - `pnpm changeset`: 新規 changeset を対話形式で作成
   - `pnpm version`: `changeset version` を実行
   - `pnpm release`: `pnpm build && changeset publish`

## ⚠️ Merge 前に必要な手動作業

**GitHub repo → Settings → Secrets and variables → Actions で `NPM_TOKEN` を登録**してください:

1. [npm.com](https://www.npmjs.com) で Automation token を作成（Classic token, type=Automation）
2. `@edv4h` org への publish 権限がある token を使う
3. GitHub Secrets の `NPM_TOKEN` に設定

Secret がない状態で main に merge しても Version PR 作成機能は動きますが、publish ステップで失敗します。

## 運用フロー（merge 後）

```
feature-branch で作業 → pnpm changeset → commit → PR merge
  ↓
main に changeset file が溜まる
  ↓
changesets/action が「Version Packages」PR を自動作成
  ↓
その PR をレビュー（CHANGELOG の内容確認）して merge
  ↓
npm publish + GitHub Release tag が自動発行
```

## Test plan

- [x] `pnpm exec turbo run typecheck` → 126 tasks successful
- [x] `pnpm exec turbo run build` → 66 tasks successful
- [x] `pnpm lint` → exit 0
- [ ] 本 PR のメタデータは Release workflow に影響しない（main に merge されるまで workflow は動かない設定）
- [ ] merge 後、NPM_TOKEN 設定 → 最初の changeset を作って Version PR が生成されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)