### PR TITLE
🐛 fix(docs): PR #571 の Copilot フォローアップ指摘 4 件を修正

### DIFF
--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -49,20 +49,6 @@ const navItems = [
 				<button type="button" data-jp-mode-set="both" aria-pressed={initialJpMode === "both"}>A/あ</button>
 				<button type="button" data-jp-mode-set="jp" aria-pressed={initialJpMode === "jp"}>JP</button>
 			</div>
-			<script is:inline>
-				// Re-sync aria-pressed with the actual data-jp-mode, which BaseLayout's
-				// FOUC guard may have overridden from localStorage (e.g. "both").
-				(function () {
-					const mode = document.documentElement.dataset.jpMode ?? "en";
-					const buttons = document.querySelectorAll(".site-header__lang [data-jp-mode-set]");
-					for (const b of buttons) {
-						b.setAttribute(
-							"aria-pressed",
-							b.getAttribute("data-jp-mode-set") === mode ? "true" : "false",
-						);
-					}
-				})();
-			</script>
 
 			<button type="button" class="site-header__search" data-open-palette aria-label="Open command palette">
 				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -10,8 +10,13 @@ const { current, lang = "en" } = Astro.props;
 type JpMode = "en" | "jp" | "both";
 const initialJpMode = (lang === "ja" ? "jp" : "en") as JpMode;
 
+const docsIntro =
+	lang === "ja"
+		? "/docs/ja/getting-started/introduction/"
+		: "/docs/getting-started/introduction/";
+
 const navItems = [
-	{ id: "docs", label: "Docs", jpLabel: "ドキュメント", path: "/docs/getting-started/introduction/" },
+	{ id: "docs", label: "Docs", jpLabel: "ドキュメント", path: docsIntro },
 	{ id: "plugins", label: "Plugins", jpLabel: "プラグイン", path: "/plugins/" },
 	{ id: "examples", label: "Examples", jpLabel: "サンプル", path: "/examples/" },
 	{ id: "api", label: "API", jpLabel: "API", path: "/api/" },
@@ -44,6 +49,20 @@ const navItems = [
 				<button type="button" data-jp-mode-set="both" aria-pressed={initialJpMode === "both"}>A/あ</button>
 				<button type="button" data-jp-mode-set="jp" aria-pressed={initialJpMode === "jp"}>JP</button>
 			</div>
+			<script is:inline>
+				// Re-sync aria-pressed with the actual data-jp-mode, which BaseLayout's
+				// FOUC guard may have overridden from localStorage (e.g. "both").
+				(function () {
+					const mode = document.documentElement.dataset.jpMode ?? "en";
+					const buttons = document.querySelectorAll(".site-header__lang [data-jp-mode-set]");
+					for (const b of buttons) {
+						b.setAttribute(
+							"aria-pressed",
+							b.getAttribute("data-jp-mode-set") === mode ? "true" : "false",
+						);
+					}
+				})();
+			</script>
 
 			<button type="button" class="site-header__search" data-open-palette aria-label="Open command palette">
 				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/apps/docs/src/components/plugins/catalog-grid.tsx
+++ b/apps/docs/src/components/plugins/catalog-grid.tsx
@@ -1,5 +1,5 @@
 import MiniSearch from "minisearch";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 export interface Plugin {
 	id: string;
@@ -26,6 +26,15 @@ interface Props {
 export default function CatalogGrid({ plugins, categories, basePath }: Props) {
 	const [query, setQuery] = useState("");
 	const [active, setActive] = useState<Set<string>>(new Set());
+
+	// Initialize category filter from the URL query (e.g. /plugins/?cat=ai&cat=tool).
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		const params = new URLSearchParams(window.location.search);
+		const validIds = new Set(categories.map((c) => c.id));
+		const fromUrl = params.getAll("cat").filter((c) => validIds.has(c));
+		if (fromUrl.length > 0) setActive(new Set(fromUrl));
+	}, [categories]);
 
 	const search = useMemo(() => {
 		const mini = new MiniSearch<Plugin>({

--- a/apps/docs/src/layouts/BaseLayout.astro
+++ b/apps/docs/src/layouts/BaseLayout.astro
@@ -23,7 +23,14 @@ interface Props {
 const { title, description, current, lang = "en" } = Astro.props;
 const fullTitle = current === "home" ? title : `${title} — uSketch`;
 
-const [docs, plugins] = await Promise.all([getCollection("docs"), getCollection("plugins")]);
+const [docsEn, docsJa, plugins] = await Promise.all([
+	getCollection("docs"),
+	getCollection("docsJa"),
+	getCollection("plugins"),
+]);
+
+const docs = lang === "ja" ? docsJa : docsEn;
+const docsPrefix = lang === "ja" ? "/docs/ja/" : "/docs/";
 
 const paletteItems = [
 	...docs
@@ -32,7 +39,7 @@ const paletteItems = [
 			id: `doc-${d.id}`,
 			title: d.data.title,
 			group: "Docs" as const,
-			href: href(`/docs/${d.id}/`),
+			href: href(`${docsPrefix}${d.id}/`),
 			hint: d.data.description,
 		})),
 	...plugins.map((p) => ({

--- a/apps/docs/src/layouts/BaseLayout.astro
+++ b/apps/docs/src/layouts/BaseLayout.astro
@@ -23,14 +23,13 @@ interface Props {
 const { title, description, current, lang = "en" } = Astro.props;
 const fullTitle = current === "home" ? title : `${title} — uSketch`;
 
-const [docsEn, docsJa, plugins] = await Promise.all([
-	getCollection("docs"),
-	getCollection("docsJa"),
+const docsCollection = lang === "ja" ? "docsJa" : "docs";
+const docsPrefix = lang === "ja" ? "/docs/ja/" : "/docs/";
+
+const [docs, plugins] = await Promise.all([
+	getCollection(docsCollection),
 	getCollection("plugins"),
 ]);
-
-const docs = lang === "ja" ? docsJa : docsEn;
-const docsPrefix = lang === "ja" ? "/docs/ja/" : "/docs/";
 
 const paletteItems = [
 	...docs


### PR DESCRIPTION
## Summary

[PR #571](https://github.com/EdV4H/usketch/pull/571) マージ後に Copilot が提出した追加レビュー 4 件に対応するフォローアップ PR。

### 対応内容

| 指摘 | 対応 |
|------|------|
| **BaseLayout**: CommandPalette が JP ページでも `docs` collection のみ参照、`/docs/...` にしか飛ばない | `lang` で `docsJa` を引き、Palette href を `/docs/ja/...` に切替 |
| **Header**: JP ページでも nav の Docs リンクが `/docs/getting-started/introduction/` 固定 | `lang` から docs intro URL を組み立て |
| **Header aria-pressed**: FOUC で localStorage から "both" 等に切り替わった場合、初期 paint で aria-pressed と実モードがズレる | `is:inline` スクリプトで `data-jp-mode` から即同期 |
| **CatalogGrid**: `/plugins/?cat=ai` のような deep link が機能しない（クエリを読んでいない） | `useEffect` で `URLSearchParams.getAll("cat")` から active を初期化 |

### 動作確認

- `pnpm --filter @edv4h/usketch-docs build` → 92 ページ生成 OK
- `astro check` → 0 errors
- Biome → clean

## Test plan

- [ ] `/docs/ja/...` にいるとき:
  - [ ] Header の「ドキュメント」リンクが `/docs/ja/getting-started/introduction/` を指す
  - [ ] ⌘K パレットで Docs 項目を選ぶと JP docs へ遷移する
  - [ ] Language トグルの `JP` が初期で pressed 状態
- [ ] Home の「AI」チップをクリック → `/plugins/?cat=ai` で AI カテゴリだけが表示される
- [ ] `localStorage.setItem("usketch-jp-mode", "both")` した状態で Home をリロード → トグルが `A/あ` で正しく pressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)