### PR TITLE
🐛 fix(plugin-domain-design): connector 表示崩れと changeset エラーを修正

### DIFF
--- a/.changeset/domain-design-plugin.md
+++ b/.changeset/domain-design-plugin.md
@@ -1,6 +1,5 @@
 ---
 "@edv4h/usketch-plugin-domain-design": minor
-"@edv4h/usketch-web": patch
 ---
 
 Add `@edv4h/usketch-plugin-domain-design` — the official plugin for drawing **DDD** diagrams (both strategic and tactical) on a uSketch board.

--- a/plugins/usketch-plugin-domain-design/src/connectors/context-map.tsx
+++ b/plugins/usketch-plugin-domain-design/src/connectors/context-map.tsx
@@ -17,15 +17,15 @@ export function renderContextMapConnector(shape: ShapeData) {
 	const relation = meta.relation ?? "customer-supplier";
 	const label = RELATION_LABEL[relation];
 
-	// shape.width / shape.height は AABB のため非負。
-	// 始点 / 終点は meta.start / meta.end（AABB 相対座標）から読む。
-	// 後方互換: meta が無い場合は対角線の左上 → 右下を使う。
+	// `ShapeLayer` が外側 `<svg>` を `viewBox=${shape.x} ${shape.y} ${w} ${h}` の
+	// world 座標で wrap するため、renderer は `<g>` を返して world 座標で描画する。
+	// meta.start / meta.end は AABB 相対なので、shape.x / shape.y を加算する。
 	const start = meta.start ?? { x: 0, y: 0 };
 	const end = meta.end ?? { x: shape.width, y: shape.height };
-	const x1 = start.x;
-	const y1 = start.y;
-	const x2 = end.x;
-	const y2 = end.y;
+	const x1 = shape.x + start.x;
+	const y1 = shape.y + start.y;
+	const x2 = shape.x + end.x;
+	const y2 = shape.y + end.y;
 	const dashed = relation === "separate-ways" || relation === "anticorruption-layer";
 	const upstreamLabel =
 		meta.upstream === "from" ? "U → D" : meta.upstream === "to" ? "D ← U" : null;
@@ -34,13 +34,7 @@ export function renderContextMapConnector(shape: ShapeData) {
 	const midY = (y1 + y2) / 2;
 
 	return (
-		<svg
-			width="100%"
-			height="100%"
-			viewBox={`0 0 ${Math.max(shape.width, 1)} ${Math.max(shape.height, 1)}`}
-			preserveAspectRatio="none"
-			style={{ overflow: "visible", opacity: shape.style.opacity }}
-		>
+		<g opacity={shape.style.opacity}>
 			<title>
 				{label.full}
 				{upstreamLabel ? ` (${upstreamLabel})` : ""}
@@ -77,6 +71,6 @@ export function renderContextMapConnector(shape: ShapeData) {
 					{label.short}
 				</text>
 			</g>
-		</svg>
+		</g>
 	);
 }

--- a/plugins/usketch-plugin-domain-design/src/connectors/tactical.tsx
+++ b/plugins/usketch-plugin-domain-design/src/connectors/tactical.tsx
@@ -21,15 +21,15 @@ export function renderTacticalConnector(shape: ShapeData) {
 	const relation: TacticalRelation = meta.relation ?? "association";
 	const styleSpec = RELATION_STYLE[relation];
 
-	// shape.width / shape.height は AABB のため非負。
-	// 始点 / 終点は meta.start / meta.end（AABB 相対座標）から読む。
-	// 後方互換: meta が無い場合は対角線の左上 → 右下を使う。
+	// `ShapeLayer` が外側 `<svg>` を `viewBox=${shape.x} ${shape.y} ${w} ${h}` の
+	// world 座標で wrap するため、renderer は `<g>` を返して world 座標で描画する。
+	// meta.start / meta.end は AABB 相対なので、shape.x / shape.y を加算する。
 	const start = meta.start ?? { x: 0, y: 0 };
 	const end = meta.end ?? { x: shape.width, y: shape.height };
-	const x1 = start.x;
-	const y1 = start.y;
-	const x2 = end.x;
-	const y2 = end.y;
+	const x1 = shape.x + start.x;
+	const y1 = shape.y + start.y;
+	const x2 = shape.x + end.x;
+	const y2 = shape.y + end.y;
 	const stroke = shape.style.stroke;
 	const sw = shape.style.strokeWidth;
 
@@ -46,7 +46,6 @@ export function renderTacticalConnector(shape: ShapeData) {
 	function head() {
 		switch (styleSpec.headShape) {
 			case "triangle": {
-				// 二等辺三角形（先端が tip、底辺が base）
 				const baseX = x2 - cos * headSize;
 				const baseY = y2 - sin * headSize;
 				const halfBase = headSize * 0.5;
@@ -105,13 +104,7 @@ export function renderTacticalConnector(shape: ShapeData) {
 	const toLabel = meta.multiplicityTo ?? "";
 
 	return (
-		<svg
-			width="100%"
-			height="100%"
-			viewBox={`0 0 ${Math.max(shape.width, 1)} ${Math.max(shape.height, 1)}`}
-			preserveAspectRatio="none"
-			style={{ overflow: "visible", opacity: shape.style.opacity }}
-		>
+		<g opacity={shape.style.opacity}>
 			<title>{`${relation}${labelText ? `: ${labelText}` : ""}`}</title>
 			<line
 				x1={x1}
@@ -150,6 +143,6 @@ export function renderTacticalConnector(shape: ShapeData) {
 					{toLabel}
 				</text>
 			)}
-		</svg>
+		</g>
 	);
 }


### PR DESCRIPTION
## Summary

PR #587 マージ後に判明した 3 件のホットフィックス。

### 1. connector が描画位置からズレる (重大)

`@edv4h/usketch-plugin-domain-design` の connector renderer が **ネストした `<svg>` + ローカル座標 + `viewBox=\"0 0 ...\"`** で描画していたため、`shape.x` / `shape.y` が非ゼロのとき connector の線とラベルが画面左上にズレて表示されていました。

`ShapeLayer` は SVG shape を `viewBox=\${shape.x} \${shape.y} \${w} \${h}` の外側 `<svg>` で wrap するため、renderer は **`<g>` を返して world 座標で描画する** のが正しい契約です（既存の `connector` plugin も同様）。

### 2. ツールバーから subtype を切り替える UI が無い

`domain-draw` ツールは `domain-design:select-subtype` イベントで subtype を切り替える設計だが、apps/web のツールバーにその picker UI が無く、先頭 subtype（BoundedContext）しか描けない状態でした。`ToolButton` に DomainDrawPicker を実装し、ツールバー上で 5 種の subtype をポップアップから選べるように。

### 3. release pipeline が \`Mixed changesets\` で失敗

\`.changeset/domain-design-plugin.md\` で \`@edv4h/usketch-plugin-domain-design\` (公開) と \`@edv4h/usketch-web\` (\`.changeset/config.json\` の \`ignore\` 配列) を 1 つの changeset に同居させていたため、\`pnpm changeset version\` が \`Mixed changesets that contain both ignored and not ignored packages are not allowed\` で失敗していました。

## 変更点

- \`plugins/usketch-plugin-domain-design/src/connectors/context-map.tsx\`: \`<svg>\` ラッパーを削除して \`<g>\` 化、line / ラベル rect / text を world 座標で描画
- \`plugins/usketch-plugin-domain-design/src/connectors/tactical.tsx\`: 同上、line / 矢頭 polygon / labels / multiplicity text を world 座標化
- \`apps/web/src/components/toolbar/tool-button.tsx\`: \`domain-draw\` 用の DomainDrawPicker を追加
- \`.changeset/domain-design-plugin.md\`: \`@edv4h/usketch-web\` 行を削除（apps/web は ignore 対象、bump 不要）

## Test plan

- [x] \`pnpm --filter @edv4h/usketch-plugin-domain-design typecheck\` — 0 エラー
- [x] \`pnpm --filter @edv4h/usketch-plugin-domain-design test\` — 12 / 12 pass
- [x] \`pnpm --filter @edv4h/usketch-web typecheck\` — clean
- [x] \`pnpm biome check apps/web plugins/usketch-plugin-domain-design\` — clean
- [x] \`pnpm changeset status\` — エラーなく status 取得可
- [ ] main マージ後にブラウザで domain-design ボードを開き、connector が正しい位置に描画されることを確認
- [ ] ツールバーから domain-draw を選択 → 5 subtype の picker が表示され、選択した subtype を描画できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)