### PR TITLE
✨ feat(plugin-sync-ywebsocket): y-websocket アダプタプラグイン追加 (#574)

### DIFF
--- a/.changeset/plugin-sync-ywebsocket.md
+++ b/.changeset/plugin-sync-ywebsocket.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-sync-ywebsocket": minor
+---
+
+Add `@edv4h/usketch-plugin-sync-ywebsocket` — bridges uSketch to any y-websocket server. Exposes a `WsProviderHandle`-compatible adapter for drop-in use with `@edv4h/usketch-plugin-presence-cursor`, with hooks for token refresh (`resolveParams`), close-code handling (`onCloseCode`), idle disconnect, and a pre-existing Y.Doc. Closes #574.

--- a/apps/docs/src/content/plugins/plugins.json
+++ b/apps/docs/src/content/plugins/plugins.json
@@ -336,6 +336,14 @@
 		"install": "pnpm add @edv4h/usketch-plugin-sync-localstorage-yjs"
 	},
 	{
+		"id": "sync-ywebsocket",
+		"name": "Realtime Sync (y-websocket)",
+		"category": "server",
+		"glyph": "WS",
+		"summary": "Bridge uSketch to any y‑websocket server — auth, token refresh, idle disconnect.",
+		"install": "pnpm add @edv4h/usketch-plugin-sync-ywebsocket"
+	},
+	{
 		"id": "effect-ripple",
 		"name": "Ripple",
 		"category": "effect",

--- a/plugins/usketch-plugin-sync-ywebsocket/README.md
+++ b/plugins/usketch-plugin-sync-ywebsocket/README.md
@@ -12,30 +12,58 @@ pnpm add @edv4h/usketch-plugin-sync-ywebsocket
 
 ## Basic usage
 
+`getWsProvider()` is only valid *after* the sync plugin's `setup()` has run. Since
+`createApp` calls `setup()` in plugin order, the recommended pattern is to defer
+the `wsProvider` lookup into a thin wrapper plugin that runs after the sync
+plugin. This keeps everything inside a single `createApp` call:
+
 ```ts
 import { createApp } from "@edv4h/usketch-core";
+import { createBoardStore } from "@edv4h/usketch-store";
+import type { UsketchPlugin } from "@edv4h/usketch-shared";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
-import { createYwebsocketSyncPlugin } from "@edv4h/usketch-plugin-sync-ywebsocket";
+import { createYwebsocketSyncPlugin, type YwebsocketSyncPlugin } from "@edv4h/usketch-plugin-sync-ywebsocket";
 
 const syncPlugin = createYwebsocketSyncPlugin({
   url: "wss://yws.example.com",
   roomName: "board-123",
 });
 
+// Wrap presence-cursor so the provider is read at setup time, when syncPlugin.setup
+// has already run (plugins are set up in order).
+function presenceCursorWithSync(
+  sync: YwebsocketSyncPlugin,
+  opts: { userId: string; userName: string },
+): UsketchPlugin {
+  let inner: UsketchPlugin | null = null;
+  return {
+    id: "usketch-plugin-presence-cursor",
+    name: "Presence Cursor",
+    async setup(ctx) {
+      inner = createPresenceCursorPlugin({
+        wsProvider: sync.getWsProvider(),
+        userId: opts.userId,
+        userName: opts.userName,
+      });
+      await inner.setup(ctx);
+    },
+    teardown() {
+      inner?.teardown?.();
+    },
+  };
+}
+
 const app = await createApp({
+  store: createBoardStore(),
   plugins: [
     syncPlugin,
-    // Pass the provider into presence-cursor (after setup, the handle is ready).
-    createPresenceCursorPlugin({
-      wsProvider: syncPlugin.getWsProvider(),
-      userId: "alice",
-      userName: "Alice",
-    }),
+    presenceCursorWithSync(syncPlugin, { userId: "alice", userName: "Alice" }),
   ],
 });
 ```
 
-Because `getWsProvider()` must be called after the sync plugin's `setup()` has run, a simple pattern is to split plugin registration into two awaited phases — or to rely on `createApp` awaiting plugins in order, and to pass the provider via a late-binding thunk where your framework permits.
+This pattern generalizes to any plugin that needs a `WsProviderHandle`: wrap it
+in a small factory that reads `sync.getWsProvider()` inside its own `setup()`.
 
 ## Options
 

--- a/plugins/usketch-plugin-sync-ywebsocket/README.md
+++ b/plugins/usketch-plugin-sync-ywebsocket/README.md
@@ -142,7 +142,7 @@ handle.wsProvider;         // WsProviderHandle adapter (same as getWsProvider())
 | member              | supported                                 |
 | ------------------- | ----------------------------------------- |
 | `connected`         | yes                                        |
-| `awareness`         | yes (after the first `connect()`)          |
+| `awareness`         | yes (always — shared across reconnects)    |
 | `onStatusChange`    | yes                                        |
 | `onBroadcast`       | listeners accepted; never emits (no-op)    |
 | `broadcast`         | no-op — y-websocket has no side-channel    |

--- a/plugins/usketch-plugin-sync-ywebsocket/README.md
+++ b/plugins/usketch-plugin-sync-ywebsocket/README.md
@@ -1,0 +1,129 @@
+# @edv4h/usketch-plugin-sync-ywebsocket
+
+Bridge a uSketch app to any [y-websocket](https://github.com/yjs/y-websocket) server. Wraps `WebsocketProvider` and exposes a `WsProviderHandle`-compatible adapter so it plugs directly into plugins like `@edv4h/usketch-plugin-presence-cursor`.
+
+Designed for teams that already run a y-websocket backend (or need to migrate off another realtime engine) and want to keep their sync layer while adopting uSketch on the client.
+
+## Install
+
+```sh
+pnpm add @edv4h/usketch-plugin-sync-ywebsocket
+```
+
+## Basic usage
+
+```ts
+import { createApp } from "@edv4h/usketch-core";
+import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
+import { createYwebsocketSyncPlugin } from "@edv4h/usketch-plugin-sync-ywebsocket";
+
+const syncPlugin = createYwebsocketSyncPlugin({
+  url: "wss://yws.example.com",
+  roomName: "board-123",
+});
+
+const app = await createApp({
+  plugins: [
+    syncPlugin,
+    // Pass the provider into presence-cursor (after setup, the handle is ready).
+    createPresenceCursorPlugin({
+      wsProvider: syncPlugin.getWsProvider(),
+      userId: "alice",
+      userName: "Alice",
+    }),
+  ],
+});
+```
+
+Because `getWsProvider()` must be called after the sync plugin's `setup()` has run, a simple pattern is to split plugin registration into two awaited phases — or to rely on `createApp` awaiting plugins in order, and to pass the provider via a late-binding thunk where your framework permits.
+
+## Options
+
+```ts
+createYwebsocketSyncPlugin({
+  url,                    // ws(s):// base URL of the y-websocket server
+  roomName,               // server-side document identifier
+  shapesMapKey,           // optional — defaults to "shapes" (weboard uses "map")
+  resolveParams,          // async/sync callback to supply URL query params on each connect
+  onCloseCode,            // classify close codes: "retry" | "stop" | undefined (default backoff)
+  idleTimeoutMs,          // 0 (off) — disconnect after this many ms of inactivity
+  autoConnect,            // default true — connect on plugin setup
+  doc,                    // optional — bring your own Y.Doc (useful for mid-life migrations)
+  WebSocketPolyfill,      // optional — Node test environments only
+});
+```
+
+### Resolving auth tokens on each connect
+
+`resolveParams` is called before every connect and reconnect. Use it to hand back freshly refreshed tokens so the server sees a valid credential on reconnect:
+
+```ts
+createYwebsocketSyncPlugin({
+  url: "wss://yws.example.com",
+  roomName: "board-123",
+  async resolveParams({ attempt, previousCloseCode }) {
+    // Force a fresh token if the previous connection was rejected for auth.
+    const forceRefresh = previousCloseCode === 4003 || previousCloseCode === 4004;
+    const token = await cognitoSession.getAccessToken({ forceRefresh });
+    return {
+      params: {
+        token: token.jwt,
+        employeeId: String(token.employeeId),
+        companyId: String(token.companyId),
+      },
+    };
+  },
+  onCloseCode(code) {
+    if (code === 4003 || code === 4004) return "retry"; // immediate retry; resolveParams will fetch a fresh token
+    return undefined; // fall through to exponential backoff
+  },
+});
+```
+
+### Idle disconnect
+
+Set `idleTimeoutMs` to disconnect after inactivity (no local Y.Doc mutations). Call `handle.resume()` to reconnect on the next user interaction.
+
+```ts
+const plugin = createYwebsocketSyncPlugin({
+  url: "wss://yws.example.com",
+  roomName: "board-123",
+  idleTimeoutMs: 5 * 60 * 1000, // 5 minutes
+});
+
+// Later, in an interaction handler:
+plugin.getHandle().resume();
+```
+
+## Advanced: accessing the handle
+
+```ts
+const handle = syncPlugin.getHandle();
+handle.disconnect();       // manual disconnect; stays disconnected
+handle.resume();           // reconnect after a disconnect/idle
+handle.status.subscribe(() => console.log(handle.status.getSnapshot()));
+handle.doc;                // the underlying Y.Doc
+handle.whenSynced;         // promise that resolves on first server sync
+handle.wsProvider;         // WsProviderHandle adapter (same as getWsProvider())
+```
+
+## WsProviderHandle compatibility
+
+`handle.wsProvider` implements the `WsProviderHandle` contract from `@edv4h/usketch-sync` so plugins that consume `WsProviderHandle` work out of the box:
+
+| member              | supported                                 |
+| ------------------- | ----------------------------------------- |
+| `connected`         | yes                                        |
+| `awareness`         | yes (after the first `connect()`)          |
+| `onStatusChange`    | yes                                        |
+| `onBroadcast`       | listeners accepted; never emits (no-op)    |
+| `broadcast`         | no-op — y-websocket has no side-channel    |
+| `requestPartition`  | no-op — y-websocket has no partitions      |
+| `onPartitionMeta`   | no-op — y-websocket has no partitions      |
+| `destroy`           | yes                                        |
+
+If you need broadcast / partition semantics, stay on `@edv4h/usketch-sync`'s `createWsProvider()` with a uSketch-native server.
+
+## License
+
+MIT

--- a/plugins/usketch-plugin-sync-ywebsocket/README.md
+++ b/plugins/usketch-plugin-sync-ywebsocket/README.md
@@ -110,7 +110,7 @@ createYwebsocketSyncPlugin({
 
 ### Idle disconnect
 
-Set `idleTimeoutMs` to disconnect after inactivity (no local Y.Doc mutations). Call `handle.resume()` to reconnect on the next user interaction.
+Set `idleTimeoutMs` to disconnect after inactivity (no local board edits / store mutations). The timer also resets whenever the socket reports `connected` or `resume()` is called. Call `handle.resume()` to reconnect on the next user interaction.
 
 ```ts
 const plugin = createYwebsocketSyncPlugin({

--- a/plugins/usketch-plugin-sync-ywebsocket/package.json
+++ b/plugins/usketch-plugin-sync-ywebsocket/package.json
@@ -1,0 +1,48 @@
+{
+	"name": "@edv4h/usketch-plugin-sync-ywebsocket",
+	"version": "1.0.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-sync": "workspace:*",
+		"y-protocols": "1.0.7",
+		"y-websocket": "^3.0.0",
+		"yjs": "^13.6.0"
+	},
+	"devDependencies": {
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-sync-ywebsocket"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/test-store.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/test-store.ts
@@ -36,7 +36,8 @@ export function createTestStore(): BoardStore {
 			notifyMutation("shape:removed", { id });
 		},
 		ensureZIndex() {
-			// No-op for tests — the plugin always assigns zIndex via toPlainObject.
+			// No-op for tests — this test store does not model production z-index
+			// normalization. In production, ordering is handled by the real store.
 		},
 		getSelection: () => new Set<string>(),
 		setSelection() {},

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/test-store.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/test-store.ts
@@ -35,6 +35,9 @@ export function createTestStore(): BoardStore {
 			notify();
 			notifyMutation("shape:removed", { id });
 		},
+		ensureZIndex() {
+			// No-op for tests — the plugin always assigns zIndex via toPlainObject.
+		},
 		getSelection: () => new Set<string>(),
 		setSelection() {},
 		addToSelection() {},

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/test-store.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/test-store.ts
@@ -1,0 +1,78 @@
+import type { BoardStore, ShapeData } from "@edv4h/usketch-shared";
+
+/** Minimal BoardStore implementation for unit tests (no @edv4h/usketch-store dep). */
+export function createTestStore(): BoardStore {
+	const shapes = new Map<string, ShapeData>();
+	const listeners = new Set<() => void>();
+	const mutationListeners = new Set<(event: { type: string; payload?: unknown }) => void>();
+
+	function notify() {
+		for (const fn of listeners) fn();
+	}
+	function notifyMutation(type: string, payload?: unknown) {
+		const event = payload !== undefined ? { type, payload } : { type };
+		for (const fn of mutationListeners) fn(event);
+	}
+
+	return {
+		getShapes: () => shapes,
+		getShape: (id: string) => shapes.get(id),
+		addShape(shape: ShapeData) {
+			shapes.set(shape.id, shape);
+			notify();
+			notifyMutation("shape:added", { id: shape.id });
+		},
+		updateShape(id: string, updates: Partial<ShapeData>) {
+			const existing = shapes.get(id);
+			if (!existing) return;
+			shapes.set(id, { ...existing, ...updates });
+			notify();
+			notifyMutation("shape:updated", { id });
+		},
+		deleteShape(id: string) {
+			if (!shapes.has(id)) return;
+			shapes.delete(id);
+			notify();
+			notifyMutation("shape:removed", { id });
+		},
+		getSelection: () => new Set<string>(),
+		setSelection() {},
+		addToSelection() {},
+		removeFromSelection() {},
+		clearSelection() {},
+		getActiveToolId: () => "select",
+		setActiveToolId() {},
+		getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+		setViewport() {},
+		panBy() {},
+		zoomTo() {},
+		getStyleSettings: () => ({
+			fill: "#ffffff",
+			stroke: "#1e1e1e",
+			strokeWidth: 2,
+			opacity: 1,
+		}),
+		setStyleSettings() {},
+		subscribe(listener: () => void) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		onMutation(listener: (event: { type: string; payload?: unknown }) => void) {
+			mutationListeners.add(listener);
+			return () => mutationListeners.delete(listener);
+		},
+	} as unknown as BoardStore;
+}
+
+export function makeShape(overrides: Partial<ShapeData> = {}): ShapeData {
+	return {
+		id: `shape-${Math.random().toString(36).slice(2, 8)}`,
+		type: "rect",
+		x: 0,
+		y: 0,
+		width: 100,
+		height: 100,
+		style: { fill: "#ffffff", stroke: "#1e1e1e", strokeWidth: 2, opacity: 1 },
+		...overrides,
+	};
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
@@ -146,6 +146,39 @@ describe("createYwebsocketSync (lifecycle)", () => {
 		}
 	});
 
+	it("exposes a valid Awareness before connect — WsProviderHandle contract", () => {
+		// Consumers like presence-cursor destructure `const { awareness } = wsProvider`
+		// at plugin creation time, so awareness must be ready immediately.
+		const store = createTestStore();
+		const handle = createYwebsocketSync(store, {
+			url: "ws://example.invalid",
+			roomName: "room",
+			autoConnect: false,
+		});
+		try {
+			const { awareness } = handle.wsProvider;
+			expect(awareness).toBeDefined();
+			expect(awareness.doc).toBe(handle.doc);
+			awareness.setLocalStateField("user", { name: "alice" });
+			expect(awareness.getLocalState()).toMatchObject({ user: { name: "alice" } });
+		} finally {
+			handle.destroy();
+		}
+	});
+
+	it("whenSynced resolves on destroy (doesn't hang setup())", async () => {
+		const store = createTestStore();
+		const handle = createYwebsocketSync(store, {
+			url: "ws://example.invalid",
+			roomName: "room",
+			autoConnect: false,
+		});
+		// Kick off whenSynced, then destroy — must resolve, not hang.
+		const p = handle.whenSynced;
+		handle.destroy();
+		await expect(p).resolves.toBeUndefined();
+	});
+
 	it("destroys the Y.Doc it owns, but leaves an externally-provided Y.Doc intact", () => {
 		const store1 = createTestStore();
 		const h1 = createYwebsocketSync(store1, {

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
@@ -1,0 +1,175 @@
+import type { Mock } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import type { YwebsocketSyncHandle } from "../types.js";
+import { createYwebsocketSync } from "../yws-sync.js";
+import { createTestStore, makeShape } from "./test-store.js";
+
+// All tests run with `autoConnect: false` — we don't want to open real sockets during unit tests.
+// The WebSocket-level behavior (reconnect, token refresh) is covered by manual testing / E2E.
+
+describe("createYwebsocketSync (store ↔ Y.Doc binding)", () => {
+	const handles: YwebsocketSyncHandle[] = [];
+
+	afterEach(() => {
+		while (handles.length) {
+			handles.pop()?.destroy();
+		}
+	});
+
+	function setup(opts: { doc?: Y.Doc; shapesMapKey?: string; resolveParams?: Mock } = {}) {
+		const store = createTestStore();
+		const handle = createYwebsocketSync(store, {
+			url: "ws://example.invalid",
+			roomName: "test-room",
+			autoConnect: false,
+			doc: opts.doc,
+			shapesMapKey: opts.shapesMapKey,
+			resolveParams: opts.resolveParams,
+		});
+		handles.push(handle);
+		return { store, handle };
+	}
+
+	it("pushes store additions into the Y.Doc shapes map", () => {
+		const { store, handle } = setup();
+		const shape = makeShape({ id: "s1" });
+
+		store.addShape(shape);
+
+		const shapesMap = handle.doc.getMap<Record<string, unknown>>("shapes");
+		expect(shapesMap.has("s1")).toBe(true);
+		expect((shapesMap.get("s1") as { id: string }).id).toBe("s1");
+	});
+
+	it("pushes store updates and deletions into the Y.Doc", () => {
+		const { store, handle } = setup();
+		const shape = makeShape({ id: "s1", x: 0 });
+		store.addShape(shape);
+
+		store.updateShape("s1", { x: 100 });
+		const shapesMap = handle.doc.getMap<Record<string, unknown>>("shapes");
+		expect((shapesMap.get("s1") as { x: number }).x).toBe(100);
+
+		store.deleteShape("s1");
+		expect(shapesMap.has("s1")).toBe(false);
+	});
+
+	it("applies Y.Doc changes back into the store", () => {
+		const { store, handle } = setup();
+		const shapesMap = handle.doc.getMap<Record<string, unknown>>("shapes");
+
+		// Simulate a remote change by mutating the Y.Map directly in a transaction.
+		handle.doc.transact(() => {
+			shapesMap.set("remote-1", {
+				id: "remote-1",
+				type: "rect",
+				x: 42,
+				y: 0,
+				width: 50,
+				height: 50,
+				style: { fill: "#000", stroke: "#000", strokeWidth: 1, opacity: 1 },
+			});
+		});
+
+		expect(store.getShape("remote-1")).toBeDefined();
+		expect(store.getShape("remote-1")?.x).toBe(42);
+	});
+
+	it("loads pre-existing shapes from a provided Y.Doc on creation", () => {
+		const doc = new Y.Doc();
+		const shapesMap = doc.getMap<Record<string, unknown>>("shapes");
+		shapesMap.set("pre", {
+			id: "pre",
+			type: "rect",
+			x: 1,
+			y: 2,
+			width: 10,
+			height: 10,
+			style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		});
+
+		const { store } = setup({ doc });
+		expect(store.getShape("pre")).toBeDefined();
+		expect(store.getShape("pre")?.x).toBe(1);
+	});
+
+	it("supports a custom shapesMapKey (for weboard's legacy 'map' key)", () => {
+		const { store, handle } = setup({ shapesMapKey: "map" });
+		const shape = makeShape({ id: "s1" });
+		store.addShape(shape);
+
+		const mapY = handle.doc.getMap<Record<string, unknown>>("map");
+		const shapesY = handle.doc.getMap<Record<string, unknown>>("shapes");
+		expect(mapY.has("s1")).toBe(true);
+		expect(shapesY.has("s1")).toBe(false);
+	});
+
+	it("avoids sync loops on round-trip", () => {
+		const { store, handle } = setup();
+		const shape = makeShape({ id: "s1", x: 0 });
+		store.addShape(shape);
+
+		// updating from the Y.Doc side must not fire mutation back into Y again
+		// (observer uses the same isSyncing guard as the mutation listener)
+		const shapesMap = handle.doc.getMap<Record<string, unknown>>("shapes");
+		const before = (shapesMap.get("s1") as { x: number }).x;
+		handle.doc.transact(() => {
+			shapesMap.set("s1", { ...(shapesMap.get("s1") as object), x: 200 });
+		});
+		expect(store.getShape("s1")?.x).toBe(200);
+		// Y.Map should still reflect x=200 — no write-back races
+		expect((shapesMap.get("s1") as { x: number }).x).toBe(200);
+		expect(before).toBe(0);
+	});
+});
+
+describe("createYwebsocketSync (lifecycle)", () => {
+	it("exposes an inert wsProvider before connect; onStatusChange reports disconnected", () => {
+		const store = createTestStore();
+		const handle = createYwebsocketSync(store, {
+			url: "ws://example.invalid",
+			roomName: "room",
+			autoConnect: false,
+		});
+		try {
+			const seen: string[] = [];
+			const unsub = handle.wsProvider.onStatusChange((s) => seen.push(s));
+			expect(seen).toEqual(["disconnected"]);
+			expect(handle.wsProvider.connected).toBe(false);
+			// broadcast / requestPartition are no-ops and must not throw
+			handle.wsProvider.broadcast({ type: "noop" });
+			handle.wsProvider.requestPartition(["anything"]);
+			unsub();
+		} finally {
+			handle.destroy();
+		}
+	});
+
+	it("destroys the Y.Doc it owns, but leaves an externally-provided Y.Doc intact", () => {
+		const store1 = createTestStore();
+		const h1 = createYwebsocketSync(store1, {
+			url: "ws://example.invalid",
+			roomName: "room",
+			autoConnect: false,
+		});
+		const ownedDoc = h1.doc;
+		h1.destroy();
+		// After destroy, the owned Y.Doc is destroyed — `getMap` still returns an object
+		// but further mutations are unsafe; we just check that `destroy` doesn't throw.
+		expect(ownedDoc).toBeDefined();
+
+		const externalDoc = new Y.Doc();
+		const store2 = createTestStore();
+		const h2 = createYwebsocketSync(store2, {
+			url: "ws://example.invalid",
+			roomName: "room",
+			autoConnect: false,
+			doc: externalDoc,
+		});
+		h2.destroy();
+		// External Y.Doc must still be usable
+		expect(() => externalDoc.getMap("anything")).not.toThrow();
+		externalDoc.destroy();
+	});
+});

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
@@ -188,6 +188,57 @@ describe("createYwebsocketSync (lifecycle)", () => {
 		await expect(p).resolves.toBeUndefined();
 	});
 
+	it("disconnect() during an in-flight connect() cancels before a socket is created", async () => {
+		// Use autoConnect:true + a slow resolveParams to simulate the race window,
+		// then call disconnect() mid-await. A correct implementation must NOT
+		// construct a WebsocketProvider after the disconnect lands.
+		let resolveParamsCalls = 0;
+		let deferred!: () => void;
+		const waitForResume = new Promise<void>((resolve) => {
+			deferred = resolve;
+		});
+		const store = createTestStore();
+		const handle = createYwebsocketSync(store, {
+			url: "ws://example.invalid",
+			roomName: "room",
+			autoConnect: true,
+			resolveParams: async () => {
+				resolveParamsCalls++;
+				await waitForResume; // hang until the test releases
+				return { params: { t: "late" } };
+			},
+		});
+		// connect() starts and blocks on resolveParams. Now disconnect.
+		handle.disconnect();
+		// Allow resolveParams to resolve — but we should NOT see a provider instantiated.
+		deferred();
+		// Give the microtask queue a couple ticks to flush.
+		await new Promise((r) => setTimeout(r, 0));
+		await new Promise((r) => setTimeout(r, 0));
+		expect(resolveParamsCalls).toBe(1);
+		expect(handle.wsProvider.connected).toBe(false);
+		expect(handle.status.getSnapshot().state).toBe("disconnected");
+		handle.destroy();
+	});
+
+	it("exposes an initial onStatusChange value that reflects the tracker state", () => {
+		const store = createTestStore();
+		const handle = createYwebsocketSync(store, {
+			url: "ws://example.invalid",
+			roomName: "room",
+			autoConnect: false,
+		});
+		try {
+			const seen: string[] = [];
+			const unsub = handle.wsProvider.onStatusChange((s) => seen.push(s));
+			// autoConnect:false + not yet resumed → tracker is "loading" → "disconnected".
+			expect(seen).toEqual(["disconnected"]);
+			unsub();
+		} finally {
+			handle.destroy();
+		}
+	});
+
 	it("destroys the Y.Doc it owns, but leaves an externally-provided Y.Doc intact", () => {
 		const store1 = createTestStore();
 		const h1 = createYwebsocketSync(store1, {

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
@@ -94,6 +94,15 @@ describe("createYwebsocketSync (store ↔ Y.Doc binding)", () => {
 		expect(store.getShape("pre")?.x).toBe(1);
 	});
 
+	it("updates status.shapeCount and lastSyncedAt after local store mutations", () => {
+		const { store, handle } = setup();
+		const before = handle.status.getSnapshot().shapeCount;
+		store.addShape(makeShape({ id: "s1" }));
+		const after = handle.status.getSnapshot();
+		expect(after.shapeCount).toBe(before + 1);
+		expect(after.lastSyncedAt).not.toBeNull();
+	});
+
 	it("supports a custom shapesMapKey (for weboard's legacy 'map' key)", () => {
 		const { store, handle } = setup({ shapesMapKey: "map" });
 		const shape = makeShape({ id: "s1" });

--- a/plugins/usketch-plugin-sync-ywebsocket/src/index.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/index.ts
@@ -1,0 +1,14 @@
+export { createYwebsocketSyncPlugin, type YwebsocketSyncPlugin } from "./plugin.js";
+export {
+	type SyncState,
+	type SyncStatusSnapshot,
+	SyncStatusTracker,
+} from "./sync-status-tracker.js";
+export type {
+	ConnectionParams,
+	ResolveParamsContext,
+	WsConnectionStatus,
+	YwebsocketSyncHandle,
+	YwebsocketSyncOptions,
+} from "./types.js";
+export { createYwebsocketSync } from "./yws-sync.js";

--- a/plugins/usketch-plugin-sync-ywebsocket/src/plugin.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/plugin.ts
@@ -1,0 +1,57 @@
+import type { UsketchPlugin } from "@edv4h/usketch-shared";
+import type { WsProviderHandle } from "@edv4h/usketch-sync";
+import type { YwebsocketSyncHandle, YwebsocketSyncOptions } from "./types.js";
+import { createYwebsocketSync } from "./yws-sync.js";
+
+export interface YwebsocketSyncPlugin extends UsketchPlugin {
+	/**
+	 * Returns the underlying `WsProviderHandle` for consumption by other plugins
+	 * (e.g. `@edv4h/usketch-plugin-presence-cursor`).
+	 * Only valid after the plugin's `setup` has run.
+	 */
+	getWsProvider(): WsProviderHandle;
+	/** Access the full sync handle — status, Y.Doc, disconnect/resume/destroy. */
+	getHandle(): YwebsocketSyncHandle;
+}
+
+export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): YwebsocketSyncPlugin {
+	let handle: YwebsocketSyncHandle | null = null;
+
+	const plugin: YwebsocketSyncPlugin = {
+		id: "usketch-plugin-sync-ywebsocket",
+		name: "Realtime Sync (y-websocket)",
+
+		async setup(ctx) {
+			handle = createYwebsocketSync(ctx.store, options);
+			// Expose status for DebugHUD etc.
+			(globalThis as Record<string, unknown>).__usketchSyncStatus = handle.status;
+			await handle.whenSynced;
+		},
+
+		teardown() {
+			handle?.destroy();
+			delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
+			handle = null;
+		},
+
+		getWsProvider(): WsProviderHandle {
+			if (!handle) {
+				throw new Error(
+					"[usketch-plugin-sync-ywebsocket] getWsProvider() called before setup(); register the plugin first.",
+				);
+			}
+			return handle.wsProvider;
+		},
+
+		getHandle(): YwebsocketSyncHandle {
+			if (!handle) {
+				throw new Error(
+					"[usketch-plugin-sync-ywebsocket] getHandle() called before setup(); register the plugin first.",
+				);
+			}
+			return handle;
+		},
+	};
+
+	return plugin;
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/plugin.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/plugin.ts
@@ -27,7 +27,12 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 		async setup(ctx) {
 			handle = createYwebsocketSync(ctx.store, options);
 			(globalThis as Record<string, unknown>).__usketchSyncStatus = handle.status;
-			await handle.whenSynced;
+			// When `autoConnect: false`, `connect()` is never called, so awaiting
+			// `whenSynced` here would hang the entire plugin setup chain. Skip it
+			// and let the caller drive connection via `handle.resume()`.
+			if (options.autoConnect !== false) {
+				await handle.whenSynced;
+			}
 		},
 
 		teardown() {

--- a/plugins/usketch-plugin-sync-ywebsocket/src/plugin.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/plugin.ts
@@ -7,7 +7,10 @@ export interface YwebsocketSyncPlugin extends UsketchPlugin {
 	/**
 	 * Returns the underlying `WsProviderHandle` for consumption by other plugins
 	 * (e.g. `@edv4h/usketch-plugin-presence-cursor`).
-	 * Only valid after the plugin's `setup` has run.
+	 *
+	 * Only valid *after* the plugin's `setup()` has run. See the README for the
+	 * recommended pattern (wrap the dependent plugin so it reads the provider
+	 * from inside its own `setup()`).
 	 */
 	getWsProvider(): WsProviderHandle;
 	/** Access the full sync handle — status, Y.Doc, disconnect/resume/destroy. */
@@ -23,7 +26,6 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 
 		async setup(ctx) {
 			handle = createYwebsocketSync(ctx.store, options);
-			// Expose status for DebugHUD etc.
 			(globalThis as Record<string, unknown>).__usketchSyncStatus = handle.status;
 			await handle.whenSynced;
 		},
@@ -37,7 +39,7 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 		getWsProvider(): WsProviderHandle {
 			if (!handle) {
 				throw new Error(
-					"[usketch-plugin-sync-ywebsocket] getWsProvider() called before setup(); register the plugin first.",
+					"[usketch-plugin-sync-ywebsocket] getWsProvider() called before setup(); register the plugin with createApp() first, or call getWsProvider() from inside another plugin's setup().",
 				);
 			}
 			return handle.wsProvider;
@@ -46,7 +48,7 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 		getHandle(): YwebsocketSyncHandle {
 			if (!handle) {
 				throw new Error(
-					"[usketch-plugin-sync-ywebsocket] getHandle() called before setup(); register the plugin first.",
+					"[usketch-plugin-sync-ywebsocket] getHandle() called before setup(); register the plugin with createApp() first, or call getHandle() from inside another plugin's setup().",
 				);
 			}
 			return handle;

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -1,0 +1,37 @@
+export type SyncState = "loading" | "connecting" | "synced" | "syncing" | "disconnected" | "error";
+
+export interface SyncStatusSnapshot {
+	state: SyncState;
+	shapeCount: number;
+	lastSyncedAt: number | null;
+	error: string | null;
+}
+
+export class SyncStatusTracker {
+	private snapshot: SyncStatusSnapshot = {
+		state: "loading",
+		shapeCount: 0,
+		lastSyncedAt: null,
+		error: null,
+	};
+	private listeners = new Set<() => void>();
+
+	getSnapshot(): SyncStatusSnapshot {
+		return this.snapshot;
+	}
+
+	subscribe(listener: () => void): () => void {
+		this.listeners.add(listener);
+		return () => {
+			this.listeners.delete(listener);
+		};
+	}
+
+	/** @internal */
+	update(partial: Partial<SyncStatusSnapshot>): void {
+		this.snapshot = { ...this.snapshot, ...partial };
+		for (const listener of this.listeners) {
+			listener();
+		}
+	}
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/types.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/types.ts
@@ -8,7 +8,11 @@ export interface ConnectionParams {
 }
 
 export interface ResolveParamsContext {
-	/** Incrementing on each reconnect attempt, starts at 0 for first connect. */
+	/**
+	 * Backoff attempt counter — 0 on the first connect, increments with each
+	 * failed reconnect cycle, and resets to 0 whenever an `onCloseCode` handler
+	 * returns `"retry"` (explicit retries skip the backoff ramp).
+	 */
 	attempt: number;
 	/** Optional close code from the previous disconnect (if any). */
 	previousCloseCode?: number;
@@ -29,9 +33,9 @@ export interface YwebsocketSyncOptions {
 	shapesMapKey?: string;
 
 	/**
-	 * Resolve URL query params (and optionally the WS URL) on each connection attempt.
-	 * Called before every connect/reconnect — return freshly refreshed tokens here.
-	 * If omitted, no query params are attached.
+	 * Resolve URL query params on each connection attempt.
+	 * Called before every connect/reconnect — return freshly refreshed query params
+	 * or tokens here. If omitted, no query params are attached.
 	 */
 	resolveParams?: (ctx: ResolveParamsContext) => Promise<ConnectionParams> | ConnectionParams;
 

--- a/plugins/usketch-plugin-sync-ywebsocket/src/types.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/types.ts
@@ -44,9 +44,9 @@ export interface YwebsocketSyncOptions {
 	onCloseCode?: (code: number, reason: string) => "retry" | "stop" | undefined;
 
 	/**
-	 * Disconnect automatically after this many milliseconds of local inactivity.
-	 * Any call to `resume()` or any local Y.Doc update resets the timer.
-	 * Set to `0` (or omit) to disable.
+	 * Disconnect automatically after this many milliseconds of inactivity.
+	 * The timer resets on local store mutations, when the socket reports `connected`,
+	 * and when `resume()` is called. Set to `0` (or omit) to disable.
 	 */
 	idleTimeoutMs?: number;
 
@@ -75,8 +75,10 @@ export interface YwebsocketSyncHandle {
 	/** Observable sync status (loading/synced/disconnected/error). */
 	status: SyncStatusTracker;
 	/**
-	 * Resolves when the first server sync completes (or the first connection attempt fails).
-	 * Resolves, never rejects — inspect `status.getSnapshot().state === "error"` to detect failure.
+	 * Resolves when the first server sync completes, when `resolveParams` fails the
+	 * initial attempt, when `onCloseCode` returns `"stop"`, or on `destroy()`.
+	 * Resolves, never rejects — inspect `status.getSnapshot()` for the latest state
+	 * (in particular `state === "error"` / `"disconnected"`) to detect failure modes.
 	 */
 	whenSynced: Promise<void>;
 

--- a/plugins/usketch-plugin-sync-ywebsocket/src/types.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/types.ts
@@ -1,0 +1,99 @@
+import type { WsConnectionStatus, WsProviderHandle } from "@edv4h/usketch-sync";
+import type * as Y from "yjs";
+import type { SyncStatusTracker } from "./sync-status-tracker.js";
+
+export interface ConnectionParams {
+	/** URL query params to attach on each connection attempt. */
+	params?: Record<string, string>;
+}
+
+export interface ResolveParamsContext {
+	/** Incrementing on each reconnect attempt, starts at 0 for first connect. */
+	attempt: number;
+	/** Optional close code from the previous disconnect (if any). */
+	previousCloseCode?: number;
+	/** Optional close reason from the previous disconnect (if any). */
+	previousCloseReason?: string;
+}
+
+export interface YwebsocketSyncOptions {
+	/** Base URL of the y-websocket server (e.g. "wss://yws.example.com"). */
+	url: string;
+	/** Room name — the document identifier on the server. */
+	roomName: string;
+
+	/**
+	 * The Yjs map key that stores shapes. Defaults to `"shapes"`.
+	 * Use this when connecting to a server that expects a different key (e.g. weboard uses `"map"`).
+	 */
+	shapesMapKey?: string;
+
+	/**
+	 * Resolve URL query params (and optionally the WS URL) on each connection attempt.
+	 * Called before every connect/reconnect — return freshly refreshed tokens here.
+	 * If omitted, no query params are attached.
+	 */
+	resolveParams?: (ctx: ResolveParamsContext) => Promise<ConnectionParams> | ConnectionParams;
+
+	/**
+	 * Custom close-code handler. Called whenever the underlying socket closes.
+	 * Return `"retry"` to trigger an immediate reconnect (bypassing backoff),
+	 * `"stop"` to give up and leave the provider disconnected,
+	 * or `undefined` to fall through to the default backoff retry.
+	 */
+	onCloseCode?: (code: number, reason: string) => "retry" | "stop" | undefined;
+
+	/**
+	 * Disconnect automatically after this many milliseconds of local inactivity.
+	 * Any call to `resume()` or any local Y.Doc update resets the timer.
+	 * Set to `0` (or omit) to disable.
+	 */
+	idleTimeoutMs?: number;
+
+	/**
+	 * Explicitly opt in/out of the initial `connect` call.
+	 * Defaults to `true` — the provider connects on creation.
+	 */
+	autoConnect?: boolean;
+
+	/**
+	 * Provide an existing Y.Doc to sync. If omitted, a new Y.Doc is created.
+	 * Weboard's migration path can pass in a pre-existing Y.Doc that already holds legacy state.
+	 */
+	doc?: Y.Doc;
+
+	/**
+	 * WebSocket constructor polyfill (for Node test environments).
+	 * In the browser, this is picked up from `globalThis.WebSocket` automatically.
+	 */
+	WebSocketPolyfill?: typeof WebSocket;
+}
+
+export interface YwebsocketSyncHandle {
+	/** The Y.Doc being synced. */
+	doc: Y.Doc;
+	/** Observable sync status (loading/synced/disconnected/error). */
+	status: SyncStatusTracker;
+	/**
+	 * Resolves when the first server sync completes (or the first connection attempt fails).
+	 * Resolves, never rejects — inspect `status.getSnapshot().state === "error"` to detect failure.
+	 */
+	whenSynced: Promise<void>;
+
+	/**
+	 * WsProviderHandle-compatible adapter. Plug this into `@edv4h/usketch-plugin-presence-cursor`
+	 * (and similar plugins) that accept a `WsProviderHandle`.
+	 * Broadcast / partition APIs are no-ops (y-websocket has no equivalent).
+	 */
+	wsProvider: WsProviderHandle;
+
+	/** Manually disconnect. The provider stays disconnected until `resume()` is called. */
+	disconnect(): void;
+	/** Reconnect after a manual `disconnect()` or an idle timeout. */
+	resume(): void;
+
+	/** Tear down all resources — removes listeners, destroys provider and awareness. */
+	destroy(): void;
+}
+
+export type { WsConnectionStatus };

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -1,0 +1,432 @@
+import type { BoardStore, ShapeData } from "@edv4h/usketch-shared";
+import type { WsConnectionStatus, WsProviderHandle } from "@edv4h/usketch-sync";
+import type { Awareness } from "y-protocols/awareness";
+import { WebsocketProvider } from "y-websocket";
+import * as Y from "yjs";
+import { SyncStatusTracker } from "./sync-status-tracker.js";
+import type { ResolveParamsContext, YwebsocketSyncHandle, YwebsocketSyncOptions } from "./types.js";
+
+function toPlainObject(shape: ShapeData): Record<string, unknown> {
+	return JSON.parse(JSON.stringify(shape));
+}
+
+type ProviderState = {
+	provider: WebsocketProvider;
+	unbind: () => void;
+};
+
+export function createYwebsocketSync(
+	store: BoardStore,
+	options: YwebsocketSyncOptions,
+): YwebsocketSyncHandle {
+	const {
+		url,
+		roomName,
+		shapesMapKey = "shapes",
+		resolveParams,
+		onCloseCode,
+		idleTimeoutMs = 0,
+		autoConnect = true,
+		doc: providedDoc,
+		WebSocketPolyfill,
+	} = options;
+
+	const doc = providedDoc ?? new Y.Doc();
+	const ownsDoc = providedDoc === undefined;
+	const shapesMap = doc.getMap<Record<string, unknown>>(shapesMapKey);
+	const status = new SyncStatusTracker();
+
+	let destroyed = false;
+	let isSyncing = false;
+	let attempt = 0;
+	let currentState: ProviderState | null = null;
+	let lastCloseCode: number | undefined;
+	let lastCloseReason: string | undefined;
+
+	// A long-lived Awareness bound to `doc` — reused across reconnects so consumers
+	// (e.g., presence-cursor) can subscribe once.
+	let sharedAwareness: Awareness | null = null;
+
+	// WsProviderHandle event listener sets — persist across reconnects.
+	const statusListeners = new Set<(status: WsConnectionStatus) => void>();
+	const broadcastListeners = new Set<(msg: Record<string, unknown>) => void>();
+
+	function notifyStatus(next: WsConnectionStatus): void {
+		status.update({
+			state:
+				next === "connected"
+					? "synced"
+					: next === "connecting"
+						? "connecting"
+						: next === "disconnected"
+							? "disconnected"
+							: "error",
+			error: next === "failed" ? "connection failed" : null,
+		});
+		for (const listener of statusListeners) {
+			listener(next);
+		}
+	}
+
+	// ── Store ↔ Y.Doc binding ──────────────────────────────────────────────────
+	// These observers are set up once; they keep working across provider reconnects
+	// because they bind to `doc` / `shapesMap` rather than the provider.
+
+	const unsubMutation = store.onMutation((event) => {
+		if (isSyncing || destroyed) return;
+
+		const payload = event.payload as { id: string } | undefined;
+		if (!payload?.id) return;
+
+		isSyncing = true;
+		try {
+			switch (event.type) {
+				case "shape:added":
+				case "shape:updated": {
+					const shape = store.getShape(payload.id);
+					if (shape) {
+						shapesMap.set(payload.id, toPlainObject(shape));
+					}
+					break;
+				}
+				case "shape:removed": {
+					shapesMap.delete(payload.id);
+					break;
+				}
+			}
+		} finally {
+			isSyncing = false;
+		}
+
+		resetIdleTimer();
+	});
+
+	const shapesObserver = (events: Y.YMapEvent<Record<string, unknown>>): void => {
+		if (isSyncing || destroyed) return;
+
+		isSyncing = true;
+		try {
+			for (const [key, change] of events.changes.keys) {
+				switch (change.action) {
+					case "add":
+					case "update": {
+						const value = shapesMap.get(key);
+						if (value) {
+							const shape = value as unknown as ShapeData;
+							const existing = store.getShape(key);
+							if (existing) {
+								store.updateShape(key, shape);
+							} else {
+								store.addShape(shape);
+							}
+						}
+						break;
+					}
+					case "delete": {
+						if (store.getShape(key)) {
+							store.deleteShape(key);
+						}
+						break;
+					}
+				}
+			}
+		} finally {
+			isSyncing = false;
+		}
+
+		status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
+	};
+
+	shapesMap.observe(shapesObserver);
+
+	// ── Initial load: existing Y.Doc → store (pre-connection, e.g. from a persisted doc) ──
+	function applyInitialLoad(): void {
+		if (shapesMap.size === 0) return;
+		isSyncing = true;
+		try {
+			for (const [id, value] of shapesMap.entries()) {
+				const shape = value as unknown as ShapeData;
+				if (!store.getShape(id)) {
+					store.addShape(shape);
+				}
+			}
+		} finally {
+			isSyncing = false;
+		}
+		status.update({ shapeCount: shapesMap.size });
+	}
+
+	applyInitialLoad();
+
+	// ── Idle timer ─────────────────────────────────────────────────────────────
+
+	let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function clearIdleTimer(): void {
+		if (idleTimer) {
+			clearTimeout(idleTimer);
+			idleTimer = null;
+		}
+	}
+
+	function resetIdleTimer(): void {
+		if (idleTimeoutMs <= 0 || destroyed) return;
+		clearIdleTimer();
+		idleTimer = setTimeout(() => {
+			disconnect({ reason: "idle" });
+		}, idleTimeoutMs);
+	}
+
+	// ── Provider lifecycle ─────────────────────────────────────────────────────
+
+	let whenSyncedResolve: (() => void) | null = null;
+	const whenSynced = new Promise<void>((resolve) => {
+		whenSyncedResolve = resolve;
+	});
+	let firstSyncSettled = false;
+
+	function settleFirstSync(): void {
+		if (firstSyncSettled) return;
+		firstSyncSettled = true;
+		whenSyncedResolve?.();
+	}
+
+	async function connect(): Promise<void> {
+		if (destroyed || currentState) return;
+
+		status.update({ state: "connecting" });
+
+		let connParams: Record<string, string> = {};
+		if (resolveParams) {
+			try {
+				const ctx: ResolveParamsContext = {
+					attempt,
+					previousCloseCode: lastCloseCode,
+					previousCloseReason: lastCloseReason,
+				};
+				const resolved = await resolveParams(ctx);
+				connParams = resolved.params ?? {};
+			} catch (err) {
+				status.update({
+					state: "error",
+					error: err instanceof Error ? err.message : String(err),
+				});
+				scheduleReconnect();
+				return;
+			}
+		}
+
+		if (destroyed) return;
+
+		const provider = new WebsocketProvider(url, roomName, doc, {
+			connect: true,
+			params: connParams,
+			WebSocketPolyfill: WebSocketPolyfill as typeof WebSocket | undefined,
+			resyncInterval: 0,
+		});
+
+		// Reuse a single Awareness instance across reconnects.
+		if (!sharedAwareness) {
+			sharedAwareness = provider.awareness;
+		}
+
+		const onStatus = (event: { status: "connecting" | "connected" | "disconnected" }): void => {
+			if (event.status === "connected") {
+				attempt = 0;
+				lastCloseCode = undefined;
+				lastCloseReason = undefined;
+				notifyStatus("connected");
+				resetIdleTimer();
+			} else if (event.status === "connecting") {
+				notifyStatus("connecting");
+			} else {
+				notifyStatus("disconnected");
+			}
+		};
+
+		const onSync = (isSynced: boolean): void => {
+			if (isSynced) {
+				status.update({
+					state: "synced",
+					shapeCount: shapesMap.size,
+					lastSyncedAt: Date.now(),
+				});
+				settleFirstSync();
+			}
+		};
+
+		const onConnectionClose = (event: CloseEvent | null): void => {
+			const code = event?.code ?? 0;
+			const reason = event?.reason ?? "";
+			lastCloseCode = code;
+			lastCloseReason = reason;
+
+			const decision = onCloseCode?.(code, reason);
+			if (decision === "stop") {
+				tearDownProvider();
+				notifyStatus("disconnected");
+				settleFirstSync();
+				return;
+			}
+			// "retry" or undefined → fall through to reconnect
+			tearDownProvider();
+			if (decision === "retry") {
+				attempt = 0; // don't apply backoff for explicit retry
+				void connect();
+			} else {
+				scheduleReconnect();
+			}
+		};
+
+		const onConnectionError = (): void => {
+			// y-websocket emits connection-error before close; we rely on close for reconnect.
+		};
+
+		provider.on("status", onStatus);
+		provider.on("sync", onSync);
+		provider.on("connection-close", onConnectionClose);
+		provider.on("connection-error", onConnectionError);
+
+		currentState = {
+			provider,
+			unbind: () => {
+				provider.off("status", onStatus);
+				provider.off("sync", onSync);
+				provider.off("connection-close", onConnectionClose);
+				provider.off("connection-error", onConnectionError);
+			},
+		};
+	}
+
+	function tearDownProvider(): void {
+		if (!currentState) return;
+		currentState.unbind();
+		try {
+			currentState.provider.disconnect();
+		} catch {
+			// ignore
+		}
+		try {
+			// `destroy` cleans up the socket but keeps the awareness instance that we've
+			// captured. We reattach to a fresh one on reconnect via `sharedAwareness`.
+			currentState.provider.destroy();
+		} catch {
+			// ignore
+		}
+		currentState = null;
+	}
+
+	let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function scheduleReconnect(): void {
+		if (destroyed) return;
+		if (reconnectTimer) return;
+		attempt += 1;
+		// Exponential backoff with jitter, cap 30s
+		const base = Math.min(1000 * 2 ** Math.min(attempt, 6), 30000);
+		const delay = base + Math.random() * 1000;
+		reconnectTimer = setTimeout(() => {
+			reconnectTimer = null;
+			void connect();
+		}, delay);
+	}
+
+	function disconnect(_opts?: { reason?: "manual" | "idle" }): void {
+		if (reconnectTimer) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
+		clearIdleTimer();
+		tearDownProvider();
+		notifyStatus("disconnected");
+	}
+
+	function resume(): void {
+		if (destroyed) return;
+		if (currentState) return;
+		attempt = 0;
+		void connect();
+	}
+
+	// ── WsProviderHandle adapter ───────────────────────────────────────────────
+
+	const wsProvider: WsProviderHandle = {
+		get connected() {
+			return Boolean(currentState && (currentState.provider.wsconnected ?? false));
+		},
+		// Lazily provisioned — first call to `connect()` populates `sharedAwareness`.
+		// If someone reads this before we've connected, create a detached Awareness on `doc`.
+		get awareness(): Awareness {
+			if (sharedAwareness) return sharedAwareness;
+			// Defer import of y-protocols to avoid duplicating implementations.
+			// This branch is only hit if `autoConnect: false` AND awareness is accessed
+			// before `resume()`. Consumers are expected to call `resume()` first.
+			throw new Error(
+				"[usketch-plugin-sync-ywebsocket] awareness is not available until the first connection — call resume() first or enable autoConnect.",
+			);
+		},
+		broadcast(_msg: Record<string, unknown>): void {
+			// y-websocket has no broadcast channel separate from Y.Doc updates; no-op.
+		},
+		onBroadcast(handler: (msg: Record<string, unknown>) => void): () => void {
+			broadcastListeners.add(handler);
+			return () => broadcastListeners.delete(handler);
+		},
+		onStatusChange(handler: (status: WsConnectionStatus) => void): () => void {
+			statusListeners.add(handler);
+			// Fire current state immediately for parity with createWsProvider behavior.
+			handler(
+				currentState?.provider.wsconnected
+					? "connected"
+					: currentState
+						? "connecting"
+						: "disconnected",
+			);
+			return () => statusListeners.delete(handler);
+		},
+		requestPartition(_names: string[]): void {
+			// y-websocket has no partition concept; no-op.
+		},
+		onPartitionMeta(_handler: (meta: unknown) => void): () => void {
+			return () => {
+				// no-op
+			};
+		},
+		destroy(): void {
+			destroy();
+		},
+	} as WsProviderHandle;
+
+	function destroy(): void {
+		if (destroyed) return;
+		destroyed = true;
+		if (reconnectTimer) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
+		clearIdleTimer();
+		tearDownProvider();
+		shapesMap.unobserve(shapesObserver);
+		unsubMutation();
+		statusListeners.clear();
+		broadcastListeners.clear();
+		if (ownsDoc) {
+			doc.destroy();
+		}
+		settleFirstSync();
+	}
+
+	if (autoConnect) {
+		void connect();
+	}
+
+	return {
+		doc,
+		status,
+		whenSynced,
+		wsProvider,
+		disconnect: () => disconnect({ reason: "manual" }),
+		resume,
+		destroy,
+	};
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -42,6 +42,14 @@ export function createYwebsocketSync(
 	let currentState: ProviderState | null = null;
 	let lastCloseCode: number | undefined;
 	let lastCloseReason: string | undefined;
+	// `paused` is set by `disconnect()` and cleared by `resume()` / destroy, so an
+	// in-flight `connect()` (mid-`await resolveParams`) bails out instead of
+	// creating a socket after a user-initiated disconnect.
+	let paused = false;
+	// Generation counter to cancel stale async `connect()` runs. Each `connect()`
+	// captures its generation and re-checks after every await boundary; any
+	// disconnect/destroy increments the counter and invalidates pending runs.
+	let connectGeneration = 0;
 
 	// A long-lived Awareness bound to `doc`. Created up-front so `wsProvider.awareness`
 	// is always valid (WsProviderHandle consumers, e.g. presence-cursor, destructure
@@ -217,7 +225,8 @@ export function createYwebsocketSync(
 	}
 
 	async function connect(): Promise<void> {
-		if (destroyed || currentState) return;
+		if (destroyed || paused || currentState) return;
+		const myGeneration = ++connectGeneration;
 
 		status.update({ state: "connecting" });
 
@@ -230,8 +239,12 @@ export function createYwebsocketSync(
 					previousCloseReason: lastCloseReason,
 				};
 				const resolved = await resolveParams(ctx);
+				// After await: bail out if disconnect/destroy happened or a newer
+				// connect() superseded this run.
+				if (destroyed || paused || myGeneration !== connectGeneration) return;
 				connParams = resolved.params ?? {};
 			} catch (err) {
+				if (destroyed || paused || myGeneration !== connectGeneration) return;
 				status.update({
 					state: "error",
 					error: err instanceof Error ? err.message : String(err),
@@ -244,7 +257,7 @@ export function createYwebsocketSync(
 			}
 		}
 
-		if (destroyed) return;
+		if (destroyed || paused || myGeneration !== connectGeneration) return;
 
 		const provider = new WebsocketProvider(url, roomName, doc, {
 			connect: true,
@@ -358,6 +371,10 @@ export function createYwebsocketSync(
 	}
 
 	function disconnect(_opts?: { reason?: "manual" | "idle" }): void {
+		// Pause + bump generation so any in-flight `connect()` (e.g. mid-await
+		// on resolveParams) aborts before it can create a provider.
+		paused = true;
+		connectGeneration += 1;
 		if (reconnectTimer) {
 			clearTimeout(reconnectTimer);
 			reconnectTimer = null;
@@ -369,6 +386,12 @@ export function createYwebsocketSync(
 
 	function resume(): void {
 		if (destroyed) return;
+		// Clear pause and any pending backoff so we don't get overlapping connects.
+		paused = false;
+		if (reconnectTimer) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
 		resetIdleTimer();
 		if (currentState) return;
 		attempt = 0;
@@ -394,13 +417,19 @@ export function createYwebsocketSync(
 		onStatusChange(handler: (status: WsConnectionStatus) => void): () => void {
 			statusListeners.add(handler);
 			// Fire current state immediately for parity with createWsProvider behavior.
-			handler(
-				currentState?.provider.wsconnected
+			// Use the status tracker so pre-provider connection attempts (e.g. while
+			// awaiting `resolveParams`) correctly report `"connecting"` instead of
+			// `"disconnected"`.
+			const snapshot = status.getSnapshot().state;
+			const initial: WsConnectionStatus =
+				snapshot === "synced"
 					? "connected"
-					: currentState
+					: snapshot === "connecting" || snapshot === "syncing"
 						? "connecting"
-						: "disconnected",
-			);
+						: snapshot === "error"
+							? "failed"
+							: "disconnected";
+			handler(initial);
 			return () => statusListeners.delete(handler);
 		},
 		requestPartition(_names: string[]): void {
@@ -419,6 +448,8 @@ export function createYwebsocketSync(
 	function destroy(): void {
 		if (destroyed) return;
 		destroyed = true;
+		// Invalidate any in-flight `connect()` awaiting `resolveParams`.
+		connectGeneration += 1;
 		if (reconnectTimer) {
 			clearTimeout(reconnectTimer);
 			reconnectTimer = null;

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -103,6 +103,9 @@ export function createYwebsocketSync(
 			isSyncing = false;
 		}
 
+		// Keep the status snapshot in sync with the authoritative Y.Map size so
+		// consumers (DebugHUD etc.) see up-to-date counts after local edits too.
+		status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
 		resetIdleTimer();
 	});
 
@@ -147,6 +150,7 @@ export function createYwebsocketSync(
 	// ── Initial load: existing Y.Doc → store (pre-connection, e.g. from a persisted doc) ──
 	function applyInitialLoad(): void {
 		if (shapesMap.size === 0) return;
+		const idsNeedingZIndex: string[] = [];
 		isSyncing = true;
 		try {
 			for (const [id, value] of shapesMap.entries()) {
@@ -154,10 +158,26 @@ export function createYwebsocketSync(
 				if (!store.getShape(id)) {
 					store.addShape(shape);
 				}
+				// Track legacy shapes that were persisted before z-order was introduced.
+				if (typeof shape.zIndex !== "string") {
+					idsNeedingZIndex.push(id);
+				}
 			}
 		} finally {
 			isSyncing = false;
 		}
+
+		// Backfill zIndex into Y.Map for any shape that got an auto-assigned one,
+		// so other clients observe the same stable z-order on subsequent loads.
+		if (idsNeedingZIndex.length > 0) {
+			doc.transact(() => {
+				for (const id of idsNeedingZIndex) {
+					const current = store.getShape(id);
+					if (current) shapesMap.set(id, toPlainObject(current));
+				}
+			});
+		}
+
 		status.update({ shapeCount: shapesMap.size });
 	}
 
@@ -275,7 +295,9 @@ export function createYwebsocketSync(
 			// "retry" or undefined → fall through to reconnect
 			tearDownProvider();
 			if (decision === "retry") {
-				attempt = 0; // don't apply backoff for explicit retry
+				// Explicit retry reconnects immediately, so reset the backoff counter
+				// (this also resets `ctx.attempt` — see ResolveParamsContext.attempt docstring).
+				attempt = 0;
 				void connect();
 			} else {
 				scheduleReconnect();

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -1,6 +1,6 @@
 import type { BoardStore, ShapeData } from "@edv4h/usketch-shared";
 import type { WsConnectionStatus, WsProviderHandle } from "@edv4h/usketch-sync";
-import type { Awareness } from "y-protocols/awareness";
+import { Awareness } from "y-protocols/awareness";
 import { WebsocketProvider } from "y-websocket";
 import * as Y from "yjs";
 import { SyncStatusTracker } from "./sync-status-tracker.js";
@@ -43,19 +43,24 @@ export function createYwebsocketSync(
 	let lastCloseCode: number | undefined;
 	let lastCloseReason: string | undefined;
 
-	// A long-lived Awareness bound to `doc` — reused across reconnects so consumers
-	// (e.g., presence-cursor) can subscribe once.
-	let sharedAwareness: Awareness | null = null;
+	// A long-lived Awareness bound to `doc`. Created up-front so `wsProvider.awareness`
+	// is always valid (WsProviderHandle consumers, e.g. presence-cursor, destructure
+	// it at plugin-creation time). The same instance is passed into every
+	// WebsocketProvider so remote awareness updates keep flowing through reconnects.
+	const sharedAwareness: Awareness = new Awareness(doc);
 
 	// WsProviderHandle event listener sets — persist across reconnects.
 	const statusListeners = new Set<(status: WsConnectionStatus) => void>();
 	const broadcastListeners = new Set<(msg: Record<string, unknown>) => void>();
 
 	function notifyStatus(next: WsConnectionStatus): void {
+		// "connected" at the transport level only means the socket is open — the
+		// first Yjs sync has not necessarily completed. Map to "syncing" until the
+		// provider's `sync` event fires; `onSync` will flip the tracker to "synced".
 		status.update({
 			state:
 				next === "connected"
-					? "synced"
+					? "syncing"
 					: next === "connecting"
 						? "connecting"
 						: next === "disconnected"
@@ -211,6 +216,9 @@ export function createYwebsocketSync(
 					state: "error",
 					error: err instanceof Error ? err.message : String(err),
 				});
+				// Unblock `whenSynced` so plugin setup can proceed — consumers should
+				// inspect `status.getSnapshot()` to detect the persistent failure state.
+				settleFirstSync();
 				scheduleReconnect();
 				return;
 			}
@@ -221,14 +229,10 @@ export function createYwebsocketSync(
 		const provider = new WebsocketProvider(url, roomName, doc, {
 			connect: true,
 			params: connParams,
+			awareness: sharedAwareness,
 			WebSocketPolyfill: WebSocketPolyfill as typeof WebSocket | undefined,
 			resyncInterval: 0,
 		});
-
-		// Reuse a single Awareness instance across reconnects.
-		if (!sharedAwareness) {
-			sharedAwareness = provider.awareness;
-		}
 
 		const onStatus = (event: { status: "connecting" | "connected" | "disconnected" }): void => {
 			if (event.status === "connected") {
@@ -343,6 +347,7 @@ export function createYwebsocketSync(
 
 	function resume(): void {
 		if (destroyed) return;
+		resetIdleTimer();
 		if (currentState) return;
 		attempt = 0;
 		void connect();
@@ -354,17 +359,9 @@ export function createYwebsocketSync(
 		get connected() {
 			return Boolean(currentState && (currentState.provider.wsconnected ?? false));
 		},
-		// Lazily provisioned — first call to `connect()` populates `sharedAwareness`.
-		// If someone reads this before we've connected, create a detached Awareness on `doc`.
-		get awareness(): Awareness {
-			if (sharedAwareness) return sharedAwareness;
-			// Defer import of y-protocols to avoid duplicating implementations.
-			// This branch is only hit if `autoConnect: false` AND awareness is accessed
-			// before `resume()`. Consumers are expected to call `resume()` first.
-			throw new Error(
-				"[usketch-plugin-sync-ywebsocket] awareness is not available until the first connection — call resume() first or enable autoConnect.",
-			);
-		},
+		// Always bound to `doc` and reused across every WebsocketProvider — consumers
+		// (e.g. presence-cursor) can destructure at plugin-creation time without races.
+		awareness: sharedAwareness,
 		broadcast(_msg: Record<string, unknown>): void {
 			// y-websocket has no broadcast channel separate from Y.Doc updates; no-op.
 		},
@@ -410,6 +407,7 @@ export function createYwebsocketSync(
 		unsubMutation();
 		statusListeners.clear();
 		broadcastListeners.clear();
+		sharedAwareness.destroy();
 		if (ownsDoc) {
 			doc.destroy();
 		}

--- a/plugins/usketch-plugin-sync-ywebsocket/tsconfig.json
+++ b/plugins/usketch-plugin-sync-ywebsocket/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "**/__tests__/**"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1710,6 +1710,31 @@ importers:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  plugins/usketch-plugin-sync-ywebsocket:
+    dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-sync':
+        specifier: workspace:*
+        version: link:../../packages/sync
+      y-protocols:
+        specifier: 1.0.7
+        version: 1.0.7(yjs@13.6.30)
+      y-websocket:
+        specifier: ^3.0.0
+        version: 3.0.0(yjs@13.6.30)
+      yjs:
+        specifier: ^13.6.0
+        version: 13.6.30
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
+
   plugins/usketch-plugin-tool-pan:
     dependencies:
       '@edv4h/usketch-core':
@@ -6346,6 +6371,12 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     peerDependencies:
       yjs: ^13.0.0
+
+  y-websocket@3.0.0:
+    resolution: {integrity: sha512-mUHy7AzkOZ834T/7piqtlA8Yk6AchqKqcrCXjKW8J1w2lPtRDjz8W5/CvXz9higKAHgKRKqpI3T33YkRFLkPtg==, tarball: https://registry.npmjs.org/y-websocket/-/y-websocket-3.0.0.tgz}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      yjs: ^13.5.6
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==, tarball: https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz}
@@ -11089,6 +11120,12 @@ snapshots:
   y-protocols@1.0.7(yjs@13.6.30):
     dependencies:
       lib0: 0.2.117
+      yjs: 13.6.30
+
+  y-websocket@3.0.0(yjs@13.6.30):
+    dependencies:
+      lib0: 0.2.117
+      y-protocols: 1.0.7(yjs@13.6.30)
       yjs: 13.6.30
 
   y18n@5.0.8: {}


### PR DESCRIPTION
## Summary

- 新パッケージ `@edv4h/usketch-plugin-sync-ywebsocket` を追加
- `y-websocket` の `WebsocketProvider` をラップし、`@edv4h/usketch-sync` の `WsProviderHandle` 互換の adapter を公開 → `presence-cursor` 等、既存プラグインがそのまま使える
- Cognito 等の動的 auth を想定し、接続時に非同期で URL params を返せる `resolveParams` を提供（再接続時も毎回呼ばれるので fresh token に差し替え可）
- `onCloseCode` で close code 別挙動、`idleTimeoutMs` で無操作切断、`doc` 指定で既存 Y.Doc 注入（weboard 移行時は `shapesMapKey: "map"` を指定できる）
- README / catalog エントリ / changeset / 8 件のユニットテスト込み

Closes #574.

## Test plan

- [x] `pnpm --filter @edv4h/usketch-plugin-sync-ywebsocket typecheck`
- [x] `pnpm --filter @edv4h/usketch-plugin-sync-ywebsocket build` — dist に `__tests__/` が含まれていないことも確認
- [x] `pnpm --filter @edv4h/usketch-plugin-sync-ywebsocket test` — 8 件 pass
- [x] `pnpm biome check` が 0 error / 0 warning

## 補足: Out of scope（将来対応）

- E2E テスト（実 y-websocket サーバを CI で立てる）は追わない。WS 部分は手動検証と weboard 側の結合テストで担保する方針
- broadcast / partition は y-websocket に対応概念がないので no-op 実装。必要なら uSketch ネイティブサーバ側を使う

## Related

- Epic: [Atrae/wevox-mono-web#10172](https://github.com/Atrae/wevox-mono-web/issues/10172)