### PR TITLE
✨ feat(shared): ShapeData に 3 層拡張契約を導入

### DIFF
--- a/.changeset/shape-data-layered-contract.md
+++ b/.changeset/shape-data-layered-contract.md
@@ -1,0 +1,85 @@
+---
+"@edv4h/usketch-shared": major
+"@edv4h/usketch-store": major
+"@edv4h/usketch-plugin-canvas-filter": major
+"@edv4h/usketch-plugin-shape-text": major
+"@edv4h/usketch-plugin-shape-sticky": major
+"@edv4h/usketch-plugin-shape-freedraw": major
+"@edv4h/usketch-plugin-shape-connector": major
+"@edv4h/usketch-plugin-shape-wireframe": major
+"@edv4h/usketch-plugin-shape-counter": major
+"@edv4h/usketch-plugin-shape-frame": major
+"@edv4h/usketch-plugin-shape-island": major
+"@edv4h/usketch-plugin-shape-image": major
+"@edv4h/usketch-plugin-shape-community-region": major
+"@edv4h/usketch-plugin-shape-board-portal": major
+"@edv4h/usketch-plugin-board-info-panel": major
+"@edv4h/usketch-plugin-community-chat": major
+"@edv4h/usketch-plugin-ai-agent": major
+"@edv4h/usketch-plugin-ai-copilot": major
+"@edv4h/usketch-plugin-ai-recognize": major
+"@edv4h/usketch-plugin-tool-select": major
+"@edv4h/usketch-plugin-debug-hud": major
+"@edv4h/usketch-shape-utils": major
+---
+
+`ShapeData` contract redesign — layered 3-tier extension model. Closes #575.
+
+## Breaking changes
+
+**1. `ShapeData` is now generic and strictly typed.**
+
+```ts
+// Before
+interface ShapeData {
+  /* core fields */
+  [key: string]: unknown;  // any field accepted
+}
+
+// After
+interface ShapeData<TMeta = Record<string, unknown>> {
+  id: string; type: string; x: number; y: number;
+  width: number; height: number; style: ShapeStyle;
+  rotation?: number; zIndex?: string;
+  createdAt?: number; updatedAt?: number;
+  parentId?: string;          // NEW — was implicit in plugins
+  meta?: TMeta;               // NEW — typed domain data
+  [key: `x-${string}`]: unknown;  // NEW — only `x-*` prefixed keys accepted
+}
+```
+
+**2. `_createdAt` / `_updatedAt` renamed** to `createdAt` / `updatedAt` (no leading underscore). The fields are now explicit core fields instead of magic strings stamped by the store.
+
+**3. `canvas-filter`**: `TimeRangeFilter.field` type is now `"createdAt" | "updatedAt"` (was `"_createdAt" | "_updatedAt"`).
+
+## Migration guide
+
+Shape data can live in three places, in this priority:
+
+1. **Core fields** — listed explicitly in `ShapeData`. Do not redefine.
+2. **Plugin-intrinsic fields** — declare an extension interface and use it inside your plugin:
+   ```ts
+   interface TextShapeData extends ShapeData {
+     text: string;
+     fontSize: number;
+   }
+   function render(shape: ShapeData) {
+     const data = shape as TextShapeData;
+     // ...
+   }
+   ```
+3. **Application/domain data — use `meta` (preferred)**:
+   ```ts
+   interface WeboardMeta { employeeId?: string }
+   const shape: ShapeData<WeboardMeta> = { ..., meta: { employeeId: "emp_1" } };
+   ```
+4. **Escape hatch — `x-*` prefix** for top-level fields `meta` cannot cover:
+   ```ts
+   const shape: ShapeData = { ..., "x-legacyFlag": true };
+   ```
+
+Previously any field name was allowed via `[key: string]: unknown`. That is no longer the case: fields outside the `x-*` namespace must be defined by a plugin extension interface or core.
+
+If you persisted shapes with top-level domain fields like `{ employeeId: "emp_1" }`, either move them to `meta.employeeId`, or rename to `x-employeeId`. If you stamped shapes with `_createdAt` / `_updatedAt`, rename to `createdAt` / `updatedAt` in stored data.
+
+See the [shape-system](https://usketch.dev/docs/concepts/shape-system/) and [shape-plugin guide](https://usketch.dev/docs/guides/shape-plugin/) for the full contract.

--- a/apps/docs/src/content/docs/concepts/shape-system.mdx
+++ b/apps/docs/src/content/docs/concepts/shape-system.mdx
@@ -9,16 +9,21 @@ order: 11
 Every shape on the canvas is represented by a `ShapeData` object:
 
 ```ts
-interface ShapeData {
+interface ShapeData<TMeta = Record<string, unknown>> {
   id: string;
-  type: string;        // Must match a registered ShapeDefinition
+  type: string;            // Must match a registered ShapeDefinition
   x: number;
   y: number;
   width: number;
   height: number;
   style: ShapeStyle;
   rotation?: number;
-  [key: string]: unknown;  // Shape-specific extra properties
+  zIndex?: string;          // Fractional index for z-order
+  createdAt?: number;       // Unix millis — set by the store on addShape
+  updatedAt?: number;       // Unix millis — updated by the store on mutation
+  parentId?: string;        // For hierarchical grouping (frames, groups)
+  meta?: TMeta;             // Application/domain data (preferred)
+  [key: `x-${string}`]: unknown;  // Escape hatch: custom top-level fields
 }
 
 interface ShapeStyle {
@@ -29,7 +34,66 @@ interface ShapeStyle {
 }
 ```
 
-The `type` field links the data to its `ShapeDefinition`. Shape-specific properties (e.g., `cornerRadius` for rectangles) are stored as extra keys.
+The `type` field links the data to its `ShapeDefinition`.
+
+## Extending shapes
+
+`ShapeData` distinguishes three places where data can live:
+
+### 1. Core fields
+
+The explicit fields listed above (`id`, `type`, `x`, `y`, `width`, `height`, `style`, `rotation`, `zIndex`, `createdAt`, `updatedAt`, `parentId`, `meta`) are managed by the uSketch core. Plugins and applications must not redefine them.
+
+### 2. Plugin-specific fields — extend the interface
+
+A plugin that needs intrinsic data (data that defines what the shape *is* — e.g. the `text` of a text shape, the `points` of a freehand stroke) should declare an extension interface:
+
+```ts
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+export interface TextShapeData extends ShapeData {
+  text: string;
+  fontSize: number;
+  fontFamily: string;
+  isEditing: boolean;
+}
+```
+
+Use the extension type inside your plugin (e.g. in `render` and `createDefault`) and export it so other plugins can read it back type-safely.
+
+### 3. Application/domain data — use `meta` (preferred)
+
+For data that is *not* intrinsic to the shape (external references, identifiers, feature flags), put it under `meta`. Pass your concrete meta type as `TMeta` for full type safety:
+
+```ts
+interface WeboardMeta {
+  employeeId?: string;
+  documentKey?: string;
+}
+
+const shape: ShapeData<WeboardMeta> = {
+  id: "note_1",
+  type: "rect",
+  x: 0, y: 0, width: 200, height: 150,
+  style: DEFAULT_STYLE,
+  meta: { employeeId: "emp_123", documentKey: "doc_456" },
+};
+shape.meta?.employeeId; // typed as string | undefined
+```
+
+### Escape hatch: the `x-*` prefix
+
+For the rare case where `meta` does not fit — e.g. a gradual migration that temporarily needs a top-level field — `ShapeData` accepts any property whose name starts with `x-`:
+
+```ts
+const shape: ShapeData = {
+  id: "2", type: "rect", x: 0, y: 0, width: 100, height: 100,
+  style: DEFAULT_STYLE,
+  "x-legacyFlag": true,
+};
+```
+
+The `x-` namespace is guaranteed to never clash with core or plugin-extension fields (this mirrors the convention used by HTTP headers, JSON-LD, OpenAPI, and `package.json`). Prefer `meta` whenever possible — it is typed, `x-*` is not.
 
 ## ShapeDefinition
 

--- a/apps/docs/src/content/docs/guides/shape-plugin.mdx
+++ b/apps/docs/src/content/docs/guides/shape-plugin.mdx
@@ -25,20 +25,26 @@ Both are registered inside a single `setup()` function.
 
 ### 1. Define the Shape Functions
 
-First, implement the required `ShapeDefinition` methods:
+First, declare an extension interface for any intrinsic fields your shape needs, then implement the required `ShapeDefinition` methods:
 
 ```tsx
 import type { BoundingBox, Point, ResizeHandle, ShapeData } from "@edv4h/usketch-shared";
 import { DEFAULT_STYLE } from "@edv4h/usketch-shared";
 
-function render(data: ShapeData) {
+/** Intrinsic data for the `rectangle` shape. Export so other plugins can read it type-safely. */
+export interface RectangleShapeData extends ShapeData {
+  cornerRadius?: number;
+}
+
+function render(shape: ShapeData) {
+  const data = shape as RectangleShapeData;
   return (
     <rect
       x={data.x}
       y={data.y}
       width={data.width}
       height={data.height}
-      rx={(data.cornerRadius as number) ?? 0}
+      rx={data.cornerRadius ?? 0}
       fill={data.style.fill}
       stroke={data.style.stroke}
       strokeWidth={data.style.strokeWidth}
@@ -60,7 +66,7 @@ function hitTest(data: ShapeData, point: Point): boolean {
   );
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): RectangleShapeData {
   return {
     id: params.id,
     type: "rectangle",
@@ -73,6 +79,8 @@ function createDefault(params: { id: string; x: number; y: number }): ShapeData 
   };
 }
 ```
+
+**Pattern.** The `ShapeRegistry` works with the base `ShapeData` type, so `render` / `resize` / `hitTest` receive `ShapeData`. Cast to your extension type inside (`const data = shape as RectangleShapeData`) to access plugin-specific fields with full type safety.
 
 ### 2. Implement Resize Logic
 
@@ -184,9 +192,41 @@ export const rectPlugin: UsketchPlugin = {
 };
 ```
 
+## Adding application data
+
+Plugin-intrinsic fields (like `cornerRadius` above) belong on the extension interface. For **application- or domain-specific data** that is not part of the shape's geometry (external references, identifiers, feature flags), use the `meta` field instead:
+
+```tsx
+interface WeboardMeta {
+  employeeId?: string;
+  companyId?: string;
+}
+
+const shape: ShapeData<WeboardMeta> = {
+  id: "note_1", type: "rect", x: 0, y: 0, width: 200, height: 150,
+  style: DEFAULT_STYLE,
+  meta: { employeeId: "emp_123", companyId: "co_456" },
+};
+shape.meta?.employeeId; // typed as string | undefined
+```
+
+Pass your concrete meta shape as `TMeta` to `ShapeData<TMeta>` at the call site — the core APIs remain `ShapeData` (the generic parameter is opt-in per consumer).
+
+For edge cases where `meta` does not fit (a gradual migration, or an exceptional top-level field), `ShapeData` also accepts any property whose name starts with `x-`:
+
+```tsx
+const shape: ShapeData = {
+  ...,
+  "x-legacyFlag": true, // escape hatch — prefer meta
+};
+```
+
+See [Shape System → Extending shapes](/docs/concepts/shape-system/#extending-shapes) for the full contract.
+
 ## Key Takeaways
 
 - Shape + tool live in the **same plugin** — they're a single concept.
 - Use **direct store mutations** for live preview, **commands** for the final action.
 - Always handle the case where the user barely drags (width/height < threshold).
 - Switch back to the select tool after drawing — this is the expected UX.
+- Declare an `extends ShapeData` interface for your plugin's intrinsic fields; put application data in `meta`.

--- a/apps/web/src/pages/benchmark/shape-generator.ts
+++ b/apps/web/src/pages/benchmark/shape-generator.ts
@@ -62,7 +62,7 @@ export function generateShapes(count: number, mix: ShapeMix): ShapeData[] {
 		};
 
 		if (type === "rectangle") {
-			shape.cornerRadius = 0;
+			(shape as { cornerRadius?: number }).cornerRadius = 0;
 		}
 
 		shapes.push(shape);

--- a/apps/web/src/pages/community/community-page.tsx
+++ b/apps/web/src/pages/community/community-page.tsx
@@ -14,7 +14,10 @@ import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
 import { createKeyboardShortcutsPlugin } from "@edv4h/usketch-plugin-keyboard-shortcuts";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
 import { createReactionsPlugin, reactionsPlugin } from "@edv4h/usketch-plugin-reactions";
-import { createBoardPortalPlugin } from "@edv4h/usketch-plugin-shape-board-portal";
+import {
+	type BoardPortalShapeData,
+	createBoardPortalPlugin,
+} from "@edv4h/usketch-plugin-shape-board-portal";
 import { groupPlugin } from "@edv4h/usketch-plugin-shape-group";
 import { islandPlugin } from "@edv4h/usketch-plugin-shape-island";
 import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
@@ -92,7 +95,7 @@ export function CommunityPage() {
 								ownerName: authUserName ?? "",
 								ownerImage: authUserImage ?? "",
 								isPublic,
-							});
+							} as Partial<BoardPortalShapeData>);
 						} catch (e) {
 							console.error("Failed to create board:", e);
 							store?.deleteShape(shapeId);

--- a/apps/web/src/pages/world-map.tsx
+++ b/apps/web/src/pages/world-map.tsx
@@ -1,7 +1,10 @@
 import { AppProvider, Canvas } from "@edv4h/usketch-canvas-engine";
 import { type AppInstance, createApp } from "@edv4h/usketch-core";
 import { createDomRendererPlugin } from "@edv4h/usketch-dom-renderer";
-import { createCommunityRegionPlugin } from "@edv4h/usketch-plugin-shape-community-region";
+import {
+	type CommunityRegionShapeData,
+	createCommunityRegionPlugin,
+} from "@edv4h/usketch-plugin-shape-community-region";
 import { panToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
 import { selectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
 import { viewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
@@ -149,7 +152,7 @@ export function WorldMapPage() {
 						themeColor: region.themeColor,
 						icon: region.icon,
 						onlineCount: 0,
-					});
+					} as CommunityRegionShapeData);
 				}
 
 				// 4. キャンバス初期化

--- a/packages/shared/src/types/shape.ts
+++ b/packages/shared/src/types/shape.ts
@@ -5,7 +5,54 @@ export interface ShapeStyle {
 	opacity: number;
 }
 
-export interface ShapeData {
+/**
+ * Base contract for every shape stored by uSketch.
+ *
+ * @typeParam TMeta - Type of application/domain-specific data carried in
+ *   `meta`. Defaults to `Record<string, unknown>` so existing code that uses
+ *   `ShapeData` without a type argument keeps compiling. Consumers can pass
+ *   a concrete meta type to get autocomplete and type-safe reads:
+ *
+ *   ```ts
+ *   interface WeboardMeta { employeeId?: string; documentKey?: string }
+ *   const shape: ShapeData<WeboardMeta> = { ... };
+ *   shape.meta?.employeeId; // typed as string | undefined
+ *   ```
+ *
+ * Fields fall into three categories:
+ *
+ * 1. **Core fields** (listed explicitly below) — managed by the uSketch core.
+ *    Plugins and applications must not redefine them.
+ *
+ * 2. **Plugin-specific fields** — a plugin that needs intrinsic data (e.g.
+ *    `text` for a text shape, `points` for a freedraw stroke) should extend
+ *    this interface:
+ *
+ *    ```ts
+ *    interface TextShapeData extends ShapeData {
+ *      text: string;
+ *      fontSize: number;
+ *    }
+ *    ```
+ *
+ * 3. **Application/domain data — use `meta` (preferred)** — put application-
+ *    specific data (e.g. `employeeId`, `documentKey`) into `meta`, and pass
+ *    your meta type as `TMeta` for type safety:
+ *
+ *    ```ts
+ *    const shape: ShapeData<WeboardMeta> = {
+ *      ...,
+ *      meta: { employeeId: "emp_123", documentKey: "doc_456" },
+ *    };
+ *    ```
+ *
+ *    **Escape hatch — `x-*` prefix**: for cases `meta` does not fit (e.g.
+ *    a gradual migration that temporarily needs a top-level field), use a
+ *    field name starting with `x-`. The `x-` namespace is guaranteed to
+ *    never clash with core or plugin-extension fields (mirrors HTTP headers,
+ *    JSON-LD, OpenAPI, `package.json`). Prefer `meta` whenever possible.
+ */
+export interface ShapeData<TMeta = Record<string, unknown>> {
 	id: string;
 	type: string;
 	x: number;
@@ -16,7 +63,20 @@ export interface ShapeData {
 	rotation?: number;
 	/** Fractional index for z-order (higher lexicographic order = front). */
 	zIndex?: string;
-	[key: string]: unknown;
+	/** Unix millis — set by the store on `addShape`. */
+	createdAt?: number;
+	/** Unix millis — updated by the store on every mutation. */
+	updatedAt?: number;
+	/** Parent shape id for hierarchical grouping (frames, islands, groups). */
+	parentId?: string;
+	/**
+	 * Application/domain-specific metadata — the **preferred** place for data
+	 * that is not intrinsic to the shape's geometry (e.g. external references,
+	 * identifiers, feature flags). Typed via the `TMeta` type parameter.
+	 */
+	meta?: TMeta;
+	/** Escape hatch for top-level application extensions. Prefer `meta`. */
+	[key: `x-${string}`]: unknown;
 }
 
 export type ResizeHandle = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";

--- a/packages/store/src/__tests__/board-store.test.ts
+++ b/packages/store/src/__tests__/board-store.test.ts
@@ -29,26 +29,26 @@ describe("BoardStore", () => {
 			expect(listener).toHaveBeenCalled();
 		});
 
-		it("addShape: stamps _createdAt and _updatedAt", () => {
+		it("addShape: stamps createdAt and updatedAt", () => {
 			const store = createBoardStore();
 			const before = Date.now();
 			store.addShape(makeShape({ id: "s1" }));
 			const after = Date.now();
 
 			const shape = store.getShape("s1")!;
-			const createdAt = shape._createdAt as number;
-			const updatedAt = shape._updatedAt as number;
+			const createdAt = shape.createdAt as number;
+			const updatedAt = shape.updatedAt as number;
 			expect(createdAt).toBeGreaterThanOrEqual(before);
 			expect(createdAt).toBeLessThanOrEqual(after);
 			expect(updatedAt).toBeGreaterThanOrEqual(before);
 		});
 
-		it("addShape: preserves existing _createdAt", () => {
+		it("addShape: preserves existing createdAt", () => {
 			const store = createBoardStore();
-			store.addShape(makeShape({ id: "s1", _createdAt: 12345 } as ShapeData));
+			store.addShape(makeShape({ id: "s1", createdAt: 12345 }));
 
 			const shape = store.getShape("s1")!;
-			expect(shape._createdAt).toBe(12345);
+			expect(shape.createdAt).toBe(12345);
 		});
 
 		it("updateShape: updates existing shape", () => {
@@ -70,14 +70,14 @@ describe("BoardStore", () => {
 			expect(listener).not.toHaveBeenCalled();
 		});
 
-		it("updateShape: stamps _updatedAt", () => {
+		it("updateShape: stamps updatedAt", () => {
 			const store = createBoardStore();
 			store.addShape(makeShape({ id: "s1" }));
 			const before = Date.now();
 
 			store.updateShape("s1", { x: 10 });
 
-			const updatedAt = store.getShape("s1")!._updatedAt as number;
+			const updatedAt = store.getShape("s1")!.updatedAt as number;
 			expect(updatedAt).toBeGreaterThanOrEqual(before);
 		});
 

--- a/packages/store/src/board-store.ts
+++ b/packages/store/src/board-store.ts
@@ -93,11 +93,11 @@ export function createBoardStore(): BoardStore {
 			// Fast path: use the tracked max-zIndex to append a tail key in O(1)
 			// rather than rescanning all existing shapes on every insert.
 			const zIndex = needsZIndex ? zIndexBetween(maxZIndex, null) : shape.zIndex;
-			const stamped = {
+			const stamped: ShapeData = {
 				...shape,
 				zIndex,
-				_createdAt: (shape as Record<string, unknown>)._createdAt ?? now,
-				_updatedAt: now,
+				createdAt: shape.createdAt ?? now,
+				updatedAt: now,
 			};
 			state.shapes = new Map(state.shapes);
 			state.shapes.set(stamped.id, stamped);
@@ -115,7 +115,7 @@ export function createBoardStore(): BoardStore {
 			const existing = state.shapes.get(id);
 			if (!existing) return;
 			state.shapes = new Map(state.shapes);
-			const updated = { ...existing, ...updates, _updatedAt: Date.now() };
+			const updated = { ...existing, ...updates, updatedAt: Date.now() };
 			state.shapes.set(id, updated);
 			spatialIndex.update(id, shapeToBounds(updated));
 			// If zIndex was touched, the cached max may be stale. Recompute lazily

--- a/packages/store/src/commands.ts
+++ b/packages/store/src/commands.ts
@@ -82,7 +82,7 @@ export function createGroupCommand(
 	groupShape: ShapeData,
 	childIds: string[],
 ): Command {
-	const prevParentIds = new Map<string, unknown>();
+	const prevParentIds = new Map<string, string | undefined>();
 	return {
 		execute() {
 			store.addShape(groupShape);
@@ -137,7 +137,7 @@ export function createReparentCommand(
 	shapeIds: string[],
 	newParentId: string | undefined,
 ): Command {
-	const prevParentIds = new Map<string, unknown>();
+	const prevParentIds = new Map<string, string | undefined>();
 	return {
 		execute() {
 			for (const id of shapeIds) {
@@ -175,9 +175,14 @@ export function createDeleteWithChildrenCommand(store: BoardStore, shapeId: stri
 			// Also collect connectors attached to any of these shapes
 			const connectorIds = new Set<string>();
 			for (const [, shape] of store.getShapes()) {
+				if (shape.type !== "connector") continue;
+				const { sourceId, targetId } = shape as {
+					sourceId?: string;
+					targetId?: string;
+				};
 				if (
-					shape.type === "connector" &&
-					(allIds.includes(shape.sourceId as string) || allIds.includes(shape.targetId as string))
+					(sourceId !== undefined && allIds.includes(sourceId)) ||
+					(targetId !== undefined && allIds.includes(targetId))
 				) {
 					connectorIds.add(shape.id);
 				}
@@ -305,7 +310,7 @@ interface SiblingGroup {
 }
 
 function parentKey(shape: ShapeData): string | null {
-	return (shape.parentId as string | undefined) ?? null;
+	return shape.parentId ?? null;
 }
 
 /**

--- a/packages/store/src/hierarchy-utils.ts
+++ b/packages/store/src/hierarchy-utils.ts
@@ -58,7 +58,9 @@ export function getTopLevelShapes(store: BoardStore): ShapeData[] {
 export function getConnectorsForShape(store: BoardStore, shapeId: string): ShapeData[] {
 	const connectors: ShapeData[] = [];
 	for (const [, shape] of store.getShapes()) {
-		if (shape.type === "connector" && (shape.sourceId === shapeId || shape.targetId === shapeId)) {
+		if (shape.type !== "connector") continue;
+		const { sourceId, targetId } = shape as { sourceId?: string; targetId?: string };
+		if (sourceId === shapeId || targetId === shapeId) {
 			connectors.push(shape);
 		}
 	}

--- a/packages/usketch-shape-utils/src/gpu.ts
+++ b/packages/usketch-shape-utils/src/gpu.ts
@@ -4,7 +4,7 @@ export function rectGpuPrimitive(data: ShapeData): GpuPrimitive {
 	return {
 		kind: "rect",
 		bounds: { x: data.x, y: data.y, width: data.width, height: data.height },
-		cornerRadius: (data.cornerRadius as number) ?? 0,
+		cornerRadius: (data as { cornerRadius?: number }).cornerRadius ?? 0,
 		fill: cssColorToRgbaOrDefault(data.style.fill),
 		stroke: cssColorToRgbaOrDefault(data.style.stroke),
 		strokeWidth: data.style.strokeWidth,

--- a/plugins/usketch-plugin-ai-agent/src/canvas-serializer.ts
+++ b/plugins/usketch-plugin-ai-agent/src/canvas-serializer.ts
@@ -102,12 +102,15 @@ function serializeShape(shape: ShapeData): Record<string, unknown> {
 	};
 
 	// freedrawはpointCountのみ
-	if (shape.type === "freedraw" && Array.isArray(shape.points)) {
-		result.pointCount = (shape.points as unknown[]).length;
+	const points = (shape as { points?: unknown[] }).points;
+	if (shape.type === "freedraw" && Array.isArray(points)) {
+		result.pointCount = points.length;
 	} else {
 		// type固有フィールド
-		if (shape.text) result.text = shape.text;
-		if (shape.cornerRadius) result.cornerRadius = shape.cornerRadius;
+		const textContent = (shape as { text?: string }).text;
+		const cornerRadius = (shape as { cornerRadius?: number }).cornerRadius;
+		if (textContent) result.text = textContent;
+		if (cornerRadius) result.cornerRadius = cornerRadius;
 	}
 
 	// default styleと異なる場合のみスタイルを含める
@@ -137,7 +140,8 @@ function findNearbyLabels(
 	for (const [id, shape] of allShapes) {
 		if (id === target.id) continue;
 		if (shape.type !== "text") continue;
-		if (!shape.text) continue;
+		const textContent = (shape as { text?: string }).text;
+		if (!textContent) continue;
 
 		// テキストの中心がターゲットの内部 or 近くにあるか
 		const textCx = shape.x + shape.width / 2;
@@ -156,7 +160,7 @@ function findNearbyLabels(
 			textCy <= target.y + target.height + PROXIMITY_THRESHOLD;
 
 		if (isInside || isNearby) {
-			labels.push({ id, text: shape.text as string });
+			labels.push({ id, text: textContent });
 		}
 	}
 

--- a/plugins/usketch-plugin-ai-copilot/src/plugin.tsx
+++ b/plugins/usketch-plugin-ai-copilot/src/plugin.tsx
@@ -64,10 +64,10 @@ export function createAiCopilotPlugin(options: CopilotOptions): UsketchPlugin {
 					shape.width = suggestion.width;
 					shape.height = suggestion.height;
 					if (suggestion.text !== undefined) {
-						(shape as Record<string, unknown>).text = suggestion.text;
+						(shape as { text?: string }).text = suggestion.text;
 					}
 					if (suggestion.fontSize !== undefined) {
-						(shape as Record<string, unknown>).fontSize = suggestion.fontSize;
+						(shape as { fontSize?: number }).fontSize = suggestion.fontSize;
 					}
 					if (suggestion.style) {
 						shape.style = { ...shape.style, ...suggestion.style };
@@ -137,15 +137,18 @@ export function createAiCopilotPlugin(options: CopilotOptions): UsketchPlugin {
 					const viewport = ctx.store.getViewport();
 					const availableTypes = [...ctx.shapes.getAll().keys()];
 
-					const shapeList = [...shapes.values()].slice(-10).map((s) => ({
-						id: s.id,
-						type: s.type,
-						x: Math.round(s.x),
-						y: Math.round(s.y),
-						w: Math.round(s.width),
-						h: Math.round(s.height),
-						...(s.text ? { text: s.text } : {}),
-					}));
+					const shapeList = [...shapes.values()].slice(-10).map((s) => {
+						const text = (s as { text?: string }).text;
+						return {
+							id: s.id,
+							type: s.type,
+							x: Math.round(s.x),
+							y: Math.round(s.y),
+							w: Math.round(s.width),
+							h: Math.round(s.height),
+							...(text ? { text } : {}),
+						};
+					});
 
 					const viewportCenter = {
 						x: Math.round(-viewport.x / viewport.zoom + window.innerWidth / 2 / viewport.zoom),

--- a/plugins/usketch-plugin-ai-recognize/src/freedraw-serializer.ts
+++ b/plugins/usketch-plugin-ai-recognize/src/freedraw-serializer.ts
@@ -23,9 +23,9 @@ function downsamplePoints(
  */
 export function serializeFreedrawForRecognition(shapes: ShapeData[]): string {
 	const strokes = shapes
-		.filter((s) => s.type === "freedraw" && Array.isArray(s.points))
+		.filter((s) => s.type === "freedraw" && Array.isArray((s as { points?: unknown }).points))
 		.map((s) => {
-			const rawPoints = s.points as Array<{ x: number; y: number }>;
+			const rawPoints = (s as { points?: Array<{ x: number; y: number }> }).points ?? [];
 			const sampled = downsamplePoints(rawPoints, 80);
 			return {
 				id: s.id,

--- a/plugins/usketch-plugin-ai-recognize/src/plugin.ts
+++ b/plugins/usketch-plugin-ai-recognize/src/plugin.ts
@@ -96,7 +96,7 @@ IMPORTANT:
 
 			function recognizeImage(ctx: PluginContext, shapes: ShapeData[]): void {
 				const shapeIds = shapes.map((s) => s.id);
-				const src = shapes[0].src as string | undefined;
+				const src = (shapes[0] as { src?: string }).src;
 				if (!src) return;
 
 				ctx.events.emit("ai:request", {

--- a/plugins/usketch-plugin-board-info-panel/src/board-info-tab.tsx
+++ b/plugins/usketch-plugin-board-info-panel/src/board-info-tab.tsx
@@ -1,7 +1,7 @@
 import { type BoardStore, DEFAULT_STYLE } from "@edv4h/usketch-shared";
 import { useCallback, useEffect, useState } from "react";
 import type { BoardInfoClient } from "./board-info-client.js";
-import type { BoardInfo, BoardListItem, BoardMember } from "./types.js";
+import type { BoardInfo, BoardListItem, BoardMember, BoardPortalShapeData } from "./types.js";
 
 interface BoardInfoTabProps {
 	boardId: string | null;
@@ -172,8 +172,9 @@ function BoardListView({
 	function getExistingPortalBoardIds(): Set<string> {
 		const ids = new Set<string>();
 		for (const [, shape] of store.getShapes()) {
-			if (shape.type === "board-portal" && shape.boardId) {
-				ids.add(shape.boardId as string);
+			const portal = shape as BoardPortalShapeData;
+			if (portal.type === "board-portal" && portal.boardId) {
+				ids.add(portal.boardId);
 			}
 		}
 		return ids;
@@ -191,7 +192,7 @@ function BoardListView({
 		const cx = worldLeft + window.innerWidth / 2 / vp.zoom - w / 2;
 		const cy = worldTop + window.innerHeight / 2 / vp.zoom - h / 2;
 
-		store.addShape({
+		const portalShape: BoardPortalShapeData = {
 			id: crypto.randomUUID(),
 			type: "board-portal",
 			x: cx,
@@ -207,7 +208,8 @@ function BoardListView({
 			isPublic: board.isPublic,
 			thumbnailUrl: board.isPublic ? client.getThumbnailUrl(board.id) : undefined,
 			style: DEFAULT_STYLE,
-		});
+		};
+		store.addShape(portalShape);
 	}
 
 	if (loading) {

--- a/plugins/usketch-plugin-board-info-panel/src/index.ts
+++ b/plugins/usketch-plugin-board-info-panel/src/index.ts
@@ -1,2 +1,3 @@
 export type { BoardInfoPanelPluginOptions } from "./plugin.js";
 export { createBoardInfoPanelPlugin } from "./plugin.js";
+export type { BoardPortalShapeData } from "./types.js";

--- a/plugins/usketch-plugin-board-info-panel/src/plugin.tsx
+++ b/plugins/usketch-plugin-board-info-panel/src/plugin.tsx
@@ -2,6 +2,7 @@ import type { SidePanelRegisterEvent } from "@edv4h/usketch-plugin-side-panel";
 import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
 import { createBoardInfoClient } from "./board-info-client.js";
 import { BoardInfoTabWrapper } from "./board-info-tab-wrapper.js";
+import type { BoardPortalShapeData } from "./types.js";
 
 export interface BoardInfoPanelPluginOptions {
 	apiUrl: string;
@@ -44,11 +45,11 @@ export function createBoardInfoPanelPlugin(options: BoardInfoPanelPluginOptions)
 
 			// ポータルシェイプにサムネイル URL を設定（未設定の場合のみ）
 			function ensureThumbnailUrl(shapeId: string, boardId: string) {
-				const shape = ctx.store.getShape(shapeId);
+				const shape = ctx.store.getShape(shapeId) as BoardPortalShapeData | undefined;
 				if (shape && !shape.thumbnailUrl && shape.isPublic !== false) {
 					ctx.store.updateShape(shapeId, {
 						thumbnailUrl: `${apiUrl}/public/boards/${boardId}/thumbnail?w=240&h=160`,
-					});
+					} as Partial<BoardPortalShapeData>);
 				}
 			}
 
@@ -56,9 +57,9 @@ export function createBoardInfoPanelPlugin(options: BoardInfoPanelPluginOptions)
 				const selection = ctx.store.getSelection();
 				if (selection.size === 1) {
 					const shapeId = [...selection][0];
-					const shape = ctx.store.getShape(shapeId);
+					const shape = ctx.store.getShape(shapeId) as BoardPortalShapeData | undefined;
 					if (shape && shape.type === "board-portal" && shape.boardId) {
-						const boardId = shape.boardId as string;
+						const boardId = shape.boardId;
 						ensureThumbnailUrl(shapeId, boardId);
 						if (boardId !== currentPortalBoardId) {
 							currentPortalBoardId = boardId;

--- a/plugins/usketch-plugin-board-info-panel/src/types.ts
+++ b/plugins/usketch-plugin-board-info-panel/src/types.ts
@@ -1,3 +1,19 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/**
+ * board-portal shape extension: intrinsic data for the `board-portal` shape,
+ * as observed/consumed by the board-info-panel plugin.
+ */
+export interface BoardPortalShapeData extends ShapeData {
+	boardId?: string;
+	boardTitle?: string;
+	ownerName?: string;
+	ownerImage?: string;
+	memberCount?: number;
+	isPublic?: boolean;
+	thumbnailUrl?: string;
+}
+
 export interface BoardInfo {
 	id: string;
 	title: string;

--- a/plugins/usketch-plugin-canvas-filter/src/filter-engine.ts
+++ b/plugins/usketch-plugin-canvas-filter/src/filter-engine.ts
@@ -18,8 +18,8 @@ function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
 }
 
 function matchTimeRange(shape: ShapeData, rule: TimeRangeFilter): boolean {
-	const value = (shape as Record<string, unknown>)[rule.field] as number | undefined;
-	// Legacy shapes without timestamps always pass (they have _createdAt = 0)
+	const value = shape[rule.field];
+	// Legacy shapes without timestamps always pass.
 	if (value == null) return true;
 	if (rule.from != null && value < rule.from) return false;
 	if (rule.to != null && value > rule.to) return false;

--- a/plugins/usketch-plugin-canvas-filter/src/filter-palette.tsx
+++ b/plugins/usketch-plugin-canvas-filter/src/filter-palette.tsx
@@ -11,7 +11,7 @@ function makeTimePreset(label: string, description: string, offsetMs: number): F
 			rules: [
 				{
 					kind: "time-range",
-					field: "_createdAt",
+					field: "createdAt",
 					from: Date.now() - offsetMs,
 				},
 			],
@@ -84,7 +84,7 @@ function parseQuery(query: string): ShapeFilterConfig | null {
 				rules: [
 					{
 						kind: "time-range",
-						field: "_createdAt",
+						field: "createdAt",
 						from,
 						...(to != null && !Number.isNaN(to) ? { to } : {}),
 					},

--- a/plugins/usketch-plugin-canvas-filter/src/types.ts
+++ b/plugins/usketch-plugin-canvas-filter/src/types.ts
@@ -4,7 +4,7 @@ import type { ShapeData } from "@edv4h/usketch-shared";
 
 export interface TimeRangeFilter {
 	kind: "time-range";
-	field: "_createdAt" | "_updatedAt";
+	field: "createdAt" | "updatedAt";
 	from?: number; // epoch ms, inclusive
 	to?: number; // epoch ms, inclusive
 }

--- a/plugins/usketch-plugin-community-chat/src/index.ts
+++ b/plugins/usketch-plugin-community-chat/src/index.ts
@@ -1,3 +1,3 @@
 export type { CommunityChatOptions } from "./plugin.js";
 export { createCommunityChatPlugin } from "./plugin.js";
-export type { ChatMessage } from "./types.js";
+export type { ChatMessage, ChatWidgetShapeData } from "./types.js";

--- a/plugins/usketch-plugin-community-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-community-chat/src/plugin.tsx
@@ -13,7 +13,7 @@ import {
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import type { WsProviderHandle } from "@edv4h/usketch-sync";
 import { createChatClient } from "./chat-client.js";
-import type { ChatNewMessageEvent } from "./types.js";
+import type { ChatNewMessageEvent, ChatWidgetShapeData } from "./types.js";
 
 export interface CommunityChatOptions {
 	apiUrl: string;
@@ -58,13 +58,14 @@ function formatRelativeTime(iso: string): string {
 
 // ── ピン描画 ──
 
-function renderChatPin(data: ShapeData) {
-	const label = (data.chatLabel as string) || "Chat";
-	const lastMessage = (data.lastMessage as string) || "";
-	const lastAuthor = (data.lastAuthor as string) || "";
-	const lastMessageAt = (data.lastMessageAt as string) || "";
+function renderChatPin(shape: ShapeData) {
+	const data = shape as ChatWidgetShapeData;
+	const label = data.chatLabel || "Chat";
+	const lastMessage = data.lastMessage || "";
+	const lastAuthor = data.lastAuthor || "";
+	const lastMessageAt = data.lastMessageAt || "";
 	const unread = Number(data.unread ?? 0);
-	const hue = threadHue((data.threadId as string) || data.id);
+	const hue = threadHue(data.threadId || data.id);
 	const accentColor = `hsl(${hue}, 70%, 60%)`;
 	const softColor = `hsl(${hue}, 70%, 85%)`;
 	const relTime = lastMessageAt ? formatRelativeTime(lastMessageAt) : "";
@@ -328,7 +329,7 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 	return { ...data, x, y, width, height };
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): ChatWidgetShapeData {
 	return {
 		id: params.id,
 		type: "chat-widget",
@@ -434,8 +435,9 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 					const shapes = ctx.store.getShapes();
 					for (const [id, shape] of shapes) {
 						if (shape.type !== "chat-widget") continue;
-						if ((shape.threadId as string) !== message.threadId) continue;
-						const prevUnread = Number(shape.unread ?? 0);
+						const data = shape as ChatWidgetShapeData;
+						if (data.threadId !== message.threadId) continue;
+						const prevUnread = Number(data.unread ?? 0);
 						const nextUnread = fromActiveTab ? 0 : prevUnread + 1;
 						ctx.store.updateShape(id, {
 							lastMessage: message.text,
@@ -443,7 +445,7 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 							lastAuthorId: message.authorId,
 							lastMessageAt: message.createdAt,
 							unread: nextUnread,
-						});
+						} as Partial<ChatWidgetShapeData>);
 					}
 				},
 			);
@@ -453,9 +455,10 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 				const shapes = ctx.store.getShapes();
 				for (const [id, shape] of shapes) {
 					if (shape.type !== "chat-widget") continue;
-					if ((shape.threadId as string) !== threadId) continue;
-					if (Number(shape.unread ?? 0) === 0) continue;
-					ctx.store.updateShape(id, { unread: 0 });
+					const data = shape as ChatWidgetShapeData;
+					if (data.threadId !== threadId) continue;
+					if (Number(data.unread ?? 0) === 0) continue;
+					ctx.store.updateShape(id, { unread: 0 } as Partial<ChatWidgetShapeData>);
 				}
 			};
 
@@ -467,13 +470,14 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 				if (!last) return;
 				const shape = ctx.store.getShape(shapeId);
 				if (!shape || shape.type !== "chat-widget") return;
-				if (shape.lastMessageAt === last.createdAt) return; // 変更なし
+				const data = shape as ChatWidgetShapeData;
+				if (data.lastMessageAt === last.createdAt) return; // 変更なし
 				ctx.store.updateShape(shapeId, {
 					lastMessage: last.text,
 					lastAuthor: last.authorName,
 					lastAuthorId: last.authorId,
 					lastMessageAt: last.createdAt,
-				});
+				} as Partial<ChatWidgetShapeData>);
 			};
 
 			// 初期同期: 現在ある chat-widget シェイプ全てを 1 回 fetch
@@ -481,7 +485,7 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 				const shapes = ctx.store.getShapes();
 				for (const [id, shape] of shapes) {
 					if (shape.type !== "chat-widget") continue;
-					const threadId = (shape.threadId as string) || "";
+					const threadId = (shape as ChatWidgetShapeData).threadId || "";
 					if (threadId) refreshShapeMetadata(id, threadId);
 				}
 			}, 0);
@@ -494,7 +498,7 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 				if (typeof shapeId !== "string") return;
 				const shape = ctx.store.getShape(shapeId);
 				if (!shape || shape.type !== "chat-widget") return;
-				const threadId = (shape.threadId as string) || "";
+				const threadId = (shape as ChatWidgetShapeData).threadId || "";
 				if (threadId) refreshShapeMetadata(shapeId, threadId);
 			});
 
@@ -513,7 +517,8 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 					prevSelectedChatId = null;
 					return;
 				}
-				const threadId = (shape.threadId as string) || "default";
+				const data = shape as ChatWidgetShapeData;
+				const threadId = data.threadId || "default";
 				if (shapeId !== prevSelectedChatId) {
 					prevSelectedChatId = shapeId;
 					activeThreadId = threadId;
@@ -523,7 +528,7 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 					ctx.events.emit("side-panel:register-tab", {
 						tab: {
 							id: "community-chat",
-							label: (shape.chatLabel as string) || "Chat",
+							label: data.chatLabel || "Chat",
 							icon: "\u{1F4AC}",
 							order: 3,
 							render: () => (

--- a/plugins/usketch-plugin-community-chat/src/types.ts
+++ b/plugins/usketch-plugin-community-chat/src/types.ts
@@ -1,3 +1,5 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
 export interface ChatMessage {
 	id: string;
 	boardId: string;
@@ -13,4 +15,17 @@ export interface ChatNewMessageEvent {
 	message: ChatMessage;
 	/** このイベントは「現在アクティブなタブで受信/送信された」= unread に計上しない */
 	fromActiveTab: boolean;
+}
+
+/**
+ * Chat widget shape extension: intrinsic data for the `chat-widget` shape.
+ */
+export interface ChatWidgetShapeData extends ShapeData {
+	chatLabel?: string;
+	threadId?: string;
+	unread?: number;
+	lastMessage?: string;
+	lastAuthor?: string;
+	lastAuthorId?: string;
+	lastMessageAt?: string;
 }

--- a/plugins/usketch-plugin-debug-hud/src/panels/shapes-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/shapes-panel.tsx
@@ -92,7 +92,7 @@ export function ShapesPanel({
 	const updateField = (id: string, field: string, value: number) => {
 		const shape = store.getShape(id);
 		if (!shape) return;
-		const from = { [field]: shape[field] as number };
+		const from = { [field]: (shape as unknown as Record<string, unknown>)[field] as number };
 		const to = { [field]: value };
 		commands.execute({
 			execute: () => store.updateShape(id, to),
@@ -245,7 +245,13 @@ function ShapeDetail({
 							wordBreak: "break-all",
 						}}
 					>
-						{JSON.stringify(Object.fromEntries(customKeys.map((k) => [k, shape[k]])), null, 1)}
+						{JSON.stringify(
+							Object.fromEntries(
+								customKeys.map((k) => [k, (shape as unknown as Record<string, unknown>)[k]]),
+							),
+							null,
+							1,
+						)}
 					</pre>
 				</div>
 			)}

--- a/plugins/usketch-plugin-shape-basic/src/index.ts
+++ b/plugins/usketch-plugin-shape-basic/src/index.ts
@@ -1,3 +1,4 @@
 export { basicShapePlugin } from "./plugin.js";
 export type { BasicShapeSubtype } from "./registry.js";
 export { BASIC_SHAPE_SUBTYPES } from "./registry.js";
+export type { RectangleShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-basic/src/shapes/rectangle.tsx
+++ b/plugins/usketch-plugin-shape-basic/src/shapes/rectangle.tsx
@@ -1,13 +1,15 @@
 import { DEFAULT_STYLE, type ShapeData } from "@edv4h/usketch-shared";
+import type { RectangleShapeData } from "../types.js";
 
 export function renderRectangle(data: ShapeData) {
+	const rect = data as RectangleShapeData;
 	return (
 		<rect
 			x={data.x}
 			y={data.y}
 			width={data.width}
 			height={data.height}
-			rx={(data.cornerRadius as number) ?? 0}
+			rx={rect.cornerRadius ?? 0}
 			fill={data.style.fill}
 			stroke={data.style.stroke}
 			strokeWidth={data.style.strokeWidth}
@@ -16,7 +18,11 @@ export function renderRectangle(data: ShapeData) {
 	);
 }
 
-export function createDefaultRectangle(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultRectangle(params: {
+	id: string;
+	x: number;
+	y: number;
+}): RectangleShapeData {
 	return {
 		id: params.id,
 		type: "rectangle",

--- a/plugins/usketch-plugin-shape-basic/src/types.ts
+++ b/plugins/usketch-plugin-shape-basic/src/types.ts
@@ -1,0 +1,6 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Rectangle shape extension: intrinsic data for the `rectangle` shape. */
+export interface RectangleShapeData extends ShapeData {
+	cornerRadius?: number;
+}

--- a/plugins/usketch-plugin-shape-board-portal/src/index.ts
+++ b/plugins/usketch-plugin-shape-board-portal/src/index.ts
@@ -1,1 +1,1 @@
-export { createBoardPortalPlugin } from "./plugin.js";
+export { type BoardPortalShapeData, createBoardPortalPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-shape-board-portal/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-board-portal/src/plugin.tsx
@@ -11,6 +11,9 @@ import {
 	type UsketchPlugin,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
+import type { BoardPortalShapeData } from "./types.js";
+
+export type { BoardPortalShapeData } from "./types.js";
 
 const PORTAL_WIDTH = 200;
 const PORTAL_HEIGHT = 120;
@@ -29,10 +32,11 @@ function pinHue(boardId: string): number {
 	return PIN_HUES[Math.abs(hash) % PIN_HUES.length] ?? 210;
 }
 
-function renderContent(data: ShapeData) {
-	const title = (data.boardTitle as string) || "Untitled";
+function renderContent(shape: ShapeData) {
+	const data = shape as BoardPortalShapeData;
+	const title = data.boardTitle || "Untitled";
 	const isPublic = data.isPublic !== false;
-	const hue = pinHue((data.boardId as string) || data.id);
+	const hue = pinHue(data.boardId || data.id);
 	// themeColor は HSL から生成 — tokens.css の var は SVG/color-mix で使う
 	const accentColor = `hsl(${hue}, 65%, 58%)`;
 
@@ -273,7 +277,7 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 	return { ...data, x, y, width, height };
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): BoardPortalShapeData {
 	return {
 		id: params.id,
 		type: "board-portal",

--- a/plugins/usketch-plugin-shape-board-portal/src/types.ts
+++ b/plugins/usketch-plugin-shape-board-portal/src/types.ts
@@ -1,0 +1,11 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Board portal shape extension: intrinsic data for the `board-portal` shape. */
+export interface BoardPortalShapeData extends ShapeData {
+	boardId: string;
+	boardTitle: string;
+	ownerName: string;
+	ownerImage: string;
+	memberCount: number;
+	isPublic: boolean;
+}

--- a/plugins/usketch-plugin-shape-community-region/src/index.ts
+++ b/plugins/usketch-plugin-shape-community-region/src/index.ts
@@ -1,2 +1,3 @@
 export type { CommunityRegionPluginOptions } from "./plugin.js";
 export { createCommunityRegionPlugin } from "./plugin.js";
+export type { CommunityRegionShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-community-region/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-community-region/src/plugin.tsx
@@ -6,6 +6,9 @@ import {
 	type ShapeData,
 	type UsketchPlugin,
 } from "@edv4h/usketch-shared";
+import type { CommunityRegionShapeData } from "./types.js";
+
+export type { CommunityRegionShapeData } from "./types.js";
 
 const CARD_WIDTH = 200;
 const CARD_HEIGHT = 180;
@@ -26,12 +29,13 @@ function softBorder(color: string, pct: number): string {
 	return `color-mix(in oklab, ${color} ${pct}%, transparent)`;
 }
 
-function RegionCard({ data }: { data: ShapeData }) {
-	const displayName = (data.displayName as string) || "Region";
-	const themeColor = (data.themeColor as string) || "#6366f1";
-	const icon = (data.icon as string) || "🏠";
-	const onlineCount = (data.onlineCount as number) || 0;
-	const memberCount = (data.memberCount as number) ?? onlineCount;
+function RegionCard({ data: shape }: { data: ShapeData }) {
+	const data = shape as CommunityRegionShapeData;
+	const displayName = data.displayName || "Region";
+	const themeColor = data.themeColor || "#6366f1";
+	const icon = data.icon || "🏠";
+	const onlineCount = data.onlineCount || 0;
+	const memberCount = data.memberCount ?? onlineCount;
 	const isActive = Boolean(data.active);
 
 	return (
@@ -178,7 +182,11 @@ export function createCommunityRegionPlugin(options?: CommunityRegionPluginOptio
 			ctx.shapes.register("community-region", {
 				renderTarget: "html",
 
-				createDefault: (params?: { id: string; x: number; y: number }) => ({
+				createDefault: (params?: {
+					id: string;
+					x: number;
+					y: number;
+				}): CommunityRegionShapeData => ({
 					id: params?.id ?? generateId(),
 					type: "community-region",
 					x: params?.x ?? 0,
@@ -232,10 +240,10 @@ export function createCommunityRegionPlugin(options?: CommunityRegionPluginOptio
 					}
 					prevSelection = new Set(selection);
 
-					const shape = ctx.store.getShapes().get(shapeId);
+					const shape = ctx.store.getShapes().get(shapeId) as CommunityRegionShapeData | undefined;
 					if (shape?.type === "community-region" && shape.slug) {
 						ctx.store.clearSelection();
-						onClick(shape.slug as string);
+						onClick(shape.slug);
 					}
 				});
 				cleanups.push(unsub);

--- a/plugins/usketch-plugin-shape-community-region/src/types.ts
+++ b/plugins/usketch-plugin-shape-community-region/src/types.ts
@@ -1,0 +1,12 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Community region shape extension: intrinsic data for the `community-region` shape. */
+export interface CommunityRegionShapeData extends ShapeData {
+	displayName?: string;
+	themeColor?: string;
+	icon?: string;
+	onlineCount?: number;
+	memberCount?: number;
+	active?: boolean;
+	slug?: string;
+}

--- a/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
@@ -10,6 +10,7 @@ import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { useCallback, useSyncExternalStore } from "react";
 import { type AnchorType, clampToShapeEdge, getAnchorPoint } from "./anchor-utils.js";
 import { createDefaultConnector } from "./shapes/connector.js";
+import type { ConnectorShapeData } from "./types.js";
 
 const HANDLE_RADIUS = 5;
 const STROKE_COLOR = "#2680eb";
@@ -194,7 +195,7 @@ function handleDrawMove(ctx: PluginContext, worldPoint: Point) {
 			y: Math.min(sourcePoint.y, targetPoint.y),
 			width: Math.abs(targetPoint.x - sourcePoint.x),
 			height: Math.abs(targetPoint.y - sourcePoint.y),
-		});
+		} as Partial<ConnectorShapeData>);
 
 		setAnchorDraw({
 			...drawState,
@@ -213,7 +214,7 @@ function handleDrawMove(ctx: PluginContext, worldPoint: Point) {
 			y: Math.min(sourcePoint.y, worldPoint.y),
 			width: Math.abs(worldPoint.x - sourcePoint.x),
 			height: Math.abs(worldPoint.y - sourcePoint.y),
-		});
+		} as Partial<ConnectorShapeData>);
 
 		setAnchorDraw({
 			...drawState,
@@ -246,7 +247,7 @@ function handleDrawEnd(ctx: PluginContext, worldPoint: Point) {
 		const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, targetPoint);
 
 		ctx.store.deleteShape(drawState.connectorId);
-		const finalShape: ShapeData = {
+		const finalShape: ConnectorShapeData = {
 			...connector,
 			targetId: releaseTarget.id,
 			targetAnchor,
@@ -272,7 +273,7 @@ function handleDrawEnd(ctx: PluginContext, worldPoint: Point) {
 	const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, targetPoint);
 
 	ctx.store.deleteShape(drawState.connectorId);
-	const finalShape: ShapeData = {
+	const finalShape: ConnectorShapeData = {
 		...connector,
 		targetId: targetShape.id,
 		targetAnchor,
@@ -464,7 +465,7 @@ function AnchorHandle({
 			const id = generateId();
 			const sourcePoint = getAnchorPoint(shape, anchor);
 
-			const connector: ShapeData = {
+			const connector: ConnectorShapeData = {
 				...createDefaultConnector({ id, x: sourcePoint.x, y: sourcePoint.y }),
 				sourceId: shape.id,
 				targetId: undefined,

--- a/plugins/usketch-plugin-shape-connector/src/connector-label.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/connector-label.tsx
@@ -1,7 +1,8 @@
 import type { PluginContext, Point, ShapeData, Viewport } from "@edv4h/usketch-shared";
 import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
-import { getPathMidpoint, type PathType } from "./path-utils.js";
+import { getPathMidpoint } from "./path-utils.js";
+import type { ConnectorShapeData } from "./types.js";
 
 // ── Label editing state ──
 
@@ -77,26 +78,31 @@ function LabelInput({
 	ctx: PluginContext;
 	viewport: Viewport;
 }) {
+	const connectorData = connector as ConnectorShapeData;
 	const inputRef = useRef<HTMLInputElement>(null);
-	const currentLabel = (connector.label as string) ?? "";
+	const currentLabel = connectorData.label ?? "";
 
 	const midpoint = getMidpointScreen(connector, viewport);
 
 	const commit = useCallback(
 		(newLabel: string) => {
 			const trimmed = newLabel.trim();
-			const oldLabel = (connector.label as string | undefined) ?? undefined;
+			const oldLabel = connectorData.label ?? undefined;
 			const nextLabel = trimmed || undefined;
 			if (oldLabel !== nextLabel) {
 				ctx.commands.execute(
 					createBatchUpdateShapesCommand(ctx.store, [
-						{ id: connectorId, from: { label: oldLabel }, to: { label: nextLabel } },
+						{
+							id: connectorId,
+							from: { label: oldLabel } as Partial<ConnectorShapeData>,
+							to: { label: nextLabel } as Partial<ConnectorShapeData>,
+						},
 					]),
 				);
 			}
 			setEditingLabel(null);
 		},
-		[connectorId, connector.label, ctx],
+		[connectorId, connectorData.label, ctx],
 	);
 
 	const handleKeyDown = useCallback(
@@ -160,16 +166,17 @@ function LabelInput({
 }
 
 function getMidpointScreen(connector: ShapeData, viewport: Viewport): Point {
-	const sourcePoint = connector.sourcePoint as Point | undefined;
-	const targetPoint = connector.targetPoint as Point | undefined;
+	const connectorData = connector as ConnectorShapeData;
+	const sourcePoint = connectorData.sourcePoint;
+	const targetPoint = connectorData.targetPoint;
 	if (!sourcePoint || !targetPoint) {
 		return {
 			x: connector.x * viewport.zoom + viewport.x,
 			y: connector.y * viewport.zoom + viewport.y,
 		};
 	}
-	const pathType = (connector.pathType as PathType) ?? "straight";
-	const controlPoint = connector.controlPoint as Point | undefined;
+	const pathType = connectorData.pathType ?? "straight";
+	const controlPoint = connectorData.controlPoint;
 	const mid = getPathMidpoint(pathType, sourcePoint, targetPoint, controlPoint);
 	return {
 		x: mid.x * viewport.zoom + viewport.x,

--- a/plugins/usketch-plugin-shape-connector/src/connector-property-bar.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/connector-property-bar.tsx
@@ -4,6 +4,7 @@ import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
 import { useCallback } from "react";
 import { type AnchorType, getAnchorPoint } from "./anchor-utils.js";
 import type { ArrowHead, PathType } from "./shapes/connector.js";
+import type { ConnectorShapeData } from "./types.js";
 
 // ── Arrow Icons ──
 
@@ -94,10 +95,11 @@ export function ConnectorPropertyBar() {
 	if (!shape || shape.type !== "connector") return null;
 
 	const connectorId = ids[0];
-	const arrowHead = (shape.arrowHead as ArrowHead) ?? "forward";
-	const pathType = (shape.pathType as PathType) ?? "straight";
-	const sourceAnchor = (shape.sourceAnchor as AnchorType) ?? "auto";
-	const targetAnchor = (shape.targetAnchor as AnchorType) ?? "auto";
+	const connectorData = shape as ConnectorShapeData;
+	const arrowHead = connectorData.arrowHead ?? "forward";
+	const pathType = connectorData.pathType ?? "straight";
+	const sourceAnchor = connectorData.sourceAnchor ?? "auto";
+	const targetAnchor = connectorData.targetAnchor ?? "auto";
 
 	return (
 		<ShapeAnchorOverlay shapeIds={[connectorId]} position="bottom" fallback="top">
@@ -165,8 +167,9 @@ function ConnectorControls({
 			if (value === current) return;
 
 			// Recalculate endpoint position with new anchor
-			const sourceId = connector.sourceId as string | undefined;
-			const targetId = connector.targetId as string | undefined;
+			const connectorData = connector as ConnectorShapeData;
+			const sourceId = connectorData.sourceId;
+			const targetId = connectorData.targetId;
 			if (!sourceId || !targetId) return;
 
 			const sourceShape = store.getShape(sourceId);
@@ -188,16 +191,16 @@ function ConnectorControls({
 			const newSourcePoint = getAnchorPoint(sourceShape, newSourceAnchor, targetCenter);
 			const newTargetPoint = getAnchorPoint(targetShape, newTargetAnchor, sourceCenter);
 
-			const from: Partial<ShapeData> = {
+			const from: Partial<ConnectorShapeData> = {
 				[key]: current,
-				sourcePoint: connector.sourcePoint,
-				targetPoint: connector.targetPoint,
+				sourcePoint: connectorData.sourcePoint,
+				targetPoint: connectorData.targetPoint,
 				x: connector.x,
 				y: connector.y,
 				width: connector.width,
 				height: connector.height,
 			};
-			const to: Partial<ShapeData> = {
+			const to: Partial<ConnectorShapeData> = {
 				[key]: value,
 				sourcePoint: newSourcePoint,
 				targetPoint: newTargetPoint,

--- a/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
@@ -10,6 +10,7 @@ import {
 } from "./endpoint-drag-state.js";
 import { getDefaultControlPoint } from "./path-utils.js";
 import { findShapeAtPoint } from "./plugin.js";
+import type { ConnectorShapeData } from "./types.js";
 
 const HANDLE_RADIUS = 5;
 const STROKE_COLOR = "#2680eb";
@@ -44,12 +45,13 @@ export function EndpointOverlay({ ctx, viewport }: EndpointOverlayProps) {
 	const connector = shapes.get(connectorId);
 	if (!connector || connector.type !== "connector") return null;
 
-	const sourcePoint = connector.sourcePoint as Point | undefined;
-	const targetPoint = connector.targetPoint as Point | undefined;
+	const connectorData = connector as ConnectorShapeData;
+	const sourcePoint = connectorData.sourcePoint;
+	const targetPoint = connectorData.targetPoint;
 	if (!sourcePoint || !targetPoint) return null;
 
-	const controlPoint = connector.controlPoint as Point | undefined;
-	const pathType = (connector.pathType as string) ?? "straight";
+	const controlPoint = connectorData.controlPoint;
+	const pathType = connectorData.pathType ?? "straight";
 	const showControlHandle = pathType === "curve";
 	const cp = controlPoint ?? getDefaultControlPoint(sourcePoint, targetPoint);
 
@@ -156,8 +158,9 @@ function DragPreview({
 	connector: ShapeData;
 	viewport: Viewport;
 }) {
-	const sourcePoint = connector.sourcePoint as Point;
-	const targetPoint = connector.targetPoint as Point;
+	const connectorData = connector as ConnectorShapeData;
+	const sourcePoint = connectorData.sourcePoint as Point;
+	const targetPoint = connectorData.targetPoint as Point;
 	const dragScreen = worldToScreen(dragState.currentPoint, viewport);
 
 	if (dragState.endpoint === "source") {
@@ -262,10 +265,9 @@ function EndpointHandle({
 			});
 
 			// The shape this endpoint is currently connected to
+			const connectorData = connector as ConnectorShapeData;
 			const currentShapeId =
-				endpoint === "source"
-					? (connector.sourceId as string | undefined)
-					: (connector.targetId as string | undefined);
+				endpoint === "source" ? connectorData.sourceId : connectorData.targetId;
 
 			const onMove = (me: PointerEvent) => {
 				const wp = screenToWorld({ x: me.clientX, y: me.clientY }, viewport);
@@ -283,9 +285,7 @@ function EndpointHandle({
 				// Check if we're over the same shape (slide anchor) or a different one (reconnect)
 				const hoverShape = findShapeAtPoint(ctx, wp);
 				const otherEndShapeId =
-					endpoint === "source"
-						? (connector.targetId as string | undefined)
-						: (connector.sourceId as string | undefined);
+					endpoint === "source" ? connectorData.targetId : connectorData.sourceId;
 
 				if (hoverShape && hoverShape.id === currentShapeId) {
 					// Sliding along current shape's edge
@@ -310,11 +310,14 @@ function EndpointHandle({
 				const drag = getEndpointDrag();
 				if (drag && drag.connectorId === connectorId) {
 					if (drag.endpoint === "controlPoint") {
-						const before = {
-							controlPoint: connector.controlPoint,
-							controlPointAuto: connector.controlPointAuto,
+						const before: Partial<ConnectorShapeData> = {
+							controlPoint: connectorData.controlPoint,
+							controlPointAuto: connectorData.controlPointAuto,
 						};
-						const after = { controlPoint: drag.currentPoint, controlPointAuto: false };
+						const after: Partial<ConnectorShapeData> = {
+							controlPoint: drag.currentPoint,
+							controlPointAuto: false,
+						};
 						ctx.commands.execute(
 							createBatchUpdateShapesCommand(ctx.store, [
 								{ id: connectorId, from: before, to: after },
@@ -379,8 +382,9 @@ function commitEndpointReconnect(
 	endpoint: "source" | "target",
 	newShape: ShapeData,
 ) {
+	const connectorData = connector as ConnectorShapeData;
 	const otherShapeId =
-		endpoint === "source" ? (connector.targetId as string) : (connector.sourceId as string);
+		endpoint === "source" ? (connectorData.targetId as string) : (connectorData.sourceId as string);
 	const otherShape = ctx.store.getShape(otherShapeId);
 	if (!otherShape) return;
 
@@ -401,20 +405,20 @@ function commitEndpointReconnect(
 		targetPoint = getAnchorPoint(newShape, "auto", otherCenter);
 	}
 
-	const fromData: Partial<ShapeData> = {
+	const fromData: Partial<ConnectorShapeData> = {
 		[endpoint === "source" ? "sourceId" : "targetId"]:
-			endpoint === "source" ? connector.sourceId : connector.targetId,
-		sourcePoint: connector.sourcePoint,
-		targetPoint: connector.targetPoint,
-		sourceAnchor: connector.sourceAnchor,
-		targetAnchor: connector.targetAnchor,
+			endpoint === "source" ? connectorData.sourceId : connectorData.targetId,
+		sourcePoint: connectorData.sourcePoint,
+		targetPoint: connectorData.targetPoint,
+		sourceAnchor: connectorData.sourceAnchor,
+		targetAnchor: connectorData.targetAnchor,
 		x: connector.x,
 		y: connector.y,
 		width: connector.width,
 		height: connector.height,
 	};
 
-	const toData: Partial<ShapeData> = {
+	const toData: Partial<ConnectorShapeData> = {
 		[endpoint === "source" ? "sourceId" : "targetId"]: newShape.id,
 		sourcePoint,
 		targetPoint,
@@ -439,40 +443,41 @@ function commitAnchorSlide(
 	shape: ShapeData,
 	dragPoint: Point,
 ) {
+	const connectorData = connector as ConnectorShapeData;
 	const edgePoint = clampToShapeEdge(shape, dragPoint);
 	const anchorKey = endpoint === "source" ? "sourceAnchor" : "targetAnchor";
 	const pointKey = endpoint === "source" ? "sourcePoint" : "targetPoint";
 
 	// Recalculate the other endpoint (it depends on the new position for "auto" anchors)
 	const otherShapeId =
-		endpoint === "source" ? (connector.targetId as string) : (connector.sourceId as string);
+		endpoint === "source" ? (connectorData.targetId as string) : (connectorData.sourceId as string);
 	const otherShape = ctx.store.getShape(otherShapeId);
 	if (!otherShape) return;
 
 	const otherAnchor =
 		endpoint === "source"
-			? ((connector.targetAnchor as string) ?? "auto")
-			: ((connector.sourceAnchor as string) ?? "auto");
+			? (connectorData.targetAnchor ?? "auto")
+			: (connectorData.sourceAnchor ?? "auto");
 	const otherPoint =
 		otherAnchor === "custom"
-			? (connector[endpoint === "source" ? "targetPoint" : "sourcePoint"] as Point)
-			: getAnchorPoint(otherShape, otherAnchor as "auto", edgePoint);
+			? ((endpoint === "source" ? connectorData.targetPoint : connectorData.sourcePoint) as Point)
+			: getAnchorPoint(otherShape, otherAnchor, edgePoint);
 
 	const newSourcePoint = endpoint === "source" ? edgePoint : otherPoint;
 	const newTargetPoint = endpoint === "target" ? edgePoint : otherPoint;
 
-	const from: Partial<ShapeData> = {
-		[anchorKey]: connector[anchorKey],
-		[pointKey]: connector[pointKey],
-		sourcePoint: connector.sourcePoint,
-		targetPoint: connector.targetPoint,
+	const from: Partial<ConnectorShapeData> = {
+		[anchorKey]: connectorData[anchorKey],
+		[pointKey]: connectorData[pointKey],
+		sourcePoint: connectorData.sourcePoint,
+		targetPoint: connectorData.targetPoint,
 		x: connector.x,
 		y: connector.y,
 		width: connector.width,
 		height: connector.height,
 	};
 
-	const to: Partial<ShapeData> = {
+	const to: Partial<ConnectorShapeData> = {
 		[anchorKey]: "custom",
 		[pointKey]: edgePoint,
 		sourcePoint: newSourcePoint,

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -21,6 +21,9 @@ import {
 	renderConnector,
 	SimplifiedConnector,
 } from "./shapes/connector.js";
+import type { ConnectorShapeData } from "./types.js";
+
+export type { ConnectorShapeData } from "./types.js";
 
 function ConnectorIcon() {
 	return (
@@ -82,7 +85,7 @@ export const connectorPlugin: UsketchPlugin = {
 			const sourceAnchor: AnchorType = "auto";
 			const sourcePoint = getAnchorPoint(sourceShape, sourceAnchor, event.worldPoint);
 
-			const connector: ShapeData = {
+			const connector: ConnectorShapeData = {
 				...createDefaultConnector({ id, x: sourcePoint.x, y: sourcePoint.y }),
 				sourceId: sourceShape.id,
 				targetId: undefined,
@@ -109,7 +112,7 @@ export const connectorPlugin: UsketchPlugin = {
 				targetPoint,
 			);
 
-			const updates: Partial<ShapeData> = {
+			const updates: Partial<ConnectorShapeData> = {
 				sourcePoint,
 				targetPoint: targetShape ? getAnchorPoint(targetShape, "auto", sourcePoint) : targetPoint,
 			};
@@ -142,7 +145,7 @@ export const connectorPlugin: UsketchPlugin = {
 			});
 			const targetPoint = getAnchorPoint(targetShape, "auto", sourcePoint);
 
-			const finalUpdates: Partial<ShapeData> = {
+			const finalUpdates: Partial<ConnectorShapeData> = {
 				targetId: targetShape.id,
 				targetAnchor: "auto",
 				sourcePoint,
@@ -154,7 +157,7 @@ export const connectorPlugin: UsketchPlugin = {
 			};
 
 			toolCtx.store.deleteShape(drawState.connectorId);
-			const finalShape: ShapeData = { ...connector, ...finalUpdates };
+			const finalShape: ConnectorShapeData = { ...connector, ...finalUpdates };
 			toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, finalShape));
 
 			drawState = null;
@@ -241,8 +244,9 @@ export const connectorPlugin: UsketchPlugin = {
 			connectorIndex.clear();
 			for (const [id, shape] of ctx.store.getShapes()) {
 				if (shape.type !== "connector") continue;
-				const src = shape.sourceId as string | undefined;
-				const tgt = shape.targetId as string | undefined;
+				const connectorData = shape as ConnectorShapeData;
+				const src = connectorData.sourceId;
+				const tgt = connectorData.targetId;
 				if (src) {
 					if (!connectorIndex.has(src)) connectorIndex.set(src, new Set());
 					connectorIndex.get(src)?.add(id);
@@ -299,18 +303,18 @@ export const connectorPlugin: UsketchPlugin = {
 			const dy = movedShape && prev ? movedShape.y - prev.y : 0;
 
 			for (const connId of connIds) {
-				const conn = ctx.store.getShape(connId);
+				const conn = ctx.store.getShape(connId) as ConnectorShapeData | undefined;
 				if (!conn) continue;
-				const sourceId = conn.sourceId as string | undefined;
-				const targetId = conn.targetId as string | undefined;
+				const sourceId = conn.sourceId;
+				const targetId = conn.targetId;
 				if (!sourceId || !targetId) continue;
 
 				const source = ctx.store.getShape(sourceId);
 				const target = ctx.store.getShape(targetId);
 				if (!source || !target) continue;
 
-				const sourceAnchor = (conn.sourceAnchor as AnchorType) ?? "auto";
-				const targetAnchor = (conn.targetAnchor as AnchorType) ?? "auto";
+				const sourceAnchor = conn.sourceAnchor ?? "auto";
+				const targetAnchor = conn.targetAnchor ?? "auto";
 
 				const targetCenter = { x: target.x + target.width / 2, y: target.y + target.height / 2 };
 				const sourceCenter = { x: source.x + source.width / 2, y: source.y + source.height / 2 };
@@ -336,7 +340,7 @@ export const connectorPlugin: UsketchPlugin = {
 					targetPoint = getAnchorPoint(target, targetAnchor, sourceCenter);
 				}
 
-				const updates: Partial<ShapeData> = {
+				const updates: Partial<ConnectorShapeData> = {
 					sourcePoint,
 					targetPoint,
 					x: Math.min(sourcePoint.x, targetPoint.x),
@@ -366,10 +370,9 @@ export const connectorPlugin: UsketchPlugin = {
 			const shapes = ctx.store.getShapes();
 			const toDelete: string[] = [];
 			for (const [id, shape] of shapes) {
-				if (
-					shape.type === "connector" &&
-					(shape.sourceId === payload.id || shape.targetId === payload.id)
-				) {
+				if (shape.type !== "connector") continue;
+				const connectorData = shape as ConnectorShapeData;
+				if (connectorData.sourceId === payload.id || connectorData.targetId === payload.id) {
 					toDelete.push(id);
 				}
 			}

--- a/plugins/usketch-plugin-shape-connector/src/shapes/connector.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/shapes/connector.tsx
@@ -8,11 +8,11 @@ import {
 	getElbowPoints,
 	getPathMidpoint,
 	isNearBezier,
-	type PathType,
 } from "../path-utils.js";
+import type { ConnectorShapeData } from "../types.js";
 
-export type ArrowHead = "none" | "forward" | "backward" | "both";
 export type { PathType } from "../path-utils.js";
+export type { ArrowHead } from "../types.js";
 
 const ARROW_SIZE = 10;
 const LABEL_FONT_SIZE = 12;
@@ -22,12 +22,12 @@ const LABEL_PADDING_Y = 3;
 // ── Helpers to extract endpoints ──
 
 function sourceXY(data: ShapeData): Point {
-	const p = data.sourcePoint as Point | undefined;
+	const p = (data as ConnectorShapeData).sourcePoint;
 	return { x: p?.x ?? data.x, y: p?.y ?? data.y };
 }
 
 function targetXY(data: ShapeData): Point {
-	const p = data.targetPoint as Point | undefined;
+	const p = (data as ConnectorShapeData).targetPoint;
 	return { x: p?.x ?? data.x + data.width, y: p?.y ?? data.y + data.height };
 }
 
@@ -86,6 +86,7 @@ function renderLabel(label: string, midpoint: Point, color: string): React.React
 // ── Main render ──
 
 export function renderConnector(data: ShapeData) {
+	const connectorData = data as ConnectorShapeData;
 	const src = sourceXY(data);
 	const tgt = targetXY(data);
 	const { x: x1, y: y1 } = src;
@@ -94,13 +95,13 @@ export function renderConnector(data: ShapeData) {
 	const color = data.style.stroke;
 	const strokeWidth = data.style.strokeWidth;
 	const opacity = data.style.opacity;
-	const arrowHead = (data.arrowHead as ArrowHead) ?? "forward";
-	const pathType = (data.pathType as PathType) ?? "straight";
+	const arrowHead = connectorData.arrowHead ?? "forward";
+	const pathType = connectorData.pathType ?? "straight";
 
 	const elements: React.ReactElement[] = [];
 
 	if (pathType === "curve") {
-		const cp = (data.controlPoint as Point | undefined) ?? getDefaultControlPoint(src, tgt);
+		const cp = connectorData.controlPoint ?? getDefaultControlPoint(src, tgt);
 		elements.push(
 			<path
 				key="line"
@@ -170,9 +171,9 @@ export function renderConnector(data: ShapeData) {
 	}
 
 	// Label
-	const label = data.label as string | undefined;
+	const label = connectorData.label;
 	if (label) {
-		const cp = (data.controlPoint as Point | undefined) ?? undefined;
+		const cp = connectorData.controlPoint;
 		const midpoint = getPathMidpoint(pathType, src, tgt, cp);
 		elements.push(renderLabel(label, midpoint, color));
 	}
@@ -183,12 +184,13 @@ export function renderConnector(data: ShapeData) {
 // ── Bounds ──
 
 export function getBoundsConnector(data: ShapeData): BoundingBox {
+	const connectorData = data as ConnectorShapeData;
 	const src = sourceXY(data);
 	const tgt = targetXY(data);
-	const pathType = (data.pathType as PathType) ?? "straight";
+	const pathType = connectorData.pathType ?? "straight";
 
 	if (pathType === "curve") {
-		const cp = (data.controlPoint as Point | undefined) ?? getDefaultControlPoint(src, tgt);
+		const cp = connectorData.controlPoint ?? getDefaultControlPoint(src, tgt);
 		return bezierBounds(src, cp, tgt);
 	}
 
@@ -205,12 +207,13 @@ export function getBoundsConnector(data: ShapeData): BoundingBox {
 // ── Hit test ──
 
 export function hitTestConnector(data: ShapeData, point: Point, tolerance = 6): boolean {
+	const connectorData = data as ConnectorShapeData;
 	const src = sourceXY(data);
 	const tgt = targetXY(data);
-	const pathType = (data.pathType as PathType) ?? "straight";
+	const pathType = connectorData.pathType ?? "straight";
 
 	if (pathType === "curve") {
-		const cp = (data.controlPoint as Point | undefined) ?? getDefaultControlPoint(src, tgt);
+		const cp = connectorData.controlPoint ?? getDefaultControlPoint(src, tgt);
 		return isNearBezier(point, src, cp, tgt, tolerance);
 	}
 
@@ -225,7 +228,11 @@ export function hitTestConnector(data: ShapeData, point: Point, tolerance = 6): 
 
 // ── Default shape ──
 
-export function createDefaultConnector(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultConnector(params: {
+	id: string;
+	x: number;
+	y: number;
+}): ConnectorShapeData {
 	return {
 		id: params.id,
 		type: "connector",
@@ -238,8 +245,8 @@ export function createDefaultConnector(params: { id: string; x: number; y: numbe
 		targetId: undefined,
 		sourceAnchor: "auto",
 		targetAnchor: "auto",
-		arrowHead: "forward" as ArrowHead,
-		pathType: "straight" as PathType,
+		arrowHead: "forward",
+		pathType: "straight",
 		sourcePoint: { x: params.x, y: params.y },
 		targetPoint: { x: params.x + 100, y: params.y },
 		controlPoint: undefined,
@@ -251,12 +258,13 @@ export function createDefaultConnector(params: { id: string; x: number; y: numbe
 // ── Simplified (LOD) component ──
 
 export function SimplifiedConnector({ shape }: { shape: ShapeData }) {
+	const connectorData = shape as ConnectorShapeData;
 	const src = sourceXY(shape);
 	const tgt = targetXY(shape);
 	const bounds = getBoundsConnector(shape);
 	const rotation = safeRotation(shape.rotation);
 	const color = shape.style.stroke ?? "#1e1e1e";
-	const arrowHead = (shape.arrowHead as ArrowHead) ?? "forward";
+	const arrowHead = connectorData.arrowHead ?? "forward";
 
 	// Minimum size to avoid zero-dimension SVGs
 	const w = Math.max(bounds.width, 2);

--- a/plugins/usketch-plugin-shape-connector/src/types.ts
+++ b/plugins/usketch-plugin-shape-connector/src/types.ts
@@ -1,0 +1,21 @@
+import type { Point, ShapeData } from "@edv4h/usketch-shared";
+import type { AnchorType } from "./anchor-utils.js";
+import type { PathType } from "./path-utils.js";
+
+/** Arrow head style for a connector. */
+export type ArrowHead = "none" | "forward" | "backward" | "both";
+
+/** Connector shape extension: intrinsic data for the `connector` shape. */
+export interface ConnectorShapeData extends ShapeData {
+	sourceId?: string;
+	targetId?: string;
+	sourceAnchor?: AnchorType;
+	targetAnchor?: AnchorType;
+	sourcePoint?: Point;
+	targetPoint?: Point;
+	controlPoint?: Point;
+	controlPointAuto?: boolean;
+	arrowHead?: ArrowHead;
+	pathType?: PathType;
+	label?: string;
+}

--- a/plugins/usketch-plugin-shape-counter/src/index.ts
+++ b/plugins/usketch-plugin-shape-counter/src/index.ts
@@ -1,1 +1,2 @@
 export { counterPlugin } from "./plugin.js";
+export type { CounterShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-counter/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-counter/src/plugin.tsx
@@ -10,6 +10,7 @@ import {
 	type UsketchPlugin,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
+import type { CounterShapeData } from "./types.js";
 
 // ── Shape Definition ──
 
@@ -18,7 +19,8 @@ import { createAddShapeCommand } from "@edv4h/usketch-store";
  * The +/- buttons are dropped because LOD mode is not interactive anyway.
  */
 function SimplifiedCounter({ shape }: { shape: ShapeData }) {
-	const count = (shape.count as number) ?? 0;
+	const data = shape as CounterShapeData;
+	const count = data.count ?? 0;
 	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
 	return (
 		<div
@@ -48,8 +50,9 @@ function SimplifiedCounter({ shape }: { shape: ShapeData }) {
 	);
 }
 
-function render(data: ShapeData) {
-	const count = (data.count as number) ?? 0;
+function render(shape: ShapeData) {
+	const data = shape as CounterShapeData;
+	const count = data.count ?? 0;
 
 	return (
 		<div
@@ -175,7 +178,7 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 	return { ...data, x, y, width: Math.max(100, width), height: Math.max(100, height) };
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): CounterShapeData {
 	return {
 		id: params.id,
 		type: "counter",
@@ -232,10 +235,10 @@ export const counterPlugin: UsketchPlugin = {
 		// Listen for counter updates from the rendered buttons
 		const onCounterUpdate = (e: Event) => {
 			const { id, delta } = (e as CustomEvent).detail;
-			const shape = ctx.store.getShape(id);
+			const shape = ctx.store.getShape(id) as CounterShapeData | undefined;
 			if (shape) {
-				const count = ((shape.count as number) ?? 0) + delta;
-				ctx.store.updateShape(id, { count });
+				const count = (shape.count ?? 0) + delta;
+				ctx.store.updateShape(id, { count } as Partial<ShapeData>);
 			}
 		};
 		window.addEventListener("usketch:counter-update", onCounterUpdate);

--- a/plugins/usketch-plugin-shape-counter/src/types.ts
+++ b/plugins/usketch-plugin-shape-counter/src/types.ts
@@ -1,0 +1,6 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Counter shape extension: intrinsic data for the `counter` shape. */
+export interface CounterShapeData extends ShapeData {
+	count: number;
+}

--- a/plugins/usketch-plugin-shape-frame/src/index.ts
+++ b/plugins/usketch-plugin-shape-frame/src/index.ts
@@ -1,1 +1,2 @@
 export { framePlugin } from "./plugin.js";
+export type { FrameShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-frame/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-frame/src/plugin.tsx
@@ -14,13 +14,15 @@ import {
 	renderFrame,
 	resizeFrame,
 } from "./shapes/frame.js";
+import type { FrameShapeData } from "./types.js";
 
 /**
  * LOD component: labeled empty frame — dashed border + top-left title.
  * Frames are containers, so they mostly need to show where they are.
  */
 function SimplifiedFrame({ shape }: { shape: ShapeData }) {
-	const label = (shape.name as string) || "Frame";
+	const data = shape as FrameShapeData;
+	const label = data.name || data.frameTitle || "Frame";
 	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
 	return (
 		<div

--- a/plugins/usketch-plugin-shape-frame/src/shapes/frame.tsx
+++ b/plugins/usketch-plugin-shape-frame/src/shapes/frame.tsx
@@ -1,9 +1,11 @@
 import type { BoundingBox, Point, ShapeData } from "@edv4h/usketch-shared";
+import type { FrameShapeData } from "../types.js";
 
 const TITLE_HEIGHT = 24;
 
-export function renderFrame(data: ShapeData) {
-	const title = (data.frameTitle as string) ?? "Frame";
+export function renderFrame(shape: ShapeData) {
+	const data = shape as FrameShapeData;
+	const title = data.frameTitle ?? "Frame";
 	const bgColor = data.style.fill === "transparent" ? "#f8f8f8" : data.style.fill;
 
 	// Position/size is handled by ShapeWrapper (position: absolute; left/top/width/height).
@@ -94,7 +96,7 @@ export function resizeFrame(data: ShapeData, handle: string, delta: Point): Shap
 	return result;
 }
 
-export function createDefaultFrame(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultFrame(params: { id: string; x: number; y: number }): FrameShapeData {
 	return {
 		id: params.id,
 		type: "frame",

--- a/plugins/usketch-plugin-shape-frame/src/types.ts
+++ b/plugins/usketch-plugin-shape-frame/src/types.ts
@@ -1,0 +1,7 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Frame shape extension: intrinsic data for the `frame` shape. */
+export interface FrameShapeData extends ShapeData {
+	frameTitle?: string;
+	name?: string;
+}

--- a/plugins/usketch-plugin-shape-freedraw/src/index.ts
+++ b/plugins/usketch-plugin-shape-freedraw/src/index.ts
@@ -1,1 +1,2 @@
 export { freedrawPlugin } from "./plugin.js";
+export type { FreedrawShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-freedraw/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-freedraw/src/plugin.tsx
@@ -13,9 +13,11 @@ import {
 	type UsketchPlugin,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
+import type { FreedrawShapeData } from "./types.js";
 
-function render(data: ShapeData) {
-	const points = (data.points as Point[]) ?? [];
+function render(shape: ShapeData) {
+	const data = shape as FreedrawShapeData;
+	const points = data.points ?? [];
 	const pointsStr = points.map((p) => `${p.x},${p.y}`).join(" ");
 	return (
 		<polyline
@@ -30,8 +32,9 @@ function render(data: ShapeData) {
 	);
 }
 
-function getBounds(data: ShapeData): BoundingBox {
-	const points = (data.points as Point[]) ?? [];
+function getBounds(shape: ShapeData): BoundingBox {
+	const data = shape as FreedrawShapeData;
+	const points = data.points ?? [];
 	if (points.length === 0) {
 		return { x: data.x, y: data.y, width: 0, height: 0 };
 	}
@@ -58,8 +61,9 @@ function hitTest(data: ShapeData, point: Point): boolean {
 	);
 }
 
-function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
-	const points = (data.points as Point[]) ?? [];
+function resize(shape: ShapeData, handle: ResizeHandle, delta: Point): FreedrawShapeData {
+	const data = shape as FreedrawShapeData;
+	const points = data.points ?? [];
 	const bounds = getBounds(data);
 	if (bounds.width === 0 && bounds.height === 0) return data;
 
@@ -126,8 +130,9 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 	};
 }
 
-function move(data: ShapeData, dx: number, dy: number): Partial<ShapeData> {
-	const points = (data.points as Point[]) ?? [];
+function move(shape: ShapeData, dx: number, dy: number): Partial<FreedrawShapeData> {
+	const data = shape as FreedrawShapeData;
+	const points = data.points ?? [];
 	return {
 		x: data.x + dx,
 		y: data.y + dy,
@@ -135,8 +140,9 @@ function move(data: ShapeData, dx: number, dy: number): Partial<ShapeData> {
 	};
 }
 
-function applyBounds(data: ShapeData, newBounds: BoundingBox): Partial<ShapeData> {
-	const points = (data.points as Point[]) ?? [];
+function applyBounds(shape: ShapeData, newBounds: BoundingBox): Partial<FreedrawShapeData> {
+	const data = shape as FreedrawShapeData;
+	const points = data.points ?? [];
 	const oldBounds = getBounds(data);
 	const scaleX = oldBounds.width !== 0 ? newBounds.width / oldBounds.width : 1;
 	const scaleY = oldBounds.height !== 0 ? newBounds.height / oldBounds.height : 1;
@@ -152,7 +158,7 @@ function applyBounds(data: ShapeData, newBounds: BoundingBox): Partial<ShapeData
 	};
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): FreedrawShapeData {
 	return {
 		id: params.id,
 		type: "freedraw",
@@ -223,7 +229,7 @@ export const freedrawPlugin: UsketchPlugin = {
 				width: bounds.width,
 				height: bounds.height,
 				points: [...drawState.points],
-			});
+			} as Partial<FreedrawShapeData>);
 		}
 
 		function onPointerUp(toolCtx: ToolContext) {
@@ -239,8 +245,9 @@ export const freedrawPlugin: UsketchPlugin = {
 			drawState = null;
 		}
 
-		function gpuPrimitive(data: ShapeData): GpuPrimitive | null {
-			const pts = (data.points as Point[]) ?? [];
+		function gpuPrimitive(shape: ShapeData): GpuPrimitive | null {
+			const data = shape as FreedrawShapeData;
+			const pts = data.points ?? [];
 			if (pts.length < 2) return null;
 			const verts = new Float32Array(pts.length * 2);
 			for (let i = 0; i < pts.length; i++) {

--- a/plugins/usketch-plugin-shape-freedraw/src/types.ts
+++ b/plugins/usketch-plugin-shape-freedraw/src/types.ts
@@ -1,0 +1,6 @@
+import type { Point, ShapeData } from "@edv4h/usketch-shared";
+
+/** Freedraw shape extension: intrinsic data for the `freedraw` shape. */
+export interface FreedrawShapeData extends ShapeData {
+	points: Point[];
+}

--- a/plugins/usketch-plugin-shape-image/src/index.ts
+++ b/plugins/usketch-plugin-shape-image/src/index.ts
@@ -1,1 +1,2 @@
 export { imageShapePlugin } from "./plugin.js";
+export type { ImageShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-image/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-image/src/plugin.tsx
@@ -8,9 +8,11 @@ import {
 	type UsketchPlugin,
 	withRotation,
 } from "@edv4h/usketch-shared";
+import type { ImageShapeData } from "./types.js";
 
-function render(data: ShapeData) {
-	const src = data.src as string | undefined;
+function render(shape: ShapeData) {
+	const data = shape as ImageShapeData;
+	const src = data.src || undefined;
 	return (
 		<div
 			style={{
@@ -100,7 +102,7 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 	return { ...data, x, y, width: Math.max(40, width), height: Math.max(40, height) };
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): ImageShapeData {
 	return {
 		id: params.id,
 		type: "image",

--- a/plugins/usketch-plugin-shape-image/src/types.ts
+++ b/plugins/usketch-plugin-shape-image/src/types.ts
@@ -1,0 +1,6 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Image shape extension: intrinsic data for the `image` shape. */
+export interface ImageShapeData extends ShapeData {
+	src: string;
+}

--- a/plugins/usketch-plugin-shape-island/src/auto-group.ts
+++ b/plugins/usketch-plugin-shape-island/src/auto-group.ts
@@ -7,6 +7,7 @@ import {
 	getChildShapes,
 	intersectsAABB,
 } from "@edv4h/usketch-store";
+import type { IslandShapeData } from "./types.js";
 
 const TOUCH_PADDING = 4;
 const MERGE_ANIMATION_MS = 700;
@@ -58,7 +59,7 @@ class UnionFind {
 const mergeTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 function triggerMergeAnimation(store: BoardStore, islandId: string) {
-	store.updateShape(islandId, { _islandJustMerged: true });
+	store.updateShape(islandId, { _islandJustMerged: true } as Partial<IslandShapeData>);
 
 	const existing = mergeTimers.get(islandId);
 	if (existing) clearTimeout(existing);
@@ -67,9 +68,9 @@ function triggerMergeAnimation(store: BoardStore, islandId: string) {
 		islandId,
 		setTimeout(() => {
 			mergeTimers.delete(islandId);
-			const shape = store.getShapes().get(islandId);
+			const shape = store.getShapes().get(islandId) as IslandShapeData | undefined;
 			if (shape?._islandJustMerged) {
-				store.updateShape(islandId, { _islandJustMerged: undefined });
+				store.updateShape(islandId, { _islandJustMerged: undefined } as Partial<IslandShapeData>);
 			}
 		}, MERGE_ANIMATION_MS),
 	);
@@ -93,7 +94,7 @@ export function reconcileIslandGroups(
 		const parentId = shape.parentId as string | undefined;
 		// Track which groups are island-groups
 		if (parentId) {
-			const parent = store.getShapes().get(parentId);
+			const parent = store.getShapes().get(parentId) as IslandShapeData | undefined;
 			if (parent?.type === "group" && parent._isIslandGroup) {
 				islandGroupIds.add(parentId);
 			}
@@ -226,7 +227,7 @@ export function reconcileIslandGroups(
 
 		const bounds = computeGroupBounds(children);
 		const groupId = generateId();
-		const groupShape: ShapeData = {
+		const groupShape: IslandShapeData = {
 			id: groupId,
 			type: "group",
 			x: bounds.x,
@@ -283,7 +284,7 @@ export function detachIsland(
 	const parentId = shape.parentId as string | undefined;
 	if (!parentId) return;
 
-	const parent = store.getShapes().get(parentId);
+	const parent = store.getShapes().get(parentId) as IslandShapeData | undefined;
 	if (!parent || parent.type !== "group" || !parent._isIslandGroup) return;
 
 	// Get remaining children
@@ -296,7 +297,7 @@ export function detachIsland(
 	if (siblings.length >= 2) {
 		const bounds = computeGroupBounds(siblings);
 		const newGroupId = generateId();
-		const newGroupShape: ShapeData = {
+		const newGroupShape: IslandShapeData = {
 			id: newGroupId,
 			type: "group",
 			x: bounds.x,

--- a/plugins/usketch-plugin-shape-island/src/index.ts
+++ b/plugins/usketch-plugin-shape-island/src/index.ts
@@ -1,1 +1,2 @@
 export { islandPlugin } from "./plugin.js";
+export type { IslandShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-island/src/island-metaball-layer.tsx
+++ b/plugins/usketch-plugin-shape-island/src/island-metaball-layer.tsx
@@ -1,5 +1,6 @@
 import type { BoardStore } from "@edv4h/usketch-shared";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { IslandShapeData } from "./types.js";
 
 interface IslandBlob {
 	id: string;
@@ -15,21 +16,22 @@ function collectBlobs(store: BoardStore): IslandBlob[] {
 	const blobs: IslandBlob[] = [];
 	for (const [, shape] of store.getShapes()) {
 		if (shape.type !== "island") continue;
+		const data = shape as IslandShapeData;
 		let groupId: string | undefined;
-		const parentId = shape.parentId as string | undefined;
+		const parentId = data.parentId as string | undefined;
 		if (parentId) {
-			const parent = store.getShapes().get(parentId);
+			const parent = store.getShapes().get(parentId) as IslandShapeData | undefined;
 			if (parent?.type === "group" && parent._isIslandGroup) {
 				groupId = parentId;
 			}
 		}
 		blobs.push({
-			id: shape.id,
-			x: shape.x,
-			y: shape.y,
-			width: shape.width,
-			height: shape.height,
-			color: (shape.islandColor as string) ?? "#a8d5ba",
+			id: data.id,
+			x: data.x,
+			y: data.y,
+			width: data.width,
+			height: data.height,
+			color: data.islandColor ?? "#a8d5ba",
 			groupId,
 		});
 	}

--- a/plugins/usketch-plugin-shape-island/src/island-render.tsx
+++ b/plugins/usketch-plugin-shape-island/src/island-render.tsx
@@ -1,4 +1,5 @@
 import type { BoundingBox, Point, ShapeData } from "@edv4h/usketch-shared";
+import type { IslandShapeData } from "./types.js";
 
 const MIN_W = 100;
 const MIN_H = 100;
@@ -24,10 +25,11 @@ function injectStyle() {
 	document.head.appendChild(style);
 }
 
-export function renderIsland(data: ShapeData) {
+export function renderIsland(shape: ShapeData) {
 	injectStyle();
 
-	const justMerged = data._islandJustMerged as boolean | undefined;
+	const data = shape as IslandShapeData;
+	const justMerged = data._islandJustMerged;
 
 	// Island body is transparent — background is rendered by the metaball layer.
 	// This div serves as the container for child shapes and hit-test target.
@@ -84,7 +86,7 @@ export function resizeIsland(data: ShapeData, handle: string, delta: Point): Sha
 	return result;
 }
 
-export function createDefaultIsland(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultIsland(params: { id: string; x: number; y: number }): IslandShapeData {
 	return {
 		id: params.id,
 		type: "island",

--- a/plugins/usketch-plugin-shape-island/src/types.ts
+++ b/plugins/usketch-plugin-shape-island/src/types.ts
@@ -1,0 +1,11 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Island shape extension: intrinsic data for the `island` shape. */
+export interface IslandShapeData extends ShapeData {
+	islandColor?: string;
+	islandTitle?: string;
+	/** Transient flag set when the island has just merged into a group (used for animation). */
+	_islandJustMerged?: boolean;
+	/** Marker placed on `group` shapes that were auto-created by the island plugin. */
+	_isIslandGroup?: boolean;
+}

--- a/plugins/usketch-plugin-shape-sticky/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-sticky/src/plugin.tsx
@@ -15,27 +15,31 @@ import { createMachine, type MachineSchema } from "@zag-js/core";
 import { VanillaMachine } from "@zag-js/vanilla";
 import { DEFAULT_STICKY_COLOR, DEFAULT_STICKY_SIZE, STICKY_COLORS } from "./constants.js";
 import { render } from "./render.js";
+import type { StickyShapeData } from "./types.js";
+
+export type { StickyShapeData } from "./types.js";
 
 /**
  * LOD component: colored rectangle with one line of text truncated.
  * Drops the rich formatting / editing affordances.
  */
 function SimplifiedSticky({ shape }: { shape: ShapeData }) {
-	const fill = (shape.style?.fill as string) || (shape.color as string) || "#fff59d";
-	const text = String((shape.text as string) || "").split("\n")[0] ?? "";
-	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
+	const data = shape as StickyShapeData;
+	const fill = data.style?.fill || data.color || "#fff59d";
+	const text = String(data.text ?? "").split("\n")[0] ?? "";
+	const rotation = typeof data.rotation === "number" ? data.rotation : 0;
 	return (
 		<div
 			style={{
 				position: "absolute",
-				left: shape.x,
-				top: shape.y,
-				width: shape.width,
-				height: shape.height,
+				left: data.x,
+				top: data.y,
+				width: data.width,
+				height: data.height,
 				background: fill,
 				boxShadow: "0 1px 2px rgba(0,0,0,0.15)",
 				padding: 6,
-				fontSize: Math.max(10, shape.height * 0.18),
+				fontSize: Math.max(10, data.height * 0.18),
 				color: "#333",
 				overflow: "hidden",
 				whiteSpace: "nowrap",
@@ -112,7 +116,7 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 	};
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): StickyShapeData {
 	return {
 		id: params.id,
 		type: "sticky",
@@ -303,14 +307,14 @@ const stickyTextMachine = createMachine<StickyTextMachineSchema>({
 				const shape = pluginCtx.store.getShape(id);
 				if (!shape || shape.type !== "sticky") return;
 
-				context.set("textSnapshot", (shape.text as string) ?? "");
+				context.set("textSnapshot", (shape as StickyShapeData).text ?? "");
 				context.set("heightSnapshot", shape.height);
 				const clickTimer = refs.get("clickTimer");
 				if (clickTimer != null) {
 					clearTimeout(clickTimer);
 					refs.set("clickTimer", null);
 				}
-				pluginCtx.store.updateShape(id, { isEditing: true });
+				pluginCtx.store.updateShape(id, { isEditing: true } as Partial<StickyShapeData>);
 			},
 
 			startSettleTimer({ refs, send }) {
@@ -343,8 +347,8 @@ const stickyTextMachine = createMachine<StickyTextMachineSchema>({
 					return;
 				}
 
-				pluginCtx.store.updateShape(id, { isEditing: false });
-				const currentText = (shape.text as string) ?? "";
+				pluginCtx.store.updateShape(id, { isEditing: false } as Partial<StickyShapeData>);
+				const currentText = (shape as StickyShapeData).text ?? "";
 
 				// Sticky notes are kept even when empty (unlike text shapes)
 				if (currentText !== prevText || shape.height !== prevHeight) {
@@ -352,8 +356,8 @@ const stickyTextMachine = createMachine<StickyTextMachineSchema>({
 						createUpdateShapeCommand(
 							pluginCtx.store,
 							id,
-							{ text: prevText, height: prevHeight ?? shape.height },
-							{ text: currentText, height: shape.height },
+							{ text: prevText, height: prevHeight ?? shape.height } as Partial<StickyShapeData>,
+							{ text: currentText, height: shape.height } as Partial<StickyShapeData>,
 						),
 					);
 				}
@@ -372,7 +376,10 @@ const stickyTextMachine = createMachine<StickyTextMachineSchema>({
 				// padding(12px top + 12px bottom = 24px) を加算した必要高さ
 				const contentHeight = event.scrollHeight;
 				const newHeight = Math.max(shape.height, contentHeight);
-				pluginCtx.store.updateShape(id, { text: event.text, height: newHeight });
+				pluginCtx.store.updateShape(id, {
+					text: event.text,
+					height: newHeight,
+				} as Partial<StickyShapeData>);
 			},
 
 			sendEnterEdit({ send }) {

--- a/plugins/usketch-plugin-shape-sticky/src/render.tsx
+++ b/plugins/usketch-plugin-shape-sticky/src/render.tsx
@@ -1,15 +1,16 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { DEFAULT_STICKY_COLOR, STICKY_COLORS } from "./constants.js";
+import type { StickyShapeData } from "./types.js";
 
-function getStickyBackground(data: ShapeData): string {
-	const colorKey = (data.stickyColor as string) ?? DEFAULT_STICKY_COLOR;
+function getStickyBackground(data: StickyShapeData): string {
+	const colorKey = data.stickyColor ?? DEFAULT_STICKY_COLOR;
 	if (data.style.fill !== "transparent" && data.style.fill !== STICKY_COLORS[colorKey]) {
 		return data.style.fill;
 	}
 	return STICKY_COLORS[colorKey] ?? STICKY_COLORS[DEFAULT_STICKY_COLOR];
 }
 
-const baseStickyStyle = (data: ShapeData): React.CSSProperties => ({
+const baseStickyStyle = (data: StickyShapeData): React.CSSProperties => ({
 	width: "100%",
 	background: getStickyBackground(data),
 	borderRadius: 8,
@@ -17,7 +18,7 @@ const baseStickyStyle = (data: ShapeData): React.CSSProperties => ({
 	padding: 12,
 	boxSizing: "border-box",
 	fontFamily: "system-ui, sans-serif",
-	fontSize: (data.fontSize as number) ?? 16,
+	fontSize: data.fontSize ?? 16,
 	color: "#1e1e1e",
 	lineHeight: 1.4,
 	whiteSpace: "pre-wrap",
@@ -37,7 +38,8 @@ function focusAtEnd(el: HTMLElement) {
 	}
 }
 
-export function render(data: ShapeData) {
+export function render(shape: ShapeData) {
+	const data = shape as StickyShapeData;
 	if (!data.isEditing) {
 		return (
 			<div
@@ -49,7 +51,7 @@ export function render(data: ShapeData) {
 					userSelect: "none",
 				}}
 			>
-				{(data.text as string) ?? ""}
+				{data.text ?? ""}
 			</div>
 		);
 	}
@@ -66,7 +68,7 @@ export function render(data: ShapeData) {
 				if (!el) return;
 				if (el.dataset.focused) return;
 				el.dataset.focused = "1";
-				el.textContent = (data.text as string) ?? "";
+				el.textContent = data.text ?? "";
 				requestAnimationFrame(() => focusAtEnd(el));
 			}}
 			onInput={(e: React.FormEvent<HTMLDivElement>) => {

--- a/plugins/usketch-plugin-shape-sticky/src/types.ts
+++ b/plugins/usketch-plugin-shape-sticky/src/types.ts
@@ -1,0 +1,10 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Sticky shape extension: intrinsic data for the `sticky` shape. */
+export interface StickyShapeData extends ShapeData {
+	text: string;
+	fontSize: number;
+	stickyColor: string;
+	color?: string;
+	isEditing: boolean;
+}

--- a/plugins/usketch-plugin-shape-text/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-text/src/plugin.tsx
@@ -14,23 +14,32 @@ import {
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { createTextEditingService } from "./text-editing-machine.js";
 
+/** Text shape extension: intrinsic data for the `text` shape. */
+export interface TextShapeData extends ShapeData {
+	text: string;
+	fontSize: number;
+	fontFamily: string;
+	isEditing: boolean;
+}
+
 /**
  * LOD component: first line of text, truncated. Dropped editing + focus ring.
  */
 function SimplifiedText({ shape }: { shape: ShapeData }) {
-	const text = String((shape.text as string) || "").split("\n")[0] ?? "";
-	const color = (shape.style?.stroke as string) || "#222";
-	const rotation = typeof shape.rotation === "number" ? shape.rotation : 0;
+	const data = shape as TextShapeData;
+	const text = String(data.text ?? "").split("\n")[0] ?? "";
+	const color = data.style?.stroke || "#222";
+	const rotation = typeof data.rotation === "number" ? data.rotation : 0;
 	return (
 		<div
 			style={{
 				position: "absolute",
-				left: shape.x,
-				top: shape.y,
-				width: shape.width,
-				height: shape.height,
-				fontSize: (shape.fontSize as number) ?? 16,
-				fontFamily: (shape.fontFamily as string) ?? "system-ui, sans-serif",
+				left: data.x,
+				top: data.y,
+				width: data.width,
+				height: data.height,
+				fontSize: data.fontSize ?? 16,
+				fontFamily: data.fontFamily ?? "system-ui, sans-serif",
 				color,
 				overflow: "hidden",
 				whiteSpace: "nowrap",
@@ -47,14 +56,14 @@ function SimplifiedText({ shape }: { shape: ShapeData }) {
 
 // ── Shape Definition ──
 
-const textStyle = (data: ShapeData): React.CSSProperties => ({
+const textStyle = (data: TextShapeData): React.CSSProperties => ({
 	width: "100%",
 	height: "100%",
 	whiteSpace: "pre-wrap",
 	wordBreak: "break-word",
 	outline: "none",
-	fontFamily: (data.fontFamily as string) ?? "system-ui, sans-serif",
-	fontSize: (data.fontSize as number) ?? 16,
+	fontFamily: data.fontFamily ?? "system-ui, sans-serif",
+	fontSize: data.fontSize ?? 16,
 	color: data.style.stroke,
 	background: data.style.fill === "transparent" ? "transparent" : data.style.fill,
 	lineHeight: 1.4,
@@ -74,11 +83,12 @@ function focusAtEnd(el: HTMLElement) {
 	}
 }
 
-function render(data: ShapeData) {
+function render(shape: ShapeData) {
+	const data = shape as TextShapeData;
 	if (!data.isEditing) {
 		return (
 			<div style={{ ...textStyle(data), pointerEvents: "none", userSelect: "none" }}>
-				{(data.text as string) ?? ""}
+				{data.text ?? ""}
 			</div>
 		);
 	}
@@ -98,7 +108,7 @@ function render(data: ShapeData) {
 				// replace it, or the cursor position will be lost.
 				if (el.dataset.focused) return;
 				el.dataset.focused = "1";
-				el.textContent = (data.text as string) ?? "";
+				el.textContent = data.text ?? "";
 				requestAnimationFrame(() => focusAtEnd(el));
 			}}
 			onInput={(e: React.FormEvent<HTMLDivElement>) => {
@@ -191,7 +201,7 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 	return { ...data, x, y, width: Math.max(40, width), height: Math.max(24, height) };
 }
 
-function createDefault(params: { id: string; x: number; y: number }): ShapeData {
+function createDefault(params: { id: string; x: number; y: number }): TextShapeData {
 	return {
 		id: params.id,
 		type: "text",

--- a/plugins/usketch-plugin-shape-text/src/text-editing-machine.ts
+++ b/plugins/usketch-plugin-shape-text/src/text-editing-machine.ts
@@ -1,7 +1,13 @@
-import type { PluginContext } from "@edv4h/usketch-shared";
+import type { PluginContext, ShapeData } from "@edv4h/usketch-shared";
 import { createDeleteShapeCommand, createUpdateShapeCommand } from "@edv4h/usketch-store";
 import { createMachine, type MachineSchema } from "@zag-js/core";
 import { VanillaMachine } from "@zag-js/vanilla";
+
+/** Subset of TextShapeData fields the machine needs (kept local to avoid circular import with plugin.tsx). */
+type TextShapeData = ShapeData & {
+	text: string;
+	isEditing: boolean;
+};
 
 // ── Event Types ──
 
@@ -181,7 +187,7 @@ const textEditingMachine = createMachine<TextMachineSchema>({
 				const shape = pluginCtx.store.getShape(id);
 				if (!shape || shape.type !== "text") return;
 
-				context.set("textSnapshot", (shape.text as string) ?? "");
+				context.set("textSnapshot", (shape as TextShapeData).text ?? "");
 				context.set("heightSnapshot", shape.height);
 				// Clear click state
 				context.set("clickedShapeId", null);
@@ -190,7 +196,7 @@ const textEditingMachine = createMachine<TextMachineSchema>({
 					clearTimeout(clickTimer);
 					refs.set("clickTimer", null);
 				}
-				pluginCtx.store.updateShape(id, { isEditing: true });
+				pluginCtx.store.updateShape(id, { isEditing: true } as Partial<TextShapeData>);
 			},
 
 			startSettleTimer({ refs, send }) {
@@ -224,8 +230,8 @@ const textEditingMachine = createMachine<TextMachineSchema>({
 					return;
 				}
 
-				pluginCtx.store.updateShape(id, { isEditing: false });
-				const currentText = (shape.text as string) ?? "";
+				pluginCtx.store.updateShape(id, { isEditing: false } as Partial<TextShapeData>);
+				const currentText = (shape as TextShapeData).text ?? "";
 
 				if (currentText.trim() === "") {
 					pluginCtx.commands.execute(createDeleteShapeCommand(pluginCtx.store, id));
@@ -234,8 +240,8 @@ const textEditingMachine = createMachine<TextMachineSchema>({
 						createUpdateShapeCommand(
 							pluginCtx.store,
 							id,
-							{ text: prevText, height: prevHeight ?? shape.height },
-							{ text: currentText, height: shape.height },
+							{ text: prevText, height: prevHeight ?? shape.height } as Partial<TextShapeData>,
+							{ text: currentText, height: shape.height } as Partial<TextShapeData>,
 						),
 					);
 				}
@@ -252,7 +258,10 @@ const textEditingMachine = createMachine<TextMachineSchema>({
 				const shape = pluginCtx.store.getShape(id);
 				if (!shape) return;
 				const newHeight = Math.max(28, event.scrollHeight);
-				pluginCtx.store.updateShape(id, { text: event.text, height: newHeight });
+				pluginCtx.store.updateShape(id, {
+					text: event.text,
+					height: newHeight,
+				} as Partial<TextShapeData>);
 			},
 
 			sendEnterEdit({ send }) {

--- a/plugins/usketch-plugin-shape-wireframe/src/index.ts
+++ b/plugins/usketch-plugin-shape-wireframe/src/index.ts
@@ -1,3 +1,26 @@
 export { wireframePlugin } from "./plugin.js";
 export type { WireframeSubtype } from "./shared/wireframe-registry.js";
 export { WIREFRAME_SUBTYPES } from "./shared/wireframe-registry.js";
+export type {
+	WireframeAccordionShapeData,
+	WireframeAlertShapeData,
+	WireframeAvatarShapeData,
+	WireframeBadgeShapeData,
+	WireframeBreadcrumbShapeData,
+	WireframeButtonShapeData,
+	WireframeCardShapeData,
+	WireframeCheckboxShapeData,
+	WireframeContainerShapeData,
+	WireframeDividerShapeData,
+	WireframeImageShapeData,
+	WireframeInputShapeData,
+	WireframeListShapeData,
+	WireframeModalShapeData,
+	WireframeNavbarShapeData,
+	WireframeProgressShapeData,
+	WireframeSelectShapeData,
+	WireframeSidebarShapeData,
+	WireframeTableShapeData,
+	WireframeTabsShapeData,
+	WireframeToastShapeData,
+} from "./types.js";

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-accordion.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-accordion.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeAccordionShapeData } from "../types.js";
 
-export function renderAccordion(data: ShapeData) {
-	const sections = (data.sections as string[]) || ["Section 1", "Section 2", "Section 3"];
-	const expandedIndex = (data.expandedIndex as number) ?? 0;
+export function renderAccordion(shape: ShapeData) {
+	const data = shape as WireframeAccordionShapeData;
+	const sections = data.sections || ["Section 1", "Section 2", "Section 3"];
+	const expandedIndex = data.expandedIndex ?? 0;
 
 	return (
 		<div
@@ -64,7 +66,11 @@ export function renderAccordion(data: ShapeData) {
 	);
 }
 
-export function createDefaultAccordion(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultAccordion(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeAccordionShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-accordion",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-alert.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-alert.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeAlertShapeData } from "../types.js";
 
-export function renderAlert(data: ShapeData) {
-	const alertMessage = (data.alertMessage as string) || "Alert message";
-	const alertType = (data.alertType as string) || "info";
+export function renderAlert(shape: ShapeData) {
+	const data = shape as WireframeAlertShapeData;
+	const alertMessage = data.alertMessage || "Alert message";
+	const alertType = data.alertType || "info";
 
 	const typeColors: Record<string, string> = {
 		info: WF.colors.primary,
@@ -37,7 +39,11 @@ export function renderAlert(data: ShapeData) {
 	);
 }
 
-export function createDefaultAlert(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultAlert(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeAlertShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-alert",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-avatar.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-avatar.tsx
@@ -1,8 +1,10 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeAvatarShapeData } from "../types.js";
 
-export function renderAvatar(data: ShapeData) {
-	const avatarLabel = (data.avatarLabel as string) || "U";
+export function renderAvatar(shape: ShapeData) {
+	const data = shape as WireframeAvatarShapeData;
+	const avatarLabel = data.avatarLabel || "U";
 
 	return (
 		<div
@@ -28,7 +30,11 @@ export function renderAvatar(data: ShapeData) {
 	);
 }
 
-export function createDefaultAvatar(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultAvatar(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeAvatarShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-avatar",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-badge.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-badge.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeBadgeShapeData } from "../types.js";
 
-export function renderBadge(data: ShapeData) {
-	const badgeLabel = (data.badgeLabel as string) || "Badge";
-	const badgeVariant = (data.badgeVariant as string) || "default";
+export function renderBadge(shape: ShapeData) {
+	const data = shape as WireframeBadgeShapeData;
+	const badgeLabel = data.badgeLabel || "Badge";
+	const badgeVariant = data.badgeVariant || "default";
 
 	const variantStyles: Record<string, { bg: string; color: string }> = {
 		default: { bg: WF.colors.surface, color: WF.colors.text },
@@ -37,7 +39,11 @@ export function renderBadge(data: ShapeData) {
 	);
 }
 
-export function createDefaultBadge(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultBadge(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeBadgeShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-badge",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-breadcrumb.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-breadcrumb.tsx
@@ -1,8 +1,10 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeBreadcrumbShapeData } from "../types.js";
 
-export function renderBreadcrumb(data: ShapeData) {
-	const items = (data.items as string[]) || ["Home", "Page", "Current"];
+export function renderBreadcrumb(shape: ShapeData) {
+	const data = shape as WireframeBreadcrumbShapeData;
+	const items = data.items || ["Home", "Page", "Current"];
 
 	return (
 		<div
@@ -36,7 +38,11 @@ export function renderBreadcrumb(data: ShapeData) {
 	);
 }
 
-export function createDefaultBreadcrumb(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultBreadcrumb(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeBreadcrumbShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-breadcrumb",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-button.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-button.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeButtonShapeData } from "../types.js";
 
-export function renderButton(data: ShapeData) {
-	const label = (data.label as string) || "Button";
-	const variant = (data.variant as string) || "primary";
+export function renderButton(shape: ShapeData) {
+	const data = shape as WireframeButtonShapeData;
+	const label = data.label || "Button";
+	const variant = data.variant || "primary";
 
 	const variantStyles: Record<string, { bg: string; color: string; border: string }> = {
 		primary: { bg: WF.colors.primary, color: WF.colors.primaryText, border: WF.colors.primary },
@@ -41,7 +43,11 @@ export function renderButton(data: ShapeData) {
 	);
 }
 
-export function createDefaultButton(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultButton(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeButtonShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-button",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-card.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-card.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeCardShapeData } from "../types.js";
 
-export function renderCard(data: ShapeData) {
-	const cardTitle = (data.cardTitle as string) || "Card Title";
-	const cardContent = (data.cardContent as string) || "Card content goes here.";
+export function renderCard(shape: ShapeData) {
+	const data = shape as WireframeCardShapeData;
+	const cardTitle = data.cardTitle || "Card Title";
+	const cardContent = data.cardContent || "Card content goes here.";
 
 	return (
 		<div
@@ -49,7 +51,11 @@ export function renderCard(data: ShapeData) {
 	);
 }
 
-export function createDefaultCard(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultCard(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeCardShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-card",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-checkbox.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-checkbox.tsx
@@ -1,8 +1,10 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeCheckboxShapeData } from "../types.js";
 
-export function renderCheckbox(data: ShapeData) {
-	const checkboxLabel = (data.checkboxLabel as string) || "Checkbox";
+export function renderCheckbox(shape: ShapeData) {
+	const data = shape as WireframeCheckboxShapeData;
+	const checkboxLabel = data.checkboxLabel || "Checkbox";
 	const checked = data.checked === true;
 
 	return (
@@ -54,7 +56,11 @@ export function renderCheckbox(data: ShapeData) {
 	);
 }
 
-export function createDefaultCheckbox(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultCheckbox(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeCheckboxShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-checkbox",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-container.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-container.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeContainerShapeData } from "../types.js";
 
-export function renderContainer(data: ShapeData) {
-	const containerTitle = (data.containerTitle as string) || "Container";
-	const borderStyle = (data.borderStyle as string) || "solid";
+export function renderContainer(shape: ShapeData) {
+	const data = shape as WireframeContainerShapeData;
+	const containerTitle = data.containerTitle || "Container";
+	const borderStyle = data.borderStyle || "solid";
 
 	return (
 		<div
@@ -39,7 +41,11 @@ export function renderContainer(data: ShapeData) {
 	);
 }
 
-export function createDefaultContainer(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultContainer(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeContainerShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-container",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-divider.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-divider.tsx
@@ -1,8 +1,10 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeDividerShapeData } from "../types.js";
 
-export function renderDivider(data: ShapeData) {
-	const dividerStyle = (data.dividerStyle as string) || "solid";
+export function renderDivider(shape: ShapeData) {
+	const data = shape as WireframeDividerShapeData;
+	const dividerStyle = data.dividerStyle || "solid";
 
 	return (
 		<div
@@ -26,7 +28,11 @@ export function renderDivider(data: ShapeData) {
 	);
 }
 
-export function createDefaultDivider(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultDivider(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeDividerShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-divider",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-image.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-image.tsx
@@ -1,8 +1,10 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeImageShapeData } from "../types.js";
 
-export function renderImage(data: ShapeData) {
-	const imageAlt = (data.imageAlt as string) || "Image";
+export function renderImage(shape: ShapeData) {
+	const data = shape as WireframeImageShapeData;
+	const imageAlt = data.imageAlt || "Image";
 
 	return (
 		<div
@@ -44,7 +46,11 @@ export function renderImage(data: ShapeData) {
 	);
 }
 
-export function createDefaultImage(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultImage(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeImageShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-image",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-input.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-input.tsx
@@ -1,10 +1,12 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeInputShapeData } from "../types.js";
 
-export function renderInput(data: ShapeData) {
-	const placeholder = (data.placeholder as string) || "Enter text...";
-	const inputLabel = (data.inputLabel as string) || "";
-	const inputType = (data.inputType as string) || "text";
+export function renderInput(shape: ShapeData) {
+	const data = shape as WireframeInputShapeData;
+	const placeholder = data.placeholder || "Enter text...";
+	const inputLabel = data.inputLabel || "";
+	const inputType = data.inputType || "text";
 
 	const isPassword = inputType === "password";
 	const displayText = isPassword ? "••••••••" : placeholder;
@@ -56,7 +58,11 @@ export function renderInput(data: ShapeData) {
 	);
 }
 
-export function createDefaultInput(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultInput(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeInputShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-input",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-list.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-list.tsx
@@ -1,8 +1,10 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeListShapeData } from "../types.js";
 
-export function renderList(data: ShapeData) {
-	const listItems = (data.listItems as string[]) || ["Item 1", "Item 2", "Item 3"];
+export function renderList(shape: ShapeData) {
+	const data = shape as WireframeListShapeData;
+	const listItems = data.listItems || ["Item 1", "Item 2", "Item 3"];
 
 	return (
 		<div
@@ -38,7 +40,11 @@ export function renderList(data: ShapeData) {
 	);
 }
 
-export function createDefaultList(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultList(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeListShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-list",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-modal.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-modal.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeModalShapeData } from "../types.js";
 
-export function renderModal(data: ShapeData) {
-	const modalTitle = (data.modalTitle as string) || "Modal Title";
-	const modalContent = (data.modalContent as string) || "Modal content goes here.";
+export function renderModal(shape: ShapeData) {
+	const data = shape as WireframeModalShapeData;
+	const modalTitle = data.modalTitle || "Modal Title";
+	const modalContent = data.modalContent || "Modal content goes here.";
 
 	return (
 		<div
@@ -99,7 +101,11 @@ export function renderModal(data: ShapeData) {
 	);
 }
 
-export function createDefaultModal(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultModal(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeModalShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-modal",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-navbar.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-navbar.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeNavbarShapeData } from "../types.js";
 
-export function renderNavbar(data: ShapeData) {
-	const items = (data.items as string[]) || ["Home", "About", "Contact"];
-	const brand = (data.brand as string) || "Brand";
+export function renderNavbar(shape: ShapeData) {
+	const data = shape as WireframeNavbarShapeData;
+	const items = data.items || ["Home", "About", "Contact"];
+	const brand = data.brand || "Brand";
 
 	return (
 		<div
@@ -49,7 +51,11 @@ export function renderNavbar(data: ShapeData) {
 	);
 }
 
-export function createDefaultNavbar(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultNavbar(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeNavbarShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-navbar",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-progress.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-progress.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeProgressShapeData } from "../types.js";
 
-export function renderProgress(data: ShapeData) {
-	const progress = Math.max(0, Math.min(100, (data.progress as number) ?? 60));
-	const progressLabel = (data.progressLabel as string) || "";
+export function renderProgress(shape: ShapeData) {
+	const data = shape as WireframeProgressShapeData;
+	const progress = Math.max(0, Math.min(100, data.progress ?? 60));
+	const progressLabel = data.progressLabel || "";
 
 	return (
 		<div
@@ -54,7 +56,11 @@ export function renderProgress(data: ShapeData) {
 	);
 }
 
-export function createDefaultProgress(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultProgress(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeProgressShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-progress",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-select.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-select.tsx
@@ -1,8 +1,10 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeSelectShapeData } from "../types.js";
 
-export function renderSelect(data: ShapeData) {
-	const placeholder = (data.placeholder as string) || "Select...";
+export function renderSelect(shape: ShapeData) {
+	const data = shape as WireframeSelectShapeData;
+	const placeholder = data.placeholder || "Select...";
 
 	return (
 		<div
@@ -39,7 +41,11 @@ export function renderSelect(data: ShapeData) {
 	);
 }
 
-export function createDefaultSelect(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultSelect(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeSelectShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-select",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-sidebar.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-sidebar.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeSidebarShapeData } from "../types.js";
 
-export function renderSidebar(data: ShapeData) {
-	const items = (data.items as string[]) || ["Dashboard", "Settings", "Profile"];
-	const sidebarTitle = (data.sidebarTitle as string) || "Menu";
+export function renderSidebar(shape: ShapeData) {
+	const data = shape as WireframeSidebarShapeData;
+	const items = data.items || ["Dashboard", "Settings", "Profile"];
+	const sidebarTitle = data.sidebarTitle || "Menu";
 
 	return (
 		<div
@@ -56,7 +58,11 @@ export function renderSidebar(data: ShapeData) {
 	);
 }
 
-export function createDefaultSidebar(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultSidebar(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeSidebarShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-sidebar",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-table.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-table.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeTableShapeData } from "../types.js";
 
-export function renderTable(data: ShapeData) {
-	const columns = (data.columns as string[]) || ["Name", "Value", "Status"];
-	const rows = (data.rows as number) ?? 3;
+export function renderTable(shape: ShapeData) {
+	const data = shape as WireframeTableShapeData;
+	const columns = data.columns || ["Name", "Value", "Status"];
+	const rows = data.rows ?? 3;
 
 	return (
 		<div
@@ -84,7 +86,11 @@ export function renderTable(data: ShapeData) {
 	);
 }
 
-export function createDefaultTable(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultTable(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeTableShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-table",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-tabs.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-tabs.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeTabsShapeData } from "../types.js";
 
-export function renderTabs(data: ShapeData) {
-	const tabs = (data.tabs as string[]) || ["Tab 1", "Tab 2", "Tab 3"];
-	const activeIndex = (data.activeIndex as number) ?? 0;
+export function renderTabs(shape: ShapeData) {
+	const data = shape as WireframeTabsShapeData;
+	const tabs = data.tabs || ["Tab 1", "Tab 2", "Tab 3"];
+	const activeIndex = data.activeIndex ?? 0;
 
 	return (
 		<div
@@ -41,7 +43,11 @@ export function renderTabs(data: ShapeData) {
 	);
 }
 
-export function createDefaultTabs(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultTabs(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeTabsShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-tabs",

--- a/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-toast.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/shapes/wireframe-toast.tsx
@@ -1,9 +1,11 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { WF } from "../shared/wireframe-styles.js";
+import type { WireframeToastShapeData } from "../types.js";
 
-export function renderToast(data: ShapeData) {
-	const toastMessage = (data.toastMessage as string) || "Notification";
-	const toastType = (data.toastType as string) || "success";
+export function renderToast(shape: ShapeData) {
+	const data = shape as WireframeToastShapeData;
+	const toastMessage = data.toastMessage || "Notification";
+	const toastType = data.toastType || "success";
 
 	const typeIcons: Record<string, string> = {
 		success: "\u2713",
@@ -72,7 +74,11 @@ export function renderToast(data: ShapeData) {
 	);
 }
 
-export function createDefaultToast(params: { id: string; x: number; y: number }): ShapeData {
+export function createDefaultToast(params: {
+	id: string;
+	x: number;
+	y: number;
+}): WireframeToastShapeData {
 	return {
 		id: params.id,
 		type: "wireframe-toast",

--- a/plugins/usketch-plugin-shape-wireframe/src/types.ts
+++ b/plugins/usketch-plugin-shape-wireframe/src/types.ts
@@ -1,0 +1,123 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Accordion wireframe: expandable sections. */
+export interface WireframeAccordionShapeData extends ShapeData {
+	sections: string[];
+	expandedIndex: number;
+}
+
+/** Alert wireframe: inline status message. */
+export interface WireframeAlertShapeData extends ShapeData {
+	alertMessage: string;
+	alertType: "info" | "success" | "warning" | "error" | string;
+}
+
+/** Avatar wireframe: circular identity marker. */
+export interface WireframeAvatarShapeData extends ShapeData {
+	avatarLabel: string;
+}
+
+/** Badge wireframe: small label/tag. */
+export interface WireframeBadgeShapeData extends ShapeData {
+	badgeLabel: string;
+	badgeVariant: "default" | "primary" | "secondary" | string;
+}
+
+/** Breadcrumb wireframe: hierarchical navigation trail. */
+export interface WireframeBreadcrumbShapeData extends ShapeData {
+	items: string[];
+}
+
+/** Button wireframe: clickable action. */
+export interface WireframeButtonShapeData extends ShapeData {
+	label: string;
+	variant: "primary" | "secondary" | "outline" | string;
+}
+
+/** Card wireframe: titled content container. */
+export interface WireframeCardShapeData extends ShapeData {
+	cardTitle: string;
+	cardContent: string;
+}
+
+/** Checkbox wireframe: toggleable option with label. */
+export interface WireframeCheckboxShapeData extends ShapeData {
+	checkboxLabel: string;
+	checked: boolean;
+}
+
+/** Container wireframe: labeled layout region. */
+export interface WireframeContainerShapeData extends ShapeData {
+	containerTitle: string;
+	borderStyle: "solid" | "dashed" | "dotted" | string;
+}
+
+/** Divider wireframe: horizontal separator. */
+export interface WireframeDividerShapeData extends ShapeData {
+	dividerStyle: "solid" | "dashed" | "dotted" | string;
+}
+
+/** Image wireframe: image placeholder. */
+export interface WireframeImageShapeData extends ShapeData {
+	imageAlt: string;
+}
+
+/** Input wireframe: single-line form field. */
+export interface WireframeInputShapeData extends ShapeData {
+	placeholder?: string;
+	inputLabel?: string;
+	inputType?: "text" | "password" | string;
+}
+
+/** List wireframe: bulleted items. */
+export interface WireframeListShapeData extends ShapeData {
+	listItems: string[];
+}
+
+/** Modal wireframe: dialog with header + body. */
+export interface WireframeModalShapeData extends ShapeData {
+	modalTitle: string;
+	modalContent: string;
+}
+
+/** Navbar wireframe: top navigation bar. */
+export interface WireframeNavbarShapeData extends ShapeData {
+	items: string[];
+	brand: string;
+}
+
+/** Progress wireframe: progress bar. */
+export interface WireframeProgressShapeData extends ShapeData {
+	progress: number;
+	progressLabel?: string;
+}
+
+/** Select wireframe: dropdown field. */
+export interface WireframeSelectShapeData extends ShapeData {
+	placeholder?: string;
+	options?: string[];
+}
+
+/** Sidebar wireframe: vertical navigation menu. */
+export interface WireframeSidebarShapeData extends ShapeData {
+	items: string[];
+	sidebarTitle: string;
+}
+
+/** Table wireframe: tabular grid. */
+export interface WireframeTableShapeData extends ShapeData {
+	columns: string[];
+	rows: number;
+}
+
+/** Tabs wireframe: tabbed navigation. */
+export interface WireframeTabsShapeData extends ShapeData {
+	tabs: string[];
+	activeIndex: number;
+}
+
+/** Toast wireframe: transient notification. */
+export interface WireframeToastShapeData extends ShapeData {
+	toastMessage: string;
+	toastType: "success" | "error" | "warning" | "info" | string;
+}

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -645,12 +645,15 @@ export const selectToolPlugin: UsketchPlugin = {
 				resized.x = fixed.x;
 				resized.y = fixed.y;
 				const updates: Partial<ShapeData> = {};
+				const resizedRecord = resized as unknown as Record<string, unknown>;
+				const startRecord = dragState.startData as unknown as Record<string, unknown>;
+				const updatesRecord = updates as Record<string, unknown>;
 				for (const key of Object.keys(resized)) {
 					if (key === "id" || key === "type" || key === "style") continue;
-					const resizedValue = resized[key];
-					const startValue = dragState.startData[key];
+					const resizedValue = resizedRecord[key];
+					const startValue = startRecord[key];
 					if (resizedValue !== startValue) {
-						updates[key] = resizedValue;
+						updatesRecord[key] = resizedValue;
 					}
 				}
 				if (Object.keys(updates).length > 0) {
@@ -955,13 +958,17 @@ export const selectToolPlugin: UsketchPlugin = {
 					// Build from/to diffs for undo
 					const from: Partial<ShapeData> = {};
 					const to: Partial<ShapeData> = {};
+					const currentRecord = currentShape as unknown as Record<string, unknown>;
+					const startRecord = dragState.startData as unknown as Record<string, unknown>;
+					const fromRecord = from as Record<string, unknown>;
+					const toRecord = to as Record<string, unknown>;
 					for (const key of Object.keys(currentShape)) {
 						if (key === "id" || key === "type" || key === "style") continue;
-						const currentValue = currentShape[key];
-						const startValue = dragState.startData[key];
+						const currentValue = currentRecord[key];
+						const startValue = startRecord[key];
 						if (currentValue !== startValue) {
-							from[key] = startValue;
-							to[key] = currentValue;
+							fromRecord[key] = startValue;
+							toRecord[key] = currentValue;
 						}
 					}
 
@@ -990,13 +997,17 @@ export const selectToolPlugin: UsketchPlugin = {
 					if (!currentShape) continue;
 					const from: Partial<ShapeData> = {};
 					const to: Partial<ShapeData> = {};
+					const currentRecord = currentShape as unknown as Record<string, unknown>;
+					const origRecord = origFullShape as unknown as Record<string, unknown>;
+					const fromRecord = from as Record<string, unknown>;
+					const toRecord = to as Record<string, unknown>;
 					for (const key of Object.keys(currentShape)) {
 						if (key === "id" || key === "type" || key === "style") continue;
-						const currentValue = currentShape[key];
-						const origValue = origFullShape[key];
+						const currentValue = currentRecord[key];
+						const origValue = origRecord[key];
 						if (currentValue !== origValue) {
-							from[key] = origValue;
-							to[key] = currentValue;
+							fromRecord[key] = origValue;
+							toRecord[key] = currentValue;
 						}
 					}
 					if (Object.keys(to).length > 0) {


### PR DESCRIPTION
## Summary

Closes #575.

`ShapeData` の拡張ポイントの契約を 3 層に整理し、`[key: string]: unknown` による型安全性ゼロの状態を解消する。

- **コアフィールド** — `id`, `type`, `x`, `y`, `width`, `height`, `style`, `rotation`, `zIndex`, `createdAt`, `updatedAt`, `parentId`, `meta` のみ明示列挙
- **プラグイン固有フィールド** — 各プラグインが `interface XxxShapeData extends ShapeData` で宣言（intrinsic データの置き場）
- **アプリ/ドメインデータ** — `meta?: TMeta`（主軸）、または `x-*` プリフィックス（助け舟）

`ShapeData<TMeta = Record<string, unknown>>` としてジェネリック化。デフォルト引数により既存コードは無変更で通り、consumer が明示した時だけ型安全な meta が得られる。

## Breaking changes

| 変更 | 影響 | 対処 |
|------|------|------|
| `[key: string]: unknown` → `[key: \`x-${string}\`]: unknown` | 任意キー代入が typecheck で失敗 | プラグイン拡張型 or `meta` or `x-*` プリフィックスに移行 |
| `_createdAt` / `_updatedAt` → `createdAt` / `updatedAt` | underscoreなし版にrename | 保存済みデータのフィールド名を rename |
| `parentId` をコア昇格 | hierarchy-utils が参照 | インターフェース変更のみ（既存動作は同じ） |

詳細な移行ガイドは `.changeset/shape-data-layered-contract.md` と [docs の shape-system.mdx](apps/docs/src/content/docs/concepts/shape-system.mdx) を参照。

## 影響範囲

21 パッケージで major bump:
- `@edv4h/usketch-shared` — 型定義本体
- `@edv4h/usketch-store` — `createdAt`/`updatedAt` rename、connector inline cast
- `@edv4h/usketch-plugin-canvas-filter` — `TimeRangeFilter.field` 型変更
- shape プラグイン 11 個（text/sticky/freedraw/connector/wireframe/counter/frame/island/image/community-region/board-portal）に拡張型導入
- アプリ系 5 個（board-info-panel, community-chat, ai-agent, ai-copilot, ai-recognize）
- ツール/ユーティリティ 4 個（tool-select, debug-hud, shape-utils, web）

## Test plan

- [x] `pnpm turbo typecheck --continue` が 0 エラー（130 パッケージ全通過）
- [x] `pnpm turbo test --continue` が 0 失敗
- [x] `pnpm biome check` が 0 errors（既存 warnings のみ）
- [x] `packages/store` の test suite（52 tests）が全 pass
- [ ] CI 全 pass 確認
- [ ] 手動: `apps/web` で主要 shape の描画・編集・undo/redo が正しく動作する

## Migration pattern (for downstream consumers)

```ts
// Before
interface MyShape extends ShapeData {}
shape.employeeId = "emp_123";  // OK (index signature)

// After — preferred
interface WeboardMeta { employeeId?: string }
const shape: ShapeData<WeboardMeta> = { ...defaults, meta: { employeeId: "emp_123" } };
shape.meta?.employeeId;  // typed as string | undefined

// After — escape hatch
const shape: ShapeData = { ...defaults, "x-employeeId": "emp_123" };

// Plugin intrinsic data
interface MyShapeData extends ShapeData { customField: string }
const shape: MyShapeData = { ...defaults, customField: "value" };
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)