### PR TITLE
🐛 fix: release workflow で npm 認証が効かず publish が 404 で失敗する問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,19 @@ jobs:
           node-version: "22"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+          scope: "@edv4h"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Configure npm auth
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          echo "@edv4h:registry=https://registry.npmjs.org/" >> ~/.npmrc
+          echo "always-auth=true" >> ~/.npmrc
+          npm whoami
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Release PR or Publish to npm
         id: changesets
@@ -47,4 +57,5 @@ jobs:
           commit: "🎉 release: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

PR #566 で入れた release workflow が、本日初動時に **全 62 パッケージで E404 Not Found** を起こして publish に失敗した問題の修正。

## 症状

```
E404 Not Found - PUT https://registry.npmjs.org/@edv4h%2fusketch-server-core - Not found
'@edv4h/usketch-server-core@1.0.0' is not in this registry.
```

`@edv4h` org は存在・owner 権限あり・token は @edv4h scope への read/write + 2FA bypass 付き Automation Classic Token。にも関わらず 404。

## 原因

`setup-node@v5` は `registry-url` を指定しても、**環境変数 `NODE_AUTH_TOKEN` を読みに行く**仕様。
現行 workflow は `NPM_TOKEN` しか env に渡していないので、`pnpm publish` が無認証で走り、404（private/未存在扱い）になっていた。

## 修正

- 明示的に `~/.npmrc` を書く「Configure npm auth」step を追加
- `NODE_AUTH_TOKEN` と `NPM_TOKEN` の両方を env に流す
- デバッグ用に `npm whoami` を実行（成功すれば npm user 名がログに出る）
- `setup-node` に `scope: "@edv4h"` を明示

## Test plan

- [ ] CI (lint / typecheck / test / build / e2e) が PR で green
- [ ] Merge 後、main の Release workflow で `npm whoami` が正しくユーザー名を返す
- [ ] 62 パッケージが npmjs.com に publish される

🤖 Generated with [Claude Code](https://claude.com/claude-code)