### PR TITLE
✨ feat(plugin-domain-design): DDD ドメイン設計プラグインを新設

### DIFF
--- a/.changeset/domain-design-plugin.md
+++ b/.changeset/domain-design-plugin.md
@@ -1,0 +1,17 @@
+---
+"@edv4h/usketch-plugin-domain-design": minor
+"@edv4h/usketch-web": patch
+---
+
+Add `@edv4h/usketch-plugin-domain-design` — the official plugin for drawing **DDD** diagrams (both strategic and tactical) on a uSketch board.
+
+Provides 5 shape types under a single `domain-draw` tool (shortcut `d`):
+
+- **Strategic**: `domain-bounded-context` (with team / Core/Supporting/Generic classification), `domain-context-map-connector` (Customer/Supplier, Conformist, ACL, Shared Kernel, OHS, Partnership, Published Language, Separate Ways).
+- **Tactical**: `domain-aggregate`, `domain-class-box` (Entity / ValueObject / Service / Repository / DomainEvent / Factory with stereotype dropdown, class name, attributes, methods), `domain-tactical-connector` (inheritance / realization / composition / aggregation / association / dependency).
+
+Inline editing is supported: double-click a `domain-bounded-context` / `domain-aggregate` / `domain-class-box` to edit its name (plus attributes / methods / stereotype for ClassBox). Edits go through the command system and are undoable.
+
+This is the **first official plugin to fully use `ShapeData<TMeta>`'s `meta` field** for domain-specific data — the pattern recommended in `shape-system.mdx`. Existing plugins (`connector`, `frame`, `text`, ...) currently put intrinsic fields directly on `ShapeData`; migrating them to `meta` is tracked as a follow-up.
+
+`apps/web` registers the plugin in its default `basePlugins` array, so it's available out of the box.

--- a/apps/docs/src/content/docs/guides/domain-design-plugin.mdx
+++ b/apps/docs/src/content/docs/guides/domain-design-plugin.mdx
@@ -1,0 +1,123 @@
+---
+title: Domain Design Plugin
+description: Use the built-in DDD plugin to draw strategic and tactical domain models on a uSketch board.
+order: 35
+---
+
+`@edv4h/usketch-plugin-domain-design` is the official plugin for drawing **DDD (Domain-Driven Design)** diagrams on a uSketch board — both **strategic** (Bounded Context, Context Map) and **tactical** (Aggregate, ClassBox, relation arrows) levels in a single plugin.
+
+This page walks through what the plugin offers, how to use it, and how it lays out domain-specific data so that the core uSketch model stays clean.
+
+## What you can draw
+
+The plugin registers **5 shape types** plus a **drawing tool** (`domain-draw`, shortcut **d**).
+
+### Strategic level
+
+| Shape type | Purpose |
+|---|---|
+| `domain-bounded-context` | A Bounded Context boundary with name, owning team, and Core/Supporting/Generic classification. |
+| `domain-context-map-connector` | A relation between two contexts: Customer/Supplier, Conformist, ACL, Shared Kernel, OHS, Partnership, Published Language, Separate Ways. |
+
+### Tactical level
+
+| Shape type | Purpose |
+|---|---|
+| `domain-aggregate` | An Aggregate Root container (rounded oval with stereotype label and root entity name). |
+| `domain-class-box` | A class box with stereotype (Entity / ValueObject / Service / Repository / DomainEvent / Factory), class name, attributes, and methods. |
+| `domain-tactical-connector` | A class relation arrow: inheritance, realization, composition, aggregation, association, dependency. |
+
+## Installing
+
+Add the plugin to your `basePlugins` array:
+
+```tsx
+import { domainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
+import { createApp } from "@edv4h/usketch-core";
+
+createApp({
+  plugins: [
+    /* ...existing plugins... */
+    domainDesignPlugin,
+  ],
+});
+```
+
+The `domain-draw` tool then appears in the toolbar. Selecting it lets you draw the currently active subtype by dragging on the canvas.
+
+## Switching subtype
+
+Tools that bundle multiple shape subtypes use a **subtype-select event**. Emit this from your toolbar / picker UI:
+
+```ts
+ctx.events.emit("domain-design:select-subtype", {
+  type: "domain-class-box", // any of DOMAIN_TYPES.*
+});
+```
+
+## Inline editing
+
+Domain shapes are editable **in place**. Double-click a shape:
+
+- `domain-bounded-context` — edit the context name on a single line.
+- `domain-aggregate` — edit the aggregate root name on a single line.
+- `domain-class-box` — edit three sections (class name / attributes / methods) and pick a stereotype from the dropdown.
+
+Pressing **Enter** or clicking outside commits the change. Pressing **Escape** cancels. Commits go through the command system, so they're undoable / redoable.
+
+## Where domain data lives
+
+Unlike most older plugins (`text`, `connector`, ...) that put intrinsic fields directly on `ShapeData`, this plugin stores all domain-specific state in **`ShapeData<TMeta>`'s `meta`** field — the contract recommended by [the shape system docs](/concepts/shape-system).
+
+```ts
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+export interface ClassBoxMeta {
+  className: string;
+  stereotype: "Entity" | "ValueObject" | "Service" | "Repository" | "DomainEvent" | "Factory";
+  attributes: string[];
+  methods: string[];
+}
+
+export type ClassBoxShape = ShapeData<ClassBoxMeta>;
+```
+
+This keeps:
+
+- **Core `ShapeData`** clean — only `id`, `type`, `x/y/width/height`, `style`, `rotation`, `zIndex`, etc.
+- **Plugin types** isolated — `ClassBoxMeta` is owned by `domain-design`. Other plugins / serializers / inspectors can opt-in to read it via `shape.meta`.
+
+This plugin is the **first official plugin** to fully use the generic `meta` pattern. It's intended as a reference for new plugins.
+
+### Reading meta in your own code
+
+To read a typed view of a shape's meta safely, use the exported `readMeta` helper:
+
+```ts
+import { type ClassBoxMeta, readMeta } from "@edv4h/usketch-plugin-domain-design";
+
+const meta = readMeta<ClassBoxMeta>(shape);
+console.log(meta.className, meta.attributes);
+```
+
+The helper is just a type-safe wrapper around `shape.meta` — it handles the `undefined`/`Partial` boundary so callers don't need to write the cast themselves.
+
+## Extending the plugin
+
+Common extensions:
+
+- **Add a new stereotype** — extend the `ClassStereotype` union and update the color map in `class-box.tsx`.
+- **Add a new ContextMap relation** — extend `ContextMapRelation` and the `RELATION_LABEL` table.
+- **Auto-layout** — read all `domain-bounded-context` shapes and pack them into a grid (independent plugin).
+
+## Limitations (MVP)
+
+- Connectors do **not** snap to source/target shapes (they are free-line connectors with relation metadata). Anchor-aware connectors are tracked as a follow-up.
+- Inline editing covers shape-level fields only; in-line **label editing on connectors** is a follow-up.
+- The toolbar UI for the subtype picker is the host application's responsibility; the plugin only listens for `domain-design:select-subtype` events.
+
+## See also
+
+- [Shape system overview](/concepts/shape-system) — the contract `meta` is part of.
+- [Building a Shape Plugin](/guides/shape-plugin) — write your own domain notation.
+- [Building a Tool Plugin](/guides/tool-plugin) — write a custom drawing tool.

--- a/apps/docs/src/content/docs/guides/domain-design-plugin.mdx
+++ b/apps/docs/src/content/docs/guides/domain-design-plugin.mdx
@@ -67,7 +67,7 @@ Pressing **Enter** or clicking outside commits the change. Pressing **Escape** c
 
 ## Where domain data lives
 
-Unlike most older plugins (`text`, `connector`, ...) that put intrinsic fields directly on `ShapeData`, this plugin stores all domain-specific state in **`ShapeData<TMeta>`'s `meta`** field — the contract recommended by [the shape system docs](/concepts/shape-system).
+Unlike most older plugins (`text`, `connector`, ...) that put intrinsic fields directly on `ShapeData`, this plugin stores all domain-specific state in **`ShapeData<TMeta>`'s `meta`** field — the contract recommended by [the shape system docs](/docs/concepts/shape-system/).
 
 ```ts
 import type { ShapeData } from "@edv4h/usketch-shared";
@@ -118,6 +118,6 @@ Common extensions:
 
 ## See also
 
-- [Shape system overview](/concepts/shape-system) — the contract `meta` is part of.
-- [Building a Shape Plugin](/guides/shape-plugin) — write your own domain notation.
-- [Building a Tool Plugin](/guides/tool-plugin) — write a custom drawing tool.
+- [Shape system overview](/docs/concepts/shape-system/) — the contract `meta` is part of.
+- [Building a Shape Plugin](/docs/guides/shape-plugin/) — write your own domain notation.
+- [Building a Tool Plugin](/docs/guides/tool-plugin/) — write a custom drawing tool.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
 		"@edv4h/usketch-plugin-spotlight": "workspace:*",
 		"@edv4h/usketch-plugin-voting": "workspace:*",
 		"@edv4h/usketch-plugin-whistle": "workspace:*",
+		"@edv4h/usketch-plugin-domain-design": "workspace:*",
 		"@edv4h/usketch-plugin-shape-counter": "workspace:*",
 		"@edv4h/usketch-plugin-shape-basic": "workspace:*",
 		"@edv4h/usketch-plugin-shape-connector": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -13,6 +13,7 @@ import { createAiVoicePlugin } from "@edv4h/usketch-plugin-ai-voice";
 import { dotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
 import { gridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
+import { domainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
 import { exportPlugin } from "@edv4h/usketch-plugin-export";
 import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
 import { createLaserPlugin, laserPlugin } from "@edv4h/usketch-plugin-laser";
@@ -95,6 +96,7 @@ const basePlugins: UsketchPlugin[] = [
 	imageShapePlugin,
 	counterPlugin,
 	wireframePlugin,
+	domainDesignPlugin,
 	snapPlugin,
 	exportPlugin,
 	createGpuRendererPlugin(),

--- a/plugins/usketch-plugin-domain-design/README.md
+++ b/plugins/usketch-plugin-domain-design/README.md
@@ -1,0 +1,53 @@
+# @edv4h/usketch-plugin-domain-design
+
+uSketch 上で **DDD（ドメイン駆動設計）の戦略 / 戦術モデリング図** を描くためのプラグイン。
+
+## 提供する shape
+
+戦略レベル:
+
+- `domain-bounded-context` — Bounded Context 枠（チーム名 / Core Domain 区分）
+- `domain-context-map-connector` — ContextMap 関係 connector（Customer/Supplier、ACL、Conformist など）
+
+戦術レベル:
+
+- `domain-aggregate` — Aggregate Root を表す丸枠
+- `domain-class-box` — Entity / ValueObject / Service / Repository / DomainEvent / Factory のクラスボックス
+- `domain-tactical-connector` — クラス間の関係矢印（inheritance / composition / association ほか）
+
+## 提供する tool
+
+- `domain-draw` — 上記 shape を切り替えながら描画するツール（ショートカット: `d`）
+
+## ドメイン固有データの保持
+
+このプラグインは **`ShapeData<TMeta>` の `meta` フィールド** に DDD 固有のデータ（クラス名、属性、コンテキスト名、関係種別など）を保持する。
+core ShapeData の geometry / style とは分離されているため、core ロジックに DDD 知識が漏れない。
+
+```typescript
+interface ClassBoxMeta {
+  className: string;
+  stereotype: "Entity" | "ValueObject" | "Service" | "Repository" | "DomainEvent" | "Factory";
+  attributes: string[];
+  methods: string[];
+}
+type ClassBoxShape = ShapeData<ClassBoxMeta>;
+```
+
+## インライン編集
+
+ClassBox / Aggregate / BoundedContext はダブルクリックでインライン編集できる。
+ClassBox は「クラス名 / 属性 / メソッド」の 3 セクション、Aggregate / BoundedContext はタイトル 1 行編集。
+編集確定（blur / Enter）で `meta` が更新され、undo / redo に対応する。
+
+## 使い方
+
+```typescript
+import { domainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
+
+createApp({
+  plugins: [/* ..., */ domainDesignPlugin],
+});
+```
+
+詳しくは [ドメイン設計プラグインのガイド](https://usketch.dev/guides/domain-design-plugin) を参照。

--- a/plugins/usketch-plugin-domain-design/README.md
+++ b/plugins/usketch-plugin-domain-design/README.md
@@ -50,4 +50,4 @@ createApp({
 });
 ```
 
-詳しくは [ドメイン設計プラグインのガイド](https://usketch.dev/guides/domain-design-plugin) を参照。
+詳しくは [ドメイン設計プラグインのガイド](https://edv4h.github.io/usketch/docs/guides/domain-design-plugin/) を参照。

--- a/plugins/usketch-plugin-domain-design/package.json
+++ b/plugins/usketch-plugin-domain-design/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@edv4h/usketch-plugin-domain-design",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-core": "workspace:*",
+		"@edv4h/usketch-shape-utils": "workspace:*",
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*",
+		"@zag-js/core": "^1.37.0",
+		"@zag-js/vanilla": "^1.37.0"
+	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.14",
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-domain-design"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
+++ b/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
@@ -77,6 +77,7 @@ function createMockContext() {
 		},
 		store: {
 			getShapes: vi.fn(() => new Map<string, ShapeData>()),
+			getShapesSorted: vi.fn(() => [] as ShapeData[]),
 			getShape: vi.fn(() => undefined),
 			getSelection: vi.fn(() => new Set<string>()),
 			subscribe: vi.fn(() => () => {}),

--- a/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
+++ b/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
@@ -5,7 +5,9 @@ import { DOMAIN_TYPES } from "../types.js";
 
 type EventHandler = (data: unknown) => void;
 
-// node 実行環境向けに window を最小モック化（addEventListener / removeEventListener / dispatchEvent）
+// node 実行環境向けに window を最小モック化（addEventListener / removeEventListener / dispatchEvent）。
+// jsdom / happy-dom 環境では既に本物の window が存在するため、元の値を退避して
+// teardown で確実に復元する（無条件に undefined にすると後続テストを壊す）。
 function installWindowMock() {
 	const listeners = new Map<string, Set<EventListener>>();
 	const win = {
@@ -21,9 +23,16 @@ function installWindowMock() {
 			return true;
 		},
 	};
-	(globalThis as unknown as { window: typeof win }).window = win;
+	const g = globalThis as unknown as { window?: unknown };
+	const hadWindow = "window" in g;
+	const previous = g.window;
+	g.window = win;
 	return () => {
-		(globalThis as unknown as { window: typeof win | undefined }).window = undefined;
+		if (hadWindow) {
+			g.window = previous;
+		} else {
+			delete g.window;
+		}
 	};
 }
 

--- a/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
+++ b/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
@@ -1,0 +1,153 @@
+import type { PluginContext, ShapeData, ShapeDefinition } from "@edv4h/usketch-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { domainDesignPlugin } from "../plugin.js";
+import { DOMAIN_TYPES } from "../types.js";
+
+type EventHandler = (data: unknown) => void;
+
+// node 実行環境向けに window を最小モック化（addEventListener / removeEventListener / dispatchEvent）
+function installWindowMock() {
+	const listeners = new Map<string, Set<EventListener>>();
+	const win = {
+		addEventListener(type: string, listener: EventListener) {
+			const set = listeners.get(type) ?? new Set();
+			set.add(listener);
+			listeners.set(type, set);
+		},
+		removeEventListener(type: string, listener: EventListener) {
+			listeners.get(type)?.delete(listener);
+		},
+		dispatchEvent() {
+			return true;
+		},
+	};
+	(globalThis as unknown as { window: typeof win }).window = win;
+	return () => {
+		(globalThis as unknown as { window: typeof win | undefined }).window = undefined;
+	};
+}
+
+function createMockContext() {
+	const shapeRegistrations = new Map<string, ShapeDefinition>();
+	const toolRegistrations = new Map<string, unknown>();
+	const eventHandlers = new Map<string, EventHandler[]>();
+
+	const ctx = {
+		shapes: {
+			register(type: string, def: ShapeDefinition) {
+				shapeRegistrations.set(type, def);
+			},
+			get(type: string) {
+				return shapeRegistrations.get(type);
+			},
+			getAll() {
+				return shapeRegistrations;
+			},
+		},
+		tools: {
+			register(id: string, def: unknown) {
+				toolRegistrations.set(id, def);
+			},
+			get(id: string) {
+				return toolRegistrations.get(id);
+			},
+			getAll() {
+				return toolRegistrations;
+			},
+			getOrdered() {
+				return [];
+			},
+		},
+		events: {
+			on(event: string, handler: EventHandler) {
+				const list = eventHandlers.get(event) ?? [];
+				list.push(handler);
+				eventHandlers.set(event, list);
+				return () => {
+					const cur = eventHandlers.get(event) ?? [];
+					eventHandlers.set(
+						event,
+						cur.filter((h) => h !== handler),
+					);
+				};
+			},
+			emit(event: string, data: unknown) {
+				for (const h of eventHandlers.get(event) ?? []) h(data);
+			},
+		},
+		store: {
+			getShapes: vi.fn(() => new Map<string, ShapeData>()),
+			getShape: vi.fn(() => undefined),
+			getSelection: vi.fn(() => new Set<string>()),
+			subscribe: vi.fn(() => () => {}),
+			updateShape: vi.fn(),
+			addShape: vi.fn(),
+			deleteShape: vi.fn(),
+			setActiveToolId: vi.fn(),
+		},
+		commands: {
+			execute: vi.fn(),
+		},
+		layers: { register: vi.fn(), unregister: vi.fn(), getLayers: () => [] },
+		shortcuts: { register: vi.fn(() => () => {}), handleKeyDown: vi.fn() },
+		transient: {
+			registerType: vi.fn(),
+			getRenderer: vi.fn(),
+			emit: vi.fn(),
+			dismiss: vi.fn(),
+			getAll: vi.fn(() => new Map()),
+			subscribe: vi.fn(() => () => {}),
+		},
+		lod: {} as unknown,
+	} as unknown as PluginContext;
+
+	return { ctx, shapeRegistrations, toolRegistrations, eventHandlers };
+}
+
+describe("domainDesignPlugin", () => {
+	let restoreWindow: () => void;
+	beforeEach(() => {
+		restoreWindow = installWindowMock();
+	});
+	afterEach(() => {
+		restoreWindow();
+	});
+
+	it("has stable id and Japanese display name", () => {
+		expect(domainDesignPlugin.id).toBe("usketch-plugin-domain-design");
+		expect(domainDesignPlugin.name).toBe("ドメイン設計");
+	});
+
+	it("registers all 5 domain shape types", async () => {
+		const { ctx, shapeRegistrations } = createMockContext();
+		await domainDesignPlugin.setup(ctx);
+		const types = Array.from(shapeRegistrations.keys()).sort();
+		expect(types).toEqual(
+			[
+				DOMAIN_TYPES.aggregate,
+				DOMAIN_TYPES.boundedContext,
+				DOMAIN_TYPES.classBox,
+				DOMAIN_TYPES.contextMapConnector,
+				DOMAIN_TYPES.tacticalConnector,
+			].sort(),
+		);
+		domainDesignPlugin.teardown?.();
+	});
+
+	it("registers the domain-draw tool with shortcut 'd'", async () => {
+		const { ctx, toolRegistrations } = createMockContext();
+		await domainDesignPlugin.setup(ctx);
+		const tool = toolRegistrations.get("domain-draw") as { shortcut?: string } | undefined;
+		expect(tool).toBeDefined();
+		expect(tool?.shortcut).toBe("d");
+		domainDesignPlugin.teardown?.();
+	});
+
+	it("teardown unregisters listeners (does not throw on second call)", async () => {
+		const { ctx } = createMockContext();
+		await domainDesignPlugin.setup(ctx);
+		expect(() => domainDesignPlugin.teardown?.()).not.toThrow();
+		// 2 度目の teardown も安全であること
+		expect(() => domainDesignPlugin.teardown?.()).not.toThrow();
+	});
+});

--- a/plugins/usketch-plugin-domain-design/src/__tests__/registry.test.ts
+++ b/plugins/usketch-plugin-domain-design/src/__tests__/registry.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { DOMAIN_SUBTYPES } from "../registry.js";
+import {
+	type AggregateMeta,
+	type BoundedContextMeta,
+	type ClassBoxMeta,
+	type ContextMapConnectorMeta,
+	DOMAIN_TYPES,
+	type TacticalConnectorMeta,
+} from "../types.js";
+
+describe("DOMAIN_SUBTYPES", () => {
+	it("provides all 5 subtypes", () => {
+		const types = DOMAIN_SUBTYPES.map((s) => s.type);
+		expect(types).toEqual([
+			DOMAIN_TYPES.boundedContext,
+			DOMAIN_TYPES.contextMapConnector,
+			DOMAIN_TYPES.aggregate,
+			DOMAIN_TYPES.classBox,
+			DOMAIN_TYPES.tacticalConnector,
+		]);
+	});
+
+	it("each subtype's createDefault sets type, geometry, and meta", () => {
+		for (const subtype of DOMAIN_SUBTYPES) {
+			const shape = subtype.createDefault({ id: "test", x: 10, y: 20 });
+			expect(shape.id).toBe("test");
+			expect(shape.type).toBe(subtype.type);
+			expect(shape.x).toBe(10);
+			expect(shape.y).toBe(20);
+			expect(shape.style).toBeDefined();
+			expect(shape.meta).toBeDefined();
+		}
+	});
+
+	it("BoundedContext default has contextName + coreDomain", () => {
+		const subtype = DOMAIN_SUBTYPES.find((s) => s.type === DOMAIN_TYPES.boundedContext);
+		const shape = subtype?.createDefault({ id: "bc", x: 0, y: 0 });
+		const meta = shape?.meta as BoundedContextMeta;
+		expect(meta.contextName).toBe("BoundedContext");
+		expect(meta.coreDomain).toBe("supporting");
+	});
+
+	it("Aggregate default has rootName", () => {
+		const subtype = DOMAIN_SUBTYPES.find((s) => s.type === DOMAIN_TYPES.aggregate);
+		const shape = subtype?.createDefault({ id: "ag", x: 0, y: 0 });
+		const meta = shape?.meta as AggregateMeta;
+		expect(meta.rootName).toBe("AggregateRoot");
+	});
+
+	it("ClassBox default has className, stereotype, attributes, methods", () => {
+		const subtype = DOMAIN_SUBTYPES.find((s) => s.type === DOMAIN_TYPES.classBox);
+		const shape = subtype?.createDefault({ id: "cb", x: 0, y: 0 });
+		const meta = shape?.meta as ClassBoxMeta;
+		expect(meta.className).toBe("ClassName");
+		expect(meta.stereotype).toBe("Entity");
+		expect(meta.attributes).toEqual(["id: ID"]);
+		expect(meta.methods).toEqual([]);
+	});
+
+	it("ContextMap connector default has relation + upstream", () => {
+		const subtype = DOMAIN_SUBTYPES.find((s) => s.type === DOMAIN_TYPES.contextMapConnector);
+		const shape = subtype?.createDefault({ id: "cm", x: 0, y: 0 });
+		const meta = shape?.meta as ContextMapConnectorMeta;
+		expect(meta.relation).toBe("customer-supplier");
+		expect(meta.upstream).toBe("from");
+	});
+
+	it("Tactical connector default has relation", () => {
+		const subtype = DOMAIN_SUBTYPES.find((s) => s.type === DOMAIN_TYPES.tacticalConnector);
+		const shape = subtype?.createDefault({ id: "tc", x: 0, y: 0 });
+		const meta = shape?.meta as TacticalConnectorMeta;
+		expect(meta.relation).toBe("association");
+	});
+
+	it("each subtype belongs to a category (strategic / tactical / relation)", () => {
+		const categories = new Set(DOMAIN_SUBTYPES.map((s) => s.category));
+		expect(categories).toEqual(new Set(["strategic", "tactical", "relation"]));
+	});
+});

--- a/plugins/usketch-plugin-domain-design/src/connectors/context-map.tsx
+++ b/plugins/usketch-plugin-domain-design/src/connectors/context-map.tsx
@@ -17,10 +17,15 @@ export function renderContextMapConnector(shape: ShapeData) {
 	const relation = meta.relation ?? "customer-supplier";
 	const label = RELATION_LABEL[relation];
 
-	const x1 = 0;
-	const y1 = 0;
-	const x2 = shape.width;
-	const y2 = shape.height;
+	// shape.width / shape.height は AABB のため非負。
+	// 始点 / 終点は meta.start / meta.end（AABB 相対座標）から読む。
+	// 後方互換: meta が無い場合は対角線の左上 → 右下を使う。
+	const start = meta.start ?? { x: 0, y: 0 };
+	const end = meta.end ?? { x: shape.width, y: shape.height };
+	const x1 = start.x;
+	const y1 = start.y;
+	const x2 = end.x;
+	const y2 = end.y;
 	const dashed = relation === "separate-ways" || relation === "anticorruption-layer";
 	const upstreamLabel =
 		meta.upstream === "from" ? "U → D" : meta.upstream === "to" ? "D ← U" : null;

--- a/plugins/usketch-plugin-domain-design/src/connectors/context-map.tsx
+++ b/plugins/usketch-plugin-domain-design/src/connectors/context-map.tsx
@@ -1,0 +1,77 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { type ContextMapConnectorMeta, type ContextMapRelation, readMeta } from "../types.js";
+
+const RELATION_LABEL: Record<ContextMapRelation, { short: string; full: string }> = {
+	"customer-supplier": { short: "C/S", full: "Customer/Supplier" },
+	conformist: { short: "CF", full: "Conformist" },
+	"anticorruption-layer": { short: "ACL", full: "Anticorruption Layer" },
+	"shared-kernel": { short: "SK", full: "Shared Kernel" },
+	"open-host-service": { short: "OHS", full: "Open Host Service" },
+	partnership: { short: "P", full: "Partnership" },
+	"published-language": { short: "PL", full: "Published Language" },
+	"separate-ways": { short: "SW", full: "Separate Ways" },
+};
+
+export function renderContextMapConnector(shape: ShapeData) {
+	const meta = readMeta<ContextMapConnectorMeta>(shape);
+	const relation = meta.relation ?? "customer-supplier";
+	const label = RELATION_LABEL[relation];
+
+	const x1 = 0;
+	const y1 = 0;
+	const x2 = shape.width;
+	const y2 = shape.height;
+	const dashed = relation === "separate-ways" || relation === "anticorruption-layer";
+	const upstreamLabel =
+		meta.upstream === "from" ? "U → D" : meta.upstream === "to" ? "D ← U" : null;
+
+	const midX = (x1 + x2) / 2;
+	const midY = (y1 + y2) / 2;
+
+	return (
+		<svg
+			width="100%"
+			height="100%"
+			viewBox={`0 0 ${Math.max(shape.width, 1)} ${Math.max(shape.height, 1)}`}
+			preserveAspectRatio="none"
+			style={{ overflow: "visible", opacity: shape.style.opacity }}
+		>
+			<title>
+				{label.full}
+				{upstreamLabel ? ` (${upstreamLabel})` : ""}
+			</title>
+			<line
+				x1={x1}
+				y1={y1}
+				x2={x2}
+				y2={y2}
+				stroke={shape.style.stroke}
+				strokeWidth={shape.style.strokeWidth}
+				strokeDasharray={dashed ? "6 4" : undefined}
+			/>
+			<g transform={`translate(${midX}, ${midY})`}>
+				<rect
+					x={-22}
+					y={-9}
+					width={44}
+					height={18}
+					rx={3}
+					fill="#ffffff"
+					stroke={shape.style.stroke}
+					strokeWidth={1}
+				/>
+				<text
+					x={0}
+					y={1}
+					textAnchor="middle"
+					dominantBaseline="middle"
+					fontSize={11}
+					fontWeight={600}
+					fill="#1e1e1e"
+				>
+					{label.short}
+				</text>
+			</g>
+		</svg>
+	);
+}

--- a/plugins/usketch-plugin-domain-design/src/connectors/tactical.tsx
+++ b/plugins/usketch-plugin-domain-design/src/connectors/tactical.tsx
@@ -1,0 +1,150 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { readMeta, type TacticalConnectorMeta, type TacticalRelation } from "../types.js";
+
+interface RelationStyle {
+	dashed: boolean;
+	headFill: string;
+	headShape: "triangle" | "diamond" | "open" | "none";
+}
+
+const RELATION_STYLE: Record<TacticalRelation, RelationStyle> = {
+	inheritance: { dashed: false, headFill: "#ffffff", headShape: "triangle" },
+	realization: { dashed: true, headFill: "#ffffff", headShape: "triangle" },
+	composition: { dashed: false, headFill: "#1e1e1e", headShape: "diamond" },
+	aggregation: { dashed: false, headFill: "#ffffff", headShape: "diamond" },
+	association: { dashed: false, headFill: "#1e1e1e", headShape: "open" },
+	dependency: { dashed: true, headFill: "#1e1e1e", headShape: "open" },
+};
+
+export function renderTacticalConnector(shape: ShapeData) {
+	const meta = readMeta<TacticalConnectorMeta>(shape);
+	const relation: TacticalRelation = meta.relation ?? "association";
+	const styleSpec = RELATION_STYLE[relation];
+
+	const x1 = 0;
+	const y1 = 0;
+	const x2 = shape.width;
+	const y2 = shape.height;
+	const stroke = shape.style.stroke;
+	const sw = shape.style.strokeWidth;
+
+	// 矢頭サイズは長さに対して相対化（極端な短い線でも描画可能）
+	const length = Math.hypot(x2 - x1, y2 - y1) || 1;
+	const headSize = Math.min(14, Math.max(8, length * 0.12));
+	const angle = Math.atan2(y2 - y1, x2 - x1);
+	const cos = Math.cos(angle);
+	const sin = Math.sin(angle);
+
+	const lineEndX = x2 - cos * headSize * 0.6;
+	const lineEndY = y2 - sin * headSize * 0.6;
+
+	function head() {
+		switch (styleSpec.headShape) {
+			case "triangle": {
+				// 二等辺三角形（先端が tip、底辺が base）
+				const baseX = x2 - cos * headSize;
+				const baseY = y2 - sin * headSize;
+				const halfBase = headSize * 0.5;
+				const px = -sin * halfBase;
+				const py = cos * halfBase;
+				return (
+					<polygon
+						points={`${x2},${y2} ${baseX + px},${baseY + py} ${baseX - px},${baseY - py}`}
+						fill={styleSpec.headFill}
+						stroke={stroke}
+						strokeWidth={sw}
+					/>
+				);
+			}
+			case "diamond": {
+				const tipX = x2;
+				const tipY = y2;
+				const midX = x2 - cos * headSize;
+				const midY = y2 - sin * headSize;
+				const baseX = x2 - cos * headSize * 2;
+				const baseY = y2 - sin * headSize * 2;
+				const halfWidth = headSize * 0.4;
+				const px = -sin * halfWidth;
+				const py = cos * halfWidth;
+				return (
+					<polygon
+						points={`${tipX},${tipY} ${midX + px},${midY + py} ${baseX},${baseY} ${midX - px},${midY - py}`}
+						fill={styleSpec.headFill}
+						stroke={stroke}
+						strokeWidth={sw}
+					/>
+				);
+			}
+			case "open": {
+				const baseX = x2 - cos * headSize;
+				const baseY = y2 - sin * headSize;
+				const halfBase = headSize * 0.5;
+				const px = -sin * halfBase;
+				const py = cos * halfBase;
+				return (
+					<polyline
+						points={`${baseX + px},${baseY + py} ${x2},${y2} ${baseX - px},${baseY - py}`}
+						fill="none"
+						stroke={stroke}
+						strokeWidth={sw}
+					/>
+				);
+			}
+			default:
+				return null;
+		}
+	}
+
+	const labelText = meta.label ?? "";
+	const fromLabel = meta.multiplicityFrom ?? "";
+	const toLabel = meta.multiplicityTo ?? "";
+
+	return (
+		<svg
+			width="100%"
+			height="100%"
+			viewBox={`0 0 ${Math.max(shape.width, 1)} ${Math.max(shape.height, 1)}`}
+			preserveAspectRatio="none"
+			style={{ overflow: "visible", opacity: shape.style.opacity }}
+		>
+			<title>{`${relation}${labelText ? `: ${labelText}` : ""}`}</title>
+			<line
+				x1={x1}
+				y1={y1}
+				x2={lineEndX}
+				y2={lineEndY}
+				stroke={stroke}
+				strokeWidth={sw}
+				strokeDasharray={styleSpec.dashed ? "5 4" : undefined}
+			/>
+			{head()}
+			{labelText && (
+				<text
+					x={(x1 + x2) / 2}
+					y={(y1 + y2) / 2 - 4}
+					textAnchor="middle"
+					fontSize={11}
+					fill="#1e1e1e"
+				>
+					{labelText}
+				</text>
+			)}
+			{fromLabel && (
+				<text x={x1 + cos * 12 - sin * 8} y={y1 + sin * 12 + cos * 8} fontSize={10} fill="#475569">
+					{fromLabel}
+				</text>
+			)}
+			{toLabel && (
+				<text
+					x={x2 - cos * 12 - sin * 8}
+					y={y2 - sin * 12 + cos * 8}
+					fontSize={10}
+					fill="#475569"
+					textAnchor="end"
+				>
+					{toLabel}
+				</text>
+			)}
+		</svg>
+	);
+}

--- a/plugins/usketch-plugin-domain-design/src/connectors/tactical.tsx
+++ b/plugins/usketch-plugin-domain-design/src/connectors/tactical.tsx
@@ -21,10 +21,15 @@ export function renderTacticalConnector(shape: ShapeData) {
 	const relation: TacticalRelation = meta.relation ?? "association";
 	const styleSpec = RELATION_STYLE[relation];
 
-	const x1 = 0;
-	const y1 = 0;
-	const x2 = shape.width;
-	const y2 = shape.height;
+	// shape.width / shape.height は AABB のため非負。
+	// 始点 / 終点は meta.start / meta.end（AABB 相対座標）から読む。
+	// 後方互換: meta が無い場合は対角線の左上 → 右下を使う。
+	const start = meta.start ?? { x: 0, y: 0 };
+	const end = meta.end ?? { x: shape.width, y: shape.height };
+	const x1 = start.x;
+	const y1 = start.y;
+	const x2 = end.x;
+	const y2 = end.y;
 	const stroke = shape.style.stroke;
 	const sw = shape.style.strokeWidth;
 

--- a/plugins/usketch-plugin-domain-design/src/editor/editing-machine.ts
+++ b/plugins/usketch-plugin-domain-design/src/editor/editing-machine.ts
@@ -12,6 +12,7 @@ export const EDITABLE_DOMAIN_TYPES: ReadonlySet<string> = new Set([
 
 type EditingEvent =
 	| { type: "POINTER_DOWN"; shapeId: string | null }
+	| { type: "OUTSIDE_CLICK" }
 	| { type: "CLICK_TIMEOUT" }
 	| { type: "COMMIT"; id: string; nextMeta: Record<string, unknown> }
 	| { type: "CANCEL"; id: string }
@@ -29,7 +30,7 @@ interface EditingMachineSchema extends MachineSchema {
 	};
 	state: "idle" | "clicked" | "editing";
 	event: EditingEvent;
-	guard: "hasShape" | "isSameShape" | "isEditingTarget";
+	guard: "hasShape" | "isSameShape" | "isSameAsEditing" | "isEditingTarget";
 	action:
 		| "setClicked"
 		| "startClickTimer"
@@ -94,11 +95,11 @@ const editingMachine = createMachine<EditingMachineSchema>({
 				COMMIT: { guard: "isEditingTarget", target: "idle", actions: ["commitEdit"] },
 				CANCEL: { guard: "isEditingTarget", target: "idle", actions: ["cancelEdit"] },
 				DESELECTED: { target: "idle", actions: ["cancelEdit"] },
-				POINTER_DOWN: [
-					// クリックが editing 中の shape 以外なら commit して閉じる
-					{ guard: "isSameShape", target: "editing" },
-					{ target: "idle", actions: ["exitEdit"] },
-				],
+				// editing 中のキャンバスクリックは state 維持。
+				// editor の onBlur が COMMIT を発火するのを待つため、
+				// ここで先回りして idle に遷移しない（events の発火順で COMMIT が
+				// 取りこぼされるのを避ける）。
+				POINTER_DOWN: [{ guard: "isSameAsEditing", target: "editing" }],
 			},
 		},
 	},
@@ -111,6 +112,10 @@ const editingMachine = createMachine<EditingMachineSchema>({
 			isSameShape({ context, event }) {
 				if (event.type !== "POINTER_DOWN") return false;
 				return event.shapeId != null && event.shapeId === context.get("clickedShapeId");
+			},
+			isSameAsEditing({ context, event }) {
+				if (event.type !== "POINTER_DOWN") return false;
+				return event.shapeId != null && event.shapeId === context.get("editingShapeId");
 			},
 			isEditingTarget({ context, event }) {
 				if (event.type !== "COMMIT" && event.type !== "CANCEL") return false;
@@ -180,9 +185,10 @@ const editingMachine = createMachine<EditingMachineSchema>({
 					"x-domain-editing": false,
 				} as Partial<ShapeData>);
 
-				const nextMeta = event.nextMeta;
 				const before = (prevMeta ?? {}) as Record<string, unknown>;
-				const after = nextMeta;
+				// nextMeta は partial patch なので、既存 meta にマージする。
+				// （TitleEditor は { contextName: text } のように 1 フィールドだけ送る）
+				const after = { ...before, ...event.nextMeta };
 				const changed = !shallowEqual(before, after);
 				if (changed) {
 					pluginCtx.commands.execute(

--- a/plugins/usketch-plugin-domain-design/src/editor/editing-machine.ts
+++ b/plugins/usketch-plugin-domain-design/src/editor/editing-machine.ts
@@ -12,7 +12,6 @@ export const EDITABLE_DOMAIN_TYPES: ReadonlySet<string> = new Set([
 
 type EditingEvent =
 	| { type: "POINTER_DOWN"; shapeId: string | null }
-	| { type: "OUTSIDE_CLICK" }
 	| { type: "CLICK_TIMEOUT" }
 	| { type: "COMMIT"; id: string; nextMeta: Record<string, unknown> }
 	| { type: "CANCEL"; id: string }
@@ -37,8 +36,7 @@ interface EditingMachineSchema extends MachineSchema {
 		| "clearClicked"
 		| "enterEdit"
 		| "commitEdit"
-		| "cancelEdit"
-		| "exitEdit";
+		| "cancelEdit";
 	effect: never;
 	tag: never;
 	props: { id: string };
@@ -224,22 +222,6 @@ const editingMachine = createMachine<EditingMachineSchema>({
 
 				context.set("editingShapeId", null);
 				context.set("metaSnapshot", null);
-			},
-
-			exitEdit({ context, refs }) {
-				// 外部クリックで editing が終わるとき。
-				// editor 側の blur で COMMIT が飛んでくる想定だが、
-				// 念のためフラグだけ落とす。
-				const id = context.get("editingShapeId");
-				if (id) {
-					const pluginCtx = refs.get("pluginCtx");
-					pluginCtx.store.updateShape(id, {
-						"x-domain-editing": false,
-					} as Partial<ShapeData>);
-				}
-				context.set("editingShapeId", null);
-				context.set("metaSnapshot", null);
-				context.set("clickedShapeId", null);
 			},
 		},
 	},

--- a/plugins/usketch-plugin-domain-design/src/editor/editing-machine.ts
+++ b/plugins/usketch-plugin-domain-design/src/editor/editing-machine.ts
@@ -1,0 +1,281 @@
+import type { PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import { createUpdateShapeCommand } from "@edv4h/usketch-store";
+import { createMachine, type MachineSchema } from "@zag-js/core";
+import { VanillaMachine } from "@zag-js/vanilla";
+import { DOMAIN_TYPES } from "../types.js";
+
+export const EDITABLE_DOMAIN_TYPES: ReadonlySet<string> = new Set([
+	DOMAIN_TYPES.boundedContext,
+	DOMAIN_TYPES.aggregate,
+	DOMAIN_TYPES.classBox,
+]);
+
+type EditingEvent =
+	| { type: "POINTER_DOWN"; shapeId: string | null }
+	| { type: "CLICK_TIMEOUT" }
+	| { type: "COMMIT"; id: string; nextMeta: Record<string, unknown> }
+	| { type: "CANCEL"; id: string }
+	| { type: "DESELECTED" };
+
+interface EditingMachineSchema extends MachineSchema {
+	context: {
+		editingShapeId: string | null;
+		clickedShapeId: string | null;
+		metaSnapshot: Record<string, unknown> | null;
+	};
+	refs: {
+		clickTimer: ReturnType<typeof setTimeout> | null;
+		pluginCtx: PluginContext;
+	};
+	state: "idle" | "clicked" | "editing";
+	event: EditingEvent;
+	guard: "hasShape" | "isSameShape" | "isEditingTarget";
+	action:
+		| "setClicked"
+		| "startClickTimer"
+		| "clearClicked"
+		| "enterEdit"
+		| "commitEdit"
+		| "cancelEdit"
+		| "exitEdit";
+	effect: never;
+	tag: never;
+	props: { id: string };
+	computed: Record<string, never>;
+}
+
+const editingMachine = createMachine<EditingMachineSchema>({
+	initialState: () => "idle",
+
+	context({ bindable }) {
+		return {
+			editingShapeId: bindable<string | null>(() => ({ defaultValue: null })),
+			clickedShapeId: bindable<string | null>(() => ({ defaultValue: null })),
+			metaSnapshot: bindable<Record<string, unknown> | null>(() => ({
+				defaultValue: null,
+			})),
+		};
+	},
+
+	refs() {
+		return {
+			clickTimer: null as ReturnType<typeof setTimeout> | null,
+			pluginCtx: null as unknown as PluginContext,
+		};
+	},
+
+	states: {
+		idle: {
+			on: {
+				POINTER_DOWN: [
+					{ guard: "hasShape", target: "clicked", actions: ["setClicked", "startClickTimer"] },
+				],
+			},
+		},
+
+		clicked: {
+			on: {
+				POINTER_DOWN: [
+					{ guard: "isSameShape", target: "editing", actions: ["enterEdit"] },
+					{
+						guard: "hasShape",
+						target: "clicked",
+						actions: ["setClicked", "startClickTimer"],
+						reenter: true,
+					},
+					{ target: "idle", actions: ["clearClicked"] },
+				],
+				CLICK_TIMEOUT: { target: "idle", actions: ["clearClicked"] },
+			},
+		},
+
+		editing: {
+			on: {
+				COMMIT: { guard: "isEditingTarget", target: "idle", actions: ["commitEdit"] },
+				CANCEL: { guard: "isEditingTarget", target: "idle", actions: ["cancelEdit"] },
+				DESELECTED: { target: "idle", actions: ["cancelEdit"] },
+				POINTER_DOWN: [
+					// クリックが editing 中の shape 以外なら commit して閉じる
+					{ guard: "isSameShape", target: "editing" },
+					{ target: "idle", actions: ["exitEdit"] },
+				],
+			},
+		},
+	},
+
+	implementations: {
+		guards: {
+			hasShape({ event }) {
+				return event.type === "POINTER_DOWN" && event.shapeId != null;
+			},
+			isSameShape({ context, event }) {
+				if (event.type !== "POINTER_DOWN") return false;
+				return event.shapeId != null && event.shapeId === context.get("clickedShapeId");
+			},
+			isEditingTarget({ context, event }) {
+				if (event.type !== "COMMIT" && event.type !== "CANCEL") return false;
+				return event.id === context.get("editingShapeId");
+			},
+		},
+
+		actions: {
+			setClicked({ context, event, refs }) {
+				if (event.type !== "POINTER_DOWN") return;
+				const prev = refs.get("clickTimer");
+				if (prev != null) clearTimeout(prev);
+				context.set("clickedShapeId", event.shapeId);
+			},
+
+			startClickTimer({ refs, send }) {
+				const prev = refs.get("clickTimer");
+				if (prev != null) clearTimeout(prev);
+				const timer = setTimeout(() => {
+					send({ type: "CLICK_TIMEOUT" });
+				}, 300);
+				refs.set("clickTimer", timer);
+			},
+
+			clearClicked({ context, refs }) {
+				context.set("clickedShapeId", null);
+				const timer = refs.get("clickTimer");
+				if (timer != null) {
+					clearTimeout(timer);
+					refs.set("clickTimer", null);
+				}
+			},
+
+			enterEdit({ context, refs }) {
+				const id = context.get("clickedShapeId");
+				if (!id) return;
+				const pluginCtx = refs.get("pluginCtx");
+				const shape = pluginCtx.store.getShape(id);
+				if (!shape) return;
+
+				context.set("editingShapeId", id);
+				context.set("metaSnapshot", { ...((shape.meta ?? {}) as Record<string, unknown>) });
+				context.set("clickedShapeId", null);
+				const clickTimer = refs.get("clickTimer");
+				if (clickTimer != null) {
+					clearTimeout(clickTimer);
+					refs.set("clickTimer", null);
+				}
+
+				pluginCtx.store.updateShape(id, { "x-domain-editing": true } as Partial<ShapeData>);
+			},
+
+			commitEdit({ context, refs, event }) {
+				if (event.type !== "COMMIT") return;
+				const id = event.id;
+				const prevMeta = context.get("metaSnapshot");
+				const pluginCtx = refs.get("pluginCtx");
+				const shape = pluginCtx.store.getShape(id);
+				if (!shape) {
+					context.set("editingShapeId", null);
+					context.set("metaSnapshot", null);
+					return;
+				}
+
+				// editing flag を消す（変更通知のため updateShape を経由）
+				pluginCtx.store.updateShape(id, {
+					"x-domain-editing": false,
+				} as Partial<ShapeData>);
+
+				const nextMeta = event.nextMeta;
+				const before = (prevMeta ?? {}) as Record<string, unknown>;
+				const after = nextMeta;
+				const changed = !shallowEqual(before, after);
+				if (changed) {
+					pluginCtx.commands.execute(
+						createUpdateShapeCommand(
+							pluginCtx.store,
+							id,
+							{ meta: before } as Partial<ShapeData>,
+							{ meta: after } as Partial<ShapeData>,
+						),
+					);
+				}
+
+				context.set("editingShapeId", null);
+				context.set("metaSnapshot", null);
+			},
+
+			cancelEdit({ context, refs }) {
+				const id = context.get("editingShapeId");
+				if (!id) return;
+				const prevMeta = context.get("metaSnapshot");
+				const pluginCtx = refs.get("pluginCtx");
+				const shape = pluginCtx.store.getShape(id);
+				if (!shape) {
+					context.set("editingShapeId", null);
+					context.set("metaSnapshot", null);
+					return;
+				}
+
+				pluginCtx.store.updateShape(id, {
+					"x-domain-editing": false,
+					meta: prevMeta ?? {},
+				} as Partial<ShapeData>);
+
+				context.set("editingShapeId", null);
+				context.set("metaSnapshot", null);
+			},
+
+			exitEdit({ context, refs }) {
+				// 外部クリックで editing が終わるとき。
+				// editor 側の blur で COMMIT が飛んでくる想定だが、
+				// 念のためフラグだけ落とす。
+				const id = context.get("editingShapeId");
+				if (id) {
+					const pluginCtx = refs.get("pluginCtx");
+					pluginCtx.store.updateShape(id, {
+						"x-domain-editing": false,
+					} as Partial<ShapeData>);
+				}
+				context.set("editingShapeId", null);
+				context.set("metaSnapshot", null);
+				context.set("clickedShapeId", null);
+			},
+		},
+	},
+});
+
+function shallowEqual(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+	const ka = Object.keys(a);
+	const kb = Object.keys(b);
+	if (ka.length !== kb.length) return false;
+	for (const k of ka) {
+		const va = a[k];
+		const vb = b[k];
+		if (Array.isArray(va) && Array.isArray(vb)) {
+			if (va.length !== vb.length) return false;
+			for (let i = 0; i < va.length; i++) {
+				if (va[i] !== vb[i]) return false;
+			}
+			continue;
+		}
+		if (va !== vb) return false;
+	}
+	return true;
+}
+
+export function createDomainEditingService(pluginCtx: PluginContext) {
+	const machine = new VanillaMachine(editingMachine);
+	machine.refs.set("pluginCtx", pluginCtx);
+	machine.start();
+
+	return {
+		send: machine.send,
+		get editingShapeId() {
+			return machine.context.get("editingShapeId");
+		},
+		matches(...values: string[]) {
+			const state = machine.state.get();
+			return values.some((v) => state === v || state.startsWith(`${v}.`));
+		},
+		stop() {
+			const clickTimer = machine.refs.get("clickTimer");
+			if (clickTimer != null) clearTimeout(clickTimer);
+			machine.stop();
+		},
+	};
+}

--- a/plugins/usketch-plugin-domain-design/src/editor/editors.tsx
+++ b/plugins/usketch-plugin-domain-design/src/editor/editors.tsx
@@ -1,0 +1,261 @@
+import type { ShapeStyle } from "@edv4h/usketch-shared";
+import type { ClassBoxMeta, ClassStereotype } from "../types.js";
+
+const STEREOTYPES: ClassStereotype[] = [
+	"Entity",
+	"ValueObject",
+	"Service",
+	"Repository",
+	"DomainEvent",
+	"Factory",
+];
+
+function focusAtEnd(el: HTMLElement) {
+	el.focus();
+	const sel = window.getSelection();
+	if (!sel) return;
+	const range = document.createRange();
+	range.selectNodeContents(el);
+	range.collapse(false);
+	sel.removeAllRanges();
+	sel.addRange(range);
+}
+
+function dispatchCommit(id: string, nextMeta: Record<string, unknown>) {
+	window.dispatchEvent(
+		new CustomEvent("usketch:domain-design:commit", { detail: { id, nextMeta } }),
+	);
+}
+
+function dispatchCancel(id: string) {
+	window.dispatchEvent(new CustomEvent("usketch:domain-design:cancel", { detail: { id } }));
+}
+
+interface TitleEditorProps {
+	shapeId: string;
+	initial: string;
+	field?: string;
+}
+
+/**
+ * 1 行タイトル編集（BoundedContext.contextName / Aggregate.rootName 用）。
+ * `field` で meta のどのキーに書き戻すか指定する（デフォルト: contextName）。
+ */
+export function TitleEditor({ shapeId, initial, field = "contextName" }: TitleEditorProps) {
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: contentEditable は inline-edit の慣用
+		<span
+			contentEditable="plaintext-only"
+			suppressContentEditableWarning
+			role="textbox"
+			tabIndex={0}
+			ref={(el: HTMLSpanElement | null) => {
+				if (!el || el.dataset.focused) return;
+				el.dataset.focused = "1";
+				el.textContent = initial;
+				requestAnimationFrame(() => focusAtEnd(el));
+			}}
+			onPointerDown={(e) => e.stopPropagation()}
+			onKeyDown={(e) => {
+				e.stopPropagation();
+				if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+					e.preventDefault();
+					(e.currentTarget as HTMLElement).blur();
+				}
+				if (e.key === "Escape" && !e.nativeEvent.isComposing) {
+					dispatchCancel(shapeId);
+				}
+			}}
+			onBlur={(e) => {
+				delete e.currentTarget.dataset.focused;
+				const text = e.currentTarget.innerText.trim();
+				dispatchCommit(shapeId, { [field]: text });
+			}}
+			style={{
+				fontSize: 16,
+				fontWeight: 600,
+				color: "#1e1e1e",
+				outline: "none",
+				cursor: "text",
+				userSelect: "auto",
+				background: "rgba(59,130,246,0.08)",
+				borderRadius: 3,
+				padding: "0 4px",
+				flex: 1,
+				minWidth: 40,
+			}}
+		/>
+	);
+}
+
+interface ClassBoxEditorProps {
+	shapeId: string;
+	meta: ClassBoxMeta;
+	accent: string;
+	style: ShapeStyle;
+}
+
+/**
+ * ClassBox の 3 セクション編集。クラス名 / 属性（複数行） / メソッド（複数行）。
+ * blur で1 つに集約してから commit する（セクション単位ではなく shape 単位の COMMIT）。
+ */
+export function ClassBoxEditor({ shapeId, meta, accent, style }: ClassBoxEditorProps) {
+	const initialName = meta.className ?? "";
+	const initialAttrs = (meta.attributes ?? []).join("\n");
+	const initialMethods = (meta.methods ?? []).join("\n");
+
+	function readAndCommit(rootEl: HTMLElement) {
+		const nameEl = rootEl.querySelector<HTMLElement>("[data-domain-field=name]");
+		const attrEl = rootEl.querySelector<HTMLElement>("[data-domain-field=attributes]");
+		const methodEl = rootEl.querySelector<HTMLElement>("[data-domain-field=methods]");
+		const stereotypeEl = rootEl.querySelector<HTMLSelectElement>("[data-domain-field=stereotype]");
+		const className = (nameEl?.innerText ?? "").trim();
+		const attributes = (attrEl?.innerText ?? "")
+			.split("\n")
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
+		const methods = (methodEl?.innerText ?? "")
+			.split("\n")
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
+		const stereotype = (stereotypeEl?.value ?? meta.stereotype) as ClassStereotype;
+
+		dispatchCommit(shapeId, {
+			className,
+			stereotype,
+			attributes,
+			methods,
+		});
+	}
+
+	let rootRef: HTMLDivElement | null = null;
+
+	function handleBlur(e: React.FocusEvent<HTMLDivElement>) {
+		// セクション間のフォーカス移動は内側に留まるので無視
+		const next = e.relatedTarget as Node | null;
+		if (next && rootRef?.contains(next)) return;
+		if (rootRef) readAndCommit(rootRef);
+	}
+
+	function handleKeyDown(e: React.KeyboardEvent) {
+		e.stopPropagation();
+		if (e.key === "Escape" && !e.nativeEvent.isComposing) {
+			dispatchCancel(shapeId);
+		}
+	}
+
+	return (
+		// biome-ignore lint/a11y/noStaticElementInteractions: editor wrapper の handler は内側の contenteditable / select に対する非バブリング処理用。インタラクティブ要素は子要素側にある
+		<div
+			ref={(el) => {
+				rootRef = el;
+			}}
+			onPointerDown={(e) => e.stopPropagation()}
+			onBlur={handleBlur}
+			onKeyDown={handleKeyDown}
+			style={{
+				width: "100%",
+				height: "100%",
+				background: style.fill,
+				border: `${style.strokeWidth}px solid ${style.stroke}`,
+				boxSizing: "border-box",
+				display: "flex",
+				flexDirection: "column",
+				overflow: "hidden",
+				opacity: style.opacity,
+				fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+			}}
+		>
+			<div
+				style={{
+					padding: "6px 8px",
+					borderBottom: `1px solid ${style.stroke}`,
+					textAlign: "center",
+					background: `${accent}10`,
+				}}
+			>
+				<select
+					data-domain-field="stereotype"
+					defaultValue={meta.stereotype}
+					onPointerDown={(e) => e.stopPropagation()}
+					style={{
+						fontSize: 10,
+						color: accent,
+						fontWeight: 500,
+						border: "none",
+						background: "transparent",
+						cursor: "pointer",
+					}}
+				>
+					{STEREOTYPES.map((s) => (
+						<option key={s} value={s}>
+							«{s}»
+						</option>
+					))}
+				</select>
+				<div
+					data-domain-field="name"
+					contentEditable="plaintext-only"
+					suppressContentEditableWarning
+					ref={(el: HTMLDivElement | null) => {
+						if (!el || el.dataset.focused) return;
+						el.dataset.focused = "1";
+						el.textContent = initialName;
+						requestAnimationFrame(() => focusAtEnd(el));
+					}}
+					style={{
+						fontSize: 14,
+						fontWeight: 600,
+						color: "#1e1e1e",
+						outline: "none",
+						cursor: "text",
+						userSelect: "auto",
+					}}
+				/>
+			</div>
+			<div
+				data-domain-field="attributes"
+				contentEditable="plaintext-only"
+				suppressContentEditableWarning
+				ref={(el: HTMLDivElement | null) => {
+					if (!el || el.dataset.focused) return;
+					el.dataset.focused = "1";
+					el.textContent = initialAttrs;
+				}}
+				style={{
+					padding: "4px 8px",
+					borderBottom: `1px solid ${style.stroke}`,
+					fontSize: 11,
+					color: "#1e1e1e",
+					flex: 1,
+					overflow: "auto",
+					whiteSpace: "pre-wrap",
+					outline: "none",
+					cursor: "text",
+					userSelect: "auto",
+				}}
+			/>
+			<div
+				data-domain-field="methods"
+				contentEditable="plaintext-only"
+				suppressContentEditableWarning
+				ref={(el: HTMLDivElement | null) => {
+					if (!el || el.dataset.focused) return;
+					el.dataset.focused = "1";
+					el.textContent = initialMethods;
+				}}
+				style={{
+					padding: "4px 8px",
+					fontSize: 11,
+					color: "#1e1e1e",
+					flex: 1,
+					overflow: "auto",
+					whiteSpace: "pre-wrap",
+					outline: "none",
+					cursor: "text",
+					userSelect: "auto",
+				}}
+			/>
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-domain-design/src/index.ts
+++ b/plugins/usketch-plugin-domain-design/src/index.ts
@@ -1,0 +1,19 @@
+export { domainDesignPlugin } from "./plugin.js";
+export { DOMAIN_SUBTYPES, type DomainSubtype } from "./registry.js";
+export {
+	type AggregateMeta,
+	type AggregateShape,
+	type BoundedContextMeta,
+	type BoundedContextShape,
+	type ClassBoxMeta,
+	type ClassBoxShape,
+	type ClassStereotype,
+	type ContextMapConnectorMeta,
+	type ContextMapConnectorShape,
+	type ContextMapRelation,
+	DOMAIN_TYPES,
+	readMeta,
+	type TacticalConnectorMeta,
+	type TacticalConnectorShape,
+	type TacticalRelation,
+} from "./types.js";

--- a/plugins/usketch-plugin-domain-design/src/plugin.tsx
+++ b/plugins/usketch-plugin-domain-design/src/plugin.tsx
@@ -136,13 +136,30 @@ export const domainDesignPlugin: UsketchPlugin = {
 				currentSubtype === DOMAIN_TYPES.tacticalConnector;
 
 			if (isConnector) {
-				// connector は (start) → (end) を x/y/width/height で表現する。
-				// width / height には符号付きの差分を入れる（負値も許容）。
-				const x = drawState.startX;
-				const y = drawState.startY;
-				const width = event.worldPoint.x - drawState.startX;
-				const height = event.worldPoint.y - drawState.startY;
-				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+				// connector は描画上 SVG だが、shape の bbox 自体は通常 shape と
+				// 同様に正規化（width/height >= 0）しておく必要がある。
+				// （shape-layer は style.width/height に shape.width/height をそのまま流すため、
+				//   負値だと CSS で 0 扱いになりレンダリングが壊れる）
+				// 実際の始点 / 終点は meta.start / meta.end に保存して方向を保持する。
+				const sx = drawState.startX;
+				const sy = drawState.startY;
+				const ex = event.worldPoint.x;
+				const ey = event.worldPoint.y;
+				const x = Math.min(sx, ex);
+				const y = Math.min(sy, ey);
+				const width = Math.abs(ex - sx);
+				const height = Math.abs(ey - sy);
+				toolCtx.store.updateShape(drawState.shapeId, {
+					x,
+					y,
+					width,
+					height,
+					meta: {
+						...((toolCtx.store.getShape(drawState.shapeId)?.meta ?? {}) as Record<string, unknown>),
+						start: { x: sx - x, y: sy - y },
+						end: { x: ex - x, y: ey - y },
+					},
+				});
 			} else {
 				const x = Math.min(drawState.startX, event.worldPoint.x);
 				const y = Math.min(drawState.startY, event.worldPoint.y);
@@ -185,7 +202,7 @@ export const domainDesignPlugin: UsketchPlugin = {
 
 		// ── インライン編集（state machine + custom events） ──
 		const editingService = createDomainEditingService(ctx);
-		const { send, matches, stop: stopMachine } = editingService;
+		const { send, stop: stopMachine } = editingService;
 		cleanups.push(stopMachine);
 
 		const onCommit = (e: Event) => {
@@ -232,16 +249,9 @@ export const domainDesignPlugin: UsketchPlugin = {
 		});
 		cleanups.push(unsubscribe);
 
-		// editor 外クリックで commit を促す（global pointerdown）
-		const onWindowPointerDown = (e: PointerEvent) => {
-			if (!matches("editing")) return;
-			const target = e.target instanceof Element ? e.target : (e.target as Node).parentElement;
-			if (target?.closest("[contenteditable=true]")) return;
-			// editor の外をクリックしたら editor の blur で COMMIT が発火する想定。
-			// ここでは何もしない（editor の onBlur に任せる）。
-		};
-		window.addEventListener("pointerdown", onWindowPointerDown, true);
-		cleanups.push(() => window.removeEventListener("pointerdown", onWindowPointerDown, true));
+		// editor 外クリック時のフォーカス移動 → editor 側の onBlur が
+		// COMMIT を発火する設計のため、ここでは追加の listener を登録しない。
+		// （以前は global pointerdown を捕捉していたが、機能していなかったため削除）
 
 		// ── teardown ──
 		(domainDesignPlugin as { teardown?: () => void }).teardown = () => {

--- a/plugins/usketch-plugin-domain-design/src/plugin.tsx
+++ b/plugins/usketch-plugin-domain-design/src/plugin.tsx
@@ -1,8 +1,10 @@
-import { aabbHitTest, createResize, getBounds, lineHitTest } from "@edv4h/usketch-shape-utils";
+import { aabbHitTest, createResize, getBounds } from "@edv4h/usketch-shape-utils";
 import {
 	type CanvasPointerEvent,
 	generateId,
 	type PluginContext,
+	type Point,
+	type ShapeData,
 	type ShapeDefinition,
 	type ToolContext,
 	type UsketchPlugin,
@@ -29,12 +31,43 @@ const SHAPE_RENDERERS: Record<string, RendererFn> = {
 	[DOMAIN_TYPES.tacticalConnector]: renderTacticalConnector,
 };
 
+/**
+ * connector 専用の hit test。
+ * 共通の `lineHitTest` は AABB 対角線（左上 → 右下）を線分として扱うため、
+ * 左下 → 右上のような対角の connector は本来の線とは別の対角線で判定されてしまい
+ * 選択できなくなる。connector は `meta.start` / `meta.end`（AABB 相対）に
+ * 始点・終点を保持しているので、それを world 座標に変換して線分距離で判定する。
+ */
+function connectorHitTest(data: ShapeData, point: Point, tolerance = 6): boolean {
+	const meta = (data.meta ?? {}) as {
+		start?: { x: number; y: number };
+		end?: { x: number; y: number };
+	};
+	const start = meta.start ?? { x: 0, y: 0 };
+	const end = meta.end ?? { x: data.width, y: data.height };
+	const x1 = data.x + start.x;
+	const y1 = data.y + start.y;
+	const x2 = data.x + end.x;
+	const y2 = data.y + end.y;
+	const dx = x2 - x1;
+	const dy = y2 - y1;
+	const lengthSq = dx * dx + dy * dy;
+	if (lengthSq === 0) {
+		return Math.hypot(point.x - x1, point.y - y1) <= tolerance;
+	}
+	let t = ((point.x - x1) * dx + (point.y - y1) * dy) / lengthSq;
+	t = Math.max(0, Math.min(1, t));
+	const nx = x1 + t * dx;
+	const ny = y1 + t * dy;
+	return Math.hypot(point.x - nx, point.y - ny) <= tolerance;
+}
+
 const SHAPE_HIT_TESTS: Record<string, HitTestFn> = {
 	[DOMAIN_TYPES.boundedContext]: withRotation(aabbHitTest),
 	[DOMAIN_TYPES.aggregate]: withRotation(aabbHitTest),
 	[DOMAIN_TYPES.classBox]: withRotation(aabbHitTest),
-	[DOMAIN_TYPES.contextMapConnector]: withRotation(lineHitTest),
-	[DOMAIN_TYPES.tacticalConnector]: withRotation(lineHitTest),
+	[DOMAIN_TYPES.contextMapConnector]: withRotation(connectorHitTest),
+	[DOMAIN_TYPES.tacticalConnector]: withRotation(connectorHitTest),
 };
 
 function DomainDrawIcon() {
@@ -253,14 +286,29 @@ export const domainDesignPlugin: UsketchPlugin = {
 		});
 		cleanups.push(offCanvasPointer);
 
-		// 選択が外れたら editing 終了
+		// 選択が外れたら editing 終了。ただし select tool が pointerdown で
+		// 選択を更新するタイミングは editor の blur より前なので、ここで即座に
+		// DESELECTED を送ると blur 経由の COMMIT が来る前に cancelEdit が走り
+		// 編集内容が捨てられる。microtask で 1 ターン遅延させ、COMMIT が先に
+		// 処理されるようにする。
+		let pendingDeselectedShapeId: string | null = null;
 		const unsubscribe = ctx.store.subscribe(() => {
 			const editingId = editingService.editingShapeId;
 			if (!editingId) return;
 			const selection = ctx.store.getSelection();
-			if (!selection.has(editingId)) {
+			if (selection.has(editingId)) return;
+			if (pendingDeselectedShapeId === editingId) return;
+			pendingDeselectedShapeId = editingId;
+			queueMicrotask(() => {
+				const stillEditingId = editingService.editingShapeId;
+				pendingDeselectedShapeId = null;
+				// COMMIT / CANCEL ですでに idle に戻っていたら何もしない
+				if (!stillEditingId) return;
+				if (stillEditingId !== editingId) return;
+				const stillSelected = ctx.store.getSelection().has(stillEditingId);
+				if (stillSelected) return;
 				send({ type: "DESELECTED" });
-			}
+			});
 		});
 		cleanups.push(unsubscribe);
 

--- a/plugins/usketch-plugin-domain-design/src/plugin.tsx
+++ b/plugins/usketch-plugin-domain-design/src/plugin.tsx
@@ -84,6 +84,13 @@ export const domainDesignPlugin: UsketchPlugin = {
 			const renderer = SHAPE_RENDERERS[subtype.type];
 			const hitTestFn = SHAPE_HIT_TESTS[subtype.type];
 			if (!renderer || !hitTestFn) continue;
+			// connector は始点 / 終点を meta.start / meta.end に保持しているため、
+			// 標準の AABB resize（width / height だけ更新）では line がズレる。
+			// 既存の `connector` plugin と同様、専用のリサイズロジックを書くまでは
+			// resize 不可にしておく（移動・回転・削除は通常通り可能）。
+			const isConnector =
+				subtype.type === DOMAIN_TYPES.contextMapConnector ||
+				subtype.type === DOMAIN_TYPES.tacticalConnector;
 			ctx.shapes.register(subtype.type, {
 				render: renderer,
 				getBounds,
@@ -92,6 +99,7 @@ export const domainDesignPlugin: UsketchPlugin = {
 					MIN_SIZE_BY_TYPE[subtype.type]?.width ?? 1,
 					MIN_SIZE_BY_TYPE[subtype.type]?.height ?? 1,
 				),
+				resizable: !isConnector,
 				createDefault: subtype.createDefault,
 				renderTarget: RENDER_TARGET_BY_TYPE[subtype.type],
 				minSize: MIN_SIZE_BY_TYPE[subtype.type],
@@ -225,13 +233,20 @@ export const domainDesignPlugin: UsketchPlugin = {
 		const offCanvasPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
 			let hitShapeId: string | null = null;
 			const point = event.worldPoint;
-			const shapes = ctx.store.getShapes();
-			for (const [id, shape] of shapes) {
+			// getShapesSorted() は zIndex 昇順（背面 → 前面）。
+			// hit test は前面から拾いたいので末尾から走査して、最初の hit で抜ける。
+			// （Map 順序は zIndex を反映しないため、getShapes() を素直に回すと
+			//   重なり合った shape のうち背面側を選んでしまうことがある）
+			const sorted = ctx.store.getShapesSorted();
+			for (let i = sorted.length - 1; i >= 0; i--) {
+				const shape = sorted[i];
+				if (!shape) continue;
 				if (!EDITABLE_DOMAIN_TYPES.has(shape.type)) continue;
 				const def: ShapeDefinition | undefined = ctx.shapes.get(shape.type);
 				if (!def) continue;
 				if (def.hitTest(shape, point)) {
-					hitShapeId = id;
+					hitShapeId = shape.id;
+					break;
 				}
 			}
 			send({ type: "POINTER_DOWN", shapeId: hitShapeId });

--- a/plugins/usketch-plugin-domain-design/src/plugin.tsx
+++ b/plugins/usketch-plugin-domain-design/src/plugin.tsx
@@ -1,0 +1,255 @@
+import { aabbHitTest, createResize, getBounds, lineHitTest } from "@edv4h/usketch-shape-utils";
+import {
+	type CanvasPointerEvent,
+	generateId,
+	type PluginContext,
+	type ShapeDefinition,
+	type ToolContext,
+	type UsketchPlugin,
+	withRotation,
+} from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { renderContextMapConnector } from "./connectors/context-map.js";
+import { renderTacticalConnector } from "./connectors/tactical.js";
+import { createDomainEditingService, EDITABLE_DOMAIN_TYPES } from "./editor/editing-machine.js";
+import { DOMAIN_SUBTYPES } from "./registry.js";
+import { renderAggregate } from "./shapes/aggregate.js";
+import { renderBoundedContext } from "./shapes/bounded-context.js";
+import { renderClassBox } from "./shapes/class-box.js";
+import { DOMAIN_TYPES } from "./types.js";
+
+type RendererFn = ShapeDefinition["render"];
+type HitTestFn = ShapeDefinition["hitTest"];
+
+const SHAPE_RENDERERS: Record<string, RendererFn> = {
+	[DOMAIN_TYPES.boundedContext]: renderBoundedContext,
+	[DOMAIN_TYPES.aggregate]: renderAggregate,
+	[DOMAIN_TYPES.classBox]: renderClassBox,
+	[DOMAIN_TYPES.contextMapConnector]: renderContextMapConnector,
+	[DOMAIN_TYPES.tacticalConnector]: renderTacticalConnector,
+};
+
+const SHAPE_HIT_TESTS: Record<string, HitTestFn> = {
+	[DOMAIN_TYPES.boundedContext]: withRotation(aabbHitTest),
+	[DOMAIN_TYPES.aggregate]: withRotation(aabbHitTest),
+	[DOMAIN_TYPES.classBox]: withRotation(aabbHitTest),
+	[DOMAIN_TYPES.contextMapConnector]: withRotation(lineHitTest),
+	[DOMAIN_TYPES.tacticalConnector]: withRotation(lineHitTest),
+};
+
+function DomainDrawIcon() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20">
+			<rect
+				x="2"
+				y="3"
+				width="9"
+				height="6"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.4"
+				strokeDasharray="2 1.5"
+			/>
+			<rect x="9" y="11" width="9" height="6" fill="none" stroke="currentColor" strokeWidth="1.4" />
+			<line x1="11" y1="6" x2="9" y2="11" stroke="currentColor" strokeWidth="1.2" />
+		</svg>
+	);
+}
+
+const RENDER_TARGET_BY_TYPE: Record<string, "html" | "svg"> = {
+	[DOMAIN_TYPES.boundedContext]: "html",
+	[DOMAIN_TYPES.aggregate]: "html",
+	[DOMAIN_TYPES.classBox]: "html",
+	[DOMAIN_TYPES.contextMapConnector]: "svg",
+	[DOMAIN_TYPES.tacticalConnector]: "svg",
+};
+
+const MIN_SIZE_BY_TYPE: Record<string, { width: number; height: number }> = {
+	[DOMAIN_TYPES.boundedContext]: { width: 120, height: 80 },
+	[DOMAIN_TYPES.aggregate]: { width: 80, height: 60 },
+	[DOMAIN_TYPES.classBox]: { width: 100, height: 80 },
+	[DOMAIN_TYPES.contextMapConnector]: { width: 1, height: 1 },
+	[DOMAIN_TYPES.tacticalConnector]: { width: 1, height: 1 },
+};
+
+export const domainDesignPlugin: UsketchPlugin = {
+	id: "usketch-plugin-domain-design",
+	name: "ドメイン設計",
+
+	setup(ctx: PluginContext) {
+		const cleanups: Array<() => void> = [];
+
+		// ── Shape 登録 ──
+		for (const subtype of DOMAIN_SUBTYPES) {
+			const renderer = SHAPE_RENDERERS[subtype.type];
+			const hitTestFn = SHAPE_HIT_TESTS[subtype.type];
+			if (!renderer || !hitTestFn) continue;
+			ctx.shapes.register(subtype.type, {
+				render: renderer,
+				getBounds,
+				hitTest: hitTestFn,
+				resize: createResize(
+					MIN_SIZE_BY_TYPE[subtype.type]?.width ?? 1,
+					MIN_SIZE_BY_TYPE[subtype.type]?.height ?? 1,
+				),
+				createDefault: subtype.createDefault,
+				renderTarget: RENDER_TARGET_BY_TYPE[subtype.type],
+				minSize: MIN_SIZE_BY_TYPE[subtype.type],
+			});
+		}
+
+		// ── Tool: subtype 切り替え ──
+		let currentSubtype = DOMAIN_SUBTYPES[0]?.type ?? DOMAIN_TYPES.boundedContext;
+		const offSubtype = ctx.events.on<{ type: string }>("domain-design:select-subtype", (data) => {
+			currentSubtype = data.type;
+		});
+		cleanups.push(offSubtype);
+
+		let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+
+		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+			const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
+			if (!subtype) return;
+			const id = generateId();
+			drawState = {
+				startX: event.worldPoint.x,
+				startY: event.worldPoint.y,
+				shapeId: id,
+			};
+			const shape = subtype.createDefault({
+				id,
+				x: event.worldPoint.x,
+				y: event.worldPoint.y,
+			});
+			shape.width = 0;
+			shape.height = 0;
+			toolCtx.store.addShape(shape);
+		}
+
+		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+			if (!drawState) return;
+			const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
+			if (!subtype) return;
+
+			const isConnector =
+				currentSubtype === DOMAIN_TYPES.contextMapConnector ||
+				currentSubtype === DOMAIN_TYPES.tacticalConnector;
+
+			if (isConnector) {
+				// connector は (start) → (end) を x/y/width/height で表現する。
+				// width / height には符号付きの差分を入れる（負値も許容）。
+				const x = drawState.startX;
+				const y = drawState.startY;
+				const width = event.worldPoint.x - drawState.startX;
+				const height = event.worldPoint.y - drawState.startY;
+				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+			} else {
+				const x = Math.min(drawState.startX, event.worldPoint.x);
+				const y = Math.min(drawState.startY, event.worldPoint.y);
+				const width = Math.abs(event.worldPoint.x - drawState.startX);
+				const height = Math.abs(event.worldPoint.y - drawState.startY);
+				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+			}
+		}
+
+		function onPointerUp(toolCtx: ToolContext) {
+			if (!drawState) return;
+			const shape = toolCtx.store.getShape(drawState.shapeId);
+			const isConnector =
+				shape?.type === DOMAIN_TYPES.contextMapConnector ||
+				shape?.type === DOMAIN_TYPES.tacticalConnector;
+			const minDim = isConnector ? 6 : 2;
+			const length = isConnector
+				? Math.hypot(shape?.width ?? 0, shape?.height ?? 0)
+				: Math.min(Math.abs(shape?.width ?? 0), Math.abs(shape?.height ?? 0));
+
+			if (shape && length > minDim) {
+				toolCtx.store.deleteShape(drawState.shapeId);
+				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+			} else {
+				toolCtx.store.deleteShape(drawState.shapeId);
+			}
+			drawState = null;
+			toolCtx.store.setActiveToolId("select");
+		}
+
+		ctx.tools.register("domain-draw", {
+			icon: DomainDrawIcon,
+			cursor: "crosshair",
+			shortcut: "d",
+			order: 12,
+			onPointerDown,
+			onPointerMove,
+			onPointerUp,
+		});
+
+		// ── インライン編集（state machine + custom events） ──
+		const editingService = createDomainEditingService(ctx);
+		const { send, matches, stop: stopMachine } = editingService;
+		cleanups.push(stopMachine);
+
+		const onCommit = (e: Event) => {
+			const detail = (e as CustomEvent).detail as {
+				id: string;
+				nextMeta: Record<string, unknown>;
+			};
+			send({ type: "COMMIT", id: detail.id, nextMeta: detail.nextMeta });
+		};
+		const onCancel = (e: Event) => {
+			const detail = (e as CustomEvent).detail as { id: string };
+			send({ type: "CANCEL", id: detail.id });
+		};
+		window.addEventListener("usketch:domain-design:commit", onCommit);
+		window.addEventListener("usketch:domain-design:cancel", onCancel);
+		cleanups.push(() => window.removeEventListener("usketch:domain-design:commit", onCommit));
+		cleanups.push(() => window.removeEventListener("usketch:domain-design:cancel", onCancel));
+
+		// canvas:pointerdown でクリック・ダブルクリック判定
+		const offCanvasPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+			let hitShapeId: string | null = null;
+			const point = event.worldPoint;
+			const shapes = ctx.store.getShapes();
+			for (const [id, shape] of shapes) {
+				if (!EDITABLE_DOMAIN_TYPES.has(shape.type)) continue;
+				const def: ShapeDefinition | undefined = ctx.shapes.get(shape.type);
+				if (!def) continue;
+				if (def.hitTest(shape, point)) {
+					hitShapeId = id;
+				}
+			}
+			send({ type: "POINTER_DOWN", shapeId: hitShapeId });
+		});
+		cleanups.push(offCanvasPointer);
+
+		// 選択が外れたら editing 終了
+		const unsubscribe = ctx.store.subscribe(() => {
+			const editingId = editingService.editingShapeId;
+			if (!editingId) return;
+			const selection = ctx.store.getSelection();
+			if (!selection.has(editingId)) {
+				send({ type: "DESELECTED" });
+			}
+		});
+		cleanups.push(unsubscribe);
+
+		// editor 外クリックで commit を促す（global pointerdown）
+		const onWindowPointerDown = (e: PointerEvent) => {
+			if (!matches("editing")) return;
+			const target = e.target instanceof Element ? e.target : (e.target as Node).parentElement;
+			if (target?.closest("[contenteditable=true]")) return;
+			// editor の外をクリックしたら editor の blur で COMMIT が発火する想定。
+			// ここでは何もしない（editor の onBlur に任せる）。
+		};
+		window.addEventListener("pointerdown", onWindowPointerDown, true);
+		cleanups.push(() => window.removeEventListener("pointerdown", onWindowPointerDown, true));
+
+		// ── teardown ──
+		(domainDesignPlugin as { teardown?: () => void }).teardown = () => {
+			for (const fn of cleanups) fn();
+		};
+	},
+
+	teardown() {
+		// setup() 内で動的に差し替えられる
+	},
+};

--- a/plugins/usketch-plugin-domain-design/src/registry.tsx
+++ b/plugins/usketch-plugin-domain-design/src/registry.tsx
@@ -1,0 +1,216 @@
+import { DEFAULT_STYLE, type ShapeData } from "@edv4h/usketch-shared";
+import type { ReactElement } from "react";
+import {
+	type AggregateShape,
+	type BoundedContextShape,
+	type ClassBoxShape,
+	type ContextMapConnectorShape,
+	DOMAIN_TYPES,
+	type TacticalConnectorShape,
+} from "./types.js";
+
+export interface DomainSubtype {
+	type: string;
+	label: string;
+	category: "strategic" | "tactical" | "relation";
+	icon: () => ReactElement;
+	createDefault: (params: { id: string; x: number; y: number }) => ShapeData;
+	defaultSize: { width: number; height: number };
+}
+
+// ── アイコン ──
+
+function BoundedContextIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<rect
+				x="1.5"
+				y="3"
+				width="13"
+				height="10"
+				rx="1"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.4"
+				strokeDasharray="2 1.5"
+			/>
+		</svg>
+	);
+}
+
+function AggregateIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<ellipse cx="8" cy="8" rx="6.5" ry="5" fill="none" stroke="currentColor" strokeWidth="1.6" />
+		</svg>
+	);
+}
+
+function ClassBoxIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<rect
+				x="2"
+				y="2"
+				width="12"
+				height="12"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.2"
+			/>
+			<line x1="2" y1="6" x2="14" y2="6" stroke="currentColor" strokeWidth="1" />
+			<line x1="2" y1="10" x2="14" y2="10" stroke="currentColor" strokeWidth="1" />
+		</svg>
+	);
+}
+
+function ContextMapIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<line
+				x1="2"
+				y1="8"
+				x2="14"
+				y2="8"
+				stroke="currentColor"
+				strokeWidth="1.4"
+				strokeDasharray="2 1.5"
+			/>
+			<text x="8" y="6" textAnchor="middle" fontSize="4" fill="currentColor">
+				U/D
+			</text>
+		</svg>
+	);
+}
+
+function TacticalRelationIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<line x1="2" y1="8" x2="12" y2="8" stroke="currentColor" strokeWidth="1.4" />
+			<polygon points="12,5 15,8 12,11" fill="none" stroke="currentColor" strokeWidth="1.2" />
+		</svg>
+	);
+}
+
+// ── createDefault ──
+
+function createBoundedContext(params: { id: string; x: number; y: number }): ShapeData {
+	return {
+		id: params.id,
+		type: DOMAIN_TYPES.boundedContext,
+		x: params.x,
+		y: params.y,
+		width: 320,
+		height: 200,
+		style: { ...DEFAULT_STYLE, fill: "#fff7ed", stroke: "#f97316", strokeWidth: 2 },
+		meta: {
+			contextName: "BoundedContext",
+			coreDomain: "supporting",
+		} satisfies BoundedContextShape["meta"],
+	} satisfies BoundedContextShape;
+}
+
+function createAggregate(params: { id: string; x: number; y: number }): ShapeData {
+	return {
+		id: params.id,
+		type: DOMAIN_TYPES.aggregate,
+		x: params.x,
+		y: params.y,
+		width: 200,
+		height: 140,
+		style: { ...DEFAULT_STYLE, fill: "#fefce8", stroke: "#a16207", strokeWidth: 3 },
+		meta: { rootName: "AggregateRoot" } satisfies AggregateShape["meta"],
+	} satisfies AggregateShape;
+}
+
+function createClassBox(params: { id: string; x: number; y: number }): ShapeData {
+	return {
+		id: params.id,
+		type: DOMAIN_TYPES.classBox,
+		x: params.x,
+		y: params.y,
+		width: 180,
+		height: 120,
+		style: { ...DEFAULT_STYLE, fill: "#ffffff", stroke: "#1e1e1e", strokeWidth: 1.5 },
+		meta: {
+			className: "ClassName",
+			stereotype: "Entity",
+			attributes: ["id: ID"],
+			methods: [],
+		} satisfies ClassBoxShape["meta"],
+	} satisfies ClassBoxShape;
+}
+
+function createContextMapConnector(params: { id: string; x: number; y: number }): ShapeData {
+	return {
+		id: params.id,
+		type: DOMAIN_TYPES.contextMapConnector,
+		x: params.x,
+		y: params.y,
+		width: 160,
+		height: 0,
+		style: { ...DEFAULT_STYLE, fill: "transparent", stroke: "#1e1e1e", strokeWidth: 1.5 },
+		meta: {
+			relation: "customer-supplier",
+			upstream: "from",
+		} satisfies ContextMapConnectorShape["meta"],
+	} satisfies ContextMapConnectorShape;
+}
+
+function createTacticalConnector(params: { id: string; x: number; y: number }): ShapeData {
+	return {
+		id: params.id,
+		type: DOMAIN_TYPES.tacticalConnector,
+		x: params.x,
+		y: params.y,
+		width: 160,
+		height: 0,
+		style: { ...DEFAULT_STYLE, fill: "transparent", stroke: "#1e1e1e", strokeWidth: 1.5 },
+		meta: { relation: "association" } satisfies TacticalConnectorShape["meta"],
+	} satisfies TacticalConnectorShape;
+}
+
+// ── 一覧 ──
+
+export const DOMAIN_SUBTYPES: DomainSubtype[] = [
+	{
+		type: DOMAIN_TYPES.boundedContext,
+		label: "Bounded Context",
+		category: "strategic",
+		icon: BoundedContextIcon,
+		createDefault: createBoundedContext,
+		defaultSize: { width: 320, height: 200 },
+	},
+	{
+		type: DOMAIN_TYPES.contextMapConnector,
+		label: "Context Map 関係",
+		category: "relation",
+		icon: ContextMapIcon,
+		createDefault: createContextMapConnector,
+		defaultSize: { width: 160, height: 0 },
+	},
+	{
+		type: DOMAIN_TYPES.aggregate,
+		label: "Aggregate",
+		category: "tactical",
+		icon: AggregateIcon,
+		createDefault: createAggregate,
+		defaultSize: { width: 200, height: 140 },
+	},
+	{
+		type: DOMAIN_TYPES.classBox,
+		label: "Class Box",
+		category: "tactical",
+		icon: ClassBoxIcon,
+		createDefault: createClassBox,
+		defaultSize: { width: 180, height: 120 },
+	},
+	{
+		type: DOMAIN_TYPES.tacticalConnector,
+		label: "戦術関係",
+		category: "relation",
+		icon: TacticalRelationIcon,
+		createDefault: createTacticalConnector,
+		defaultSize: { width: 160, height: 0 },
+	},
+];

--- a/plugins/usketch-plugin-domain-design/src/shapes/aggregate.tsx
+++ b/plugins/usketch-plugin-domain-design/src/shapes/aggregate.tsx
@@ -1,0 +1,76 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { TitleEditor } from "../editor/editors.js";
+import { type AggregateMeta, readMeta } from "../types.js";
+
+export function renderAggregate(shape: ShapeData) {
+	const meta = readMeta<AggregateMeta>(shape);
+	const isEditing = shape["x-domain-editing"] === true;
+
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				background: shape.style.fill,
+				border: `${shape.style.strokeWidth}px solid ${shape.style.stroke}`,
+				borderRadius: "50%",
+				boxSizing: "border-box",
+				padding: 16,
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				gap: 4,
+				overflow: "hidden",
+				opacity: shape.style.opacity,
+			}}
+		>
+			<span
+				style={{
+					fontSize: 9,
+					fontWeight: 500,
+					letterSpacing: 1,
+					color: "#a16207",
+					textTransform: "uppercase",
+				}}
+			>
+				«Aggregate»
+			</span>
+			{isEditing ? (
+				<TitleEditor shapeId={shape.id} initial={meta.rootName ?? ""} field="rootName" />
+			) : (
+				<span
+					style={{
+						fontSize: 16,
+						fontWeight: 600,
+						color: "#1e1e1e",
+						textAlign: "center",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+						maxWidth: "100%",
+					}}
+				>
+					{meta.rootName || "(no name)"}
+				</span>
+			)}
+			{meta.invariants && meta.invariants.length > 0 && (
+				<ul
+					style={{
+						margin: "4px 0 0",
+						padding: "0 0 0 16px",
+						fontSize: 10,
+						color: "#475569",
+						maxHeight: "40%",
+						overflow: "hidden",
+					}}
+				>
+					{meta.invariants.slice(0, 3).map((inv, i) => (
+						// biome-ignore lint/suspicious/noArrayIndexKey: invariant order is stable per shape
+						<li key={i}>{inv}</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-domain-design/src/shapes/bounded-context.tsx
+++ b/plugins/usketch-plugin-domain-design/src/shapes/bounded-context.tsx
@@ -1,0 +1,97 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { TitleEditor } from "../editor/editors.js";
+import { type BoundedContextMeta, readMeta } from "../types.js";
+
+const CORE_DOMAIN_LABEL: Record<NonNullable<BoundedContextMeta["coreDomain"]>, string> = {
+	core: "Core",
+	supporting: "Supporting",
+	generic: "Generic",
+};
+
+const CORE_DOMAIN_ACCENT: Record<NonNullable<BoundedContextMeta["coreDomain"]>, string> = {
+	core: "#dc2626",
+	supporting: "#f97316",
+	generic: "#64748b",
+};
+
+export function renderBoundedContext(shape: ShapeData) {
+	const meta = readMeta<BoundedContextMeta>(shape);
+	const isEditing = shape["x-domain-editing"] === true;
+	const accent = meta.coreDomain != null ? CORE_DOMAIN_ACCENT[meta.coreDomain] : shape.style.stroke;
+
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				background: shape.style.fill,
+				border: `${shape.style.strokeWidth}px dashed ${shape.style.stroke}`,
+				borderRadius: 6,
+				boxSizing: "border-box",
+				padding: 12,
+				display: "flex",
+				flexDirection: "column",
+				gap: 6,
+				overflow: "hidden",
+				opacity: shape.style.opacity,
+			}}
+		>
+			<div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+				<span
+					style={{
+						width: 8,
+						height: 8,
+						borderRadius: 999,
+						background: accent,
+						flexShrink: 0,
+					}}
+				/>
+				{isEditing ? (
+					<TitleEditor shapeId={shape.id} initial={meta.contextName ?? ""} />
+				) : (
+					<span
+						style={{
+							fontSize: 16,
+							fontWeight: 600,
+							color: "#1e1e1e",
+							overflow: "hidden",
+							textOverflow: "ellipsis",
+							whiteSpace: "nowrap",
+						}}
+					>
+						{meta.contextName || "(no name)"}
+					</span>
+				)}
+				{meta.coreDomain != null && (
+					<span
+						style={{
+							marginLeft: "auto",
+							fontSize: 10,
+							fontWeight: 500,
+							color: accent,
+							border: `1px solid ${accent}`,
+							borderRadius: 4,
+							padding: "2px 6px",
+							flexShrink: 0,
+						}}
+					>
+						{CORE_DOMAIN_LABEL[meta.coreDomain]}
+					</span>
+				)}
+			</div>
+			{meta.team && <div style={{ fontSize: 11, color: "#475569" }}>Team: {meta.team}</div>}
+			{meta.description && (
+				<div
+					style={{
+						fontSize: 12,
+						color: "#475569",
+						whiteSpace: "pre-wrap",
+						overflow: "hidden",
+					}}
+				>
+					{meta.description}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-domain-design/src/shapes/class-box.tsx
+++ b/plugins/usketch-plugin-domain-design/src/shapes/class-box.tsx
@@ -1,0 +1,93 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { ClassBoxEditor } from "../editor/editors.js";
+import { type ClassBoxMeta, type ClassStereotype, readMeta } from "../types.js";
+
+const STEREOTYPE_ACCENT: Record<ClassStereotype, string> = {
+	Entity: "#2563eb",
+	ValueObject: "#0891b2",
+	Service: "#7c3aed",
+	Repository: "#16a34a",
+	DomainEvent: "#ea580c",
+	Factory: "#db2777",
+};
+
+export function renderClassBox(shape: ShapeData) {
+	const partial = readMeta<ClassBoxMeta>(shape);
+	const meta: ClassBoxMeta = {
+		className: partial.className ?? "",
+		stereotype: partial.stereotype ?? "Entity",
+		attributes: partial.attributes ?? [],
+		methods: partial.methods ?? [],
+	};
+	const isEditing = shape["x-domain-editing"] === true;
+	const accent = STEREOTYPE_ACCENT[meta.stereotype];
+
+	if (isEditing) {
+		return <ClassBoxEditor shapeId={shape.id} meta={meta} accent={accent} style={shape.style} />;
+	}
+
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				background: shape.style.fill,
+				border: `${shape.style.strokeWidth}px solid ${shape.style.stroke}`,
+				boxSizing: "border-box",
+				display: "flex",
+				flexDirection: "column",
+				overflow: "hidden",
+				opacity: shape.style.opacity,
+				fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+			}}
+		>
+			<div
+				style={{
+					padding: "6px 8px",
+					borderBottom: `1px solid ${shape.style.stroke}`,
+					textAlign: "center",
+					background: `${accent}10`,
+				}}
+			>
+				<div style={{ fontSize: 10, color: accent, fontWeight: 500 }}>«{meta.stereotype}»</div>
+				<div
+					style={{
+						fontSize: 14,
+						fontWeight: 600,
+						color: "#1e1e1e",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+					}}
+				>
+					{meta.className || "(no name)"}
+				</div>
+			</div>
+			<div
+				style={{
+					padding: "4px 8px",
+					borderBottom: `1px solid ${shape.style.stroke}`,
+					fontSize: 11,
+					color: "#1e1e1e",
+					flex: 1,
+					overflow: "hidden",
+					whiteSpace: "pre-wrap",
+				}}
+			>
+				{(meta.attributes ?? []).join("\n")}
+			</div>
+			<div
+				style={{
+					padding: "4px 8px",
+					fontSize: 11,
+					color: "#1e1e1e",
+					flex: 1,
+					overflow: "hidden",
+					whiteSpace: "pre-wrap",
+				}}
+			>
+				{(meta.methods ?? []).join("\n")}
+			</div>
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-domain-design/src/types.ts
+++ b/plugins/usketch-plugin-domain-design/src/types.ts
@@ -1,0 +1,93 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/**
+ * `shape.meta` を型付き view に変換する境界 helper。
+ * `ShapeData<TMeta>` の `meta` は generic 共変性の制約上、render 側で
+ * unknown 経由のキャストが必要になる。その escape をこの関数 1 箇所に閉じ込め、
+ * 利用側 (shapes/* / connectors/*) は型付きアクセスだけで済むようにする。
+ */
+export function readMeta<T>(shape: ShapeData): Partial<T> {
+	return (shape.meta ?? {}) as unknown as Partial<T>;
+}
+
+// ── 識別子 ──
+
+export const DOMAIN_TYPES = {
+	boundedContext: "domain-bounded-context",
+	aggregate: "domain-aggregate",
+	classBox: "domain-class-box",
+	contextMapConnector: "domain-context-map-connector",
+	tacticalConnector: "domain-tactical-connector",
+} as const;
+
+// ── 戦略レベル ──
+
+export interface BoundedContextMeta {
+	contextName: string;
+	team?: string;
+	coreDomain?: "core" | "supporting" | "generic";
+	description?: string;
+}
+
+export type BoundedContextShape = ShapeData<BoundedContextMeta>;
+
+export type ContextMapRelation =
+	| "customer-supplier"
+	| "conformist"
+	| "anticorruption-layer"
+	| "shared-kernel"
+	| "open-host-service"
+	| "partnership"
+	| "published-language"
+	| "separate-ways";
+
+export interface ContextMapConnectorMeta {
+	relation: ContextMapRelation;
+	upstream?: "from" | "to";
+	notes?: string;
+}
+
+export type ContextMapConnectorShape = ShapeData<ContextMapConnectorMeta>;
+
+// ── 戦術レベル ──
+
+export interface AggregateMeta {
+	rootName: string;
+	invariants?: string[];
+}
+
+export type AggregateShape = ShapeData<AggregateMeta>;
+
+export type ClassStereotype =
+	| "Entity"
+	| "ValueObject"
+	| "Service"
+	| "Repository"
+	| "DomainEvent"
+	| "Factory";
+
+export interface ClassBoxMeta {
+	className: string;
+	stereotype: ClassStereotype;
+	attributes: string[];
+	methods: string[];
+}
+
+export type ClassBoxShape = ShapeData<ClassBoxMeta>;
+
+export type TacticalRelation =
+	| "inheritance"
+	| "composition"
+	| "aggregation"
+	| "association"
+	| "dependency"
+	| "realization";
+
+export interface TacticalConnectorMeta {
+	relation: TacticalRelation;
+	multiplicityFrom?: string;
+	multiplicityTo?: string;
+	label?: string;
+}
+
+export type TacticalConnectorShape = ShapeData<TacticalConnectorMeta>;

--- a/plugins/usketch-plugin-domain-design/src/types.ts
+++ b/plugins/usketch-plugin-domain-design/src/types.ts
@@ -41,7 +41,17 @@ export type ContextMapRelation =
 	| "published-language"
 	| "separate-ways";
 
-export interface ContextMapConnectorMeta {
+/**
+ * connector の bbox は通常 shape と同じく非負化された AABB。
+ * 始点 / 終点座標は AABB 相対で `start` / `end` に保持し、
+ * 矢印方向や反転を表現する。
+ */
+export interface ConnectorEndpoints {
+	start: { x: number; y: number };
+	end: { x: number; y: number };
+}
+
+export interface ContextMapConnectorMeta extends Partial<ConnectorEndpoints> {
 	relation: ContextMapRelation;
 	upstream?: "from" | "to";
 	notes?: string;
@@ -83,7 +93,7 @@ export type TacticalRelation =
 	| "dependency"
 	| "realization";
 
-export interface TacticalConnectorMeta {
+export interface TacticalConnectorMeta extends Partial<ConnectorEndpoints> {
 	relation: TacticalRelation;
 	multiplicityFrom?: string;
 	multiplicityTo?: string;

--- a/plugins/usketch-plugin-domain-design/tsconfig.json
+++ b/plugins/usketch-plugin-domain-design/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       '@edv4h/usketch-plugin-community-chat':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-community-chat
+      '@edv4h/usketch-plugin-domain-design':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-domain-design
       '@edv4h/usketch-plugin-effect-ripple':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-effect-ripple
@@ -923,6 +926,40 @@ importers:
       react:
         specifier: '>=19'
         version: 19.1.0
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  plugins/usketch-plugin-domain-design:
+    dependencies:
+      '@edv4h/usketch-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@edv4h/usketch-shape-utils':
+        specifier: workspace:*
+        version: link:../../packages/usketch-shape-utils
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@zag-js/core':
+        specifier: ^1.37.0
+        version: 1.37.0
+      '@zag-js/vanilla':
+        specifier: ^1.37.0
+        version: 1.37.0
+      react:
+        specifier: '>=19'
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -3673,19 +3710,19 @@ packages:
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
   '@zag-js/core@1.37.0':
-    resolution: {integrity: sha512-KtMccuGPIR8MF7XKKNBgudyt4W37jnM0PFSFZmYrlOZOqUe3kBDdVqDcRKcEPUj1+XwUGTANmFAahNqsSt8I7Q==}
+    resolution: {integrity: sha512-KtMccuGPIR8MF7XKKNBgudyt4W37jnM0PFSFZmYrlOZOqUe3kBDdVqDcRKcEPUj1+XwUGTANmFAahNqsSt8I7Q==, tarball: https://registry.npmjs.org/@zag-js/core/-/core-1.37.0.tgz}
 
   '@zag-js/dom-query@1.37.0':
-    resolution: {integrity: sha512-nL3z5UOvRMDL5iBrNMs6Rm8vm5qC6Vt0FykFAhEL++mC01W0xpO/KKJNcpdooGFYQxwHBbgI/djE+sq9yY3pNw==}
+    resolution: {integrity: sha512-nL3z5UOvRMDL5iBrNMs6Rm8vm5qC6Vt0FykFAhEL++mC01W0xpO/KKJNcpdooGFYQxwHBbgI/djE+sq9yY3pNw==, tarball: https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.37.0.tgz}
 
   '@zag-js/store@1.37.0':
     resolution: {integrity: sha512-7/wHuiSPVlq+OK9TMpZMWB8QC1LidWV9w1eelpID9oL274441re4ydB+bcHWJFtBv6Mio5ujDmFoVhDgLDig6A==}
 
   '@zag-js/types@1.37.0':
-    resolution: {integrity: sha512-auzzQI7+MtZvU8q5C9yNkg/DQqAT3ar9drE4rQFz1OERpaXtyp/JaeT3/t7IXDrocJBy0CY7vfrJSb+CIfjPzw==}
+    resolution: {integrity: sha512-auzzQI7+MtZvU8q5C9yNkg/DQqAT3ar9drE4rQFz1OERpaXtyp/JaeT3/t7IXDrocJBy0CY7vfrJSb+CIfjPzw==, tarball: https://registry.npmjs.org/@zag-js/types/-/types-1.37.0.tgz}
 
   '@zag-js/utils@1.37.0':
-    resolution: {integrity: sha512-3YUZAT5LMiBK0FwEBLOaujbsHMC2uAQ7RyCEhiFYkRm0zvmqehPLCqccMtOnh9lBsLG3GKf+OWKxwfTtkvbh3w==}
+    resolution: {integrity: sha512-3YUZAT5LMiBK0FwEBLOaujbsHMC2uAQ7RyCEhiFYkRm0zvmqehPLCqccMtOnh9lBsLG3GKf+OWKxwfTtkvbh3w==, tarball: https://registry.npmjs.org/@zag-js/utils/-/utils-1.37.0.tgz}
 
   '@zag-js/vanilla@1.37.0':
     resolution: {integrity: sha512-2k3KME2WXRqqR8MRi09UWExcaZx8Y1050fGYxqL4KfOZaXPDNMfiQChEAMU9atdudnzx//HcxEl/orZU8G+qFg==}
@@ -4128,7 +4165,7 @@ packages:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==, tarball: https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz}
 
   debug@4.4.3:
-    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==, tarball: https://registry.npmjs.org/debug/-/debug-4.4.3.tgz}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'


### PR DESCRIPTION
## Summary

DDD（戦略 + 戦術）の図を描くための新プラグイン \`@edv4h/usketch-plugin-domain-design\` を追加します。

- **戦略レベル**: BoundedContext shape, ContextMap relation connector (Customer/Supplier, Conformist, ACL, Shared Kernel, OHS, Partnership, Published Language, Separate Ways)
- **戦術レベル**: Aggregate shape, ClassBox shape (Entity / ValueObject / Service / Repository / DomainEvent / Factory + 属性 + メソッド), 関係矢印 (inheritance / realization / composition / aggregation / association / dependency)
- **ツール**: \`domain-draw\` (shortcut \`d\`) で 5 shape を切り替えながら描画
- **インライン編集**: ClassBox / Aggregate / BoundedContext はダブルクリック編集対応 (state machine + contentEditable)
- **\`meta\` 利用**: \`ShapeData<TMeta>\` の \`meta\` フィールドにドメインデータを保持する初の公式プラグイン (shape-system.mdx の推奨パターンを実体化)

\`apps/web\` の \`basePlugins\` にも追加済み。\`apps/docs\` にガイドページ \`/guides/domain-design-plugin\` を追加。

## Test plan

- [x] \`pnpm --filter @edv4h/usketch-plugin-domain-design typecheck\` — 0 エラー
- [x] \`pnpm --filter @edv4h/usketch-plugin-domain-design test\` — 12 / 12 pass
- [x] \`pnpm turbo typecheck --continue\` — 132 / 132 pass
- [x] \`pnpm turbo test --continue\` — 131 / 131 pass
- [x] \`pnpm biome check plugins/usketch-plugin-domain-design apps/web apps/docs\` — clean
- [ ] \`apps/web\` 起動後、ブラウザで以下を確認 (リリース前にレビュアーが手動確認):
  - [ ] ツールバーから domain-draw を選択 → BoundedContext / Aggregate / ClassBox が描画できる
  - [ ] ContextMap / Tactical connector が 2 点クリックで描画できる
  - [ ] ClassBox をダブルクリック → 3 セクションのインライン編集が起動
  - [ ] BoundedContext / Aggregate のタイトル 1 行編集が起動
  - [ ] 編集確定 (blur / Enter) で meta が更新される
  - [ ] undo / redo で編集前後の meta が正しく復元

## フォローアップ (本 PR スコープ外)

- 既存プラグイン (\`connector\` / \`frame\` / \`text\` / \`wireframe\`) を \`meta\` ベースに移行する RFC
- connector ラベルの編集 UX (線上のラベル位置管理)
- イベントストーミング用プラグイン (Event / Command / Policy / ReadModel)
- DDD 図の export (PlantUML / Mermaid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)