### PR TITLE
🐛 fix(release): pnpm version → pnpm run version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm version
+          version: pnpm run version
           publish: pnpm release
           title: "🎉 release: Version Packages"
           commit: "🎉 release: version packages"


### PR DESCRIPTION
## Summary

release workflow が PR #568 の merge 後に `GitHub Actions is not permitted to create or approve pull requests` で落ちていた問題を修正。

### 根本原因

`.github/workflows/release.yml` の `version: pnpm version` は、pnpm 組み込みの `pnpm version` コマンド（node/npm のバージョン情報を表示するだけ）を実行してしまい、`package.json` の `scripts.version`（= `changeset version`）が呼ばれない。

結果として changeset action は「diff 0 の空コミットで PR を作ろうとする」フローに入り、`GITHUB_TOKEN` 権限不足で失敗していた。

### 修正

`pnpm run version` と明示することで、必ず package.json の scripts を呼ぶようにした。

### v1.0.0 時に動いていた理由

v1.0.0 時は changeset が先に適用されていたため、release workflow は version 側を skip して publish パスに入っており、この不具合は顕在化しなかった。

## Test plan

- [ ] CI 通過
- [ ] main merge 後、release workflow が Version PR を正しく作成すること（shape-utils@1.0.0 + shape-basic@1.1.0）
- [ ] Version PR merge で npm publish が走ること

## 補足: repo 設定の変更が別途必要な可能性

Version PR 作成には GitHub Actions の PR 作成権限が必要。Settings → Actions → General → Workflow permissions で **\"Allow GitHub Actions to create and approve pull requests\"** を有効にする必要あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)