### PR TITLE
♻️ refactor(shared): diffShape ユーティリティで tool-select の Record キャストを排除

### DIFF
--- a/.changeset/shape-diff-utility.md
+++ b/.changeset/shape-diff-utility.md
@@ -1,0 +1,10 @@
+---
+"@edv4h/usketch-shared": minor
+"@edv4h/usketch-plugin-tool-select": patch
+---
+
+Add `diffShape` / `bidiffShape` utilities to `@edv4h/usketch-shared` and migrate `tool-select` to use them.
+
+These helpers compute the field-level diff between two shapes of the same type without knowing the concrete shape type at compile time — the dynamic field iteration that `tool-select` needs for resize undo/redo. The `Record<string, unknown>` cast required to iterate `ShapeData` fields is now encapsulated in the utility, so the type escape is confined to one place instead of being repeated at every call site.
+
+Follow-up to #582 / #575 — eliminates the three local `as unknown as Record<string, unknown>` casts that the `[key: \`x-${string}\`]: unknown` index signature change introduced in `tool-select`.

--- a/packages/shared/src/__tests__/shape-diff.test.ts
+++ b/packages/shared/src/__tests__/shape-diff.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { ShapeData } from "../types/shape.js";
+import { bidiffShape, diffShape } from "../utils/shape-diff.js";
+
+const baseShape: ShapeData = {
+	id: "s1",
+	type: "rect",
+	x: 0,
+	y: 0,
+	width: 100,
+	height: 100,
+	style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+};
+
+describe("diffShape", () => {
+	it("同一 shape は空オブジェクト", () => {
+		expect(diffShape(baseShape, baseShape)).toEqual({});
+		expect(diffShape(baseShape, { ...baseShape })).toEqual({});
+	});
+
+	it("x / y のみ変更されたフィールドだけ返す", () => {
+		const after: ShapeData = { ...baseShape, x: 50, y: 75 };
+		expect(diffShape(baseShape, after)).toEqual({ x: 50, y: 75 });
+	});
+
+	it("id / type / style の差異は無視する", () => {
+		const after: ShapeData = {
+			...baseShape,
+			id: "different",
+			type: "ellipse",
+			style: { fill: "#f00", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		};
+		expect(diffShape(baseShape, after)).toEqual({});
+	});
+
+	it("プラグイン拡張フィールドの差異も検出する", () => {
+		// e.g. freedraw points / text content
+		const before = { ...baseShape, points: [{ x: 0, y: 0 }] } as ShapeData;
+		const after = { ...baseShape, points: [{ x: 1, y: 1 }] } as ShapeData;
+		const result = diffShape(before, after);
+		expect(result).toHaveProperty("points");
+		expect((result as { points: unknown }).points).toEqual([{ x: 1, y: 1 }]);
+	});
+
+	it("after にだけある新フィールドも検出する", () => {
+		const before = { ...baseShape };
+		const after = { ...baseShape, text: "hello" } as ShapeData;
+		expect(diffShape(before, after)).toEqual({ text: "hello" });
+	});
+
+	it("rotation / zIndex / parentId / meta も diff 対象", () => {
+		const before: ShapeData = { ...baseShape, rotation: 0, zIndex: "a0" };
+		const after: ShapeData = {
+			...baseShape,
+			rotation: 90,
+			zIndex: "a1",
+			parentId: "frame_1",
+			meta: { foo: "bar" },
+		};
+		expect(diffShape(before, after)).toEqual({
+			rotation: 90,
+			zIndex: "a1",
+			parentId: "frame_1",
+			meta: { foo: "bar" },
+		});
+	});
+});
+
+describe("bidiffShape", () => {
+	it("同一 shape は from / to ともに空", () => {
+		expect(bidiffShape(baseShape, baseShape)).toEqual({ from: {}, to: {} });
+	});
+
+	it("変わった field のみ from / to に含まれる", () => {
+		const after: ShapeData = { ...baseShape, x: 50, width: 200 };
+		expect(bidiffShape(baseShape, after)).toEqual({
+			from: { x: 0, width: 100 },
+			to: { x: 50, width: 200 },
+		});
+	});
+
+	it("id / type / style の差異は無視する", () => {
+		const after: ShapeData = {
+			...baseShape,
+			type: "ellipse",
+			style: { fill: "#f00", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		};
+		expect(bidiffShape(baseShape, after)).toEqual({ from: {}, to: {} });
+	});
+
+	it("undo 用に before の値が from に正しく入る", () => {
+		const before: ShapeData = { ...baseShape, rotation: 0 };
+		const after: ShapeData = { ...baseShape, rotation: 45 };
+		const { from, to } = bidiffShape(before, after);
+		expect(from).toEqual({ rotation: 0 });
+		expect(to).toEqual({ rotation: 45 });
+	});
+});

--- a/packages/shared/src/__tests__/shape-diff.test.ts
+++ b/packages/shared/src/__tests__/shape-diff.test.ts
@@ -33,6 +33,12 @@ describe("diffShape", () => {
 		expect(diffShape(baseShape, after)).toEqual({});
 	});
 
+	it("createdAt / updatedAt は store 管理のため diff から除外する", () => {
+		const before: ShapeData = { ...baseShape, createdAt: 1000, updatedAt: 1000 };
+		const after: ShapeData = { ...baseShape, createdAt: 1000, updatedAt: 9999 };
+		expect(diffShape(before, after)).toEqual({});
+	});
+
 	it("プラグイン拡張フィールドの差異も検出する", () => {
 		// e.g. freedraw points / text content
 		const before = { ...baseShape, points: [{ x: 0, y: 0 }] } as ShapeData;
@@ -86,6 +92,26 @@ describe("bidiffShape", () => {
 			style: { fill: "#f00", stroke: "#000", strokeWidth: 1, opacity: 1 },
 		};
 		expect(bidiffShape(baseShape, after)).toEqual({ from: {}, to: {} });
+	});
+
+	it("createdAt / updatedAt は store 管理のため diff から除外する", () => {
+		const before: ShapeData = { ...baseShape, createdAt: 1000, updatedAt: 1000 };
+		const after: ShapeData = { ...baseShape, createdAt: 1000, updatedAt: 9999 };
+		expect(bidiffShape(before, after)).toEqual({ from: {}, to: {} });
+	});
+
+	it("ジェネリック T が呼び出し側の subtype を保持する", () => {
+		// 拡張型（plugin が宣言する extension type を模擬）
+		interface TextShapeLike extends ShapeData {
+			text: string;
+		}
+		const before: TextShapeLike = { ...baseShape, text: "hello" };
+		const after: TextShapeLike = { ...baseShape, text: "world" };
+		const { from, to } = bidiffShape(before, after);
+		// `from` / `to` が Partial<TextShapeLike> として推論されるかは型レベル
+		// （コンパイル通過 = 検証済み）。ランタイムでは text の値が含まれることを確認。
+		expect(from.text).toBe("hello");
+		expect(to.text).toBe("world");
 	});
 
 	it("undo 用に before の値が from に正しく入る", () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -68,6 +68,8 @@ export {
 	unrotatePoint,
 	withRotation,
 } from "./utils/rotation.js";
+// Shape diff
+export { bidiffShape, diffShape } from "./utils/shape-diff.js";
 // Z-order
 export {
 	compareZIndex,

--- a/packages/shared/src/utils/shape-diff.ts
+++ b/packages/shared/src/utils/shape-diff.ts
@@ -1,25 +1,36 @@
 import type { ShapeData } from "../types/shape.js";
 
 /**
- * Keys that are never part of a shape diff: identity, type discriminator, and
- * style (treated as a single object reference, not field-by-field).
+ * Keys excluded from shape diffs:
+ * - `id` / `type`: identity and type discriminator (never diffed)
+ * - `style`: style changes are ignored
+ * - `createdAt` / `updatedAt`: store-managed timestamps that the store
+ *   overwrites on every mutation; including them would produce non-empty
+ *   diffs (and undo/redo commands) even when no user-visible field changed.
  */
-const NEVER_DIFF_KEYS: ReadonlySet<string> = new Set(["id", "type", "style"]);
+const NEVER_DIFF_KEYS: ReadonlySet<string> = new Set([
+	"id",
+	"type",
+	"style",
+	"createdAt",
+	"updatedAt",
+]);
 
 /**
  * Compute the field-level diff between two shapes of the same type.
  *
- * Returns a `Partial<ShapeData>` containing only the keys whose values differ
- * by referential `!==` comparison. Used by tools (e.g. `tool-select`) that need
+ * Returns a `Partial<T>` containing only the keys whose values differ by
+ * referential `!==` comparison. Used by tools (e.g. `tool-select`) that need
  * to track shape mutations across plugin-defined fields without knowing the
- * concrete shape type at compile time.
+ * concrete shape type at compile time. The generic parameter `T` preserves
+ * plugin-defined extension types when the caller has a more specific type.
  *
  * @remarks
  * Encapsulates the `Record<string, unknown>` cast required to iterate over
  * `ShapeData` fields dynamically. Callers should rely on this function rather
  * than re-implementing the loop, so the type escape stays in one place.
  */
-export function diffShape(before: ShapeData, after: ShapeData): Partial<ShapeData> {
+export function diffShape<T extends ShapeData>(before: T, after: T): Partial<T> {
 	const result: Record<string, unknown> = {};
 	const beforeRec = before as unknown as Record<string, unknown>;
 	const afterRec = after as unknown as Record<string, unknown>;
@@ -29,17 +40,17 @@ export function diffShape(before: ShapeData, after: ShapeData): Partial<ShapeDat
 			result[key] = afterRec[key];
 		}
 	}
-	return result as Partial<ShapeData>;
+	return result as Partial<T>;
 }
 
 /**
  * Compute a bidirectional diff (`from` / `to`) for undo/redo command construction.
  * Equivalent to calling `diffShape` twice but iterates fields once.
  */
-export function bidiffShape(
-	before: ShapeData,
-	after: ShapeData,
-): { from: Partial<ShapeData>; to: Partial<ShapeData> } {
+export function bidiffShape<T extends ShapeData>(
+	before: T,
+	after: T,
+): { from: Partial<T>; to: Partial<T> } {
 	const from: Record<string, unknown> = {};
 	const to: Record<string, unknown> = {};
 	const beforeRec = before as unknown as Record<string, unknown>;
@@ -52,7 +63,7 @@ export function bidiffShape(
 		}
 	}
 	return {
-		from: from as Partial<ShapeData>,
-		to: to as Partial<ShapeData>,
+		from: from as Partial<T>,
+		to: to as Partial<T>,
 	};
 }

--- a/packages/shared/src/utils/shape-diff.ts
+++ b/packages/shared/src/utils/shape-diff.ts
@@ -1,0 +1,58 @@
+import type { ShapeData } from "../types/shape.js";
+
+/**
+ * Keys that are never part of a shape diff: identity, type discriminator, and
+ * style (treated as a single object reference, not field-by-field).
+ */
+const NEVER_DIFF_KEYS: ReadonlySet<string> = new Set(["id", "type", "style"]);
+
+/**
+ * Compute the field-level diff between two shapes of the same type.
+ *
+ * Returns a `Partial<ShapeData>` containing only the keys whose values differ
+ * by referential `!==` comparison. Used by tools (e.g. `tool-select`) that need
+ * to track shape mutations across plugin-defined fields without knowing the
+ * concrete shape type at compile time.
+ *
+ * @remarks
+ * Encapsulates the `Record<string, unknown>` cast required to iterate over
+ * `ShapeData` fields dynamically. Callers should rely on this function rather
+ * than re-implementing the loop, so the type escape stays in one place.
+ */
+export function diffShape(before: ShapeData, after: ShapeData): Partial<ShapeData> {
+	const result: Record<string, unknown> = {};
+	const beforeRec = before as unknown as Record<string, unknown>;
+	const afterRec = after as unknown as Record<string, unknown>;
+	for (const key of Object.keys(after)) {
+		if (NEVER_DIFF_KEYS.has(key)) continue;
+		if (afterRec[key] !== beforeRec[key]) {
+			result[key] = afterRec[key];
+		}
+	}
+	return result as Partial<ShapeData>;
+}
+
+/**
+ * Compute a bidirectional diff (`from` / `to`) for undo/redo command construction.
+ * Equivalent to calling `diffShape` twice but iterates fields once.
+ */
+export function bidiffShape(
+	before: ShapeData,
+	after: ShapeData,
+): { from: Partial<ShapeData>; to: Partial<ShapeData> } {
+	const from: Record<string, unknown> = {};
+	const to: Record<string, unknown> = {};
+	const beforeRec = before as unknown as Record<string, unknown>;
+	const afterRec = after as unknown as Record<string, unknown>;
+	for (const key of Object.keys(after)) {
+		if (NEVER_DIFF_KEYS.has(key)) continue;
+		if (afterRec[key] !== beforeRec[key]) {
+			from[key] = beforeRec[key];
+			to[key] = afterRec[key];
+		}
+	}
+	return {
+		from: from as Partial<ShapeData>,
+		to: to as Partial<ShapeData>,
+	};
+}

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -9,7 +9,9 @@ import type {
 	UsketchPlugin,
 } from "@edv4h/usketch-shared";
 import {
+	bidiffShape,
 	deltaToLocal,
+	diffShape,
 	normalizeAngle,
 	safeRotation,
 	snapAngle,
@@ -644,18 +646,7 @@ export const selectToolPlugin: UsketchPlugin = {
 				const fixed = fixAnchorDrift(dragState.handle, dragState.startData, resized);
 				resized.x = fixed.x;
 				resized.y = fixed.y;
-				const updates: Partial<ShapeData> = {};
-				const resizedRecord = resized as unknown as Record<string, unknown>;
-				const startRecord = dragState.startData as unknown as Record<string, unknown>;
-				const updatesRecord = updates as Record<string, unknown>;
-				for (const key of Object.keys(resized)) {
-					if (key === "id" || key === "type" || key === "style") continue;
-					const resizedValue = resizedRecord[key];
-					const startValue = startRecord[key];
-					if (resizedValue !== startValue) {
-						updatesRecord[key] = resizedValue;
-					}
-				}
+				const updates = diffShape(dragState.startData, resized);
 				if (Object.keys(updates).length > 0) {
 					toolCtx.store.updateShape(dragState.shapeId, updates);
 				}
@@ -955,23 +946,7 @@ export const selectToolPlugin: UsketchPlugin = {
 				setOverrideCursor("");
 				const currentShape = toolCtx.store.getShape(dragState.shapeId);
 				if (currentShape) {
-					// Build from/to diffs for undo
-					const from: Partial<ShapeData> = {};
-					const to: Partial<ShapeData> = {};
-					const currentRecord = currentShape as unknown as Record<string, unknown>;
-					const startRecord = dragState.startData as unknown as Record<string, unknown>;
-					const fromRecord = from as Record<string, unknown>;
-					const toRecord = to as Record<string, unknown>;
-					for (const key of Object.keys(currentShape)) {
-						if (key === "id" || key === "type" || key === "style") continue;
-						const currentValue = currentRecord[key];
-						const startValue = startRecord[key];
-						if (currentValue !== startValue) {
-							fromRecord[key] = startValue;
-							toRecord[key] = currentValue;
-						}
-					}
-
+					const { from, to } = bidiffShape(dragState.startData, currentShape);
 					if (Object.keys(to).length > 0) {
 						// Defer reset+execute to after canvas:pointerup disables snap
 						const shapeId = dragState.shapeId;
@@ -995,21 +970,7 @@ export const selectToolPlugin: UsketchPlugin = {
 				for (const [id, origFullShape] of dragState.originalFullShapes) {
 					const currentShape = toolCtx.store.getShape(id);
 					if (!currentShape) continue;
-					const from: Partial<ShapeData> = {};
-					const to: Partial<ShapeData> = {};
-					const currentRecord = currentShape as unknown as Record<string, unknown>;
-					const origRecord = origFullShape as unknown as Record<string, unknown>;
-					const fromRecord = from as Record<string, unknown>;
-					const toRecord = to as Record<string, unknown>;
-					for (const key of Object.keys(currentShape)) {
-						if (key === "id" || key === "type" || key === "style") continue;
-						const currentValue = currentRecord[key];
-						const origValue = origRecord[key];
-						if (currentValue !== origValue) {
-							fromRecord[key] = origValue;
-							toRecord[key] = currentValue;
-						}
-					}
+					const { from, to } = bidiffShape(origFullShape, currentShape);
 					if (Object.keys(to).length > 0) {
 						batchUpdates.push({ id, from, to });
 					}


### PR DESCRIPTION
## Summary

PR #582（Issue #575）のフォローアップ。`ShapeData` のインデックスシグネチャを `[key: \`x-${string}\`]: unknown` に制限した影響で `tool-select` の resize ロジックに残っていた `as unknown as Record<string, unknown>` キャスト 3 箇所を、共通 utility に閉じ込めて排除する。

## What

- `@edv4h/usketch-shared` に新 utility:
  - `diffShape(before, after): Partial<ShapeData>` — 単方向 diff（resize 中の updateShape 用）
  - `bidiffShape(before, after): { from, to }` — undo/redo コマンド用の双方向 diff
- 内部で必要な `Record<string, unknown>` への型キャストは utility 実装に集約。呼び出し側はキャストゼロ
- `tool-select` の 3 箇所（resize during drag / single resize end / multi-resize end）を utility 呼び出しに置換
- 除外キー（`id` / `type` / `style`）の暗黙の契約も utility 内に集約され、振る舞いテスト 10 件で固定化

## Why

- 各呼び出し箇所で「型安全性をオプトアウトする」ローカル cast が発生していた → 1 箇所に閉じ込める
- 同じ diff ロジックが 3 箇所で手書きされており DRY 違反 → utility 化
- 3 層契約（コア / プラグイン拡張 / x-\*）の理念に沿うコードに揃える

## Test plan

- [x] `pnpm --filter @edv4h/usketch-shared test` — 新規 shape-diff.test.ts 含む全 62 件 pass
- [x] `pnpm turbo typecheck test --continue --force` — 197/197 全 pass
- [x] `grep "Record<string, unknown>" plugins/usketch-plugin-tool-select/src/plugin.tsx` — 0 hit
- [x] biome check — 私の変更箇所はクリーン（既存 warning 1 件のみ）
- [ ] CI 全 pass
- [ ] 手動: resize / multi-resize / undo・redo の挙動が PR #582 と同じであること

## Out of scope

以下は別 RFC が必要:
- `ShapeDefinition.resize` を `Partial<ShapeData>` 返却に変える案（プラグインが自分で diff を返す）
- `BoardStore.updateShape<T>` のジェネリクス化
- store / hierarchy-utils / ai-* に残る inline cast の整理

🤖 Generated with [Claude Code](https://claude.com/claude-code)