### PR TITLE
♻️ refactor(shape-basic): GPU primitive helpers を shape-utils から移動

### DIFF
--- a/.changeset/move-gpu-helpers-to-shape-basic.md
+++ b/.changeset/move-gpu-helpers-to-shape-basic.md
@@ -9,4 +9,4 @@ These helpers were the only callers of the `cornerRadius` field and were used ex
 
 This also aligns the codebase with `shape-freedraw`, which already keeps its own `gpuPrimitive` implementation inside the plugin.
 
-If you imported these from `@edv4h/usketch-shape-utils`, switch to `@edv4h/usketch-plugin-shape-basic` (or move equivalent logic into your own plugin).
+If you imported these from `@edv4h/usketch-shape-utils`, switch the import path to `@edv4h/usketch-plugin-shape-basic` (the helpers are now re-exported from the plugin's public entry point alongside `RectangleShapeData`).

--- a/.changeset/move-gpu-helpers-to-shape-basic.md
+++ b/.changeset/move-gpu-helpers-to-shape-basic.md
@@ -1,0 +1,12 @@
+---
+"@edv4h/usketch-shape-utils": major
+"@edv4h/usketch-plugin-shape-basic": patch
+---
+
+Move `rectGpuPrimitive` / `roundedRectGpuPrimitive` / `ellipseGpuPrimitive` / `lineGpuPrimitive` from `@edv4h/usketch-shape-utils` to `@edv4h/usketch-plugin-shape-basic`.
+
+These helpers were the only callers of the `cornerRadius` field and were used exclusively by `shape-basic` (no other plugin depended on them). Keeping them in the generic `shape-utils` package leaked plugin-specific knowledge and required an unsafe `(data as { cornerRadius?: number }).cornerRadius` cast inside the otherwise plugin-agnostic utility. Moving them lets `rectGpuPrimitive` accept the typed `RectangleShapeData` directly, eliminating the cast.
+
+This also aligns the codebase with `shape-freedraw`, which already keeps its own `gpuPrimitive` implementation inside the plugin.
+
+If you imported these from `@edv4h/usketch-shape-utils`, switch to `@edv4h/usketch-plugin-shape-basic` (or move equivalent logic into your own plugin).

--- a/packages/usketch-shape-utils/src/index.ts
+++ b/packages/usketch-shape-utils/src/index.ts
@@ -1,9 +1,3 @@
 export { getBounds } from "./bounds.js";
-export {
-	ellipseGpuPrimitive,
-	lineGpuPrimitive,
-	rectGpuPrimitive,
-	roundedRectGpuPrimitive,
-} from "./gpu.js";
 export { aabbHitTest, ellipseHitTest, lineHitTest, pointInPolygon } from "./hit-test.js";
 export { createResize } from "./resize.js";

--- a/plugins/usketch-plugin-shape-basic/src/gpu.ts
+++ b/plugins/usketch-plugin-shape-basic/src/gpu.ts
@@ -1,10 +1,11 @@
 import { cssColorToRgbaOrDefault, type GpuPrimitive, type ShapeData } from "@edv4h/usketch-shared";
+import type { RectangleShapeData } from "./types.js";
 
-export function rectGpuPrimitive(data: ShapeData): GpuPrimitive {
+export function rectGpuPrimitive(data: RectangleShapeData): GpuPrimitive {
 	return {
 		kind: "rect",
 		bounds: { x: data.x, y: data.y, width: data.width, height: data.height },
-		cornerRadius: (data as { cornerRadius?: number }).cornerRadius ?? 0,
+		cornerRadius: data.cornerRadius ?? 0,
 		fill: cssColorToRgbaOrDefault(data.style.fill),
 		stroke: cssColorToRgbaOrDefault(data.style.stroke),
 		strokeWidth: data.style.strokeWidth,

--- a/plugins/usketch-plugin-shape-basic/src/index.ts
+++ b/plugins/usketch-plugin-shape-basic/src/index.ts
@@ -1,3 +1,9 @@
+export {
+	ellipseGpuPrimitive,
+	lineGpuPrimitive,
+	rectGpuPrimitive,
+	roundedRectGpuPrimitive,
+} from "./gpu.js";
 export { basicShapePlugin } from "./plugin.js";
 export type { BasicShapeSubtype } from "./registry.js";
 export { BASIC_SHAPE_SUBTYPES } from "./registry.js";

--- a/plugins/usketch-plugin-shape-basic/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-basic/src/plugin.tsx
@@ -1,14 +1,10 @@
 import {
 	aabbHitTest,
 	createResize,
-	ellipseGpuPrimitive,
 	ellipseHitTest,
 	getBounds,
-	lineGpuPrimitive,
 	lineHitTest,
 	pointInPolygon,
-	rectGpuPrimitive,
-	roundedRectGpuPrimitive,
 } from "@edv4h/usketch-shape-utils";
 import {
 	type CanvasPointerEvent,
@@ -21,6 +17,12 @@ import {
 	withRotation,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
+import {
+	ellipseGpuPrimitive,
+	lineGpuPrimitive,
+	rectGpuPrimitive,
+	roundedRectGpuPrimitive,
+} from "./gpu.js";
 import { BASIC_SHAPE_SUBTYPES } from "./registry.js";
 import { getArrowPoints, renderArrow } from "./shapes/arrow.js";
 import { getDiamondPoints, renderDiamond } from "./shapes/diamond.js";
@@ -30,6 +32,7 @@ import { renderRectangle } from "./shapes/rectangle.js";
 import { renderRoundedRect } from "./shapes/rounded-rect.js";
 import { getStarPoints, renderStar } from "./shapes/star.js";
 import { getTrianglePoints, renderTriangle } from "./shapes/triangle.js";
+import type { RectangleShapeData } from "./types.js";
 
 const SHAPE_RENDERERS: Record<
 	string,
@@ -64,7 +67,7 @@ const SHAPE_HIT_TESTS: Record<string, HitTestFn> = {
 type GpuPrimitiveFn = (data: ShapeData) => GpuPrimitive | null;
 
 const SHAPE_GPU_PRIMITIVES: Record<string, GpuPrimitiveFn> = {
-	rectangle: rectGpuPrimitive,
+	rectangle: (data) => rectGpuPrimitive(data as RectangleShapeData),
 	"rounded-rect": roundedRectGpuPrimitive,
 	ellipse: ellipseGpuPrimitive,
 	line: lineGpuPrimitive,

--- a/plugins/usketch-plugin-shape-basic/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-basic/src/plugin.tsx
@@ -32,7 +32,6 @@ import { renderRectangle } from "./shapes/rectangle.js";
 import { renderRoundedRect } from "./shapes/rounded-rect.js";
 import { getStarPoints, renderStar } from "./shapes/star.js";
 import { getTrianglePoints, renderTriangle } from "./shapes/triangle.js";
-import type { RectangleShapeData } from "./types.js";
 
 const SHAPE_RENDERERS: Record<
 	string,
@@ -67,7 +66,7 @@ const SHAPE_HIT_TESTS: Record<string, HitTestFn> = {
 type GpuPrimitiveFn = (data: ShapeData) => GpuPrimitive | null;
 
 const SHAPE_GPU_PRIMITIVES: Record<string, GpuPrimitiveFn> = {
-	rectangle: (data) => rectGpuPrimitive(data as RectangleShapeData),
+	rectangle: rectGpuPrimitive,
 	"rounded-rect": roundedRectGpuPrimitive,
 	ellipse: ellipseGpuPrimitive,
 	line: lineGpuPrimitive,


### PR DESCRIPTION
## Summary

`rectGpuPrimitive` / `roundedRectGpuPrimitive` / `ellipseGpuPrimitive` / `lineGpuPrimitive` を `@edv4h/usketch-shape-utils` から `@edv4h/usketch-plugin-shape-basic` に移動。

## Why

調査で判明したこと:
- これら 4 関数の **唯一の呼び出し元は shape-basic プラグイン**（モノレポ全体で他に呼んでいる箇所はゼロ）
- `cornerRadius` を読むため shape-utils 内で `(data as { cornerRadius?: number }).cornerRadius` という unsafe cast が発生していた
- 一方で shape-freedraw は元から「プラグイン内で `gpuPrimitive` を完結させる」自然なパターンを採用していた

shape-utils は本来「複数プラグインで共有される汎用ジオメトリ計算」が役目（実際 `aabbHitTest`, `ellipseHitTest`, `lineHitTest`, `pointInPolygon`, `getBounds`, `createResize` などはまさにそれ）。GPU primitive 関数群は shape-basic 専用なので、そちらに移動するのが責務分離として自然。

## What

- `packages/usketch-shape-utils/src/gpu.ts` → `plugins/usketch-plugin-shape-basic/src/gpu.ts` (rename)
- `rectGpuPrimitive(data: RectangleShapeData)` のように **既存の plugin extension type を引数に取る形に変更** → `data.cornerRadius` を型安全に直接アクセス、cast 完全消滅
- `packages/usketch-shape-utils/src/index.ts` から 4 関数の export 削除
- `plugins/usketch-plugin-shape-basic/src/plugin.tsx` の import 元を `@edv4h/usketch-shape-utils` から `./gpu.js` に変更

shape-freedraw と同じ「プラグイン内 gpuPrimitive 完結」パターンに揃った。

## Test plan

- [x] `pnpm turbo typecheck test --continue --force` — 197/197 全 pass
- [x] `cornerRadius` の Record cast が消えていることを確認（grep で 0 hit）
- [x] biome check クリーン
- [ ] CI 全 pass

## Breaking change (consumer 観点)

OSS の外部利用者が `@edv4h/usketch-shape-utils` から GPU helper を import していた場合は、`@edv4h/usketch-plugin-shape-basic` に切り替えが必要。changeset の migration note 参照。

## Related

- Follow-up to #582 / #583 / #585（PR #582 で発生した cast の段階的清掃の一環）
- 関連 RFC: #584（shape プラグイン自己宣言系拡張ポイント）

🤖 Generated with [Claude Code](https://claude.com/claude-code)