### PR TITLE
✨ feat: Selection Foreground 交換 API (#577)

### DIFF
--- a/.changeset/selection-foreground-api.md
+++ b/.changeset/selection-foreground-api.md
@@ -1,0 +1,16 @@
+---
+"@edv4h/usketch-shared": minor
+"@edv4h/usketch-core": minor
+"@edv4h/usketch-canvas-engine": minor
+"@edv4h/usketch-plugin-tool-select": patch
+---
+
+Selection foreground (selection UI) を外部から差し替え可能にする API を追加 (#577)。
+
+- `createApp({ selectionForeground: { render } })` ホスト向けオプション (priority 100 で登録)。
+- `ctx.ui.registerSelectionForeground({ id, priority, render })` プラグイン向け registrar。
+- 解決ルール: priority 数値大が勝ち、同値なら last-wins。
+- `usketch-plugin-tool-select` は priority 0 のデフォルトとして自己登録 (`id: "tool-select-default"`)。挙動・互換性は維持。
+- canvas-engine は active エントリを内部 layer `__selection-foreground` として動的にマウント。
+
+詳細は `guides/selection-foreground` (en/ja) を参照。

--- a/apps/docs/src/content/docs-ja/concepts/layer-system.mdx
+++ b/apps/docs/src/content/docs-ja/concepts/layer-system.mdx
@@ -97,4 +97,4 @@ setup(ctx: PluginContext) {
 
 ## Selection UI の差し替え
 
-既定の selection UI（ハンドル・バウンディングボックス・マーキー）は `ctx.layers` から直接登録されているわけではなく、優先度付きの専用レジストリでマウントされます。これによりアプリ／プラグインから安全に差し替え可能です。詳しくは [Selection Foreground](/docs-ja/guides/selection-foreground/) を参照してください。
+既定の selection UI（ハンドル・バウンディングボックス・マーキー）は `ctx.layers` から直接登録されているわけではなく、優先度付きの専用レジストリでマウントされます。これによりアプリ／プラグインから安全に差し替え可能です。詳しくは [Selection Foreground](/docs/ja/guides/selection-foreground/) を参照してください。

--- a/apps/docs/src/content/docs-ja/concepts/layer-system.mdx
+++ b/apps/docs/src/content/docs-ja/concepts/layer-system.mdx
@@ -94,3 +94,7 @@ setup(ctx: PluginContext) {
   });
 }
 ```
+
+## Selection UI の差し替え
+
+既定の selection UI（ハンドル・バウンディングボックス・マーキー）は `ctx.layers` から直接登録されているわけではなく、優先度付きの専用レジストリでマウントされます。これによりアプリ／プラグインから安全に差し替え可能です。詳しくは [Selection Foreground](/docs-ja/guides/selection-foreground/) を参照してください。

--- a/apps/docs/src/content/docs-ja/guides/selection-foreground.mdx
+++ b/apps/docs/src/content/docs-ja/guides/selection-foreground.mdx
@@ -1,0 +1,142 @@
+---
+title: Selection Foreground (selection UI の差し替え)
+description: ハンドル、バウンディングボックス、マーキーを独自の React コンポーネントで置き換える方法。
+order: 22
+---
+
+既定の selection UI（バウンディングボックス、8 方向リサイズハンドル、回転ハンドル、マーキー矩形、ホバーハイライト、ドロップターゲット表示）は `usketch-plugin-tool-select` が描画しています。多くのアプリではこれで十分ですが、視覚や挙動を大きく変えたい場合（クロップ用ハンドル、テキスト編集用ハンドル、独自スタイル、特定ブラウザ向け回避など）、uSketch は selection UI 全体を React コンポーネント 1 つで差し替えるための API を提供します。
+
+## いつ使うか
+
+以下のような要件があるときに使ってください:
+
+- 既定とは本質的に異なるハンドル（画像用クロップ、テキスト編集、ロール別の表示など）を描画したい。
+- アプリ固有のラッパー UI（埋め込み iframe オーバレイ、ブラウザ別の workaround）が必要。
+- React canvas 以外のスタイル（HTML オーバレイ、選択近傍のアンカーボタンなど）を出したい。
+
+シェイプの **リサイズ挙動** だけを変えたい場合（アスペクト比固定など）は、シェイプの `resize` 関数を変更してください。色や線幅などの小さな見た目調整は可能なら CSS で行います。本 API は selection UI を **丸ごと** 置換するためのもので、部分置換用の slot ではありません。
+
+## 2 つの登録経路
+
+機能的には等価です。配布形態に合わせて選んでください。
+
+### アプリオプションとして
+
+キャンバスの埋め込みオーナーが固定の selection UI を出したい場合:
+
+```ts
+import { createApp } from "@edv4h/usketch-core";
+
+const app = await createApp({
+  store,
+  plugins,
+  selectionForeground: {
+    render: (ctx) => <MySelectionForeground ctx={ctx} />,
+  },
+});
+```
+
+内部的には `__app:selectionForeground` という id で **priority 100** にて、全プラグイン setup の **後** に登録されます。任意のプラグイン default に勝ちます。
+
+### プラグインとして
+
+他アプリにオプトインで配布したい場合:
+
+```ts
+import type { UsketchPlugin } from "@edv4h/usketch-shared";
+
+export const myFancyHandlesPlugin: UsketchPlugin = {
+  id: "fancy-handles",
+  name: "Fancy Handles",
+  setup(ctx) {
+    const off = ctx.ui.registerSelectionForeground({
+      id: "fancy-handles",
+      priority: 50,
+      order: 80,
+      fixed: true,
+      render: (renderCtx) => <FancyHandles ctx={renderCtx} />,
+    });
+    (this as UsketchPlugin).teardown = () => off();
+  },
+};
+```
+
+## 優先度の規約
+
+`priority` 数値が大きい方が勝ち、同値なら **最後に登録された方** が勝ちます。
+
+| 提供元                                              | priority |
+| --------------------------------------------------- | -------- |
+| プラグイン default（`usketch-plugin-tool-select`） | **0**    |
+| 第三者プラグインのカスタム UI                       | **50**   |
+| `createApp({ selectionForeground })` のホスト指定   | **100**  |
+
+これらは推奨値であって強制ではありません。アプリオプションはプラグイン setup の **後** に登録されるため、プラグインが誤って priority 100 で登録しても、同値の場合は last-wins でアプリ側が勝ちます。
+
+## render 契約
+
+`render` 関数には通常の layer と同じ `LayerRenderContext` が渡されます:
+
+| フィールド      | 内容                                                                |
+| --------------- | ------------------------------------------------------------------- |
+| `viewport`      | 現在の `{ x, y, zoom }`。world→screen 座標変換に使用。              |
+| `shapes`        | 全シェイプ `ReadonlyMap<string, ShapeData>`。                       |
+| `shapesSorted`  | zIndex 昇順（背面→前面）にソート済みのシェイプ。                    |
+| `selection`     | 現在の選択中シェイプ ID `ReadonlySet<string>`。                     |
+| `theme`         | 有効なテーマトークン。                                              |
+| `renderMode`    | LOD モード（`"interactive"` / `"simplified"`）。                    |
+
+`fixed: true`（デフォルト）にすると、コンポーネントは viewport transform の外側で描画されます — screen-space SVG / HTML オーバレイを書きやすくなります。world 座標で描きたい場合は `fixed: false` を指定してください。
+
+## 最小サンプル
+
+選択中のシェイプを橙色の点線ボックスで囲む（回転対応）例:
+
+```tsx
+import type { SelectionForeground } from "@edv4h/usketch-shared";
+
+const orangeBox: SelectionForeground = {
+  id: "orange-selection",
+  priority: 100,
+  fixed: true,
+  render: ({ viewport, shapes, selection }) => {
+    if (selection.size !== 1) return null;
+    const id = [...selection][0]!;
+    const shape = shapes.get(id);
+    if (!shape) return null;
+
+    const x = shape.x * viewport.zoom + viewport.x;
+    const y = shape.y * viewport.zoom + viewport.y;
+    const w = shape.width * viewport.zoom;
+    const h = shape.height * viewport.zoom;
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+    const rotation = shape.rotation ?? 0;
+
+    return (
+      <svg style={{ position: "absolute", inset: 0, overflow: "visible", pointerEvents: "none" }}>
+        <g transform={rotation ? `rotate(${rotation}, ${cx}, ${cy})` : undefined}>
+          <rect
+            x={x}
+            y={y}
+            width={w}
+            height={h}
+            fill="none"
+            stroke="#ff8800"
+            strokeWidth={2}
+            strokeDasharray="6 3"
+          />
+        </g>
+      </svg>
+    );
+  },
+};
+
+const app = await createApp({ store, plugins, selectionForeground: orangeBox });
+```
+
+## デフォルト挙動とフォールバック
+
+`usketch-plugin-tool-select` は priority 0 で default エントリ（`id: "tool-select-default"`、`order: 80`、`fixed: true`）を自己登録します。tool-select を読み込まず **かつ** アプリオプションも指定しない場合、selection UI は何も描画されません（レジストリの active が null）。キャンバス自体は動作しますが、視覚的なオーバレイのみが消えます。
+
+予約済 layer id `__selection-foreground` は active エントリのマウントに内部で使われます。外部から `ctx.layers` でこの id を登録しないでください。

--- a/apps/docs/src/content/docs-ja/guides/selection-foreground.mdx
+++ b/apps/docs/src/content/docs-ja/guides/selection-foreground.mdx
@@ -90,50 +90,49 @@ export const myFancyHandlesPlugin: UsketchPlugin = {
 
 ## 最小サンプル
 
-選択中のシェイプを橙色の点線ボックスで囲む（回転対応）例:
+選択中のシェイプを橙色の点線ボックスで囲む（回転対応）例を `createApp` のオプションとして渡します。オプションが受け取るのは `render`（必須）と任意の `priority` / `order` / `fixed` です。エントリの `id` は内部で `__app:selectionForeground` に固定されるため、ここでは指定しません。
 
 ```tsx
-import type { SelectionForeground } from "@edv4h/usketch-shared";
+const app = await createApp({
+  store,
+  plugins,
+  selectionForeground: {
+    render: ({ viewport, shapes, selection }) => {
+      if (selection.size !== 1) return null;
+      const id = [...selection][0]!;
+      const shape = shapes.get(id);
+      if (!shape) return null;
 
-const orangeBox: SelectionForeground = {
-  id: "orange-selection",
-  priority: 100,
-  fixed: true,
-  render: ({ viewport, shapes, selection }) => {
-    if (selection.size !== 1) return null;
-    const id = [...selection][0]!;
-    const shape = shapes.get(id);
-    if (!shape) return null;
+      const x = shape.x * viewport.zoom + viewport.x;
+      const y = shape.y * viewport.zoom + viewport.y;
+      const w = shape.width * viewport.zoom;
+      const h = shape.height * viewport.zoom;
+      const cx = x + w / 2;
+      const cy = y + h / 2;
+      const rotation = shape.rotation ?? 0;
 
-    const x = shape.x * viewport.zoom + viewport.x;
-    const y = shape.y * viewport.zoom + viewport.y;
-    const w = shape.width * viewport.zoom;
-    const h = shape.height * viewport.zoom;
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-    const rotation = shape.rotation ?? 0;
-
-    return (
-      <svg style={{ position: "absolute", inset: 0, overflow: "visible", pointerEvents: "none" }}>
-        <g transform={rotation ? `rotate(${rotation}, ${cx}, ${cy})` : undefined}>
-          <rect
-            x={x}
-            y={y}
-            width={w}
-            height={h}
-            fill="none"
-            stroke="#ff8800"
-            strokeWidth={2}
-            strokeDasharray="6 3"
-          />
-        </g>
-      </svg>
-    );
+      return (
+        <svg style={{ position: "absolute", inset: 0, overflow: "visible", pointerEvents: "none" }}>
+          <g transform={rotation ? `rotate(${rotation}, ${cx}, ${cy})` : undefined}>
+            <rect
+              x={x}
+              y={y}
+              width={w}
+              height={h}
+              fill="none"
+              stroke="#ff8800"
+              strokeWidth={2}
+              strokeDasharray="6 3"
+            />
+          </g>
+        </svg>
+      );
+    },
   },
-};
-
-const app = await createApp({ store, plugins, selectionForeground: orangeBox });
+});
 ```
+
+自前の `id` や `priority` を持つ完全な `SelectionForeground` が必要な場合（例: `ctx.ui.registerSelectionForeground(...)` で登録するプラグインを配布したい場合）は、本ガイド前半の plugin サンプルを参照してください。
 
 ## デフォルト挙動とフォールバック
 

--- a/apps/docs/src/content/docs/concepts/layer-system.mdx
+++ b/apps/docs/src/content/docs/concepts/layer-system.mdx
@@ -97,4 +97,4 @@ setup(ctx: PluginContext) {
 
 ## Replacing the selection UI
 
-The default selection UI (handles, bounding box, marquee) is **not** registered through `ctx.layers` directly — it is mounted by a separate, priority-aware registry so apps and plugins can swap it out cleanly. See [Selection Foreground](/guides/selection-foreground/) for the replacement API.
+The default selection UI (handles, bounding box, marquee) is **not** registered through `ctx.layers` directly — it is mounted by a separate, priority-aware registry so apps and plugins can swap it out cleanly. See [Selection Foreground](/docs/guides/selection-foreground/) for the replacement API.

--- a/apps/docs/src/content/docs/concepts/layer-system.mdx
+++ b/apps/docs/src/content/docs/concepts/layer-system.mdx
@@ -94,3 +94,7 @@ setup(ctx: PluginContext) {
   });
 }
 ```
+
+## Replacing the selection UI
+
+The default selection UI (handles, bounding box, marquee) is **not** registered through `ctx.layers` directly — it is mounted by a separate, priority-aware registry so apps and plugins can swap it out cleanly. See [Selection Foreground](/guides/selection-foreground/) for the replacement API.

--- a/apps/docs/src/content/docs/guides/selection-foreground.mdx
+++ b/apps/docs/src/content/docs/guides/selection-foreground.mdx
@@ -1,0 +1,142 @@
+---
+title: Selection Foreground (replacing the selection UI)
+description: Swap out the default handles, bounding box, and marquee with a custom React component.
+order: 22
+---
+
+The default selection UI — bounding box, eight resize handles, rotation handle, marquee rectangle, hover highlight, drop-target indicator — is rendered by `usketch-plugin-tool-select`. For most apps that is what you want. When you need a substantially different visual or behavior (e.g. integrating a host app's own selection UI with extra handles, custom adornments, or branded styling), uSketch lets you replace the entire foreground with a single React component.
+
+## When to use this API
+
+Reach for the selection foreground API when you want to:
+
+- Render fundamentally different handles (crop handles for images, text-editing handles, role-specific adornments).
+- Wrap selection in app-specific chrome (e.g. embedded iframe overlays, browser-specific workarounds).
+- Provide a non-React-canvas-style UI (HTML overlay, anchored buttons next to the selection).
+
+If you only want to change a shape's *resize behavior* (e.g. constrain aspect ratio), modify the shape's `resize` function instead. If you only need a small visual tweak (color, stroke), restyle via CSS where possible. The selection foreground API replaces the **entire** overlay; it is not a slot for partial overrides.
+
+## Two ways to register
+
+There are two equivalent paths to register an entry — pick whichever fits your distribution model.
+
+### As an app option
+
+For apps that own the canvas embedding and want a fixed selection UI:
+
+```ts
+import { createApp } from "@edv4h/usketch-core";
+
+const app = await createApp({
+  store,
+  plugins,
+  selectionForeground: {
+    render: (ctx) => <MySelectionForeground ctx={ctx} />,
+  },
+});
+```
+
+Internally registered with id `__app:selectionForeground` at **priority 100**, after all plugins have run. This wins over any plugin default.
+
+### As a plugin
+
+For shareable plugins that other apps can opt into:
+
+```ts
+import type { UsketchPlugin } from "@edv4h/usketch-shared";
+
+export const myFancyHandlesPlugin: UsketchPlugin = {
+  id: "fancy-handles",
+  name: "Fancy Handles",
+  setup(ctx) {
+    const off = ctx.ui.registerSelectionForeground({
+      id: "fancy-handles",
+      priority: 50,
+      order: 80,
+      fixed: true,
+      render: (renderCtx) => <FancyHandles ctx={renderCtx} />,
+    });
+    (this as UsketchPlugin).teardown = () => off();
+  },
+};
+```
+
+## Priority conventions
+
+Higher `priority` wins. On a tie, the most recently registered entry wins.
+
+| Source                                          | Priority |
+| ----------------------------------------------- | -------- |
+| Plugin default (`usketch-plugin-tool-select`)   | **0**    |
+| Third-party plugin custom UI                    | **50**   |
+| `createApp({ selectionForeground })` host option | **100**  |
+
+These are conventions, not enforced ranges. App options are registered *after* plugin `setup`, so an app option at priority 100 also wins on ties with a plugin that registered at priority 100.
+
+## The render contract
+
+Your `render` function receives the same `LayerRenderContext` that regular layers receive:
+
+| Field           | What it gives you                                                          |
+| --------------- | -------------------------------------------------------------------------- |
+| `viewport`      | Current `{ x, y, zoom }` — used to convert world to screen coordinates.    |
+| `shapes`        | All shapes on the canvas as `ReadonlyMap<string, ShapeData>`.              |
+| `shapesSorted`  | The same shapes sorted by zIndex (back-to-front).                          |
+| `selection`     | The currently selected shape IDs as `ReadonlySet<string>`.                 |
+| `theme`         | Active theme tokens.                                                       |
+| `renderMode`    | LOD mode (`"interactive"` / `"simplified"`).                               |
+
+Set `fixed: true` (the default) and your component will be rendered outside the viewport transform — useful for screen-space SVG/HTML overlays. Set `fixed: false` if your component lives in world coordinates.
+
+## Minimal example
+
+A dashed orange box that follows the rotation of a single selected shape:
+
+```tsx
+import type { SelectionForeground } from "@edv4h/usketch-shared";
+
+const orangeBox: SelectionForeground = {
+  id: "orange-selection",
+  priority: 100,
+  fixed: true,
+  render: ({ viewport, shapes, selection }) => {
+    if (selection.size !== 1) return null;
+    const id = [...selection][0]!;
+    const shape = shapes.get(id);
+    if (!shape) return null;
+
+    const x = shape.x * viewport.zoom + viewport.x;
+    const y = shape.y * viewport.zoom + viewport.y;
+    const w = shape.width * viewport.zoom;
+    const h = shape.height * viewport.zoom;
+    const cx = x + w / 2;
+    const cy = y + h / 2;
+    const rotation = shape.rotation ?? 0;
+
+    return (
+      <svg style={{ position: "absolute", inset: 0, overflow: "visible", pointerEvents: "none" }}>
+        <g transform={rotation ? `rotate(${rotation}, ${cx}, ${cy})` : undefined}>
+          <rect
+            x={x}
+            y={y}
+            width={w}
+            height={h}
+            fill="none"
+            stroke="#ff8800"
+            strokeWidth={2}
+            strokeDasharray="6 3"
+          />
+        </g>
+      </svg>
+    );
+  },
+};
+
+const app = await createApp({ store, plugins, selectionForeground: orangeBox });
+```
+
+## Default behavior and fallback
+
+`usketch-plugin-tool-select` self-registers a default entry at priority 0 (`id: "tool-select-default"`, `order: 80`, `fixed: true`). If you do not load tool-select **and** do not provide an app option, nothing is rendered for the selection UI — the registry simply has no active entry. The canvas itself continues to work; only the visual overlay disappears.
+
+The reserved layer id `__selection-foreground` is used internally to mount the active entry. Do not register a regular `ctx.layers` layer with that id from outside.

--- a/apps/docs/src/content/docs/guides/selection-foreground.mdx
+++ b/apps/docs/src/content/docs/guides/selection-foreground.mdx
@@ -90,50 +90,49 @@ Set `fixed: true` (the default) and your component will be rendered outside the 
 
 ## Minimal example
 
-A dashed orange box that follows the rotation of a single selected shape:
+A dashed orange box that follows the rotation of a single selected shape, passed as a `createApp` option. The option accepts `render` (required) plus optional `priority` / `order` / `fixed` — the entry id is always set internally to `__app:selectionForeground`, so don't supply one here.
 
 ```tsx
-import type { SelectionForeground } from "@edv4h/usketch-shared";
+const app = await createApp({
+  store,
+  plugins,
+  selectionForeground: {
+    render: ({ viewport, shapes, selection }) => {
+      if (selection.size !== 1) return null;
+      const id = [...selection][0]!;
+      const shape = shapes.get(id);
+      if (!shape) return null;
 
-const orangeBox: SelectionForeground = {
-  id: "orange-selection",
-  priority: 100,
-  fixed: true,
-  render: ({ viewport, shapes, selection }) => {
-    if (selection.size !== 1) return null;
-    const id = [...selection][0]!;
-    const shape = shapes.get(id);
-    if (!shape) return null;
+      const x = shape.x * viewport.zoom + viewport.x;
+      const y = shape.y * viewport.zoom + viewport.y;
+      const w = shape.width * viewport.zoom;
+      const h = shape.height * viewport.zoom;
+      const cx = x + w / 2;
+      const cy = y + h / 2;
+      const rotation = shape.rotation ?? 0;
 
-    const x = shape.x * viewport.zoom + viewport.x;
-    const y = shape.y * viewport.zoom + viewport.y;
-    const w = shape.width * viewport.zoom;
-    const h = shape.height * viewport.zoom;
-    const cx = x + w / 2;
-    const cy = y + h / 2;
-    const rotation = shape.rotation ?? 0;
-
-    return (
-      <svg style={{ position: "absolute", inset: 0, overflow: "visible", pointerEvents: "none" }}>
-        <g transform={rotation ? `rotate(${rotation}, ${cx}, ${cy})` : undefined}>
-          <rect
-            x={x}
-            y={y}
-            width={w}
-            height={h}
-            fill="none"
-            stroke="#ff8800"
-            strokeWidth={2}
-            strokeDasharray="6 3"
-          />
-        </g>
-      </svg>
-    );
+      return (
+        <svg style={{ position: "absolute", inset: 0, overflow: "visible", pointerEvents: "none" }}>
+          <g transform={rotation ? `rotate(${rotation}, ${cx}, ${cy})` : undefined}>
+            <rect
+              x={x}
+              y={y}
+              width={w}
+              height={h}
+              fill="none"
+              stroke="#ff8800"
+              strokeWidth={2}
+              strokeDasharray="6 3"
+            />
+          </g>
+        </svg>
+      );
+    },
   },
-};
-
-const app = await createApp({ store, plugins, selectionForeground: orangeBox });
+});
 ```
+
+If you need a full `SelectionForeground` (with your own `id` and `priority`) — for example when distributing a plugin that registers via `ctx.ui.registerSelectionForeground(...)` — use the plugin-shaped example earlier in this guide instead.
 
 ## Default behavior and fallback
 

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -149,6 +149,28 @@ export function Canvas() {
 		return app.events.on("layers:changed", () => setLayerVersion((v) => v + 1));
 	}, [app.events]);
 
+	// ── Selection foreground: mount the active registry entry as an internal layer ──
+	// The id `__selection-foreground` is reserved; do not register a regular
+	// layer with the same id from outside.
+	useEffect(() => {
+		const sync = () => {
+			const active = app.selectionForeground.getActive();
+			if (active) {
+				app.layers.register({
+					id: "__selection-foreground",
+					order: active.order ?? 80,
+					fixed: active.fixed ?? true,
+					render: active.render,
+				});
+			} else {
+				app.layers.unregister("__selection-foreground");
+			}
+			app.events.emit("layers:changed", {});
+		};
+		sync();
+		return app.selectionForeground.subscribe(sync);
+	}, [app.selectionForeground, app.layers, app.events]);
+
 	// ── Tool activate / deactivate lifecycle ──
 	const prevToolIdRef = useRef<string | null>(null);
 	const activeToolRef = useRef(activeTool);

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -168,7 +168,12 @@ export function Canvas() {
 			app.events.emit("layers:changed", {});
 		};
 		sync();
-		return app.selectionForeground.subscribe(sync);
+		const unsubscribe = app.selectionForeground.subscribe(sync);
+		return () => {
+			unsubscribe();
+			app.layers.unregister("__selection-foreground");
+			app.events.emit("layers:changed", {});
+		};
 	}, [app.selectionForeground, app.layers, app.events]);
 
 	// ── Tool activate / deactivate lifecycle ──

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -145,7 +145,10 @@ export function Canvas() {
 	// ── Re-render when layers change dynamically ──
 	// Plugins that register/unregister layers at runtime must emit
 	// "layers:changed" via ctx.events after mutation.
-	useEffect(() => {
+	// Installed via useLayoutEffect so that emissions made from the
+	// selection-foreground layout effect below (which also runs synchronously
+	// before paint on initial mount) are not missed.
+	useLayoutEffect(() => {
 		return app.events.on("layers:changed", () => setLayerVersion((v) => v + 1));
 	}, [app.events]);
 
@@ -154,11 +157,6 @@ export function Canvas() {
 	// layer with the same id from outside.
 	// Uses useLayoutEffect so the layer is registered before the first paint —
 	// otherwise the selection UI would be missing for one frame on initial mount.
-	// Drives the Canvas re-render directly via `setLayerVersion` (not via
-	// `layers:changed`) because the event listener is installed in a passive
-	// `useEffect` that runs after this layout effect — the very first
-	// emission from `sync()` would otherwise be missed. The event is still
-	// emitted for external listeners that rely on it.
 	useLayoutEffect(() => {
 		let mounted = false;
 		const sync = () => {
@@ -171,12 +169,10 @@ export function Canvas() {
 					render: active.render,
 				});
 				mounted = true;
-				setLayerVersion((v) => v + 1);
 				app.events.emit("layers:changed", {});
 			} else if (mounted) {
 				app.layers.unregister("__selection-foreground");
 				mounted = false;
-				setLayerVersion((v) => v + 1);
 				app.events.emit("layers:changed", {});
 			}
 		};
@@ -186,7 +182,6 @@ export function Canvas() {
 			unsubscribe();
 			if (mounted) {
 				app.layers.unregister("__selection-foreground");
-				setLayerVersion((v) => v + 1);
 				app.events.emit("layers:changed", {});
 			}
 		};

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -154,6 +154,11 @@ export function Canvas() {
 	// layer with the same id from outside.
 	// Uses useLayoutEffect so the layer is registered before the first paint —
 	// otherwise the selection UI would be missing for one frame on initial mount.
+	// Drives the Canvas re-render directly via `setLayerVersion` (not via
+	// `layers:changed`) because the event listener is installed in a passive
+	// `useEffect` that runs after this layout effect — the very first
+	// emission from `sync()` would otherwise be missed. The event is still
+	// emitted for external listeners that rely on it.
 	useLayoutEffect(() => {
 		let mounted = false;
 		const sync = () => {
@@ -166,10 +171,12 @@ export function Canvas() {
 					render: active.render,
 				});
 				mounted = true;
+				setLayerVersion((v) => v + 1);
 				app.events.emit("layers:changed", {});
 			} else if (mounted) {
 				app.layers.unregister("__selection-foreground");
 				mounted = false;
+				setLayerVersion((v) => v + 1);
 				app.events.emit("layers:changed", {});
 			}
 		};
@@ -179,6 +186,7 @@ export function Canvas() {
 			unsubscribe();
 			if (mounted) {
 				app.layers.unregister("__selection-foreground");
+				setLayerVersion((v) => v + 1);
 				app.events.emit("layers:changed", {});
 			}
 		};

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -153,6 +153,7 @@ export function Canvas() {
 	// The id `__selection-foreground` is reserved; do not register a regular
 	// layer with the same id from outside.
 	useEffect(() => {
+		let mounted = false;
 		const sync = () => {
 			const active = app.selectionForeground.getActive();
 			if (active) {
@@ -162,17 +163,22 @@ export function Canvas() {
 					fixed: active.fixed ?? true,
 					render: active.render,
 				});
-			} else {
+				mounted = true;
+				app.events.emit("layers:changed", {});
+			} else if (mounted) {
 				app.layers.unregister("__selection-foreground");
+				mounted = false;
+				app.events.emit("layers:changed", {});
 			}
-			app.events.emit("layers:changed", {});
 		};
 		sync();
 		const unsubscribe = app.selectionForeground.subscribe(sync);
 		return () => {
 			unsubscribe();
-			app.layers.unregister("__selection-foreground");
-			app.events.emit("layers:changed", {});
+			if (mounted) {
+				app.layers.unregister("__selection-foreground");
+				app.events.emit("layers:changed", {});
+			}
 		};
 	}, [app.selectionForeground, app.layers, app.events]);
 

--- a/packages/canvas-engine/src/components/canvas.tsx
+++ b/packages/canvas-engine/src/components/canvas.tsx
@@ -1,6 +1,6 @@
 import type { CanvasPointerEvent, RenderMode } from "@edv4h/usketch-shared";
 import { compareZIndex, DEFAULT_THEME } from "@edv4h/usketch-shared";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useApp } from "../context.js";
 import { screenToWorld } from "../coordinate-transformer.js";
 import { useFilterPredicate } from "../hooks/use-filter-predicate.js";
@@ -152,7 +152,9 @@ export function Canvas() {
 	// ── Selection foreground: mount the active registry entry as an internal layer ──
 	// The id `__selection-foreground` is reserved; do not register a regular
 	// layer with the same id from outside.
-	useEffect(() => {
+	// Uses useLayoutEffect so the layer is registered before the first paint —
+	// otherwise the selection UI would be missing for one frame on initial mount.
+	useLayoutEffect(() => {
 		let mounted = false;
 		const sync = () => {
 			const active = app.selectionForeground.getActive();

--- a/packages/core/src/__tests__/create-app-selection-foreground.test.ts
+++ b/packages/core/src/__tests__/create-app-selection-foreground.test.ts
@@ -1,0 +1,126 @@
+import type {
+	BoardStore,
+	PluginContext,
+	SelectionForeground,
+	UsketchPlugin,
+} from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { createApp } from "../create-app.js";
+
+function createStubStore(): BoardStore {
+	const listeners = new Set<() => void>();
+	return {
+		getShapes: () => new Map(),
+		getShapesSorted: () => [],
+		getShape: () => undefined,
+		addShape() {},
+		updateShape() {},
+		deleteShape() {},
+		ensureZIndex() {},
+		getSelection: () => new Set(),
+		setSelection() {},
+		addToSelection() {},
+		removeFromSelection() {},
+		clearSelection() {},
+		getActiveToolId: () => "select",
+		setActiveToolId() {},
+		getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+		setViewport() {},
+		panBy() {},
+		zoomTo() {},
+		fitToBounds() {},
+		getStyleSettings: () => ({
+			fill: "#ffffff",
+			stroke: "#1e1e1e",
+			strokeWidth: 2,
+			opacity: 1,
+		}),
+		setStyleSettings() {},
+		getVisibleShapeIds: () => [],
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		onMutation: () => () => {},
+	} as unknown as BoardStore;
+}
+
+function defaultPlugin(entry: SelectionForeground): UsketchPlugin {
+	let off: (() => void) | undefined;
+	return {
+		id: "test-default-plugin",
+		name: "test default",
+		setup(ctx: PluginContext) {
+			off = ctx.ui.registerSelectionForeground(entry);
+		},
+		teardown() {
+			off?.();
+		},
+	};
+}
+
+describe("createApp — selection foreground integration", () => {
+	it("registers ctx.ui on PluginContext so plugins can hook in", async () => {
+		const renderFn = () => null;
+		const plugin = defaultPlugin({
+			id: "tool-select-default",
+			priority: 0,
+			render: renderFn,
+		});
+
+		const app = await createApp({ store: createStubStore(), plugins: [plugin] });
+
+		expect(app.selectionForeground.getActive()?.id).toBe("tool-select-default");
+		expect(app.selectionForeground.getActive()?.render).toBe(renderFn);
+
+		app.destroy();
+	});
+
+	it("createApp({ selectionForeground }) wins over a plugin default", async () => {
+		const plugin = defaultPlugin({
+			id: "tool-select-default",
+			priority: 0,
+			render: () => null,
+		});
+		const hostRender = () => null;
+
+		const app = await createApp({
+			store: createStubStore(),
+			plugins: [plugin],
+			selectionForeground: { render: hostRender },
+		});
+
+		const active = app.selectionForeground.getActive();
+		expect(active?.id).toBe("__app:selectionForeground");
+		expect(active?.priority).toBe(100);
+		expect(active?.render).toBe(hostRender);
+
+		app.destroy();
+	});
+
+	it("createApp({ selectionForeground }) wins on tie against a priority-100 plugin (registered after)", async () => {
+		const plugin = defaultPlugin({
+			id: "custom-plugin",
+			priority: 100,
+			render: () => null,
+		});
+		const hostRender = () => null;
+
+		const app = await createApp({
+			store: createStubStore(),
+			plugins: [plugin],
+			selectionForeground: { render: hostRender },
+		});
+
+		// app option is registered after plugin setup, so on equal priority it wins.
+		expect(app.selectionForeground.getActive()?.id).toBe("__app:selectionForeground");
+
+		app.destroy();
+	});
+
+	it("with no host option and no plugin, getActive() is null", async () => {
+		const app = await createApp({ store: createStubStore(), plugins: [] });
+		expect(app.selectionForeground.getActive()).toBeNull();
+		app.destroy();
+	});
+});

--- a/packages/core/src/__tests__/selection-foreground-registry.test.ts
+++ b/packages/core/src/__tests__/selection-foreground-registry.test.ts
@@ -1,0 +1,71 @@
+import type { SelectionForeground } from "@edv4h/usketch-shared";
+import { describe, expect, it, vi } from "vitest";
+import { createSelectionForegroundRegistry } from "../selection-foreground-registry.js";
+
+function entry(id: string, priority: number): SelectionForeground {
+	return { id, priority, render: () => null };
+}
+
+describe("createSelectionForegroundRegistry", () => {
+	it("returns null when nothing is registered", () => {
+		const r = createSelectionForegroundRegistry();
+		expect(r.getActive()).toBeNull();
+	});
+
+	it("higher priority wins", () => {
+		const r = createSelectionForegroundRegistry();
+		r.register(entry("a", 0));
+		r.register(entry("b", 50));
+		expect(r.getActive()?.id).toBe("b");
+	});
+
+	it("on tie, last registered wins", () => {
+		const r = createSelectionForegroundRegistry();
+		r.register(entry("a", 10));
+		r.register(entry("b", 10));
+		expect(r.getActive()?.id).toBe("b");
+	});
+
+	it("re-registering same id bumps it to last (wins on tie)", () => {
+		const r = createSelectionForegroundRegistry();
+		r.register(entry("a", 10));
+		r.register(entry("b", 10));
+		expect(r.getActive()?.id).toBe("b");
+		r.register(entry("a", 10));
+		expect(r.getActive()?.id).toBe("a");
+	});
+
+	it("unregister falls back to next-best", () => {
+		const r = createSelectionForegroundRegistry();
+		r.register(entry("a", 0));
+		r.register(entry("b", 100));
+		expect(r.getActive()?.id).toBe("b");
+		r.unregister("b");
+		expect(r.getActive()?.id).toBe("a");
+	});
+
+	it("unsubscribe returned by register removes the entry", () => {
+		const r = createSelectionForegroundRegistry();
+		const off = r.register(entry("a", 0));
+		expect(r.getActive()?.id).toBe("a");
+		off();
+		expect(r.getActive()).toBeNull();
+	});
+
+	it("subscribe notifies when active actually changes", () => {
+		const r = createSelectionForegroundRegistry();
+		const listener = vi.fn();
+		r.subscribe(listener);
+
+		r.register(entry("a", 0));
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		// Lower-priority entry does not change the active — no notification.
+		r.register({ id: "b", priority: -5, render: () => null });
+		expect(listener).toHaveBeenCalledTimes(1);
+
+		// Higher-priority entry takes over — one notification.
+		r.register(entry("c", 100));
+		expect(listener).toHaveBeenCalledTimes(2);
+	});
+});

--- a/packages/core/src/create-app.ts
+++ b/packages/core/src/create-app.ts
@@ -6,10 +6,13 @@ import type {
 	LodPolicy,
 	PluginContext,
 	RenderMode,
+	SelectionForeground,
+	SelectionForegroundRegistry,
 	ShapeRegistry,
 	ShortcutRegistry,
 	ToolRegistry,
 	TransientRegistry,
+	UiRegistry,
 	UsketchPlugin,
 } from "@edv4h/usketch-shared";
 import { createCommandRegistry } from "./command-registry.js";
@@ -23,10 +26,14 @@ import {
 	type LodControllerInternal,
 } from "./lod/index.js";
 import { createPluginRegistry } from "./plugin-registry.js";
+import { createSelectionForegroundRegistry } from "./selection-foreground-registry.js";
 import { createShapeRegistry } from "./shape-registry.js";
 import { createShortcutRegistry } from "./shortcut-registry.js";
 import { createToolRegistry } from "./tool-registry.js";
 import { createTransientRegistry } from "./transient-registry.js";
+
+/** Internal id used when `CreateAppOptions.selectionForeground` is provided. */
+const APP_SELECTION_FOREGROUND_ID = "__app:selectionForeground";
 
 export interface AppInstance {
 	store: BoardStore;
@@ -38,6 +45,9 @@ export interface AppInstance {
 	events: EventBus;
 	transient: TransientRegistry;
 	lod: LodControllerInternal;
+	ui: UiRegistry;
+	/** Exposed so canvas-engine can subscribe to the active entry. */
+	selectionForeground: SelectionForegroundRegistry;
 	plugins: readonly UsketchPlugin[];
 	destroy(): void;
 }
@@ -53,6 +63,15 @@ export interface CreateAppOptions {
 		policy?: LodPolicy;
 		initialMode?: RenderMode;
 	};
+	/**
+	 * Replace the default selection UI (handles, bounding box, marquee) with
+	 * a host-provided implementation. Internally registered at priority 100,
+	 * so it wins over plugin defaults (priority 0) and typical third-party
+	 * plugin overrides (priority 50 by convention). Pass priority explicitly
+	 * to override.
+	 */
+	selectionForeground?: Pick<SelectionForeground, "render"> &
+		Partial<Pick<SelectionForeground, "priority" | "order" | "fixed">>;
 }
 
 export async function createApp(options: CreateAppOptions): Promise<AppInstance> {
@@ -65,6 +84,10 @@ export async function createApp(options: CreateAppOptions): Promise<AppInstance>
 	const shortcuts = createShortcutRegistry();
 	const events = createEventBus();
 	const transient = createTransientRegistry();
+	const selectionForeground = createSelectionForegroundRegistry();
+	const ui: UiRegistry = {
+		registerSelectionForeground: (entry) => selectionForeground.register(entry),
+	};
 	const pluginRegistry = createPluginRegistry();
 
 	const lodPolicy =
@@ -88,6 +111,7 @@ export async function createApp(options: CreateAppOptions): Promise<AppInstance>
 		events,
 		transient,
 		lod,
+		ui,
 	};
 
 	// Bridge store mutations to EventBus
@@ -110,6 +134,19 @@ export async function createApp(options: CreateAppOptions): Promise<AppInstance>
 	shortcuts.register("Ctrl+Z", () => commands.undo());
 	shortcuts.register("Ctrl+Shift+Z", () => commands.redo());
 
+	// App-level selection foreground option is registered AFTER plugin setup
+	// so it wins on ties against a plugin that registered priority 100.
+	if (options.selectionForeground) {
+		const opt = options.selectionForeground;
+		selectionForeground.register({
+			id: APP_SELECTION_FOREGROUND_ID,
+			priority: opt.priority ?? 100,
+			order: opt.order ?? 80,
+			fixed: opt.fixed ?? true,
+			render: opt.render,
+		});
+	}
+
 	return {
 		store,
 		layers,
@@ -120,6 +157,8 @@ export async function createApp(options: CreateAppOptions): Promise<AppInstance>
 		events,
 		transient,
 		lod,
+		ui,
+		selectionForeground,
 		plugins: pluginRegistry.getAll(),
 		destroy() {
 			for (const plugin of plugins) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export {
 	createZoomLodPolicy,
 } from "./lod/index.js";
 export { createPluginRegistry } from "./plugin-registry.js";
+export { createSelectionForegroundRegistry } from "./selection-foreground-registry.js";
 export { createShapeRegistry } from "./shape-registry.js";
 export { createShortcutRegistry } from "./shortcut-registry.js";
 export { createToolRegistry } from "./tool-registry.js";

--- a/packages/core/src/selection-foreground-registry.ts
+++ b/packages/core/src/selection-foreground-registry.ts
@@ -1,0 +1,63 @@
+import type { SelectionForeground, SelectionForegroundRegistry } from "@edv4h/usketch-shared";
+
+/**
+ * Registry for the canvas selection foreground (handles, bounding box, marquee).
+ *
+ * Resolution rules:
+ * - Higher `priority` wins.
+ * - On ties, the most-recently-registered entry wins (last-wins).
+ * - Re-registering the same `id` replaces the previous entry and bumps it to
+ *   the end of insertion order (so the new entry wins on tie).
+ *
+ * Listeners registered via `subscribe` are notified only when the active
+ * entry actually changes (by referential identity).
+ */
+export function createSelectionForegroundRegistry(): SelectionForegroundRegistry {
+	const entries = new Map<string, SelectionForeground>();
+	const listeners = new Set<() => void>();
+	let active: SelectionForeground | null = null;
+
+	function computeActive(): SelectionForeground | null {
+		let winner: SelectionForeground | null = null;
+		for (const e of entries.values()) {
+			if (!winner || e.priority >= winner.priority) winner = e;
+		}
+		return winner;
+	}
+
+	function refreshActive() {
+		const next = computeActive();
+		if (next === active) return;
+		active = next;
+		for (const l of listeners) l();
+	}
+
+	return {
+		register(entry) {
+			entries.delete(entry.id);
+			entries.set(entry.id, entry);
+			refreshActive();
+			return () => {
+				if (entries.get(entry.id) === entry) {
+					entries.delete(entry.id);
+					refreshActive();
+				}
+			};
+		},
+
+		unregister(id) {
+			if (entries.delete(id)) refreshActive();
+		},
+
+		getActive() {
+			return active;
+		},
+
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => {
+				listeners.delete(listener);
+			};
+		},
+	};
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,8 @@ export type {
 	LayerRenderContext,
 	PluginContext,
 	RenderTarget,
+	SelectionForeground,
+	SelectionForegroundRegistry,
 	ShapeDefinition,
 	ShapeRegistry,
 	ShapeSerializeContext,
@@ -29,6 +31,7 @@ export type {
 	TransientObject,
 	TransientRegistry,
 	TransientRenderer,
+	UiRegistry,
 	UsketchPlugin,
 } from "./types/plugin.js";
 // Shape

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -50,6 +50,46 @@ export interface LayerManager {
 	getLayers(): readonly Layer[];
 }
 
+// ── Selection Foreground (UI extension point) ──
+
+/**
+ * A replaceable rendering of the selection UI (handles, bounding box, marquee,
+ * rotation handle, etc.). Apps and plugins can register one or more entries;
+ * the registry picks a single winner using `priority` (higher wins) with
+ * last-registered winning on ties.
+ *
+ * Priority conventions (recommended, not enforced):
+ * - `0`   — plugin default (e.g. `usketch-plugin-tool-select`).
+ * - `50`  — third-party plugin custom UI.
+ * - `100` — `createApp({ selectionForeground })` host option.
+ *
+ * The `render` function has the same shape as a regular `Layer.render` so
+ * the active entry can be mounted as an internal canvas layer.
+ */
+export interface SelectionForeground {
+	id: string;
+	priority: number;
+	/** z-order hint when mounted as a layer. Defaults to 80. */
+	order?: number;
+	/** Whether the mounted layer should skip viewport transform. Defaults to true. */
+	fixed?: boolean;
+	render: (ctx: LayerRenderContext) => ReactElement | null;
+}
+
+export interface SelectionForegroundRegistry {
+	/** Register an entry. Re-registering the same `id` replaces and bumps to last (wins on ties). */
+	register(entry: SelectionForeground): () => void;
+	unregister(id: string): void;
+	/** The currently winning entry, or `null` when nothing is registered. */
+	getActive(): SelectionForeground | null;
+	/** Notified whenever the active entry changes. */
+	subscribe(listener: () => void): () => void;
+}
+
+export interface UiRegistry {
+	registerSelectionForeground(entry: SelectionForeground): () => void;
+}
+
 // ── Shape System ──
 
 /**
@@ -326,6 +366,7 @@ export interface PluginContext {
 	events: EventBus;
 	transient: TransientRegistry;
 	lod: LodController;
+	ui: UiRegistry;
 }
 
 export interface UsketchPlugin {

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -445,10 +445,12 @@ export const selectToolPlugin: UsketchPlugin = {
 			onDeactivate,
 		});
 
-		// ── Selection overlay layer ──
-
-		ctx.layers.register({
-			id: "selection-overlay",
+		// ── Selection foreground (default) ──
+		// Registered at priority 0 so any app option or third-party plugin
+		// (recommended: 50) replaces it. See guides/selection-foreground.
+		const unregisterSelectionForeground = ctx.ui.registerSelectionForeground({
+			id: "tool-select-default",
+			priority: 0,
 			order: 80,
 			fixed: true,
 			render: (renderCtx) => (
@@ -474,7 +476,7 @@ export const selectToolPlugin: UsketchPlugin = {
 			clearHoveredShapeListeners();
 			clearDropTargetListeners();
 			styleEl.remove();
-			ctx.layers.unregister("selection-overlay");
+			unregisterSelectionForeground();
 		};
 	},
 };


### PR DESCRIPTION
## Summary

Closes #577.

Selection UI (handles / bounding box / marquee / rotation handle / hover highlight / drop-target indicator) を外部から差し替え可能にする API を追加。weboard (Atrae/wevox-mono-web #10172) のような独自 selection UI を持つアプリが、tool-select の default に乗っかる代わりに丸ごと置き換えられるようにする。

## 設計判断

- **配置先**: 新規 `ctx.ui` registrar (将来 toolbar / context-menu もここに集める枠) + `createApp({ selectionForeground })` option。
- **差し替え単位**: layer 丸ごと (`SelectionOverlay` 全体を 1 React component で置換)。
- **優先順位**: `priority` 数値大が勝ち、同値なら **last-wins**。
- **既存 SelectionOverlay は tool-select に残置**: `priority: 0` の default として自己登録 (`id: "tool-select-default"`)。外部から何も登録しなければ挙動・互換性は維持。
- **既存実装は tool-select 内に温存**: `plugins/usketch-plugin-tool-select/src/selection-overlay.tsx` は無変更、登録経路だけ差し替え。
- **canvas-engine の同期**: active エントリを内部 layer `__selection-foreground` として動的に register/unregister し、既存 layer pipeline (fixed wrap, viewport transform) を流用。

## priority 規約

| 提供元 | priority |
|---|---|
| plugin default (`usketch-plugin-tool-select`) | 0 |
| 第三者プラグインのカスタム UI | 50 (推奨) |
| `createApp({ selectionForeground })` | 100 |

`createApp` option は **plugin setup の後** に登録するため、プラグインが誤って priority 100 を使っても last-wins で app option が勝つ。

## 主要な変更ファイル

- `packages/shared/src/types/plugin.ts` — `SelectionForeground` / `SelectionForegroundRegistry` / `UiRegistry` 型を追加、`PluginContext.ui` を追加
- `packages/core/src/selection-foreground-registry.ts` — **新規** registry (Map+挿入順+priority+last-wins)
- `packages/core/src/create-app.ts` — registry 作成、`ctx.ui` thin wrapper、option 経由 register (priority 100)、`AppInstance.{ui, selectionForeground}` expose
- `packages/canvas-engine/src/components/canvas.tsx` — active 同期 useEffect 追加、内部 layer `__selection-foreground` を動的に register/unregister
- `plugins/usketch-plugin-tool-select/src/plugin.tsx` — `ctx.layers.register("selection-overlay")` → `ctx.ui.registerSelectionForeground("tool-select-default", priority: 0)` に置換
- `apps/docs/src/content/docs/guides/selection-foreground.mdx` / `docs-ja/...` — **新規** ガイド (使い方、priority 規約、render contract、minimal sample)
- `apps/docs/src/content/docs/concepts/layer-system.mdx` / `docs-ja/...` — guide への cross-link 追記

## Test plan

- [x] 新規 unit test (`packages/core/src/__tests__/selection-foreground-registry.test.ts`): registry の 7 ケース — null初期 / priority 大が勝つ / tie last-wins / 同 id 再登録 / unregister 次点復活 / unsubscribe / subscribe 通知タイミング
- [x] 新規 integration test (`packages/core/src/__tests__/create-app-selection-foreground.test.ts`): 4 ケース — `ctx.ui` がプラグインから使える / `createApp({ selectionForeground })` が plugin default に勝つ / option が priority 100 plugin にも last-wins で勝つ / 何も登録されてない時 null
- [x] `pnpm turbo typecheck --continue` — 137 タスク全 pass
- [x] `pnpm turbo test --continue` — 136 タスク全 pass (うち registry+integration 11 本が新規)
- [x] `pnpm biome check` — error 0
- [x] `pnpm turbo build` (関連 4 パッケージ) — 全 pass

### 手動シナリオ (PR レビュー時推奨)

- [ ] apps/web を立ち上げ、option 未指定で shape の drag / resize / rotate / marquee / hover が現行と完全一致すること (回帰なし確認)
- [ ] apps/web で `createApp({ store, plugins, selectionForeground: { render: () => <div style={{position:'absolute', inset:0, background:'rgba(255,0,0,0.2)'}} /> } })` を一時的に挟み、shape 選択時にデフォルトの青枠ではなく赤いオーバレイが描画されることを確認

## フォローアップ (本 PR スコープ外)

1. weboard 側 (Atrae/wevox-mono-web #10172) で `createApp({ selectionForeground })` を使って独自 selection UI を統合
2. `ctx.ui` に toolbar / context-menu / shape inspector slot を追加 (別 Issue が立った時点で)
3. `apps/example` に「カスタム selection foreground のサンプルプラグイン」を実プロダクト化

🤖 Generated with [Claude Code](https://claude.com/claude-code)