### PR TITLE
🔥 chore(store): 未使用の getConnectorsForShape を削除

### DIFF
--- a/.changeset/remove-unused-get-connectors-for-shape.md
+++ b/.changeset/remove-unused-get-connectors-for-shape.md
@@ -1,0 +1,9 @@
+---
+"@edv4h/usketch-store": major
+---
+
+Remove unused `getConnectorsForShape` export.
+
+This helper was added speculatively but never called anywhere in the monorepo (the actual delete-cascade logic in `commands.ts:createDeleteWithChildrenCommand` inlines its own connector lookup). Since the function leaks `connector`-specific knowledge (`sourceId` / `targetId` field names, `type === "connector"` check) into the generic store package, removing it both deletes dead code and reduces the store's coupling to a particular shape plugin.
+
+If you were importing this function externally, replace with an inline implementation or wait for the upcoming `ShapeDefinition.getReferencedShapeIds` registry-based replacement (#584-related).

--- a/packages/store/src/hierarchy-utils.ts
+++ b/packages/store/src/hierarchy-utils.ts
@@ -54,19 +54,6 @@ export function getTopLevelShapes(store: BoardStore): ShapeData[] {
 	return result;
 }
 
-/** Get all connectors attached to a shape (as source or target) */
-export function getConnectorsForShape(store: BoardStore, shapeId: string): ShapeData[] {
-	const connectors: ShapeData[] = [];
-	for (const [, shape] of store.getShapes()) {
-		if (shape.type !== "connector") continue;
-		const { sourceId, targetId } = shape as { sourceId?: string; targetId?: string };
-		if (sourceId === shapeId || targetId === shapeId) {
-			connectors.push(shape);
-		}
-	}
-	return connectors;
-}
-
 /** Compute the bounding box that encloses all given shapes */
 export function computeGroupBounds(children: ShapeData[]): BoundingBox {
 	if (children.length === 0) return { x: 0, y: 0, width: 0, height: 0 };

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -29,7 +29,6 @@ export {
 	computeGroupBounds,
 	getAncestorChain,
 	getChildShapes,
-	getConnectorsForShape,
 	getParentShape,
 	getTopLevelAncestor,
 	getTopLevelShapes,


### PR DESCRIPTION
## Summary

`packages/store/src/hierarchy-utils.ts` から `getConnectorsForShape` を削除する。

## Why

PR #582 で追加されたが、モノレポ全体（packages / plugins / apps / docs）で**一度も呼ばれていない dead code** だった。実際の削除連動ロジックは `commands.ts:createDeleteWithChildrenCommand` 内にインライン実装されている。

加えて、この関数は store パッケージから `connector` shape 固有の知識（`type === "connector"` の文字列リテラル、`sourceId`/`targetId` フィールド名への inline cast）を漏れ出させていた。削除することで:

- dead code 除去
- 汎用 store パッケージのプラグイン非依存性向上
- `as { sourceId?: string; targetId?: string }` という cast が 1 箇所減る

## What

- `packages/store/src/hierarchy-utils.ts`: `getConnectorsForShape` 関数削除
- `packages/store/src/index.ts`: re-export 削除
- `.changeset/remove-unused-get-connectors-for-shape.md`: store の major bump（public API 削除）

`commands.ts` 側の同等の inline cast は実際に使われているため、別途 RFC（#584 関連）で `ShapeDefinition.getReferencedShapeIds` registry 経由パターンに置き換える予定。

## Test plan

- [x] `pnpm --filter @edv4h/usketch-store build / typecheck / test` — 全 pass（52/52）
- [x] `pnpm turbo typecheck --continue --force` — 130/130 全 pass
- [x] モノレポ全体 grep で呼び出し元ゼロ確認済み
- [ ] CI 全 pass

## Related

- Follow-up to #582 / #583
- Related: #584（ShapeDefinition extension points RFC）

🤖 Generated with [Claude Code](https://claude.com/claude-code)