### PR TITLE
✨ feat: サーバ未同期 Shape を UI で警告

### DIFF
--- a/.changeset/sync-divergence-indicator.md
+++ b/.changeset/sync-divergence-indicator.md
@@ -1,0 +1,22 @@
+---
+"@edv4h/usketch-plugin-sync-ywebsocket": minor
+"@edv4h/usketch-plugin-debug-hud": minor
+---
+
+サーバ未同期 Shape を UI で警告できるようにした。
+
+`SyncStatusTracker` に `unconfirmedShapeIds: readonly string[]` を追加し、
+`provider.on("sync")` 時にサーバが認識している shape ID 集合を確定スナップショット
+として記録。以降、ローカル側のみで `shape:added` された (= サーバから来ていない、
+あるいは IndexedDB に残っていただけの) shape は「未確定」として識別される。
+
+UI の表示先:
+
+- ywebsocket plugin が新しい canvas overlay (`unconfirmed-shapes-overlay`,
+  layer order 250) を register。未確定 shape の右上に小さな赤い `!` バッジを
+  描画 (pointer events 無効、診断のみ)。
+- debug HUD の General パネルに「⚠ サーバ未同期 Shape: N 件」行を追加。
+- debug HUD の Shapes パネルで各行に「⚠ 未同期」バッジを表示。ヘッダの件数
+  バッジをクリックすると未同期のみフィルタ。
+
+ywebsocket plugin が組まれていない (IndexedDB-only) ボードでは何も表示されない。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,6 +61,7 @@
 		"@edv4h/usketch-plugin-shape-wireframe": "workspace:*",
 		"@edv4h/usketch-plugin-snap": "workspace:*",
 		"@edv4h/usketch-plugin-sync-localstorage-yjs": "workspace:*",
+		"@edv4h/usketch-plugin-sync-ywebsocket": "workspace:*",
 		"@edv4h/usketch-plugin-tool-pan": "workspace:*",
 		"@edv4h/usketch-plugin-tool-select": "workspace:*",
 		"@edv4h/usketch-plugin-viewport-nav": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -34,6 +34,11 @@ import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
 import { snapPlugin } from "@edv4h/usketch-plugin-snap";
 import { createSpotlightPlugin, spotlightPlugin } from "@edv4h/usketch-plugin-spotlight";
 import { createYjsSync } from "@edv4h/usketch-plugin-sync-localstorage-yjs";
+import {
+	createDivergenceTracker,
+	type DivergenceTrackerHandle,
+	UnconfirmedOverlay,
+} from "@edv4h/usketch-plugin-sync-ywebsocket";
 import { panToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
 import { selectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
 import { viewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
@@ -163,6 +168,10 @@ export function App() {
 
 		const extraPlugins: UsketchPlugin[] = [];
 		let wsProvider: WsProviderHandle | null = null;
+		// Divergence tracker — surfaces shapes that exist in the local Y.Doc
+		// but the server hasn't acknowledged. Wired up only for cloud boards
+		// because local boards never round-trip with a server.
+		let divergenceHandle: DivergenceTrackerHandle | null = null;
 
 		if (isCloudBoard) {
 			const apiUrl = import.meta.env.VITE_API_URL ?? "http://localhost:8787";
@@ -177,6 +186,18 @@ export function App() {
 			wsProvider = createWsProvider({ url: wsUrl, doc: syncHandle.doc });
 			wsProviderRef.current = wsProvider;
 			wsProvider.onStatusChange(setWsStatus);
+
+			// Replace the IDB-only sync status (which can't see server divergence)
+			// with the divergence-aware tracker for cloud boards. The Debug HUD and
+			// the canvas overlay both read from `__usketchSyncStatus`.
+			const wsP = wsProvider;
+			divergenceHandle = createDivergenceTracker({
+				store,
+				doc: syncHandle.doc,
+				shapesMap: syncHandle.doc.getMap<Record<string, unknown>>("shapes"),
+				onConnectionStatusChange: (handler) => wsP.onStatusChange(handler),
+			});
+			(globalThis as Record<string, unknown>).__usketchSyncStatus = divergenceHandle.status;
 
 			extraPlugins.push(createLaserPlugin(wsProvider));
 			extraPlugins.push(createSpotlightPlugin(wsProvider));
@@ -261,6 +282,25 @@ export function App() {
 							render: (renderCtx) => <TransientLayer registry={a.transient} ctx={renderCtx} />,
 						});
 
+						// Surface shapes that diverge from the server's Y.Doc.
+						// Cloud boards only — local boards have no server to diverge from.
+						if (divergenceHandle) {
+							const tracker = divergenceHandle.status;
+							a.layers.register({
+								id: "unconfirmed-shapes-overlay",
+								order: 250,
+								fixed: true,
+								render: (renderCtx) => (
+									<UnconfirmedOverlay
+										store={a.store}
+										shapes={a.shapes}
+										viewport={renderCtx.viewport}
+										syncStatus={tracker}
+									/>
+								),
+							});
+						}
+
 						setApp(instance);
 					});
 			})
@@ -275,6 +315,7 @@ export function App() {
 			instance?.destroy();
 			wsProvider?.destroy();
 			wsProviderRef.current = null;
+			divergenceHandle?.destroy();
 			syncHandle.destroy();
 			delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
 			setApp(null);

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
 		"@j178/prek": "0.3.8",
 		"turbo": "2.8.20",
 		"typescript": "5.9.3"
+	},
+	"pnpm": {
+		"overrides": {
+			"react": "19.2.4",
+			"react-dom": "19.2.4"
+		}
 	}
 }

--- a/plugins/usketch-plugin-debug-hud/src/debug-hud.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/debug-hud.tsx
@@ -7,7 +7,7 @@ import type {
 	ShapeRegistry,
 	ToolRegistry,
 } from "@edv4h/usketch-shared";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import type { EventLogger } from "./event-logger.js";
 import type { FpsCounter } from "./fps-counter.js";
 import { Minimap } from "./overlays/minimap.js";
@@ -88,6 +88,18 @@ export function DebugHud({
 	const { viewport, shapes: shapeMap, selection } = ctx;
 	const activeToolId = store.getActiveToolId();
 
+	// Subscribe to sync status so the Shapes panel can highlight unconfirmed
+	// shape IDs. Snapshot is undefined when no sync layer is loaded.
+	const syncSnapshot = useSyncExternalStore(
+		(cb) => syncStatus?.subscribe(cb) ?? (() => {}),
+		() => syncStatus?.getSnapshot(),
+		() => syncStatus?.getSnapshot(),
+	);
+	const unconfirmedShapeIdSet = useMemo(
+		() => new Set(syncSnapshot?.unconfirmedShapeIds ?? []),
+		[syncSnapshot?.unconfirmedShapeIds],
+	);
+
 	const hoveredShape = hoveredShapeId ? shapeMap.get(hoveredShapeId) : undefined;
 
 	// Shortcut hint — bottom-center (always visible)
@@ -141,6 +153,7 @@ export function DebugHud({
 				shapes={shapeMap}
 				selection={selection}
 				onHoverShape={setHoveredShapeId}
+				unconfirmedShapeIds={unconfirmedShapeIdSet}
 			/>
 
 			{/* Right-bottom: Event Log */}

--- a/plugins/usketch-plugin-debug-hud/src/debug-hud.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/debug-hud.tsx
@@ -7,7 +7,7 @@ import type {
 	ShapeRegistry,
 	ToolRegistry,
 } from "@edv4h/usketch-shared";
-import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import type { EventLogger } from "./event-logger.js";
 import type { FpsCounter } from "./fps-counter.js";
 import { Minimap } from "./overlays/minimap.js";
@@ -89,12 +89,15 @@ export function DebugHud({
 	const activeToolId = store.getActiveToolId();
 
 	// Subscribe to sync status so the Shapes panel can highlight unconfirmed
-	// shape IDs. Snapshot is undefined when no sync layer is loaded.
-	const syncSnapshot = useSyncExternalStore(
-		(cb) => syncStatus?.subscribe(cb) ?? (() => {}),
-		() => syncStatus?.getSnapshot(),
-		() => syncStatus?.getSnapshot(),
+	// shape IDs. Snapshot is undefined when no sync layer is loaded. Stable
+	// callbacks avoid resubscribe churn during unrelated re-renders (HUD
+	// re-renders frequently due to FPS / pointer / event log updates).
+	const subscribeSync = useCallback(
+		(cb: () => void) => syncStatus?.subscribe(cb) ?? (() => {}),
+		[syncStatus],
 	);
+	const getSyncSnapshot = useCallback(() => syncStatus?.getSnapshot(), [syncStatus]);
+	const syncSnapshot = useSyncExternalStore(subscribeSync, getSyncSnapshot, getSyncSnapshot);
 	const unconfirmedShapeIdSet = useMemo(
 		() => new Set(syncSnapshot?.unconfirmedShapeIds ?? []),
 		[syncSnapshot?.unconfirmedShapeIds],

--- a/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
@@ -21,7 +21,7 @@ import {
 	PANEL_BASE,
 	SECTION_STYLE,
 } from "../styles.js";
-import type { SyncStatusTrackerLike } from "../sync-status-types.js";
+import type { SyncStatusSnapshot, SyncStatusTrackerLike } from "../sync-status-types.js";
 
 interface GpuStats {
 	gpuShapeCount: number;
@@ -43,11 +43,12 @@ interface GeneralPanelProps {
 	activeToolId: string;
 }
 
-const DEFAULT_SYNC_SNAPSHOT = {
-	state: "loading" as const,
+const DEFAULT_SYNC_SNAPSHOT: SyncStatusSnapshot = {
+	state: "loading",
 	shapeCount: 0,
 	lastSyncedAt: null,
 	error: null,
+	unconfirmedShapeIds: [],
 };
 
 const SYNC_STATE_COLORS: Record<string, string> = {
@@ -254,6 +255,22 @@ export function GeneralPanel({
 				<div>
 					Shapes: {syncSnapshot.shapeCount} · Last: {formatTimestamp(syncSnapshot.lastSyncedAt)}
 				</div>
+				{syncSnapshot.unconfirmedShapeIds && syncSnapshot.unconfirmedShapeIds.length > 0 && (
+					<div
+						style={{
+							marginTop: 4,
+							padding: "3px 6px",
+							borderRadius: 3,
+							background: "#7f1d1d",
+							color: "#fecaca",
+							fontSize: 10,
+							fontWeight: 600,
+						}}
+						title="サーバの Y.Doc に存在しない Shape が IndexedDB に残っています"
+					>
+						⚠ サーバ未同期 Shape: {syncSnapshot.unconfirmedShapeIds.length} 件
+					</div>
+				)}
 				{syncSnapshot.error && (
 					<div style={{ color: "#f87171", fontSize: 10 }}>{syncSnapshot.error}</div>
 				)}

--- a/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
@@ -53,15 +53,19 @@ const DEFAULT_SYNC_SNAPSHOT: SyncStatusSnapshot = {
 
 const SYNC_STATE_COLORS: Record<string, string> = {
 	loading: "#fbbf24",
+	connecting: "#fbbf24",
 	synced: "#4ade80",
 	syncing: "#60a5fa",
+	disconnected: "#9ca3af",
 	error: "#f87171",
 };
 
 const SYNC_STATE_LABELS: Record<string, string> = {
 	loading: "Loading…",
+	connecting: "Connecting…",
 	synced: "Synced",
 	syncing: "Syncing…",
+	disconnected: "Disconnected",
 	error: "Error",
 };
 
@@ -255,10 +259,11 @@ export function GeneralPanel({
 				<div>
 					Shapes: {syncSnapshot.shapeCount} · Last: {formatTimestamp(syncSnapshot.lastSyncedAt)}
 				</div>
-				{/* Only show divergence once we've actually synced with the server.
-				    Before that, every IndexedDB-restored shape would look "unconfirmed"
-				    because we don't know yet what the server holds. */}
-				{syncSnapshot.state === "synced" &&
+				{/* Only show divergence after we've heard from the server at least
+				    once. Use `lastSyncedAt != null` (rather than the current state)
+				    so the warning persists when the connection later drops — that's
+				    when offline edits accumulate and the user needs to know. */}
+				{syncSnapshot.lastSyncedAt !== null &&
 					syncSnapshot.unconfirmedShapeIds &&
 					syncSnapshot.unconfirmedShapeIds.length > 0 && (
 						<div

--- a/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
@@ -47,6 +47,7 @@ const DEFAULT_SYNC_SNAPSHOT: SyncStatusSnapshot = {
 	state: "loading",
 	shapeCount: 0,
 	lastSyncedAt: null,
+	firstServerSyncAt: null,
 	error: null,
 	unconfirmedShapeIds: [],
 };
@@ -259,11 +260,13 @@ export function GeneralPanel({
 				<div>
 					Shapes: {syncSnapshot.shapeCount} · Last: {formatTimestamp(syncSnapshot.lastSyncedAt)}
 				</div>
-				{/* Only show divergence after we've heard from the server at least
-				    once. Use `lastSyncedAt != null` (rather than the current state)
-				    so the warning persists when the connection later drops — that's
-				    when offline edits accumulate and the user needs to know. */}
-				{syncSnapshot.lastSyncedAt !== null &&
+				{/* Only show divergence after the server has confirmed us at least
+				    once. We rely on `firstServerSyncAt` (set only on `provider sync`)
+				    rather than `lastSyncedAt` (which also moves on local edits) so
+				    warnings don't leak during the initial connecting phase. Once
+				    that timestamp is set the gate stays open across reconnections,
+				    which is exactly when offline edits accumulate. */}
+				{syncSnapshot.firstServerSyncAt != null &&
 					syncSnapshot.unconfirmedShapeIds &&
 					syncSnapshot.unconfirmedShapeIds.length > 0 && (
 						<div

--- a/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
@@ -255,22 +255,27 @@ export function GeneralPanel({
 				<div>
 					Shapes: {syncSnapshot.shapeCount} · Last: {formatTimestamp(syncSnapshot.lastSyncedAt)}
 				</div>
-				{syncSnapshot.unconfirmedShapeIds && syncSnapshot.unconfirmedShapeIds.length > 0 && (
-					<div
-						style={{
-							marginTop: 4,
-							padding: "3px 6px",
-							borderRadius: 3,
-							background: "#7f1d1d",
-							color: "#fecaca",
-							fontSize: 10,
-							fontWeight: 600,
-						}}
-						title="サーバの Y.Doc に存在しない Shape が IndexedDB に残っています"
-					>
-						⚠ サーバ未同期 Shape: {syncSnapshot.unconfirmedShapeIds.length} 件
-					</div>
-				)}
+				{/* Only show divergence once we've actually synced with the server.
+				    Before that, every IndexedDB-restored shape would look "unconfirmed"
+				    because we don't know yet what the server holds. */}
+				{syncSnapshot.state === "synced" &&
+					syncSnapshot.unconfirmedShapeIds &&
+					syncSnapshot.unconfirmedShapeIds.length > 0 && (
+						<div
+							style={{
+								marginTop: 4,
+								padding: "3px 6px",
+								borderRadius: 3,
+								background: "#7f1d1d",
+								color: "#fecaca",
+								fontSize: 10,
+								fontWeight: 600,
+							}}
+							title="サーバの Y.Doc に存在しない Shape が IndexedDB に残っています"
+						>
+							⚠ サーバ未同期 Shape: {syncSnapshot.unconfirmedShapeIds.length} 件
+						</div>
+					)}
 				{syncSnapshot.error && (
 					<div style={{ color: "#f87171", fontSize: 10 }}>{syncSnapshot.error}</div>
 				)}

--- a/plugins/usketch-plugin-debug-hud/src/panels/shapes-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/shapes-panel.tsx
@@ -19,6 +19,9 @@ interface ShapesPanelProps {
 	shapes: ReadonlyMap<string, ShapeData>;
 	selection: ReadonlySet<string>;
 	onHoverShape: (id: string | null) => void;
+	/** Shapes that exist locally but the server hasn't acknowledged. Empty if the
+	 * sync layer doesn't track divergence. */
+	unconfirmedShapeIds?: ReadonlySet<string>;
 }
 
 const KNOWN_KEYS = new Set(["id", "type", "x", "y", "width", "height", "style", "rotation"]);
@@ -85,9 +88,14 @@ export function ShapesPanel({
 	shapes,
 	selection,
 	onHoverShape,
+	unconfirmedShapeIds,
 }: ShapesPanelProps) {
 	const [expandedId, setExpandedId] = useState<string | null>(null);
-	const shapeEntries = Array.from(shapes.values());
+	const [filterUnconfirmed, setFilterUnconfirmed] = useState(false);
+	const unconfirmedCount = unconfirmedShapeIds?.size ?? 0;
+	const shapeEntries = Array.from(shapes.values()).filter((s) =>
+		filterUnconfirmed ? unconfirmedShapeIds?.has(s.id) : true,
+	);
 
 	const updateField = (id: string, field: string, value: number) => {
 		const shape = store.getShape(id);
@@ -122,7 +130,32 @@ export function ShapesPanel({
 				flexDirection: "column",
 			}}
 		>
-			<div style={LABEL_STYLE}>Shapes ({shapes.size})</div>
+			<div
+				style={{
+					...LABEL_STYLE,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					gap: 6,
+				}}
+			>
+				<span>Shapes ({shapes.size})</span>
+				{unconfirmedCount > 0 && (
+					<button
+						type="button"
+						onClick={() => setFilterUnconfirmed((v) => !v)}
+						style={{
+							...MINI_BUTTON,
+							background: filterUnconfirmed ? "#7f1d1d" : "transparent",
+							color: filterUnconfirmed ? "#fecaca" : "#f87171",
+							border: "1px solid #7f1d1d",
+						}}
+						title="サーバ未同期 Shape のみを表示"
+					>
+						⚠ {unconfirmedCount}
+					</button>
+				)}
+			</div>
 			<div style={{ ...SCROLLABLE_STYLE, flexGrow: 1, maxHeight: "none" }}>
 				{shapeEntries.length === 0 ? (
 					<div style={{ color: TEXT_MUTED }}>No shapes</div>
@@ -130,6 +163,7 @@ export function ShapesPanel({
 					shapeEntries.map((s) => {
 						const isSelected = selection.has(s.id);
 						const isExpanded = expandedId === s.id;
+						const isUnconfirmed = unconfirmedShapeIds?.has(s.id) ?? false;
 						return (
 							// biome-ignore lint/a11y/noStaticElementInteractions: debug tool
 							<div
@@ -154,6 +188,22 @@ export function ShapesPanel({
 									<span>
 										{isExpanded ? "▾" : "▸"} {shortId(s.id)}{" "}
 										<span style={{ color: TEXT_MUTED }}>{s.type}</span>
+										{isUnconfirmed && (
+											<span
+												style={{
+													marginLeft: 4,
+													padding: "0 4px",
+													borderRadius: 2,
+													background: "#7f1d1d",
+													color: "#fecaca",
+													fontSize: 9,
+													fontWeight: 600,
+												}}
+												title="サーバの Y.Doc に存在しません"
+											>
+												⚠ 未同期
+											</span>
+										)}
 									</span>
 									<span style={{ color: TEXT_MUTED, fontSize: 9 }}>
 										({fmt(s.x)}, {fmt(s.y)})

--- a/plugins/usketch-plugin-debug-hud/src/panels/shapes-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/shapes-panel.tsx
@@ -1,5 +1,5 @@
 import type { BoardStore, CommandRegistry, ShapeData } from "@edv4h/usketch-shared";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
 	ACCENT_DIM,
 	fmt,
@@ -93,6 +93,17 @@ export function ShapesPanel({
 	const [expandedId, setExpandedId] = useState<string | null>(null);
 	const [filterUnconfirmed, setFilterUnconfirmed] = useState(false);
 	const unconfirmedCount = unconfirmedShapeIds?.size ?? 0;
+
+	// If divergence resolves while the filter is on, the toggle button
+	// disappears (its render is gated on `unconfirmedCount > 0`) — leaving
+	// the user stuck with an empty list. Auto-clear the filter so the full
+	// shape list returns.
+	useEffect(() => {
+		if (unconfirmedCount === 0 && filterUnconfirmed) {
+			setFilterUnconfirmed(false);
+		}
+	}, [unconfirmedCount, filterUnconfirmed]);
+
 	const shapeEntries = Array.from(shapes.values()).filter((s) =>
 		filterUnconfirmed ? unconfirmedShapeIds?.has(s.id) : true,
 	);

--- a/plugins/usketch-plugin-debug-hud/src/sync-status-types.ts
+++ b/plugins/usketch-plugin-debug-hud/src/sync-status-types.ts
@@ -13,6 +13,12 @@ export interface SyncStatusSnapshot {
 	state: SyncState;
 	shapeCount: number;
 	lastSyncedAt: number | null;
+	/**
+	 * Timestamp of the first successful server sync, or null if the client
+	 * has not yet heard back from the server. Use this (not `lastSyncedAt`,
+	 * which also moves on local edits) to gate divergence UI.
+	 */
+	firstServerSyncAt?: number | null;
 	error: string | null;
 	unconfirmedShapeIds?: readonly string[];
 }

--- a/plugins/usketch-plugin-debug-hud/src/sync-status-types.ts
+++ b/plugins/usketch-plugin-debug-hud/src/sync-status-types.ts
@@ -1,15 +1,20 @@
 /**
- * Structural types matching SyncStatusTracker from @edv4h/usketch-store.
- * Defined locally to avoid adding a dependency on the store package.
+ * Structural types matching SyncStatusTracker from @edv4h/usketch-store
+ * and @edv4h/usketch-plugin-sync-ywebsocket. Defined locally to avoid taking
+ * a runtime dependency on either package.
+ *
+ * `unconfirmedShapeIds` is contributed by the ywebsocket tracker only —
+ * IndexedDB-only trackers leave it empty.
  */
 
-export type SyncState = "loading" | "synced" | "syncing" | "error";
+export type SyncState = "loading" | "connecting" | "synced" | "syncing" | "disconnected" | "error";
 
 export interface SyncStatusSnapshot {
 	state: SyncState;
 	shapeCount: number;
 	lastSyncedAt: number | null;
 	error: string | null;
+	unconfirmedShapeIds?: readonly string[];
 }
 
 export interface SyncStatusTrackerLike {

--- a/plugins/usketch-plugin-sync-ywebsocket/package.json
+++ b/plugins/usketch-plugin-sync-ywebsocket/package.json
@@ -24,7 +24,11 @@
 		"y-websocket": "^3.0.0",
 		"yjs": "^13.6.0"
 	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
 	"devDependencies": {
+		"@types/react": "19.2.14",
 		"typescript": "5.9.3",
 		"vitest": "3.2.4"
 	},

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/divergence-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/divergence-tracker.test.ts
@@ -108,6 +108,28 @@ describe("createDivergenceTracker", () => {
 		handle.destroy();
 	});
 
+	it("connection state transitions are mirrored onto the snapshot", () => {
+		// Debug HUD's Persistence indicator subscribes to `state` — this needs
+		// to track connecting → syncing → synced → disconnected.
+		const { handle, setWsStatus, applyRemoteUpdate, makeRemoteAddUpdate } = setup();
+		expect(handle.status.getSnapshot().state).toBe("disconnected");
+
+		setWsStatus("connecting");
+		expect(handle.status.getSnapshot().state).toBe("connecting");
+
+		setWsStatus("connected");
+		// Connected but no remote update yet → "syncing".
+		expect(handle.status.getSnapshot().state).toBe("syncing");
+
+		// First remote update lands → "synced".
+		applyRemoteUpdate(makeRemoteAddUpdate("server-1"));
+		expect(handle.status.getSnapshot().state).toBe("synced");
+
+		setWsStatus("disconnected");
+		expect(handle.status.getSnapshot().state).toBe("disconnected");
+		handle.destroy();
+	});
+
 	it("destroy() unsubscribes everything — later mutations don't notify", () => {
 		const { store, handle, setWsStatus } = setup();
 		let calls = 0;

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/divergence-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/divergence-tracker.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { createDivergenceTracker } from "../divergence-tracker.js";
+import { createTestStore, makeShape } from "./test-store.js";
+
+/**
+ * Helper: build the smallest possible setup the divergence tracker needs.
+ * Mirrors what `apps/web/src/app.tsx` does (IDB sync handle's doc/shapesMap +
+ * a WsProvider-style status callback) without touching the real IDB or
+ * WebSocket code.
+ */
+function setup() {
+	const doc = new Y.Doc();
+	const shapesMap = doc.getMap<Record<string, unknown>>("shapes");
+	const store = createTestStore();
+	const statusListeners = new Set<(status: string) => void>();
+	let currentStatus = "disconnected";
+
+	const handle = createDivergenceTracker({
+		store,
+		doc,
+		shapesMap,
+		onConnectionStatusChange: (handler) => {
+			statusListeners.add(handler);
+			handler(currentStatus);
+			return () => statusListeners.delete(handler);
+		},
+	});
+
+	function setWsStatus(next: string) {
+		currentStatus = next;
+		for (const l of statusListeners) l(next);
+	}
+
+	function applyRemoteUpdate(update: Uint8Array) {
+		Y.applyUpdate(doc, update, "remote");
+	}
+
+	function makeRemoteAddUpdate(id: string): Uint8Array {
+		const tmpDoc = new Y.Doc();
+		const tmpMap = tmpDoc.getMap<Record<string, unknown>>("shapes");
+		tmpMap.set(id, makeShape({ id }) as unknown as Record<string, unknown>);
+		return Y.encodeStateAsUpdate(tmpDoc);
+	}
+
+	return { doc, shapesMap, store, handle, setWsStatus, applyRemoteUpdate, makeRemoteAddUpdate };
+}
+
+describe("createDivergenceTracker", () => {
+	it("flags a locally-added shape as unconfirmed while offline", () => {
+		const { store, handle } = setup();
+		store.addShape(makeShape({ id: "offline-1" }));
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual(["offline-1"]);
+		handle.destroy();
+	});
+
+	it("does NOT flag locally-added shapes while online (server will broadcast immediately)", () => {
+		const { store, handle, setWsStatus } = setup();
+		setWsStatus("connected");
+		store.addShape(makeShape({ id: "online-1" }));
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual([]);
+		handle.destroy();
+	});
+
+	it("first remote-origin doc update stamps firstServerSyncAt", () => {
+		const { handle, applyRemoteUpdate, makeRemoteAddUpdate } = setup();
+		expect(handle.status.getSnapshot().firstServerSyncAt).toBeNull();
+
+		// Server sends a remote update — this is our "first sync" signal.
+		applyRemoteUpdate(makeRemoteAddUpdate("server-1"));
+
+		const snap = handle.status.getSnapshot();
+		expect(snap.firstServerSyncAt).not.toBeNull();
+		expect(typeof snap.firstServerSyncAt).toBe("number");
+		// The shape from the server is confirmed, not unconfirmed.
+		expect(snap.unconfirmedShapeIds).toEqual([]);
+		handle.destroy();
+	});
+
+	it("a shape created locally before first sync stays unconfirmed if server didn't include it", () => {
+		// Phantom shape scenario: client added X offline; server's first sync
+		// arrives but didn't actually contain X. After the sync, the divergence
+		// snapshot should still flag X.
+		const { store, handle, applyRemoteUpdate, makeRemoteAddUpdate } = setup();
+		store.addShape(makeShape({ id: "ghost" }));
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual(["ghost"]);
+
+		// Server's first sync only confirms `server-1` (no `ghost`).
+		applyRemoteUpdate(makeRemoteAddUpdate("server-1"));
+
+		const snap = handle.status.getSnapshot();
+		expect(snap.firstServerSyncAt).not.toBeNull();
+		// `ghost` is in shapesMap (we added it locally) but not in the
+		// confirmed snapshot, so it remains in `unconfirmedShapeIds`.
+		expect(snap.unconfirmedShapeIds).toEqual(["ghost"]);
+		handle.destroy();
+	});
+
+	it("after first sync, going offline and adding a shape flags it as unconfirmed", () => {
+		const { store, handle, setWsStatus, applyRemoteUpdate, makeRemoteAddUpdate } = setup();
+		setWsStatus("connected");
+		applyRemoteUpdate(makeRemoteAddUpdate("server-1"));
+
+		// Drop offline, add a shape — should diverge.
+		setWsStatus("disconnected");
+		store.addShape(makeShape({ id: "offline-2" }));
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual(["offline-2"]);
+		handle.destroy();
+	});
+
+	it("destroy() unsubscribes everything — later mutations don't notify", () => {
+		const { store, handle, setWsStatus } = setup();
+		let calls = 0;
+		handle.status.subscribe(() => {
+			calls++;
+		});
+		handle.destroy();
+		setWsStatus("connected");
+		store.addShape(makeShape({ id: "after-destroy" }));
+		expect(calls).toBe(0);
+	});
+});

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/divergence-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/divergence-tracker.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
 import { createDivergenceTracker } from "../divergence-tracker.js";
 import { createTestStore, makeShape } from "./test-store.js";
@@ -8,8 +8,12 @@ import { createTestStore, makeShape } from "./test-store.js";
  * Mirrors what `apps/web/src/app.tsx` does (IDB sync handle's doc/shapesMap +
  * a WsProvider-style status callback) without touching the real IDB or
  * WebSocket code.
+ *
+ * `emptyServerGraceMs` defaults to 0 here (timer disabled) so the existing
+ * tests don't need to deal with timers. Tests that exercise the empty-server
+ * fallback opt in by passing a number.
  */
-function setup() {
+function setup(emptyServerGraceMs = 0) {
 	const doc = new Y.Doc();
 	const shapesMap = doc.getMap<Record<string, unknown>>("shapes");
 	const store = createTestStore();
@@ -20,6 +24,7 @@ function setup() {
 		store,
 		doc,
 		shapesMap,
+		emptyServerGraceMs,
 		onConnectionStatusChange: (handler) => {
 			statusListeners.add(handler);
 			handler(currentStatus);
@@ -47,6 +52,10 @@ function setup() {
 }
 
 describe("createDivergenceTracker", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
 	it("flags a locally-added shape as unconfirmed while offline", () => {
 		const { store, handle } = setup();
 		store.addShape(makeShape({ id: "offline-1" }));
@@ -127,6 +136,53 @@ describe("createDivergenceTracker", () => {
 
 		setWsStatus("disconnected");
 		expect(handle.status.getSnapshot().state).toBe("disconnected");
+		handle.destroy();
+	});
+
+	it("empty-server fallback: timer fires firstServerSyncAt after grace period elapses with no remote update", () => {
+		// Connecting to a server that has nothing to push (new room, lost
+		// history) means `doc.on("update")` never fires. The grace timer
+		// should kick in and stamp anyway.
+		vi.useFakeTimers();
+		const { handle, setWsStatus } = setup(2000);
+
+		setWsStatus("connected");
+		expect(handle.status.getSnapshot().firstServerSyncAt).toBeNull();
+		expect(handle.status.getSnapshot().state).toBe("syncing");
+
+		vi.advanceTimersByTime(1999);
+		expect(handle.status.getSnapshot().firstServerSyncAt).toBeNull();
+
+		vi.advanceTimersByTime(1);
+		expect(handle.status.getSnapshot().firstServerSyncAt).not.toBeNull();
+		expect(handle.status.getSnapshot().state).toBe("synced");
+		handle.destroy();
+	});
+
+	it("empty-server fallback: cancelled if disconnect happens before grace expires", () => {
+		vi.useFakeTimers();
+		const { handle, setWsStatus } = setup(2000);
+		setWsStatus("connected");
+		vi.advanceTimersByTime(1000);
+		setWsStatus("disconnected");
+		vi.advanceTimersByTime(2000);
+		// Timer should have been cancelled — never stamp on disconnect.
+		expect(handle.status.getSnapshot().firstServerSyncAt).toBeNull();
+		handle.destroy();
+	});
+
+	it("empty-server fallback: a real remote update before grace expires wins", () => {
+		vi.useFakeTimers();
+		const { handle, setWsStatus, applyRemoteUpdate, makeRemoteAddUpdate } = setup(2000);
+		setWsStatus("connected");
+		vi.advanceTimersByTime(500);
+		applyRemoteUpdate(makeRemoteAddUpdate("server-1"));
+		const stamped = handle.status.getSnapshot().firstServerSyncAt;
+		expect(stamped).not.toBeNull();
+		// The grace timer should be cancelled — advancing further must not
+		// re-stamp (firstServerSyncAt is monotonic).
+		vi.advanceTimersByTime(2000);
+		expect(handle.status.getSnapshot().firstServerSyncAt).toBe(stamped);
 		handle.destroy();
 	});
 

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
@@ -77,4 +77,24 @@ describe("SyncStatusTracker — divergence tracking", () => {
 		expect(snap.lastSyncedAt).toBe(123);
 		expect(snap.unconfirmedShapeIds).toEqual(["a"]);
 	});
+
+	it("noteShapesLoaded ingests bulk IDs and notifies subscribers exactly once", () => {
+		const t = new SyncStatusTracker();
+		let calls = 0;
+		t.subscribe(() => {
+			calls++;
+		});
+		t.noteShapesLoaded(["a", "b", "c"], "local");
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual(["a", "b", "c"]);
+		expect(t.getSnapshot().shapeCount).toBe(3);
+		// Single notification for the whole batch (vs 3 if we'd looped over
+		// `noteShapeAdded`).
+		expect(calls).toBe(1);
+	});
+
+	it("noteShapesLoaded with 'remote' source pre-confirms every id", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapesLoaded(["a", "b"], "remote");
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual([]);
+	});
 });

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
@@ -122,4 +122,57 @@ describe("SyncStatusTracker — divergence tracking", () => {
 		t.setConfirmedFromServer(["a", "b"]);
 		expect(t.getSnapshot().firstServerSyncAt).toBe(first);
 	});
+
+	it("batch() coalesces multiple mutations into a single notification", () => {
+		const t = new SyncStatusTracker();
+		let calls = 0;
+		t.subscribe(() => {
+			calls++;
+		});
+
+		t.batch(() => {
+			t.noteShapeAdded("a", "local");
+			t.noteShapeAdded("b", "local");
+			t.update({ state: "synced", lastSyncedAt: 1 });
+			t.update({ shapeCount: 999 }); // shapeCount is recomputed below — last write wins via recompute
+		});
+
+		// Inside batch we made 4 mutator calls, but listeners hear about it once.
+		expect(calls).toBe(1);
+		// Final snapshot reflects all changes.
+		const snap = t.getSnapshot();
+		expect(snap.unconfirmedShapeIds).toEqual(["a", "b"]);
+		expect(snap.state).toBe("synced");
+		expect(snap.lastSyncedAt).toBe(1);
+	});
+
+	it("batch() with no mutations doesn't notify", () => {
+		const t = new SyncStatusTracker();
+		let calls = 0;
+		t.subscribe(() => {
+			calls++;
+		});
+		t.batch(() => {
+			// no-op
+		});
+		expect(calls).toBe(0);
+	});
+
+	it("nested batch() defers notification to the outermost close", () => {
+		const t = new SyncStatusTracker();
+		let calls = 0;
+		t.subscribe(() => {
+			calls++;
+		});
+		t.batch(() => {
+			t.noteShapeAdded("a", "local");
+			t.batch(() => {
+				t.noteShapeAdded("b", "local");
+			});
+			// inner batch closed but outer is still open, so still 0 notifications
+			expect(calls).toBe(0);
+		});
+		// outermost close: exactly one notification
+		expect(calls).toBe(1);
+	});
 });

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { SyncStatusTracker } from "../sync-status-tracker.js";
+
+describe("SyncStatusTracker — divergence tracking", () => {
+	it("starts with empty unconfirmedShapeIds", () => {
+		const t = new SyncStatusTracker();
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual([]);
+	});
+
+	it("treats locally-added shapes as unconfirmed until a server sync", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("a", "local");
+		t.noteShapeAdded("b", "local");
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual(["a", "b"]);
+	});
+
+	it("treats remote-added shapes as already confirmed", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("a", "remote");
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual([]);
+	});
+
+	it("setConfirmedFromServer promotes all current shapes to confirmed", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("a", "local");
+		t.noteShapeAdded("b", "local");
+		expect(t.getSnapshot().unconfirmedShapeIds).toHaveLength(2);
+
+		// Sync with server: server's view contains both shapes.
+		t.setConfirmedFromServer(["a", "b"]);
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual([]);
+
+		// New local add after sync diverges again until next sync.
+		t.noteShapeAdded("c", "local");
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual(["c"]);
+	});
+
+	it("setConfirmedFromServer with subset leaves extras unconfirmed", () => {
+		// This is the "phantom shape" scenario: client has shapes the server
+		// has never seen (or the server cleared them). After sync, the server's
+		// view (`["a"]`) does NOT include "ghost" — so "ghost" is flagged.
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("a", "local");
+		t.noteShapeAdded("ghost", "local");
+		t.setConfirmedFromServer(["a"]);
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual(["ghost"]);
+	});
+
+	it("noteShapeRemoved drops the id from both maps", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("a", "local");
+		t.noteShapeRemoved("a");
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual([]);
+		expect(t.getSnapshot().shapeCount).toBe(0);
+	});
+
+	it("notifies subscribers on each mutation", () => {
+		const t = new SyncStatusTracker();
+		let calls = 0;
+		const unsubscribe = t.subscribe(() => {
+			calls++;
+		});
+		t.noteShapeAdded("a", "local");
+		t.noteShapeAdded("b", "remote");
+		t.setConfirmedFromServer(["a", "b"]);
+		t.noteShapeRemoved("a");
+		expect(calls).toBeGreaterThanOrEqual(4);
+		unsubscribe();
+	});
+
+	it("update() (legacy state-only mutator) leaves unconfirmedShapeIds untouched", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("a", "local");
+		t.update({ state: "synced", lastSyncedAt: 123 });
+		const snap = t.getSnapshot();
+		expect(snap.state).toBe("synced");
+		expect(snap.lastSyncedAt).toBe(123);
+		expect(snap.unconfirmedShapeIds).toEqual(["a"]);
+	});
+});

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
@@ -97,4 +97,29 @@ describe("SyncStatusTracker — divergence tracking", () => {
 		t.noteShapesLoaded(["a", "b"], "remote");
 		expect(t.getSnapshot().unconfirmedShapeIds).toEqual([]);
 	});
+
+	it("firstServerSyncAt stays null until the first server sync", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("a", "local");
+		t.update({ state: "synced", lastSyncedAt: 100 });
+		// Local mutations bump `lastSyncedAt` but not `firstServerSyncAt`.
+		expect(t.getSnapshot().firstServerSyncAt).toBeNull();
+
+		t.setConfirmedFromServer(["a"]);
+		const after = t.getSnapshot();
+		expect(after.firstServerSyncAt).not.toBeNull();
+		expect(typeof after.firstServerSyncAt).toBe("number");
+	});
+
+	it("firstServerSyncAt is stamped only on the first sync, never reset", () => {
+		const t = new SyncStatusTracker();
+		t.setConfirmedFromServer(["a"]);
+		const first = t.getSnapshot().firstServerSyncAt;
+		expect(first).not.toBeNull();
+
+		// A subsequent sync (e.g. after a reconnection) should NOT overwrite
+		// the original timestamp — consumers rely on it being monotonic.
+		t.setConfirmedFromServer(["a", "b"]);
+		expect(t.getSnapshot().firstServerSyncAt).toBe(first);
+	});
 });

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/sync-status-tracker.test.ts
@@ -158,6 +158,28 @@ describe("SyncStatusTracker — divergence tracking", () => {
 		expect(calls).toBe(0);
 	});
 
+	it("markFirstServerSyncObserved() stamps timestamp without touching confirmed set", () => {
+		const t = new SyncStatusTracker();
+		t.noteShapeAdded("ghost", "local"); // local-only, server doesn't know
+		expect(t.getSnapshot().unconfirmedShapeIds).toEqual(["ghost"]);
+		expect(t.getSnapshot().firstServerSyncAt).toBeNull();
+
+		t.markFirstServerSyncObserved();
+		// Stamped, but ghost is still unconfirmed (we never confirmed it).
+		const snap = t.getSnapshot();
+		expect(snap.firstServerSyncAt).not.toBeNull();
+		expect(snap.unconfirmedShapeIds).toEqual(["ghost"]);
+	});
+
+	it("markFirstServerSyncObserved() is idempotent — only stamps once", () => {
+		const t = new SyncStatusTracker();
+		t.markFirstServerSyncObserved();
+		const first = t.getSnapshot().firstServerSyncAt;
+		expect(first).not.toBeNull();
+		t.markFirstServerSyncObserved();
+		expect(t.getSnapshot().firstServerSyncAt).toBe(first);
+	});
+
 	it("nested batch() defers notification to the outermost close", () => {
 		const t = new SyncStatusTracker();
 		let calls = 0;

--- a/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/__tests__/yws-sync.test.ts
@@ -133,6 +133,62 @@ describe("createYwebsocketSync (store ↔ Y.Doc binding)", () => {
 	});
 });
 
+describe("createYwebsocketSync (divergence tracking)", () => {
+	const handles: YwebsocketSyncHandle[] = [];
+
+	afterEach(() => {
+		while (handles.length) {
+			handles.pop()?.destroy();
+		}
+	});
+
+	function setup() {
+		const store = createTestStore();
+		const handle = createYwebsocketSync(store, {
+			url: "ws://example.invalid",
+			roomName: "test-room",
+			autoConnect: false,
+		});
+		handles.push(handle);
+		return { store, handle };
+	}
+
+	it("flags shapes added while offline as unconfirmed", () => {
+		const { store, handle } = setup();
+		// `autoConnect: false` → currentWsStatus is "disconnected".
+		store.addShape(makeShape({ id: "offline-1" }));
+		store.addShape(makeShape({ id: "offline-2" }));
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual(["offline-1", "offline-2"]);
+	});
+
+	it("setConfirmedFromServer clears unconfirmed for shapes the server knows", () => {
+		const { store, handle } = setup();
+		store.addShape(makeShape({ id: "a" }));
+		store.addShape(makeShape({ id: "b" }));
+		// Simulate the `sync` event landing — both shapes are now in the
+		// merged server view.
+		handle.status.setConfirmedFromServer(["a", "b"]);
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual([]);
+	});
+
+	it("a shape on the client but absent from the server snapshot stays unconfirmed", () => {
+		// The phantom-shape scenario: server's view does NOT contain `ghost`.
+		const { store, handle } = setup();
+		store.addShape(makeShape({ id: "ghost" }));
+		store.addShape(makeShape({ id: "real" }));
+		handle.status.setConfirmedFromServer(["real"]);
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual(["ghost"]);
+	});
+
+	it("removing an unconfirmed shape drops it from the divergence list", () => {
+		const { store, handle } = setup();
+		store.addShape(makeShape({ id: "tmp" }));
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual(["tmp"]);
+		store.deleteShape("tmp");
+		expect(handle.status.getSnapshot().unconfirmedShapeIds).toEqual([]);
+	});
+});
+
 describe("createYwebsocketSync (lifecycle)", () => {
 	it("exposes an inert wsProvider before connect; onStatusChange reports disconnected", () => {
 		const store = createTestStore();

--- a/plugins/usketch-plugin-sync-ywebsocket/src/divergence-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/divergence-tracker.ts
@@ -1,0 +1,118 @@
+import type { BoardStore } from "@edv4h/usketch-shared";
+import type * as Y from "yjs";
+import { SyncStatusTracker } from "./sync-status-tracker.js";
+
+/**
+ * Standalone divergence tracker for apps that wire IDB sync + WsProvider
+ * **manually** (rather than via `createYwebsocketSyncPlugin`). It watches the
+ * store, the Y.Map of shapes, and the WebSocket connection, then exposes a
+ * `SyncStatusTracker` whose `unconfirmedShapeIds` reflects shapes that exist
+ * locally but the server hasn't acknowledged.
+ *
+ * Why this exists: the full plugin embeds y-websocket's `provider.on("sync")`
+ * event for the "first server sync" stamp, but `@edv4h/usketch-sync`'s
+ * `createWsProvider` doesn't expose that signal. We approximate by stamping
+ * `firstServerSyncAt` on the first remote-origin Y.Doc update, which is the
+ * earliest moment we can be sure the server has talked back to us.
+ */
+export interface DivergenceTrackerOptions {
+	store: BoardStore;
+	doc: Y.Doc;
+	shapesMap: Y.Map<Record<string, unknown>>;
+	/** Subscribe to socket-level connection state (`"connected"` / `"connecting"` / `"disconnected"`). */
+	onConnectionStatusChange: (handler: (status: string) => void) => () => void;
+}
+
+export interface DivergenceTrackerHandle {
+	status: SyncStatusTracker;
+	destroy: () => void;
+}
+
+export function createDivergenceTracker(opts: DivergenceTrackerOptions): DivergenceTrackerHandle {
+	const { store, doc, shapesMap, onConnectionStatusChange } = opts;
+	const status = new SyncStatusTracker();
+
+	let currentWsStatus = "disconnected";
+
+	// 1. Connection state — drives the "is local add already confirmed?" decision
+	//    in the store mutation handler below.
+	const offStatus = onConnectionStatusChange((next) => {
+		currentWsStatus = next;
+	});
+
+	// 2. Initial load: every shape already in the Y.Map (typically restored from
+	//    IndexedDB) is "local-only" until the server confirms.
+	if (shapesMap.size > 0) {
+		const initialIds: string[] = [];
+		for (const id of shapesMap.keys()) initialIds.push(id);
+		status.noteShapesLoaded(initialIds, "local");
+	}
+
+	// 3. Local mutations from the store — online → confirmed (broadcast goes
+	//    out immediately), offline → unconfirmed.
+	const offMutation = store.onMutation((event) => {
+		const payload = event.payload as { id?: string } | undefined;
+		if (!payload?.id) return;
+		status.batch(() => {
+			if (event.type === "shape:added") {
+				const isOnline = currentWsStatus === "connected";
+				status.noteShapeAdded(payload.id as string, isOnline ? "remote" : "local");
+			} else if (event.type === "shape:removed") {
+				status.noteShapeRemoved(payload.id as string);
+			}
+			status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
+		});
+	});
+
+	// 4. Y.Map observe — for remote-origin additions (server pushed a shape
+	//    we didn't have, or another peer added one).
+	const observer = (events: Y.YMapEvent<Record<string, unknown>>): void => {
+		const isLocalTxn = events.transaction.local;
+		status.batch(() => {
+			for (const [key, change] of events.changes.keys) {
+				if (change.action === "add" && !isLocalTxn) {
+					// Remote add → confirmed by server.
+					status.noteShapeAdded(key, "remote");
+				} else if (change.action === "delete") {
+					status.noteShapeRemoved(key);
+				}
+			}
+			status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
+		});
+	};
+	shapesMap.observe(observer);
+
+	// 5. First remote-origin doc update marks the server as "synced with us"
+	//    once and for all. After that, every key currently in the map is
+	//    treated as confirmed (we wouldn't have it locally otherwise — the
+	//    merged state is the union we just received).
+	let serverSynced = false;
+	function onDocUpdate(_update: Uint8Array, origin: unknown): void {
+		if (serverSynced) return;
+		if (origin !== "remote") return;
+		serverSynced = true;
+		const ids: string[] = [];
+		for (const id of shapesMap.keys()) ids.push(id);
+		status.setConfirmedFromServer(ids);
+	}
+	doc.on("update", onDocUpdate);
+
+	// 6. As shapes propagate from Y.Map → store, the existing `addShape` /
+	//    `deleteShape` calls in the consumer's IDB sync pipeline will fire
+	//    `store.onMutation` events. We don't want those to be re-noted as
+	//    "local" — but the store mutation handler above can't tell IDB-driven
+	//    mutations apart from user-driven ones. The `transaction.local` check
+	//    in the Y.Map observer means we only `noteShapeAdded("remote", ...)`
+	//    for genuinely remote ones, and the store mutation will see the same
+	//    id already in `shapeIds` so it's effectively a no-op (Set.add is
+	//    idempotent). Confirm preservation is also idempotent.
+
+	function destroy() {
+		offStatus();
+		offMutation();
+		shapesMap.unobserve(observer);
+		doc.off("update", onDocUpdate);
+	}
+
+	return { status, destroy };
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/divergence-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/divergence-tracker.ts
@@ -33,11 +33,31 @@ export function createDivergenceTracker(opts: DivergenceTrackerOptions): Diverge
 	const status = new SyncStatusTracker();
 
 	let currentWsStatus = "disconnected";
+	let serverSynced = false;
 
 	// 1. Connection state — drives the "is local add already confirmed?" decision
-	//    in the store mutation handler below.
+	//    in the store mutation handler below, and is mirrored onto the snapshot
+	//    `state` field so consumers (e.g. Debug HUD's Persistence indicator)
+	//    show the right thing.
 	const offStatus = onConnectionStatusChange((next) => {
 		currentWsStatus = next;
+		// Mirror transport state into the snapshot using the same mapping the
+		// full ywebsocket plugin uses: socket-level "connected" maps to
+		// "syncing" until the first remote update arrives, then "synced".
+		const mappedState =
+			next === "connected"
+				? serverSynced
+					? "synced"
+					: "syncing"
+				: next === "connecting"
+					? "connecting"
+					: next === "disconnected"
+						? "disconnected"
+						: "error";
+		status.update({
+			state: mappedState,
+			error: next === "failed" ? "connection failed" : null,
+		});
 	});
 
 	// 2. Initial load: every shape already in the Y.Map (typically restored from
@@ -82,30 +102,27 @@ export function createDivergenceTracker(opts: DivergenceTrackerOptions): Diverge
 	};
 	shapesMap.observe(observer);
 
-	// 5. First remote-origin doc update marks the server as "synced with us"
-	//    once and for all. After that, every key currently in the map is
-	//    treated as confirmed (we wouldn't have it locally otherwise — the
-	//    merged state is the union we just received).
-	let serverSynced = false;
+	// 5. First remote-origin doc update marks the server as "synced with us".
+	//    We deliberately DO NOT bulk-confirm `shapesMap.keys()` here — that
+	//    would silently mark every IndexedDB-restored shape as "the server
+	//    knows about it", which is exactly what we want to NOT assume (the
+	//    whole point of this overlay is to surface phantom/orphaned shapes).
+	//    Instead, the Y.Map observer above marks individual remote-origin
+	//    additions as confirmed via `noteShapeAdded(key, "remote")`. Anything
+	//    the server didn't push to us during this session stays unconfirmed.
 	function onDocUpdate(_update: Uint8Array, origin: unknown): void {
 		if (serverSynced) return;
 		if (origin !== "remote") return;
 		serverSynced = true;
-		const ids: string[] = [];
-		for (const id of shapesMap.keys()) ids.push(id);
-		status.setConfirmedFromServer(ids);
+		status.batch(() => {
+			status.markFirstServerSyncObserved();
+			// Bump state to "synced" if the socket was in "syncing".
+			if (currentWsStatus === "connected") {
+				status.update({ state: "synced" });
+			}
+		});
 	}
 	doc.on("update", onDocUpdate);
-
-	// 6. As shapes propagate from Y.Map → store, the existing `addShape` /
-	//    `deleteShape` calls in the consumer's IDB sync pipeline will fire
-	//    `store.onMutation` events. We don't want those to be re-noted as
-	//    "local" — but the store mutation handler above can't tell IDB-driven
-	//    mutations apart from user-driven ones. The `transaction.local` check
-	//    in the Y.Map observer means we only `noteShapeAdded("remote", ...)`
-	//    for genuinely remote ones, and the store mutation will see the same
-	//    id already in `shapeIds` so it's effectively a no-op (Set.add is
-	//    idempotent). Confirm preservation is also idempotent.
 
 	function destroy() {
 		offStatus();

--- a/plugins/usketch-plugin-sync-ywebsocket/src/divergence-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/divergence-tracker.ts
@@ -21,6 +21,17 @@ export interface DivergenceTrackerOptions {
 	shapesMap: Y.Map<Record<string, unknown>>;
 	/** Subscribe to socket-level connection state (`"connected"` / `"connecting"` / `"disconnected"`). */
 	onConnectionStatusChange: (handler: (status: string) => void) => () => void;
+	/**
+	 * Grace period (ms) to wait after the socket reaches `"connected"` before
+	 * concluding "first sync completed" if no remote Y.Doc update has arrived.
+	 * The y-websocket SYNC_STEP1/STEP2 round-trip is normally fast, so even an
+	 * empty server (no shapes to push) will resolve well under a second. We
+	 * pick a generous default to avoid false positives on slow networks.
+	 *
+	 * Defaults to 2000ms. Set to 0 to disable the timer-based fallback (only
+	 * the first remote update will stamp).
+	 */
+	emptyServerGraceMs?: number;
 }
 
 export interface DivergenceTrackerHandle {
@@ -29,11 +40,34 @@ export interface DivergenceTrackerHandle {
 }
 
 export function createDivergenceTracker(opts: DivergenceTrackerOptions): DivergenceTrackerHandle {
-	const { store, doc, shapesMap, onConnectionStatusChange } = opts;
+	const { store, doc, shapesMap, onConnectionStatusChange, emptyServerGraceMs = 2000 } = opts;
 	const status = new SyncStatusTracker();
 
 	let currentWsStatus = "disconnected";
 	let serverSynced = false;
+	// Timer that fires `markServerSynced()` if `connected` persists for
+	// `emptyServerGraceMs` without any remote Y.Doc update. Covers the
+	// "empty server / no history" case where a remote update never comes.
+	let emptyServerTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function clearEmptyServerTimer(): void {
+		if (emptyServerTimer !== null) {
+			clearTimeout(emptyServerTimer);
+			emptyServerTimer = null;
+		}
+	}
+
+	function markServerSynced(): void {
+		if (serverSynced) return;
+		serverSynced = true;
+		clearEmptyServerTimer();
+		status.batch(() => {
+			status.markFirstServerSyncObserved();
+			if (currentWsStatus === "connected") {
+				status.update({ state: "synced" });
+			}
+		});
+	}
 
 	// 1. Connection state — drives the "is local add already confirmed?" decision
 	//    in the store mutation handler below, and is mirrored onto the snapshot
@@ -58,6 +92,18 @@ export function createDivergenceTracker(opts: DivergenceTrackerOptions): Diverge
 			state: mappedState,
 			error: next === "failed" ? "connection failed" : null,
 		});
+
+		// Empty-server fallback: when we connect but the server has nothing to
+		// push (new room, lost history), `doc.on("update")` never fires. Start
+		// a timer so `firstServerSyncAt` is still stamped after the SYNC round-
+		// trip has had time to complete. `emptyServerGraceMs: 0` opts out.
+		if (next === "connected" && !serverSynced && emptyServerGraceMs > 0) {
+			clearEmptyServerTimer();
+			emptyServerTimer = setTimeout(markServerSynced, emptyServerGraceMs);
+		} else if (next !== "connected") {
+			// Drop the timer if we got disconnected before the grace expired.
+			clearEmptyServerTimer();
+		}
 	});
 
 	// 2. Initial load: every shape already in the Y.Map (typically restored from
@@ -110,21 +156,18 @@ export function createDivergenceTracker(opts: DivergenceTrackerOptions): Diverge
 	//    Instead, the Y.Map observer above marks individual remote-origin
 	//    additions as confirmed via `noteShapeAdded(key, "remote")`. Anything
 	//    the server didn't push to us during this session stays unconfirmed.
+	//
+	//    Note: an "empty" server sync (no shapes to push) won't trigger this
+	//    handler — the `emptyServerTimer` started above is the fallback that
+	//    catches that case.
 	function onDocUpdate(_update: Uint8Array, origin: unknown): void {
-		if (serverSynced) return;
 		if (origin !== "remote") return;
-		serverSynced = true;
-		status.batch(() => {
-			status.markFirstServerSyncObserved();
-			// Bump state to "synced" if the socket was in "syncing".
-			if (currentWsStatus === "connected") {
-				status.update({ state: "synced" });
-			}
-		});
+		markServerSynced();
 	}
 	doc.on("update", onDocUpdate);
 
 	function destroy() {
+		clearEmptyServerTimer();
 		offStatus();
 		offMutation();
 		shapesMap.unobserve(observer);

--- a/plugins/usketch-plugin-sync-ywebsocket/src/index.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/index.ts
@@ -1,3 +1,12 @@
+// Standalone helpers for apps that wire IDB sync + WsProvider manually
+// (rather than via `createYwebsocketSyncPlugin`). `createDivergenceTracker`
+// produces a SyncStatusTracker driven by a Y.Doc + WsProvider, and
+// `<UnconfirmedOverlay />` renders the SVG badge layer.
+export {
+	createDivergenceTracker,
+	type DivergenceTrackerHandle,
+	type DivergenceTrackerOptions,
+} from "./divergence-tracker.js";
 export { createYwebsocketSyncPlugin, type YwebsocketSyncPlugin } from "./plugin.js";
 export {
 	type SyncState,
@@ -11,4 +20,5 @@ export type {
 	YwebsocketSyncHandle,
 	YwebsocketSyncOptions,
 } from "./types.js";
+export { UnconfirmedOverlay } from "./unconfirmed-overlay.js";
 export { createYwebsocketSync } from "./yws-sync.js";

--- a/plugins/usketch-plugin-sync-ywebsocket/src/plugin.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/plugin.tsx
@@ -1,6 +1,7 @@
 import type { UsketchPlugin } from "@edv4h/usketch-shared";
 import type { WsProviderHandle } from "@edv4h/usketch-sync";
 import type { YwebsocketSyncHandle, YwebsocketSyncOptions } from "./types.js";
+import { UnconfirmedOverlay } from "./unconfirmed-overlay.js";
 import { createYwebsocketSync } from "./yws-sync.js";
 
 export interface YwebsocketSyncPlugin extends UsketchPlugin {
@@ -17,8 +18,11 @@ export interface YwebsocketSyncPlugin extends UsketchPlugin {
 	getHandle(): YwebsocketSyncHandle;
 }
 
+const UNCONFIRMED_OVERLAY_LAYER_ID = "unconfirmed-shapes-overlay";
+
 export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): YwebsocketSyncPlugin {
 	let handle: YwebsocketSyncHandle | null = null;
+	let unregisterOverlay: (() => void) | null = null;
 
 	const plugin: YwebsocketSyncPlugin = {
 		id: "usketch-plugin-sync-ywebsocket",
@@ -27,6 +31,26 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 		async setup(ctx) {
 			handle = createYwebsocketSync(ctx.store, options);
 			(globalThis as Record<string, unknown>).__usketchSyncStatus = handle.status;
+
+			// Diagnostic overlay: draws a red badge on shapes that exist locally
+			// but haven't been confirmed by the server. Sits between standard
+			// shapes (default order) and the debug HUD (9999).
+			const overlayHandle = handle;
+			ctx.layers.register({
+				id: UNCONFIRMED_OVERLAY_LAYER_ID,
+				order: 250,
+				fixed: true,
+				render: (renderCtx) => (
+					<UnconfirmedOverlay
+						store={ctx.store}
+						shapes={ctx.shapes}
+						viewport={renderCtx.viewport}
+						syncStatus={overlayHandle.status}
+					/>
+				),
+			});
+			unregisterOverlay = () => ctx.layers.unregister(UNCONFIRMED_OVERLAY_LAYER_ID);
+
 			// When `autoConnect: false`, `connect()` is never called, so awaiting
 			// `whenSynced` here would hang the entire plugin setup chain. Skip it
 			// and let the caller drive connection via `handle.resume()`.
@@ -36,6 +60,8 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 		},
 
 		teardown() {
+			unregisterOverlay?.();
+			unregisterOverlay = null;
 			handle?.destroy();
 			delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
 			handle = null;

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -87,11 +87,17 @@ export class SyncStatusTracker {
 	}
 
 	/**
-	 * Replace the "server-confirmed" set with the given IDs. Call this from the
-	 * provider's `sync` event when `isSynced === true` — at that point the
-	 * Y.Map state is the merged result of (server state ∪ what we uploaded),
-	 * so every key currently in the map IS confirmed. Any local-only shape
-	 * created later will diverge until the next sync event.
+	 * Replace the "server-confirmed" set with the given IDs. Use this only when
+	 * you have authoritative knowledge of which IDs the server has acknowledged
+	 * — typically from y-websocket's `provider.on("sync")` event, where the
+	 * Y.Map post-merge represents the union of (server view ∪ our uploads), so
+	 * every current key IS confirmed.
+	 *
+	 * Do **not** call this with `shapesMap.keys()` if your transport can't tell
+	 * you which keys originated from the server: that would silently confirm
+	 * orphaned IndexedDB shapes the server never had, defeating the divergence
+	 * detection. Use `markFirstServerSyncObserved()` + the `noteShapeAdded(...,
+	 * "remote")` per-key path instead.
 	 *
 	 * Also stamps `firstServerSyncAt` on the first call so consumers can gate
 	 * divergence UI on "have we ever heard back from the server?".
@@ -102,10 +108,28 @@ export class SyncStatusTracker {
 		// Ensure shapeIds is a superset (ids that exist server-side must exist
 		// locally too — they were just merged into our doc).
 		for (const id of this.confirmedShapeIds) this.shapeIds.add(id);
+		this.markFirstServerSyncObservedInternal();
+		this.recompute();
+	}
+
+	/**
+	 * Stamp `firstServerSyncAt` on the first call without touching the
+	 * confirmed set. For transports that can't atomically tell you which
+	 * shape IDs the server already knew at sync time (e.g. raw `WsProvider`
+	 * without an `onSync` event), this is the right hook: the per-key
+	 * `noteShapeAdded(id, "remote")` calls from the Y.Map observer fill in
+	 * the confirmed set incrementally.
+	 */
+	markFirstServerSyncObserved(): void {
+		if (this.snapshot.firstServerSyncAt !== null) return;
+		this.markFirstServerSyncObservedInternal();
+		this.notify();
+	}
+
+	private markFirstServerSyncObservedInternal(): void {
 		if (this.snapshot.firstServerSyncAt === null) {
 			this.snapshot = { ...this.snapshot, firstServerSyncAt: Date.now() };
 		}
-		this.recompute();
 	}
 
 	/**

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -8,12 +8,17 @@ export interface SyncStatusSnapshot {
 	/**
 	 * Shape IDs present in the local Y.Doc that the server has NOT confirmed.
 	 *
-	 * Populated by `noteShapeAdded("local", id)` (a shape created locally that
-	 * hasn't been seen by the server yet) or by being absent from the snapshot
-	 * `setConfirmedFromServer(...)` recorded at the most recent `sync` event.
+	 * Populated by `noteShapeAdded(id, "local")` (a shape created locally that
+	 * hasn't been seen by the server yet) and by `noteShapesLoaded(...)` for
+	 * pre-connection IndexedDB restoration. Becomes accurate only **after** the
+	 * first `setConfirmedFromServer(...)` (`sync` event with `isSynced: true`):
+	 * before that, every shape from a persisted Y.Doc looks "local-only" because
+	 * we genuinely don't know what the server holds yet.
 	 *
-	 * Empty until the first server sync; clients should only show divergence UI
-	 * once `state === "synced"` has been observed at least once.
+	 * Consumers should gate divergence UI on `state === "synced"` (or check
+	 * `lastSyncedAt != null`) so the warning isn't surfaced during the
+	 * `loading` / `connecting` phase, which would generate noise on every
+	 * cold start.
 	 */
 	unconfirmedShapeIds: readonly string[];
 }
@@ -74,6 +79,22 @@ export class SyncStatusTracker {
 		this.shapeIds.add(id);
 		if (source === "remote") {
 			this.confirmedShapeIds.add(id);
+		}
+		this.recompute();
+	}
+
+	/**
+	 * Bulk variant of `noteShapeAdded` for initial load. Avoids the O(n²)
+	 * cost of calling the single-shape mutator in a loop (each call would
+	 * re-scan `shapeIds` and notify subscribers). Recompute and notify
+	 * happen once after all IDs are ingested.
+	 */
+	noteShapesLoaded(ids: Iterable<string>, source: "local" | "remote"): void {
+		for (const id of ids) {
+			this.shapeIds.add(id);
+			if (source === "remote") {
+				this.confirmedShapeIds.add(id);
+			}
 		}
 		this.recompute();
 	}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -65,8 +65,18 @@ export class SyncStatusTracker {
 		};
 	}
 
-	/** @internal */
-	update(partial: Partial<Omit<SyncStatusSnapshot, "unconfirmedShapeIds">>): void {
+	/**
+	 * Update the "free-form" snapshot fields (state / shapeCount / lastSyncedAt
+	 * / error). The divergence-tracking fields (`unconfirmedShapeIds` and
+	 * `firstServerSyncAt`) are intentionally excluded so callers can't bypass
+	 * the dedicated APIs and break the invariant that `firstServerSyncAt` is
+	 * stamped exactly once on the first server sync.
+	 *
+	 * @internal
+	 */
+	update(
+		partial: Partial<Omit<SyncStatusSnapshot, "unconfirmedShapeIds" | "firstServerSyncAt">>,
+	): void {
 		this.snapshot = { ...this.snapshot, ...partial };
 		this.notify();
 	}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -15,10 +15,12 @@ export interface SyncStatusSnapshot {
 	 * before that, every shape from a persisted Y.Doc looks "local-only" because
 	 * we genuinely don't know what the server holds yet.
 	 *
-	 * Consumers should gate divergence UI on `state === "synced"` (or check
-	 * `lastSyncedAt != null`) so the warning isn't surfaced during the
-	 * `loading` / `connecting` phase, which would generate noise on every
-	 * cold start.
+	 * Consumers should gate divergence UI on `lastSyncedAt != null` so the
+	 * warning isn't surfaced during the initial `loading` / `connecting` phase
+	 * (every cold start would otherwise look full of "unconfirmed" shapes). We
+	 * deliberately pick `lastSyncedAt` over `state === "synced"` so a later
+	 * disconnection still surfaces the warning — that's when offline edits
+	 * accumulate and the user actually needs to know.
 	 */
 	unconfirmedShapeIds: readonly string[];
 }

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -53,6 +53,11 @@ export class SyncStatusTracker {
 	// can only mutate via the dedicated methods below.
 	private readonly shapeIds = new Set<string>();
 	private readonly confirmedShapeIds = new Set<string>();
+	// Batch mode: while > 0, mutators skip notification and a single notify is
+	// fired when the batch closes. Used by yws-sync to combine `noteShapeAdded`
+	// + `update({ shapeCount, lastSyncedAt })` into one render per mutation.
+	private batchDepth = 0;
+	private batchDirty = false;
 
 	getSnapshot(): SyncStatusSnapshot {
 		return this.snapshot;
@@ -151,7 +156,32 @@ export class SyncStatusTracker {
 		this.notify();
 	}
 
+	/**
+	 * Combine multiple mutator calls into a single notification. Useful when
+	 * the caller wants to e.g. `noteShapeAdded(...)` and `update({ shapeCount })`
+	 * back-to-back without paying for two re-renders.
+	 *
+	 * Re-entrant: nested calls are tolerated, the listeners fire once when the
+	 * outermost batch closes.
+	 */
+	batch<T>(fn: () => T): T {
+		this.batchDepth++;
+		try {
+			return fn();
+		} finally {
+			this.batchDepth--;
+			if (this.batchDepth === 0 && this.batchDirty) {
+				this.batchDirty = false;
+				this.notify();
+			}
+		}
+	}
+
 	private notify(): void {
+		if (this.batchDepth > 0) {
+			this.batchDirty = true;
+			return;
+		}
 		for (const listener of this.listeners) listener();
 	}
 }

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -5,6 +5,17 @@ export interface SyncStatusSnapshot {
 	shapeCount: number;
 	lastSyncedAt: number | null;
 	error: string | null;
+	/**
+	 * Shape IDs present in the local Y.Doc that the server has NOT confirmed.
+	 *
+	 * Populated by `noteShapeAdded("local", id)` (a shape created locally that
+	 * hasn't been seen by the server yet) or by being absent from the snapshot
+	 * `setConfirmedFromServer(...)` recorded at the most recent `sync` event.
+	 *
+	 * Empty until the first server sync; clients should only show divergence UI
+	 * once `state === "synced"` has been observed at least once.
+	 */
+	unconfirmedShapeIds: readonly string[];
 }
 
 export class SyncStatusTracker {
@@ -13,8 +24,13 @@ export class SyncStatusTracker {
 		shapeCount: 0,
 		lastSyncedAt: null,
 		error: null,
+		unconfirmedShapeIds: [],
 	};
 	private listeners = new Set<() => void>();
+	// Local sources of truth for divergence calculation. Kept private so callers
+	// can only mutate via the dedicated methods below.
+	private readonly shapeIds = new Set<string>();
+	private readonly confirmedShapeIds = new Set<string>();
 
 	getSnapshot(): SyncStatusSnapshot {
 		return this.snapshot;
@@ -28,10 +44,60 @@ export class SyncStatusTracker {
 	}
 
 	/** @internal */
-	update(partial: Partial<SyncStatusSnapshot>): void {
+	update(partial: Partial<Omit<SyncStatusSnapshot, "unconfirmedShapeIds">>): void {
 		this.snapshot = { ...this.snapshot, ...partial };
-		for (const listener of this.listeners) {
-			listener();
+		this.notify();
+	}
+
+	/**
+	 * Replace the "server-confirmed" set with the given IDs. Call this from the
+	 * provider's `sync` event when `isSynced === true` — at that point the
+	 * Y.Map state is the merged result of (server state ∪ what we uploaded),
+	 * so every key currently in the map IS confirmed. Any local-only shape
+	 * created later will diverge until the next sync event.
+	 */
+	setConfirmedFromServer(ids: Iterable<string>): void {
+		this.confirmedShapeIds.clear();
+		for (const id of ids) this.confirmedShapeIds.add(id);
+		// Ensure shapeIds is a superset (ids that exist server-side must exist
+		// locally too — they were just merged into our doc).
+		for (const id of this.confirmedShapeIds) this.shapeIds.add(id);
+		this.recompute();
+	}
+
+	/**
+	 * Note a shape addition. `source = "remote"` means the shape arrived via the
+	 * Yjs provider (server origin), so it's already confirmed. `source = "local"`
+	 * means we created it client-side and the server has yet to acknowledge.
+	 */
+	noteShapeAdded(id: string, source: "local" | "remote"): void {
+		this.shapeIds.add(id);
+		if (source === "remote") {
+			this.confirmedShapeIds.add(id);
 		}
+		this.recompute();
+	}
+
+	noteShapeRemoved(id: string): void {
+		this.shapeIds.delete(id);
+		this.confirmedShapeIds.delete(id);
+		this.recompute();
+	}
+
+	private recompute(): void {
+		const unconfirmed: string[] = [];
+		for (const id of this.shapeIds) {
+			if (!this.confirmedShapeIds.has(id)) unconfirmed.push(id);
+		}
+		this.snapshot = {
+			...this.snapshot,
+			shapeCount: this.shapeIds.size,
+			unconfirmedShapeIds: unconfirmed,
+		};
+		this.notify();
+	}
+
+	private notify(): void {
+		for (const listener of this.listeners) listener();
 	}
 }

--- a/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/sync-status-tracker.ts
@@ -3,7 +3,22 @@ export type SyncState = "loading" | "connecting" | "synced" | "syncing" | "disco
 export interface SyncStatusSnapshot {
 	state: SyncState;
 	shapeCount: number;
+	/**
+	 * Timestamp of the most recent activity that touched the snapshot — local
+	 * mutations and server syncs alike. Useful for "last activity" displays
+	 * but NOT a reliable indicator that the server has acknowledged anything.
+	 * For divergence gating use `firstServerSyncAt` instead.
+	 */
 	lastSyncedAt: number | null;
+	/**
+	 * Timestamp of the first successful `setConfirmedFromServer(...)` call
+	 * (i.e. the first `provider.on("sync", true)` event). Stays `null` until
+	 * the server has actually merged its state with us. Set once and never
+	 * cleared: a later disconnection should still allow consumers to surface
+	 * divergence (offline edits accumulate exactly when the user needs the
+	 * warning).
+	 */
+	firstServerSyncAt: number | null;
 	error: string | null;
 	/**
 	 * Shape IDs present in the local Y.Doc that the server has NOT confirmed.
@@ -15,12 +30,11 @@ export interface SyncStatusSnapshot {
 	 * before that, every shape from a persisted Y.Doc looks "local-only" because
 	 * we genuinely don't know what the server holds yet.
 	 *
-	 * Consumers should gate divergence UI on `lastSyncedAt != null` so the
-	 * warning isn't surfaced during the initial `loading` / `connecting` phase
-	 * (every cold start would otherwise look full of "unconfirmed" shapes). We
-	 * deliberately pick `lastSyncedAt` over `state === "synced"` so a later
-	 * disconnection still surfaces the warning — that's when offline edits
-	 * accumulate and the user actually needs to know.
+	 * Consumers should gate divergence UI on `firstServerSyncAt !== null` so
+	 * the warning isn't surfaced during the initial `loading` / `connecting`
+	 * phase (every cold start would otherwise look full of "unconfirmed"
+	 * shapes). Once that first server sync has happened, the gate stays open
+	 * even across later disconnections.
 	 */
 	unconfirmedShapeIds: readonly string[];
 }
@@ -30,6 +44,7 @@ export class SyncStatusTracker {
 		state: "loading",
 		shapeCount: 0,
 		lastSyncedAt: null,
+		firstServerSyncAt: null,
 		error: null,
 		unconfirmedShapeIds: [],
 	};
@@ -62,6 +77,9 @@ export class SyncStatusTracker {
 	 * Y.Map state is the merged result of (server state ∪ what we uploaded),
 	 * so every key currently in the map IS confirmed. Any local-only shape
 	 * created later will diverge until the next sync event.
+	 *
+	 * Also stamps `firstServerSyncAt` on the first call so consumers can gate
+	 * divergence UI on "have we ever heard back from the server?".
 	 */
 	setConfirmedFromServer(ids: Iterable<string>): void {
 		this.confirmedShapeIds.clear();
@@ -69,6 +87,9 @@ export class SyncStatusTracker {
 		// Ensure shapeIds is a superset (ids that exist server-side must exist
 		// locally too — they were just merged into our doc).
 		for (const id of this.confirmedShapeIds) this.shapeIds.add(id);
+		if (this.snapshot.firstServerSyncAt === null) {
+			this.snapshot = { ...this.snapshot, firstServerSyncAt: Date.now() };
+		}
 		this.recompute();
 	}
 

--- a/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
@@ -34,14 +34,13 @@ export function UnconfirmedOverlay({
 		() => syncStatus.getSnapshot(),
 	);
 
-	// Only surface divergence after we've actually heard from the server at
-	// least once. Pre-sync (loading / connecting on a cold start) every
-	// IndexedDB-restored shape would look "unconfirmed" because we don't yet
-	// know what the server holds — flagging them then would be noise.
-	// We use `lastSyncedAt != null` rather than `state === "synced"` so a
-	// later disconnection (offline edits, network drop) still surfaces
-	// divergence: that's exactly when the user needs the warning.
-	if (snapshot.lastSyncedAt === null) return null;
+	// Only surface divergence after the server has confirmed us at least once.
+	// `firstServerSyncAt` is set exactly by `setConfirmedFromServer(...)` so
+	// it's the only field that means "we've actually heard back from the
+	// server" — `lastSyncedAt` also moves on local edits and would let warnings
+	// leak out during the initial connecting phase. Once set, the gate stays
+	// open across later disconnections so offline edits surface as divergence.
+	if (snapshot.firstServerSyncAt === null) return null;
 	if (snapshot.unconfirmedShapeIds.length === 0) return null;
 
 	return (

--- a/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
@@ -14,9 +14,11 @@ const BADGE_RADIUS = 9;
 const BADGE_OFFSET = 4;
 
 /**
- * SVG overlay that draws a small red `⚠` badge on the top-right corner of any
- * shape whose ID is in `syncStatus.snapshot.unconfirmedShapeIds` — i.e. shapes
- * that exist in the local Y.Doc but the server hasn't acknowledged.
+ * SVG overlay that draws a small red exclamation badge on the top-right corner
+ * of any shape whose ID is in `syncStatus.snapshot.unconfirmedShapeIds` —
+ * i.e. shapes that exist in the local Y.Doc but the server hasn't acknowledged.
+ * The debug HUD uses the `⚠` glyph; here we render a circle + `!` so the badge
+ * stays legible at small zoom levels where multi-codepoint emoji distort.
  *
  * This is purely diagnostic; clicks pass through to the underlying shape.
  */
@@ -32,11 +34,14 @@ export function UnconfirmedOverlay({
 		() => syncStatus.getSnapshot(),
 	);
 
-	// Only surface divergence after we've actually heard from the server.
-	// Pre-sync (loading / connecting / disconnected) every IndexedDB-restored
-	// shape would look "unconfirmed" because we don't yet know what the server
-	// holds — flagging them then would be noise on every cold start.
-	if (snapshot.state !== "synced") return null;
+	// Only surface divergence after we've actually heard from the server at
+	// least once. Pre-sync (loading / connecting on a cold start) every
+	// IndexedDB-restored shape would look "unconfirmed" because we don't yet
+	// know what the server holds — flagging them then would be noise.
+	// We use `lastSyncedAt != null` rather than `state === "synced"` so a
+	// later disconnection (offline edits, network drop) still surfaces
+	// divergence: that's exactly when the user needs the warning.
+	if (snapshot.lastSyncedAt === null) return null;
 	if (snapshot.unconfirmedShapeIds.length === 0) return null;
 
 	return (

--- a/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
@@ -1,5 +1,5 @@
 import type { BoardStore, ShapeRegistry, Viewport } from "@edv4h/usketch-shared";
-import { useSyncExternalStore } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import type { SyncStatusTracker } from "./sync-status-tracker.js";
 
 interface UnconfirmedOverlayProps {
@@ -29,11 +29,16 @@ export function UnconfirmedOverlay({
 	viewport,
 	syncStatus,
 }: UnconfirmedOverlayProps) {
-	const snapshot = useSyncExternalStore(
-		(listener) => syncStatus.subscribe(listener),
-		() => syncStatus.getSnapshot(),
-		() => syncStatus.getSnapshot(),
+	// Keep `subscribe` / `getSnapshot` identities stable across renders so that
+	// re-renders triggered by viewport changes don't churn through unsubscribe
+	// /resubscribe cycles. Dependent only on `syncStatus`, which is itself
+	// stable for the lifetime of the plugin.
+	const subscribe = useCallback(
+		(listener: () => void) => syncStatus.subscribe(listener),
+		[syncStatus],
 	);
+	const getSnapshot = useCallback(() => syncStatus.getSnapshot(), [syncStatus]);
+	const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
 	// Only surface divergence after the server has confirmed us at least once.
 	// `firstServerSyncAt` is set exactly by `setConfirmedFromServer(...)` so

--- a/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
@@ -1,0 +1,102 @@
+import type { BoardStore, ShapeRegistry, Viewport } from "@edv4h/usketch-shared";
+import { useSyncExternalStore } from "react";
+import type { SyncStatusTracker } from "./sync-status-tracker.js";
+
+interface UnconfirmedOverlayProps {
+	store: BoardStore;
+	shapes: ShapeRegistry;
+	viewport: Viewport;
+	syncStatus: SyncStatusTracker;
+}
+
+const BADGE_FILL = "#dc2626";
+const BADGE_RADIUS = 9;
+const BADGE_OFFSET = 4;
+
+/**
+ * SVG overlay that draws a small red `⚠` badge on the top-right corner of any
+ * shape whose ID is in `syncStatus.snapshot.unconfirmedShapeIds` — i.e. shapes
+ * that exist in the local Y.Doc but the server hasn't acknowledged.
+ *
+ * This is purely diagnostic; clicks pass through to the underlying shape.
+ */
+export function UnconfirmedOverlay({
+	store,
+	shapes,
+	viewport,
+	syncStatus,
+}: UnconfirmedOverlayProps) {
+	const snapshot = useSyncExternalStore(
+		(listener) => syncStatus.subscribe(listener),
+		() => syncStatus.getSnapshot(),
+		() => syncStatus.getSnapshot(),
+	);
+
+	if (snapshot.unconfirmedShapeIds.length === 0) return null;
+
+	return (
+		<svg
+			style={{
+				position: "absolute",
+				inset: 0,
+				width: "100%",
+				height: "100%",
+				pointerEvents: "none",
+			}}
+		>
+			<title>サーバ未同期 Shape</title>
+			{snapshot.unconfirmedShapeIds.map((id) => (
+				<UnconfirmedBadge key={id} store={store} shapes={shapes} viewport={viewport} shapeId={id} />
+			))}
+		</svg>
+	);
+}
+
+function UnconfirmedBadge({
+	store,
+	shapes,
+	viewport,
+	shapeId,
+}: {
+	store: BoardStore;
+	shapes: ShapeRegistry;
+	viewport: Viewport;
+	shapeId: string;
+}) {
+	const shape = store.getShape(shapeId);
+	if (!shape) return null;
+
+	// Use the shape definition's bounds when available, falling back to the
+	// raw `x/y/width/height` for shapes without a registered type (e.g. legacy
+	// shape types that disappeared after a refactor — the very case this
+	// overlay was designed to surface).
+	const def = shapes.get(shape.type);
+	const bounds = def?.getBounds(shape) ?? {
+		x: shape.x,
+		y: shape.y,
+		width: shape.width,
+		height: shape.height,
+	};
+
+	const cx = (bounds.x + bounds.width) * viewport.zoom + viewport.x + BADGE_OFFSET;
+	const cy = bounds.y * viewport.zoom + viewport.y - BADGE_OFFSET;
+
+	return (
+		<g>
+			<title>{`${shape.type} (${shapeId.slice(0, 8)}…) — サーバに存在しません`}</title>
+			<circle cx={cx} cy={cy} r={BADGE_RADIUS} fill={BADGE_FILL} />
+			<text
+				x={cx}
+				y={cy + 1}
+				textAnchor="middle"
+				dominantBaseline="middle"
+				fontSize={11}
+				fontWeight={700}
+				fill="#ffffff"
+				style={{ userSelect: "none" }}
+			>
+				!
+			</text>
+		</g>
+	);
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
@@ -32,6 +32,11 @@ export function UnconfirmedOverlay({
 		() => syncStatus.getSnapshot(),
 	);
 
+	// Only surface divergence after we've actually heard from the server.
+	// Pre-sync (loading / connecting / disconnected) every IndexedDB-restored
+	// shape would look "unconfirmed" because we don't yet know what the server
+	// holds — flagging them then would be noise on every cold start.
+	if (snapshot.state !== "synced") return null;
 	if (snapshot.unconfirmedShapeIds.length === 0) return null;
 
 	return (

--- a/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/unconfirmed-overlay.tsx
@@ -15,10 +15,11 @@ const BADGE_OFFSET = 4;
 
 /**
  * SVG overlay that draws a small red exclamation badge on the top-right corner
- * of any shape whose ID is in `syncStatus.snapshot.unconfirmedShapeIds` —
- * i.e. shapes that exist in the local Y.Doc but the server hasn't acknowledged.
- * The debug HUD uses the `⚠` glyph; here we render a circle + `!` so the badge
- * stays legible at small zoom levels where multi-codepoint emoji distort.
+ * of any shape whose ID appears in `syncStatus.getSnapshot().unconfirmedShapeIds`
+ * — i.e. shapes that exist in the local Y.Doc but the server hasn't
+ * acknowledged. The debug HUD uses the `⚠` glyph; here we render a circle +
+ * `!` so the badge stays legible at small zoom levels where multi-codepoint
+ * emoji distort.
  *
  * This is purely diagnostic; clicks pass through to the underlying shape.
  */

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -139,9 +139,10 @@ export function createYwebsocketSync(
 		if (isSyncing || destroyed) return;
 
 		// `transaction.local === true` means this Y.Doc edit originated from
-		// our own client (already noted via `noteShapeAdded("local", ...)` in
-		// the store mutation handler). `false` means the change came from the
-		// server / another peer, so it's already confirmed.
+		// our own client — the store mutation handler above has already noted
+		// the addition (as "remote" if the socket was open, "local" otherwise).
+		// `false` means the change came from the server / another peer, so it
+		// must be marked as confirmed here when we forward it to the store.
 		const isLocalTxn = events.transaction.local;
 
 		isSyncing = true;

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -61,7 +61,14 @@ export function createYwebsocketSync(
 	const statusListeners = new Set<(status: WsConnectionStatus) => void>();
 	const broadcastListeners = new Set<(msg: Record<string, unknown>) => void>();
 
+	// Latest socket-level status. Read by the local mutation handler to decide
+	// whether a freshly-added shape should be treated as already "confirmed"
+	// (the socket is open so y-websocket immediately broadcasts the update) or
+	// as "pending" (offline → diverges until a re-sync).
+	let currentWsStatus: WsConnectionStatus = "disconnected";
+
 	function notifyStatus(next: WsConnectionStatus): void {
+		currentWsStatus = next;
 		// "connected" at the transport level only means the socket is open — the
 		// first Yjs sync has not necessarily completed. Map to "syncing" until the
 		// provider's `sync` event fires; `onSync` will flip the tracker to "synced".
@@ -100,10 +107,14 @@ export function createYwebsocketSync(
 					if (shape) {
 						const isNew = !shapesMap.has(payload.id);
 						shapesMap.set(payload.id, toPlainObject(shape));
-						// New shape created locally → diverges from server state
-						// until a `sync` confirmation arrives.
 						if (isNew && event.type === "shape:added") {
-							status.noteShapeAdded(payload.id, "local");
+							// Socket open → y-websocket immediately broadcasts this
+							// shape to the server, so it's effectively confirmed. We
+							// only flag local adds as "unconfirmed" while the
+							// connection is down, so the warning shows up exactly
+							// for offline edits / orphaned IndexedDB state.
+							const isOnline = currentWsStatus === "connected";
+							status.noteShapeAdded(payload.id, isOnline ? "remote" : "local");
 						}
 					}
 					break;

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -177,6 +177,7 @@ export function createYwebsocketSync(
 	function applyInitialLoad(): void {
 		if (shapesMap.size === 0) return;
 		const idsNeedingZIndex: string[] = [];
+		const loadedIds: string[] = [];
 		isSyncing = true;
 		try {
 			for (const [id, value] of shapesMap.entries()) {
@@ -188,14 +189,19 @@ export function createYwebsocketSync(
 				if (typeof shape.zIndex !== "string") {
 					idsNeedingZIndex.push(id);
 				}
-				// Pre-connection load (typically from IndexedDB). These haven't
-				// been confirmed by the current server session yet — they'll be
-				// promoted to "confirmed" by `setConfirmedFromServer` when the
-				// first sync event fires.
-				status.noteShapeAdded(id, "local");
+				loadedIds.push(id);
 			}
 		} finally {
 			isSyncing = false;
+		}
+
+		// Pre-connection load (typically from IndexedDB). These haven't been
+		// confirmed by the current server session yet — they'll be promoted to
+		// "confirmed" by `setConfirmedFromServer` when the first sync event
+		// fires. Use the bulk API so initial-load shapes don't trigger O(n²)
+		// recompute cycles.
+		if (loadedIds.length > 0) {
+			status.noteShapesLoaded(loadedIds, "local");
 		}
 
 		// Backfill zIndex into Y.Map for any shape that got an auto-assigned one,

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -98,12 +98,19 @@ export function createYwebsocketSync(
 				case "shape:updated": {
 					const shape = store.getShape(payload.id);
 					if (shape) {
+						const isNew = !shapesMap.has(payload.id);
 						shapesMap.set(payload.id, toPlainObject(shape));
+						// New shape created locally → diverges from server state
+						// until a `sync` confirmation arrives.
+						if (isNew && event.type === "shape:added") {
+							status.noteShapeAdded(payload.id, "local");
+						}
 					}
 					break;
 				}
 				case "shape:removed": {
 					shapesMap.delete(payload.id);
+					status.noteShapeRemoved(payload.id);
 					break;
 				}
 			}
@@ -120,6 +127,12 @@ export function createYwebsocketSync(
 	const shapesObserver = (events: Y.YMapEvent<Record<string, unknown>>): void => {
 		if (isSyncing || destroyed) return;
 
+		// `transaction.local === true` means this Y.Doc edit originated from
+		// our own client (already noted via `noteShapeAdded("local", ...)` in
+		// the store mutation handler). `false` means the change came from the
+		// server / another peer, so it's already confirmed.
+		const isLocalTxn = events.transaction.local;
+
 		isSyncing = true;
 		try {
 			for (const [key, change] of events.changes.keys) {
@@ -134,6 +147,10 @@ export function createYwebsocketSync(
 								store.updateShape(key, shape);
 							} else {
 								store.addShape(shape);
+								if (!isLocalTxn) {
+									// Remote add → confirmed by server.
+									status.noteShapeAdded(key, "remote");
+								}
 							}
 						}
 						break;
@@ -142,6 +159,7 @@ export function createYwebsocketSync(
 						if (store.getShape(key)) {
 							store.deleteShape(key);
 						}
+						status.noteShapeRemoved(key);
 						break;
 					}
 				}
@@ -170,6 +188,11 @@ export function createYwebsocketSync(
 				if (typeof shape.zIndex !== "string") {
 					idsNeedingZIndex.push(id);
 				}
+				// Pre-connection load (typically from IndexedDB). These haven't
+				// been confirmed by the current server session yet — they'll be
+				// promoted to "confirmed" by `setConfirmedFromServer` when the
+				// first sync event fires.
+				status.noteShapeAdded(id, "local");
 			}
 		} finally {
 			isSyncing = false;
@@ -283,6 +306,11 @@ export function createYwebsocketSync(
 
 		const onSync = (isSynced: boolean): void => {
 			if (isSynced) {
+				// At this moment `shapesMap` reflects the merged server state
+				// (server's view ∪ what we uploaded). Treat every key here as
+				// confirmed. Anything added afterward without a subsequent
+				// sync event will diverge.
+				status.setConfirmedFromServer(shapesMap.keys());
 				status.update({
 					state: "synced",
 					shapeCount: shapesMap.size,

--- a/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/yws-sync.ts
@@ -98,40 +98,44 @@ export function createYwebsocketSync(
 		const payload = event.payload as { id: string } | undefined;
 		if (!payload?.id) return;
 
-		isSyncing = true;
-		try {
-			switch (event.type) {
-				case "shape:added":
-				case "shape:updated": {
-					const shape = store.getShape(payload.id);
-					if (shape) {
-						const isNew = !shapesMap.has(payload.id);
-						shapesMap.set(payload.id, toPlainObject(shape));
-						if (isNew && event.type === "shape:added") {
-							// Socket open → y-websocket immediately broadcasts this
-							// shape to the server, so it's effectively confirmed. We
-							// only flag local adds as "unconfirmed" while the
-							// connection is down, so the warning shows up exactly
-							// for offline edits / orphaned IndexedDB state.
-							const isOnline = currentWsStatus === "connected";
-							status.noteShapeAdded(payload.id, isOnline ? "remote" : "local");
+		// Batch the divergence note + the shapeCount/lastSyncedAt update so
+		// subscribers see exactly one snapshot change per local mutation.
+		status.batch(() => {
+			isSyncing = true;
+			try {
+				switch (event.type) {
+					case "shape:added":
+					case "shape:updated": {
+						const shape = store.getShape(payload.id);
+						if (shape) {
+							const isNew = !shapesMap.has(payload.id);
+							shapesMap.set(payload.id, toPlainObject(shape));
+							if (isNew && event.type === "shape:added") {
+								// Socket open → y-websocket immediately broadcasts this
+								// shape to the server, so it's effectively confirmed. We
+								// only flag local adds as "unconfirmed" while the
+								// connection is down, so the warning shows up exactly
+								// for offline edits / orphaned IndexedDB state.
+								const isOnline = currentWsStatus === "connected";
+								status.noteShapeAdded(payload.id, isOnline ? "remote" : "local");
+							}
 						}
+						break;
 					}
-					break;
+					case "shape:removed": {
+						shapesMap.delete(payload.id);
+						status.noteShapeRemoved(payload.id);
+						break;
+					}
 				}
-				case "shape:removed": {
-					shapesMap.delete(payload.id);
-					status.noteShapeRemoved(payload.id);
-					break;
-				}
+			} finally {
+				isSyncing = false;
 			}
-		} finally {
-			isSyncing = false;
-		}
 
-		// Keep the status snapshot in sync with the authoritative Y.Map size so
-		// consumers (DebugHUD etc.) see up-to-date counts after local edits too.
-		status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
+			// Keep the status snapshot in sync with the authoritative Y.Map size so
+			// consumers (DebugHUD etc.) see up-to-date counts after local edits too.
+			status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
+		});
 		resetIdleTimer();
 	});
 
@@ -145,42 +149,46 @@ export function createYwebsocketSync(
 		// must be marked as confirmed here when we forward it to the store.
 		const isLocalTxn = events.transaction.local;
 
-		isSyncing = true;
-		try {
-			for (const [key, change] of events.changes.keys) {
-				switch (change.action) {
-					case "add":
-					case "update": {
-						const value = shapesMap.get(key);
-						if (value) {
-							const shape = value as unknown as ShapeData;
-							const existing = store.getShape(key);
-							if (existing) {
-								store.updateShape(key, shape);
-							} else {
-								store.addShape(shape);
-								if (!isLocalTxn) {
-									// Remote add → confirmed by server.
-									status.noteShapeAdded(key, "remote");
+		// Batch all per-key notes plus the trailing `update(...)` so we fire
+		// exactly one notification per Yjs transaction.
+		status.batch(() => {
+			isSyncing = true;
+			try {
+				for (const [key, change] of events.changes.keys) {
+					switch (change.action) {
+						case "add":
+						case "update": {
+							const value = shapesMap.get(key);
+							if (value) {
+								const shape = value as unknown as ShapeData;
+								const existing = store.getShape(key);
+								if (existing) {
+									store.updateShape(key, shape);
+								} else {
+									store.addShape(shape);
+									if (!isLocalTxn) {
+										// Remote add → confirmed by server.
+										status.noteShapeAdded(key, "remote");
+									}
 								}
 							}
+							break;
 						}
-						break;
-					}
-					case "delete": {
-						if (store.getShape(key)) {
-							store.deleteShape(key);
+						case "delete": {
+							if (store.getShape(key)) {
+								store.deleteShape(key);
+							}
+							status.noteShapeRemoved(key);
+							break;
 						}
-						status.noteShapeRemoved(key);
-						break;
 					}
 				}
+			} finally {
+				isSyncing = false;
 			}
-		} finally {
-			isSyncing = false;
-		}
 
-		status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
+			status.update({ shapeCount: shapesMap.size, lastSyncedAt: Date.now() });
+		});
 	};
 
 	shapesMap.observe(shapesObserver);
@@ -226,8 +234,9 @@ export function createYwebsocketSync(
 				}
 			});
 		}
-
-		status.update({ shapeCount: shapesMap.size });
+		// `noteShapesLoaded(...)` above already recomputed `shapeCount` and
+		// notified once for the batch, so no follow-up `update({ shapeCount })`
+		// is needed here.
 	}
 
 	applyInitialLoad();

--- a/plugins/usketch-plugin-sync-ywebsocket/tsconfig.json
+++ b/plugins/usketch-plugin-sync-ywebsocket/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "../../tsconfig.lib.json",
 	"compilerOptions": {
 		"outDir": "./dist",
-		"rootDir": "./src"
+		"rootDir": "./src",
+		"jsx": "react-jsx"
 	},
 	"include": ["src"],
 	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "**/__tests__/**"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       '@edv4h/usketch-plugin-sync-localstorage-yjs':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-sync-localstorage-yjs
+      '@edv4h/usketch-plugin-sync-ywebsocket':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-sync-ywebsocket
       '@edv4h/usketch-plugin-tool-pan':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-tool-pan

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  react: 19.2.4
+  react-dom: 19.2.4
+
 importers:
 
   .:
@@ -51,10 +55,10 @@ importers:
         specifier: ^7.1
         version: 7.2.0
       react:
-        specifier: ^19.1
+        specifier: 19.2.4
         version: 19.2.4
       react-dom:
-        specifier: ^19.1
+        specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
       rehype-autolink-headings:
         specifier: ^7.1
@@ -397,7 +401,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -416,11 +420,11 @@ importers:
         specifier: workspace:*
         version: link:../shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
       react-dom:
-        specifier: '>=19'
-        version: 19.1.0(react@19.1.0)
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -454,10 +458,10 @@ importers:
         specifier: workspace:*
         version: link:../shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
       react-dom:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@types/react':
@@ -479,10 +483,10 @@ importers:
         specifier: workspace:*
         version: link:../shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
       react-dom:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@types/react':
@@ -526,8 +530,8 @@ importers:
         specifier: 3.2.0
         version: 3.2.0
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
       xid-ts:
         specifier: 1.2.2
         version: 1.2.2
@@ -625,8 +629,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -650,7 +654,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -688,8 +692,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -710,8 +714,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -780,8 +784,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -802,7 +806,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -824,7 +828,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -849,7 +853,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -871,7 +875,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -893,8 +897,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -918,7 +922,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -937,8 +941,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -977,7 +981,7 @@ importers:
         specifier: ^1.37.0
         version: 1.37.0
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -999,8 +1003,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1021,11 +1025,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
       react-dom:
-        specifier: '>=19'
-        version: 19.1.0(react@19.1.0)
+        specifier: 19.2.4
+        version: 19.2.4(react@19.2.4)
       satori:
         specifier: 0.26.0
         version: 0.26.0
@@ -1052,8 +1056,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1077,7 +1081,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1099,8 +1103,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1121,8 +1125,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1143,8 +1147,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1165,7 +1169,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1193,8 +1197,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1352,8 +1356,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1374,8 +1378,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1393,7 +1397,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1424,7 +1428,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1449,8 +1453,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1474,7 +1478,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1499,8 +1503,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1524,7 +1528,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1543,8 +1547,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1565,7 +1569,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1596,7 +1600,7 @@ importers:
         specifier: ^1.37.0
         version: 1.37.0
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1627,8 +1631,8 @@ importers:
         specifier: ^1.37.0
         version: 1.37.0
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1649,8 +1653,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1668,8 +1672,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1690,8 +1694,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1712,8 +1716,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1734,8 +1738,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1778,7 +1782,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
       y-protocols:
         specifier: 1.0.7
@@ -1812,8 +1816,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1837,8 +1841,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/store
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1878,8 +1882,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
-        version: 19.1.0
+        specifier: 19.2.4
+        version: 19.2.4
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -1900,7 +1904,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sync
       react:
-        specifier: '>=19'
+        specifier: 19.2.4
         version: 19.2.4
     devDependencies:
       '@types/react':
@@ -1958,8 +1962,8 @@ packages:
     peerDependencies:
       '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
-      react: ^17.0.2 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react: 19.2.4
+      react-dom: 19.2.4
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -3197,7 +3201,7 @@ packages:
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==, tarball: https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3206,7 +3210,7 @@ packages:
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==, tarball: https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3216,8 +3220,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3229,8 +3233,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3241,7 +3245,7 @@ packages:
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==, tarball: https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3251,8 +3255,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3263,7 +3267,7 @@ packages:
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==, tarball: https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3273,8 +3277,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3286,8 +3290,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3299,8 +3303,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3312,8 +3316,8 @@ packages:
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3324,7 +3328,7 @@ packages:
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==, tarball: https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3333,7 +3337,7 @@ packages:
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==, tarball: https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3342,7 +3346,7 @@ packages:
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==, tarball: https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3351,7 +3355,7 @@ packages:
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==, tarball: https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3360,7 +3364,7 @@ packages:
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==, tarball: https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3369,7 +3373,7 @@ packages:
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==, tarball: https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3378,7 +3382,7 @@ packages:
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==, tarball: https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -3897,8 +3901,8 @@ packages:
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
       pg: ^8.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: 19.2.4
+      react-dom: 19.2.4
       solid-js: ^1.0.0
       svelte: ^4.0.0 || ^5.0.0
       vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
@@ -4080,8 +4084,8 @@ packages:
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==, tarball: https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
+      react: 19.2.4
+      react-dom: 19.2.4
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==, tarball: https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz}
@@ -5497,15 +5501,10 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
-  react-dom@19.1.0:
-    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
-    peerDependencies:
-      react: ^19.1.0
-
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==, tarball: https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz}
     peerDependencies:
-      react: ^19.2.4
+      react: 19.2.4
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -5516,7 +5515,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5526,7 +5525,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5535,8 +5534,8 @@ packages:
     resolution: {integrity: sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: 19.2.4
+      react-dom: 19.2.4
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -5546,17 +5545,13 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  react@19.1.0:
-    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
-    engines: {node: '>=0.10.0'}
-
   react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==, tarball: https://registry.npmjs.org/react/-/react-19.2.4.tgz}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -5705,9 +5700,6 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
-
-  scheduler@0.26.0:
-    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz}
@@ -6103,7 +6095,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6113,7 +6105,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -10179,11 +10171,6 @@ snapshots:
       iconv-lite: 0.7.2
       unpipe: 1.0.0
 
-  react-dom@19.1.0(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      scheduler: 0.26.0
-
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -10225,8 +10212,6 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
-
-  react@19.1.0: {}
 
   react@19.2.4: {}
 
@@ -10488,8 +10473,6 @@ snapshots:
       yoga-layout: 3.2.1
 
   sax@1.6.0: {}
-
-  scheduler@0.26.0: {}
 
   scheduler@0.27.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1777,6 +1777,9 @@ importers:
       '@edv4h/usketch-sync':
         specifier: workspace:*
         version: link:../../packages/sync
+      react:
+        specifier: '>=19'
+        version: 19.2.4
       y-protocols:
         specifier: 1.0.7
         version: 1.0.7(yjs@13.6.30)
@@ -1787,6 +1790,9 @@ importers:
         specifier: ^13.6.0
         version: 13.6.30
     devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

サーバの Y.Doc に存在しないが、ブラウザの IndexedDB / ローカル Y.Doc には残っている shape を **可視化** する機能を追加。

きっかけ: `canvas_clear` でサーバ側を空にしてもブラウザに古い shape が描画され続ける事故が発生。サーバとローカルの乖離にユーザが気付けるようにする。

- `SyncStatusTracker` に `unconfirmedShapeIds: readonly string[]` を追加
- ywebsocket の `provider.on("sync", isSynced)` 時にサーバが認識している shape ID 集合を確定スナップショットとして記録
- 以降ローカルのみで存在する shape を「未確定」として識別

## UI

- **canvas overlay** (`unconfirmed-shapes-overlay`, layer order 250): 未確定 shape の右上に小さな赤い `!` バッジ。`pointerEvents: none` で診断のみ。
- **debug HUD General パネル**: 「⚠ サーバ未同期 Shape: N 件」行
- **debug HUD Shapes パネル**: 各行にバッジ + ヘッダの件数バッジクリックで「未同期のみ」フィルタ切替

ywebsocket plugin が積まれていない (IndexedDB-only) ボードでは何も表示されない。

## Test plan

- [x] `pnpm turbo typecheck --continue` 134/134 pass
- [x] `pnpm turbo test --continue` 133/133 pass (新規 8 tests + 既存 13 tests)
- [x] `pnpm biome check` clean
- [ ] `apps/web` 起動後、ブラウザ確認:
  - [ ] 新 cloud ボード作成 → 3 shape 描画 → 同期完了で debug HUD に件数 0
  - [ ] DevTools Network → Offline → 4 つ目を描く → debug HUD に「⚠ 1 件」+ canvas に赤バッジ
  - [ ] Network 戻して再同期 → バッジが消える
  - [ ] 別タブで MCP `canvas_clear` → ブラウザの IndexedDB には shape が残るが、再 sync で全部 unconfirmed 扱い → debug HUD で件数表示

## フォローアップ (本 PR のスコープ外)

- 「未同期 Shape 一括削除」ボタン (誤爆懸念で今回は入れない)
- 廃止 type の shape を別チャネルで検出 (gray dashed box の fallback とは別に件数表示)
- ywebsocket plugin README に SyncStatus API のドキュメント

🤖 Generated with [Claude Code](https://claude.com/claude-code)