### PR TITLE
📝 docs: tldraw → uSketch 移行ガイドを追加 (#579)

### DIFF
--- a/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
@@ -510,7 +510,7 @@ uSketch の対応はフラットな `ShapeData`:
 
 ```ts
 import * as Y from "yjs";
-import { type ShapeData, DEFAULT_STYLE, generateId } from "@edv4h/usketch-shared";
+import { type ShapeData, DEFAULT_STYLE } from "@edv4h/usketch-shared";
 
 type TLRecord = {
   id: string;

--- a/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
@@ -498,9 +498,9 @@ uSketch の対応はフラットな `ShapeData`:
 
 | tldraw `type` + `props` | uSketch `type` | フィールド対応 | 備考 |
 | ----------------------- | -------------- | -------------- | ---- |
-| `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`、色解決 | `usketch-plugin-shape-basic` の rectangle plugin を使う |
+| `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`、色解決 | `@edv4h/usketch-plugin-shape-basic` の rectangle plugin を使う |
 | `geo` + `props.geo = "ellipse"` | `ellipse` | 同上 | 同 plugin |
-| `arrow` | `connector` | `props.start.boundShapeId → sourceId`（無ければ `sourcePoint`）、`props.end.boundShapeId → targetId`（無ければ `targetPoint`） | uSketch に `arrow` shape は無く、近いのは `usketch-plugin-shape-connector`。`ConnectorShapeData` は `sourceAnchor` / `targetAnchor` / `arrowHead` / `pathType` のデフォルトも必要 — `createDefaultConnector` で土台を作って endpoint を上書きするのが楽 |
+| `arrow` | `connector` | `props.start.boundShapeId → sourceId`（無ければ `sourcePoint`）、`props.end.boundShapeId → targetId`（無ければ `targetPoint`） | uSketch に `arrow` shape は無く、近いのは `@edv4h/usketch-plugin-shape-connector`。`ConnectorShapeData` は `sourceAnchor` / `targetAnchor` / `arrowHead` / `pathType` のデフォルトも必要 — `createDefaultConnector` で土台を作って endpoint を上書きするのが楽 |
 | `text` | `text` | `props.text → text`、size enum (`s/m/l/xl`) → px (`12/16/24/36`)、font enum → CSS family | width / height は tldraw record から |
 | `image` | `image` | `props.assetId → src`（asset map 経由）、`props.w/h → width/height` | tldraw は画像バイトを別 `TLAsset` レコードに保存する。先 pass で集めて URL に解決してから shape を移行 |
 
@@ -648,7 +648,7 @@ export function migrateTldrawSnapshot(snapshot: TLRecord[], yDoc: Y.Doc): number
 }
 ```
 
-実行手順: tldraw snapshot を読み込み（通常 tldraw の `getSnapshot(store)` か、export した `.tldr` JSON）、新しい `Y.Doc` を作って `migrateTldrawSnapshot` を呼び、`usketch-plugin-sync-localstorage-yjs` の `createYjsSync` で uSketch にアタッチする。sync plugin が `Y.Map` を観察して shape を `BoardStore` に流し込む。
+実行手順: tldraw snapshot を読み込み（通常 tldraw の `getSnapshot(store)` か、export した `.tldr` JSON）、新しい `Y.Doc` を作って `migrateTldrawSnapshot` を呼び、`@edv4h/usketch-plugin-sync-localstorage-yjs` の `createYjsSync` で uSketch にアタッチする。sync plugin が `Y.Map` を観察して shape を `BoardStore` に流し込む。
 
 > **画像 asset について。** tldraw snapshot で画像バイトが `TLAsset.src` に base64 で残っている場合、移行後の `image` shape は `data.src` にバイトをインライン保持する。動作はするが document が肥大化するので、先に asset を CDN へアップロードして解決済み URL を asset map に書く方が良い。
 
@@ -717,7 +717,7 @@ const app = await createApp({
 });
 ```
 
-プラグインも `ctx.ui.registerSelectionForeground({ id, priority, render })` で opt-in できる。registry は priority 最大のエントリを選び、同値は last-registered が勝つ。`usketch-plugin-tool-select` が priority 0 でデフォルトを自己登録する。詳しくは [Selection Foreground](./selection-foreground) を参照。
+プラグインも `ctx.ui.registerSelectionForeground({ id, priority, render })` で opt-in できる。registry は priority 最大のエントリを選び、同値は last-registered が勝つ。`@edv4h/usketch-plugin-tool-select` が priority 0 でデフォルトを自己登録する。詳しくは [Selection Foreground](./selection-foreground) を参照。
 
 ## よくある落とし穴
 

--- a/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
@@ -374,7 +374,7 @@ function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
 }
 ```
 
-複雑な遷移がある場合、あるいはビルトイン select tool と drag / resize / rotate 挙動を共有したい場合は [`@edv4h/usketch-tool-helpers`](../../reference/tool-helpers) を使う。`startDragSession` / `startResizeSession` / `startRotateSession` / `startMarqueeSession` は tldraw `StateNode` ライブラリの提供する大部分をカバーする。詳しくは [Tool プラグイン作成ガイド](./tool-plugin) の「Reusable Session Helpers」を参照。
+複雑な遷移がある場合、あるいはビルトイン select tool と drag / resize / rotate 挙動を共有したい場合は `@edv4h/usketch-tool-helpers` を使う。`startDragSession` / `startResizeSession` / `startRotateSession` / `startMarqueeSession` は tldraw `StateNode` ライブラリの提供する大部分をカバーする。詳しくは Tool プラグイン作成ガイドの [Reusable Session Helpers](./tool-plugin#reusable-session-helpers) を参照。
 
 ### 手順 3. Inputs API
 
@@ -500,7 +500,7 @@ uSketch の対応はフラットな `ShapeData`:
 | ----------------------- | -------------- | -------------- | ---- |
 | `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`、色解決 | `usketch-plugin-shape-basic` の rectangle plugin を使う |
 | `geo` + `props.geo = "ellipse"` | `ellipse` | 同上 | 同 plugin |
-| `arrow` | `connector` | `props.start/end → from/to` anchor refs | anchor 解決できない場合は絶対座標にフォールバック。uSketch に `arrow` shape は無く、近いのは `usketch-plugin-shape-connector` |
+| `arrow` | `connector` | `props.start.boundShapeId → sourceId`（無ければ `sourcePoint`）、`props.end.boundShapeId → targetId`（無ければ `targetPoint`） | uSketch に `arrow` shape は無く、近いのは `usketch-plugin-shape-connector`。`ConnectorShapeData` は `sourceAnchor` / `targetAnchor` / `arrowHead` / `pathType` のデフォルトも必要 — `createDefaultConnector` で土台を作って endpoint を上書きするのが楽 |
 | `text` | `text` | `props.text → text`、size enum (`s/m/l/xl`) → px (`12/16/24/36`)、font enum → CSS family | width / height は tldraw record から |
 | `image` | `image` | `props.assetId → src`（asset map 経由）、`props.w/h → width/height` | tldraw は画像バイトを別 `TLAsset` レコードに保存する。先 pass で集めて URL に解決してから shape を移行 |
 
@@ -570,30 +570,41 @@ function migrateRecord(rec: TLRecord, assetMap: Map<string, string>): ShapeData 
       } as ShapeData;
     }
     case "text":
+      // TextShapeData は text / fontSize / fontFamily / isEditing が必須。
+      // text plugin は背景透過で描画するので base.style を text plugin の
+      // 既定（fill: "transparent", strokeWidth: 0）で上書きする。
       return {
         ...base,
         type: "text",
         width: (p.w as number) ?? 200,
         height: 40,
+        style: { ...base.style, fill: "transparent", strokeWidth: 0 },
         text: (p.text as string) ?? "",
         fontSize: FONT_SIZE_PX[(p.size as string) ?? "m"] ?? 16,
+        fontFamily: "system-ui, sans-serif",
+        isEditing: false,
       } as ShapeData;
     case "arrow": {
       const start = p.start as { x?: number; y?: number; boundShapeId?: string } | undefined;
       const end = p.end as { x?: number; y?: number; boundShapeId?: string } | undefined;
-      // arrow が他 shape にバインドされていれば anchor ref を優先、
-      // そうでなければ絶対座標にフォールバック。
+      const sourceId = start?.boundShapeId?.replace(/^shape:/, "");
+      const targetId = end?.boundShapeId?.replace(/^shape:/, "");
+      // ConnectorShapeData は下記すべて必須 — sourcePoint / targetPoint は
+      // sourceId / targetId が無いときの fallback。anchor / arrowHead /
+      // pathType は connector plugin の既定値を踏襲する。
       return {
         ...base,
         type: "connector",
         width: 0,
         height: 0,
-        from: start?.boundShapeId
-          ? { shapeId: start.boundShapeId.replace(/^shape:/, "") }
-          : { x: start?.x ?? 0, y: start?.y ?? 0 },
-        to: end?.boundShapeId
-          ? { shapeId: end.boundShapeId.replace(/^shape:/, "") }
-          : { x: end?.x ?? 0, y: end?.y ?? 0 },
+        sourceId,
+        targetId,
+        sourceAnchor: "auto",
+        targetAnchor: "auto",
+        arrowHead: "forward",
+        pathType: "straight",
+        sourcePoint: { x: start?.x ?? base.x, y: start?.y ?? base.y },
+        targetPoint: { x: end?.x ?? base.x + 100, y: end?.y ?? base.y },
       } as ShapeData;
     }
     case "image": {

--- a/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx
@@ -1,0 +1,819 @@
+---
+title: tldraw からの移行
+description: tldraw v2 アプリを uSketch へ移行する手順。API 対応表、shape / tool / Yjs データ移行のコード例、よくある落とし穴。
+order: 30
+---
+
+すでに tldraw v2 でアプリを作っており、uSketch に移行したい — tldraw v2 のライセンス層が用途に合わなくなった、あるいはより小さく MIT ライセンスの canvas ランタイムが欲しい — このガイドはその近道。両ライブラリは多くの概念（shape utility / tool / 不変な record store / Yjs アダプター）を共有しているが、API の梱包が違う。移植を始める前に一度読んでおけば、各差分を試行錯誤で再発見せずに済む。
+
+## このガイドの目的
+
+tldraw v2 は 2024 年に非自由ライセンス層を導入し、寛容なライセンスの canvas ランタイムへの移行経路を求める声が多かった。uSketch v2 は MIT ライセンスで、明示的なプラグイン API を備え、見覚えのあるプリミティブ（`ShapeData` は `TLBaseShape` のフラットな従兄弟、Yjs sync も同様の「`Y.Map` of shapes」レイアウト）を再利用している。
+
+このガイドは以下のいずれかを書いたことがある人を対象とする:
+
+- カスタム shape のための `class MyShapeUtil extends ShapeUtil<TMyShape>`
+- カスタム tool のための `class MyTool extends StateNode`
+- `editor.createShape(...)` / `editor.updateShapes(...)` を呼ぶコード
+
+入門チュートリアルではない — uSketch を初めて書く人は [Shape プラグイン作成ガイド](./shape-plugin) と [Tool プラグイン作成ガイド](./tool-plugin) から始めてほしい。両ライブラリで共有されない機能（tldraw の共同編集 presence / AI agent / 独自 `.tldr` フォーマット import 等）もスコープ外。
+
+## 概念の対応
+
+3 つのメンタルモデルシフトを抑えれば 80% の移行作業がカバーできる。これらを腑に落としてから API レベルの翻訳に進むと、機械的に処理できる。
+
+### `Editor` 一極集中 → `useApp()` + 5 個の registrar
+
+tldraw はすべてを `Editor` インスタンスに集約する: `editor.createShape`、`editor.select`、`editor.zoomToFit`、`editor.sideEffects.registerBeforeCreateHandler` はすべて同じオブジェクトにぶら下がる。uSketch はこれらを複数の協調する registry に分け、`useApp()` 経由で取得する:
+
+| 関心 | uSketch 入口 |
+| ---- | ------------ |
+| Shape / viewport / 選択の読み書き | `app.store` (`BoardStore`) |
+| Undo / redo、バッチ操作 | `app.commands` |
+| Shape 定義の register / lookup | `app.shapes` |
+| Tool の register / activate | `app.tools` |
+| Event の emit / 購読 | `app.events` |
+| Drop / paste / URL ハンドラ | `app.externalContent` |
+| Selection UI の差し替え | `app.ui` |
+
+プラグインの `setup(ctx)` 内では同じ registry が `ctx.store`、`ctx.commands` 等として渡される。
+
+### `track()` → `useStoreSubscribe(store, selector)`
+
+tldraw は signia signals を使う: `track(Component)` HOC がコンポーネント内のすべての reactive read を購読し、自動再レンダーする。uSketch は内部で Zustand を使い、React コンポーネントは `useStoreSubscribe(store, selector)` を **明示的に** 呼んで購読する。selector は primitive または安定した参照を返す必要がある。コンポーネントごとに少しだけ boilerplate が増える代わりに、購読が明示的でデバッグしやすくなる。
+
+### クラス → オブジェクト
+
+`ShapeUtil` と `StateNode` は extend する抽象クラスだが、uSketch の `ShapeDefinition` / `ToolDefinition` はメソッドを property に持つただのオブジェクト。継承はなく、合成はヘルパ関数（`@edv4h/usketch-shape-utils`、`@edv4h/usketch-tool-helpers`）で行う。tool 内の「子 state」は `setup()` 内のクロージャ変数になる。
+
+### ネストした `props` がフラットな `ShapeData` に展開
+
+tldraw では shape の固有データが `shape.props.w` / `shape.props.text` 等にある。uSketch では `width`、`height`、`x`、`y`、`rotation`、`zIndex`、`style`、`parentId`、`meta`、`createdAt`、`updatedAt` は `ShapeData` の **コアフィールド** として予約済み。プラグイン固有のフィールド（付箋の `text`、画像 shape の `src`）は同じトップレベルに置かれる — `data.props` の入れ物はない。ジオメトリ的な意味を持たないアプリケーションデータは `meta` に入れる。
+
+## API 対応表
+
+| tldraw 概念 | uSketch 対応 |
+| ----------- | ------------ |
+| `ShapeUtil.component(shape)` | `ShapeDefinition.render(data)` |
+| `ShapeUtil.getGeometry(shape)` | `ShapeDefinition.getBounds(data)` + `hitTest(data, point)` |
+| `ShapeUtil.onResize(info)` | `ShapeDefinition.resize(data, handle, delta)` |
+| `ShapeUtil.getDefaultProps()` | `ShapeDefinition.createDefault({ id, x, y })` |
+| `TLBaseShape<T, Props>` | `ShapeData & { type: T; ...intrinsicFields }`（フラット） |
+| `Editor.createShapes([...])` | `store.addShape(shape)` を `commands.execute({ execute, undo })` でラップ |
+| `track(Component)` | コンポーネント内で `useStoreSubscribe(store, selector)` |
+| `class extends StateNode` | `ToolDefinition` オブジェクト + `setup()` 内クロージャ state |
+| `editor.registerExternalContentHandler(kind, fn)` | `ctx.externalContent.register({ id, kind, match, handle })` |
+| `useEditor()` | `useApp()` |
+| `WeakMapCache` / `createComputedCache` | 通常 `Map<id, T>` を `store.onMutation` で無効化、または `useMemo` |
+
+以降の各章でそれぞれの行をコード付きで解説する。
+
+## Shape の移行
+
+### 手順 1. ShapeUtil クラス → ShapeDefinition オブジェクト
+
+tldraw の shape util は次のような形:
+
+```tsx
+// ─── tldraw v2 (移行前) ──────────────────────────────────────────────
+import { BaseBoxShapeUtil, HTMLContainer, type TLBaseShape } from "tldraw";
+
+type CardShape = TLBaseShape<"card", { w: number; h: number; title: string }>;
+
+class CardShapeUtil extends BaseBoxShapeUtil<CardShape> {
+  static override type = "card" as const;
+
+  override getDefaultProps(): CardShape["props"] {
+    return { w: 240, h: 120, title: "New card" };
+  }
+
+  override component(shape: CardShape) {
+    return (
+      <HTMLContainer
+        style={{ width: shape.props.w, height: shape.props.h, padding: 8 }}
+      >
+        <strong>{shape.props.title}</strong>
+      </HTMLContainer>
+    );
+  }
+  // getGeometry / onResize は BaseBoxShapeUtil 提供
+}
+```
+
+uSketch では `ctx.shapes.register()` に渡す plain function 群になる:
+
+```tsx
+// ─── uSketch v2 (移行後) ──────────────────────────────────────────────
+import type {
+  BoundingBox,
+  Point,
+  ResizeHandle,
+  ShapeData,
+  PluginContext,
+  UsketchPlugin,
+} from "@edv4h/usketch-shared";
+import { DEFAULT_STYLE } from "@edv4h/usketch-shared";
+
+export interface CardShapeData extends ShapeData {
+  title: string;
+}
+
+function render(shape: ShapeData) {
+  const data = shape as CardShapeData;
+  return (
+    <foreignObject x={data.x} y={data.y} width={data.width} height={data.height}>
+      <div
+        xmlns="http://www.w3.org/1999/xhtml"
+        style={{ width: "100%", height: "100%", padding: 8, boxSizing: "border-box" }}
+      >
+        <strong>{data.title}</strong>
+      </div>
+    </foreignObject>
+  );
+}
+
+function getBounds(data: ShapeData): BoundingBox {
+  return { x: data.x, y: data.y, width: data.width, height: data.height };
+}
+
+function hitTest(data: ShapeData, point: Point): boolean {
+  return (
+    point.x >= data.x &&
+    point.x <= data.x + data.width &&
+    point.y >= data.y &&
+    point.y <= data.y + data.height
+  );
+}
+
+function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
+  // rectangle plugin と同じ 8 方向 switch — Shape プラグイン作成ガイドの
+  // 「リサイズロジックを実装する」を参照。
+  return data;
+}
+
+function createDefault(params: { id: string; x: number; y: number }): CardShapeData {
+  return {
+    id: params.id,
+    type: "card",
+    x: params.x,
+    y: params.y,
+    width: 240,
+    height: 120,
+    style: { ...DEFAULT_STYLE },
+    title: "New card",
+  };
+}
+
+export const cardPlugin: UsketchPlugin = {
+  id: "card-shape",
+  name: "Card",
+  setup(ctx: PluginContext) {
+    ctx.shapes.register("card", { render, getBounds, hitTest, resize, createDefault });
+  },
+};
+```
+
+2 つのパターンを抑えておく:
+
+- **ラッパークラスがない。** `ShapeDefinition` はオブジェクトリテラル、`this` も無い。state（キャッシュ・タイマー）は `setup()` クロージャに置く。
+- **`ShapeData` を extension interface にキャストする** （`render` / `hitTest` / `resize` の中で）。プラグイン固有フィールドを型安全に扱える。[Shape プラグイン作成ガイド](./shape-plugin) の `as RectangleShapeData` パターンと同じ。
+
+### 手順 2. TLBaseShape の props → フラットな ShapeData
+
+tldraw は固有データを `props` に包む:
+
+```ts
+type CardShape = TLBaseShape<"card", { w: number; h: number; title: string }>;
+// アクセス: shape.props.w、shape.props.title
+```
+
+uSketch は **コアフィールド**（`width`、`height`、`x`、`y`、`rotation`、…）を再利用し、プラグイン固有フィールドは同じ階層に置く:
+
+```ts
+interface CardShapeData extends ShapeData {
+  title: string;
+}
+// アクセス: data.width、data.title
+```
+
+予約されているコアフィールド一覧（再定義してはいけない）:
+
+| フィールド | 型 | 備考 |
+| ---------- | -- | ---- |
+| `id` | `string` | board 内で一意 |
+| `type` | `string` | `ShapeRegistry` のキー |
+| `x`、`y` | `number` | world 座標の左上 |
+| `width`、`height` | `number` | 常に存在（`props.w` ではない） |
+| `rotation` | `number?` | ラジアン、`undefined` ≡ 0 |
+| `zIndex` | `string?` | Fractional Index、tldraw `index` と同じエンコード |
+| `style` | `ShapeStyle` | `{ fill, stroke, strokeWidth, opacity }` |
+| `parentId` | `string?` | group / frame 内 shape 用 |
+| `meta` | `TMeta` | アプリケーションデータ（後述） |
+| `createdAt`、`updatedAt` | `number?` | ミリ秒タイムスタンプ |
+
+ジオメトリでない値（`employeeId`、外部の `versionId` 等）は `meta` に入れる。レガシー移行用の `x-*` エスケープハッチもあるが、新規コードでは `meta` を使う。詳しくは [Shape System → Extending shapes](/docs/concepts/shape-system/#extending-shapes) を参照。
+
+### 手順 3. createShapes → store.addShape + commands
+
+tldraw は `editor.run` でミューテーションをバッチする:
+
+```ts
+editor.run(() => {
+  editor.createShapes([{ id, type: "card", x: 100, y: 100, props: { /*…*/ } }]);
+});
+```
+
+uSketch は store ミューテーションと undo 管理を分離している。store は即座に更新し、commands が undo を提供する:
+
+```ts
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+
+ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
+```
+
+`createAddShapeCommand` は `{ execute: () => store.addShape(shape), undo: () => store.deleteShape(shape.id) }` を返す。`@edv4h/usketch-store` のヘルパ一覧は `editor.X` 相当をカバーする:
+
+| 操作 | ヘルパ |
+| ---- | ------ |
+| shape 作成 | `createAddShapeCommand(store, shape)` |
+| shape 削除 | `createDeleteShapeCommand(store, id)` |
+| shape 更新（from / to スナップショット付き） | `createUpdateShapeCommand(store, id, from, to)` |
+| 複数 shape 移動 | `createMoveShapesCommand(store, beforeMap, afterMap)` |
+| バッチ更新 | `createBatchUpdateShapesCommand(store, updates)` |
+| Group / ungroup | `createGroupCommand`、`createUngroupCommand` |
+| z-order 操作 | `createBringToFrontCommand`、`createSendToBackCommand`、… |
+
+現状 `commands.batch(fn)` のような wrapper はない — 複数操作を 1 つの undo ステップにまとめるには、すべてのミューテーションを `execute` で実行し、逆操作を `undo` で行う合成 `Command` を 1 つ作る。
+
+## Tool の移行
+
+### 手順 1. StateNode → ToolDefinition
+
+tldraw の tool はクラスの階層:
+
+```tsx
+// ─── tldraw v2 (移行前) ──────────────────────────────────────────────
+import { StateNode, type TLPointerEventInfo } from "tldraw";
+
+class CardTool extends StateNode {
+  static override id = "card";
+  static override initial = "idle";
+  static override children = () => [Idle, Drawing];
+}
+
+class Idle extends StateNode {
+  static override id = "idle";
+  override onPointerDown = () => this.parent.transition("drawing");
+}
+
+class Drawing extends StateNode {
+  static override id = "drawing";
+  override onEnter = () => {
+    const { currentPagePoint } = this.editor.inputs;
+    this.editor.createShape({
+      type: "card",
+      x: currentPagePoint.x,
+      y: currentPagePoint.y,
+    });
+  };
+  override onPointerUp = () => this.parent.transition("idle");
+}
+```
+
+uSketch では tool は単一のオブジェクトリテラル。子 state は closure 変数 — 典型的には `phase` discriminator + phase 局所データ — に潰す:
+
+```tsx
+// ─── uSketch v2 (移行後) ──────────────────────────────────────────────
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import {
+  generateId,
+  type CanvasPointerEvent,
+  type PluginContext,
+  type ToolContext,
+  type UsketchPlugin,
+} from "@edv4h/usketch-shared";
+
+function CardIcon() {
+  return <svg width="20" height="20" viewBox="0 0 20 20" /* … */ />;
+}
+
+export const cardToolPlugin: UsketchPlugin = {
+  id: "card-tool",
+  name: "Card tool",
+  setup(ctx: PluginContext) {
+    // tldraw の子 state 階層の置き換え。
+    // setup() クロージャ内に持つ（プラグインオブジェクトには置かない）ことで
+    // 各 plugin インスタンスが固有の state を持つ。
+    type Phase = "idle" | "drawing";
+    let phase: Phase = "idle";
+    let drawingId: string | null = null;
+
+    function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+      const id = generateId();
+      drawingId = id;
+      phase = "drawing";
+      const shape = toolCtx.shapes
+        .get("card")!
+        .createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+      // ライブプレビュー用の一時 shape ミューテーション。
+      toolCtx.store.addShape(shape);
+    }
+
+    function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+      if (phase !== "drawing" || !drawingId) return;
+      const start = toolCtx.store.getShape(drawingId);
+      if (!start) return;
+      toolCtx.store.updateShape(drawingId, {
+        width: Math.max(1, event.worldPoint.x - start.x),
+        height: Math.max(1, event.worldPoint.y - start.y),
+      });
+    }
+
+    function onPointerUp(toolCtx: ToolContext) {
+      if (phase !== "drawing" || !drawingId) return;
+      const shape = toolCtx.store.getShape(drawingId);
+      if (shape) {
+        // 一時 shape を undo 可能な command に差し替える。
+        toolCtx.store.deleteShape(drawingId);
+        toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+      }
+      drawingId = null;
+      phase = "idle";
+      toolCtx.store.setActiveToolId("select");
+    }
+
+    ctx.tools.register("card-draw", {
+      icon: CardIcon,
+      cursor: "crosshair",
+      shortcut: "c",
+      order: 12,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+    });
+  },
+};
+```
+
+### 手順 2. 子 state → phase 変数
+
+tldraw の `StateNode` 子 state は `editor` を継承し、`transition("name")` で兄弟へ遷移する。uSketch では同じ形を discriminated union で実現する:
+
+```ts
+type Phase =
+  | { kind: "idle" }
+  | { kind: "drawing"; shapeId: string; startPoint: Point }
+  | { kind: "rotating"; shapeId: string; pivot: Point };
+
+let phase: Phase = { kind: "idle" };
+
+function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+  // phase 局所データを伴って "drawing" phase へ遷移
+  phase = { kind: "drawing", shapeId: generateId(), startPoint: event.worldPoint };
+  // …
+}
+```
+
+複雑な遷移がある場合、あるいはビルトイン select tool と drag / resize / rotate 挙動を共有したい場合は [`@edv4h/usketch-tool-helpers`](../../reference/tool-helpers) を使う。`startDragSession` / `startResizeSession` / `startRotateSession` / `startMarqueeSession` は tldraw `StateNode` ライブラリの提供する大部分をカバーする。詳しくは [Tool プラグイン作成ガイド](./tool-plugin) の「Reusable Session Helpers」を参照。
+
+### 手順 3. Inputs API
+
+tldraw は入力状態を `editor.inputs.*` から読むが、uSketch は各 event に渡す:
+
+| tldraw | uSketch |
+| ------ | ------- |
+| `editor.inputs.currentPagePoint` | `event.worldPoint`（各 handler に渡される） |
+| `editor.inputs.currentScreenPoint` | `event.screenPoint` |
+| `editor.inputs.shiftKey` | `event.shiftKey` |
+| `editor.inputs.ctrlKey` / `altKey` / `metaKey` | `event.ctrlKey` / `event.altKey` / `event.metaKey` |
+| `editor.inputs.isDragging` | `phase` 変数から導出 |
+| `editor.getSelectedShapeIds()` | `app.store.getSelection()`（`ReadonlySet<string>` を返す） |
+
+`CanvasPointerEvent` はただのオブジェクトで、グローバルもなく、event 間で editor を問い合わせる必要もない。
+
+## リアクティビティと selector
+
+### track() → useStoreSubscribe
+
+tldraw:
+
+```tsx
+import { useEditor, track } from "tldraw";
+
+const SelectionCount = track(function SelectionCount() {
+  const editor = useEditor();
+  const count = editor.getSelectedShapeIds().length;
+  return <div>{count} selected</div>;
+});
+```
+
+uSketch では明示的に購読する。selector は store を受け取って値を返す関数で、selector の戻り値が `Object.is` で変化したときコンポーネントが再レンダーする:
+
+```tsx
+import { useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
+import type { BoardStore } from "@edv4h/usketch-shared";
+
+const selectSelectionCount = (s: BoardStore) => s.getSelection().size;
+
+function SelectionCount() {
+  const app = useApp();
+  // primitive を返すと equality check が軽く・安定する。
+  const count = useStoreSubscribe(app.store, selectSelectionCount);
+  return <div>{count} selected</div>;
+}
+```
+
+> **Selector の衛生。** selector は安定した参照を返さないと購読比較が thrash する。`Array.from(s.getSelection())` は毎回新規 array を allocate して store tick ごとに再レンダーを引き起こす — 元の `ReadonlySet`（identity 安定）、そこから導出した primitive、あるいは memoize した結果を返す。
+
+### useEditor → useApp
+
+tldraw の `useEditor()` は uSketch の `useApp()` になり、同じアクセスを提供する。パターンの違いは、1 オブジェクトのメソッドではなく異なる registry を呼ぶ点:
+
+```tsx
+function CreateCard() {
+  const app = useApp();
+  const handleClick = () => {
+    const shape = app.shapes.get("card")!.createDefault({ id: generateId(), x: 0, y: 0 });
+    app.commands.execute(createAddShapeCommand(app.store, shape));
+  };
+  return <button onClick={handleClick}>Add card</button>;
+}
+```
+
+React 外の consumer（event source、デバッグパネル）は `store.subscribe(listener)` で「何か変わった」を、`store.onMutation((event) => …)` で型付きミューテーション event を受け取れる。
+
+### createComputedCache → useMemo または onMutation
+
+tldraw の `createComputedCache` は record 群から導出した値を identity と同期させる。自然な置換は 2 通り:
+
+- **React コンポーネント内**: `useMemo(() => derive(shape), [shape])`。Zustand は更新時に新しい shape 参照を返し、React が memo を無効化する。
+- **React 外**: 通常の `Map<id, Cached>` を `store.onMutation` で無効化する。mutation event には影響を受けた shape ID が含まれる。エントリを clear して lazy に再計算する。
+
+`WeakMapCache` には直接対応する uSketch 機構はない — plain `ShapeData` オブジェクトは更新時に identity が変わるため（更新で新オブジェクトが返る）。キャッシュは `shape.id` をキーにする。
+
+## Yjs データ移行
+
+両ライブラリとも shape を Yjs `Y.Map` に持つが、record 形状が違う。tldraw は shape ごとに `TLRecord` を持つ:
+
+```json
+{
+  "id": "shape:abc",
+  "type": "geo",
+  "typeName": "shape",
+  "x": 100,
+  "y": 200,
+  "rotation": 0,
+  "index": "a1",
+  "parentId": "page:page",
+  "isLocked": false,
+  "opacity": 1,
+  "props": { "geo": "rectangle", "w": 200, "h": 100, "color": "blue", "fill": "solid" },
+  "meta": {}
+}
+```
+
+uSketch の対応はフラットな `ShapeData`:
+
+```json
+{
+  "id": "abc",
+  "type": "rectangle",
+  "x": 100,
+  "y": 200,
+  "width": 200,
+  "height": 100,
+  "rotation": 0,
+  "zIndex": "a1",
+  "style": { "fill": "#3b82f6", "stroke": "#0f172a", "strokeWidth": 2, "opacity": 1 }
+}
+```
+
+3 つの主要差分:
+
+- `props.w` / `props.h` → トップレベル `width` / `height`
+- `index`（Fractional Index）→ `zIndex` にリネーム — エンコードは同一なので文字列をそのまま 1:1 で再利用できる
+- tldraw の色 enum（`"blue"`、`"red"`、…）→ hex トークンに解決
+
+### shape 別フィールド対応
+
+| tldraw `type` + `props` | uSketch `type` | フィールド対応 | 備考 |
+| ----------------------- | -------------- | -------------- | ---- |
+| `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`、色解決 | `usketch-plugin-shape-basic` の rectangle plugin を使う |
+| `geo` + `props.geo = "ellipse"` | `ellipse` | 同上 | 同 plugin |
+| `arrow` | `connector` | `props.start/end → from/to` anchor refs | anchor 解決できない場合は絶対座標にフォールバック。uSketch に `arrow` shape は無く、近いのは `usketch-plugin-shape-connector` |
+| `text` | `text` | `props.text → text`、size enum (`s/m/l/xl`) → px (`12/16/24/36`)、font enum → CSS family | width / height は tldraw record から |
+| `image` | `image` | `props.assetId → src`（asset map 経由）、`props.w/h → width/height` | tldraw は画像バイトを別 `TLAsset` レコードに保存する。先 pass で集めて URL に解決してから shape を移行 |
+
+### 移行スクリプト
+
+下記は説明用 — tldraw は minor バージョン間で snapshot 形状が変わるため、自分の snapshot に合わせて検証してから使う。出発点として扱い、色 / font enum を実際の tldraw 設定に合わせる。
+
+```ts
+import * as Y from "yjs";
+import { type ShapeData, DEFAULT_STYLE, generateId } from "@edv4h/usketch-shared";
+
+type TLRecord = {
+  id: string;
+  typeName: string;
+  type?: string;
+  x?: number;
+  y?: number;
+  rotation?: number;
+  index?: string;
+  parentId?: string;
+  opacity?: number;
+  props?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+};
+
+const COLOR_HEX: Record<string, string> = {
+  blue: "#3b82f6",
+  red: "#ef4444",
+  green: "#22c55e",
+  yellow: "#eab308",
+  black: "#0f172a",
+  grey: "#64748b",
+  "light-blue": "#93c5fd",
+};
+
+const FONT_SIZE_PX: Record<string, number> = { s: 12, m: 16, l: 24, xl: 36 };
+
+function resolveColor(name: unknown): string {
+  return (typeof name === "string" && COLOR_HEX[name]) || "#0f172a";
+}
+
+function migrateRecord(rec: TLRecord, assetMap: Map<string, string>): ShapeData | null {
+  if (rec.typeName !== "shape") return null;
+
+  const base = {
+    id: rec.id.replace(/^shape:/, ""),
+    x: rec.x ?? 0,
+    y: rec.y ?? 0,
+    rotation: rec.rotation ?? 0,
+    zIndex: rec.index, // 1:1 再利用 — 同じ Fractional Index エンコード
+    parentId: rec.parentId === "page:page" ? undefined : rec.parentId,
+    style: { ...DEFAULT_STYLE, opacity: rec.opacity ?? 1 },
+  };
+  const p = (rec.props ?? {}) as Record<string, unknown>;
+
+  switch (rec.type) {
+    case "geo": {
+      const geo = (p.geo as string | undefined) ?? "rectangle";
+      const type = geo === "ellipse" ? "ellipse" : "rectangle";
+      const color = resolveColor(p.color);
+      return {
+        ...base,
+        type,
+        width: (p.w as number) ?? 100,
+        height: (p.h as number) ?? 100,
+        style: { ...base.style, fill: color, stroke: "#0f172a", strokeWidth: 2 },
+      } as ShapeData;
+    }
+    case "text":
+      return {
+        ...base,
+        type: "text",
+        width: (p.w as number) ?? 200,
+        height: 40,
+        text: (p.text as string) ?? "",
+        fontSize: FONT_SIZE_PX[(p.size as string) ?? "m"] ?? 16,
+      } as ShapeData;
+    case "arrow": {
+      const start = p.start as { x?: number; y?: number; boundShapeId?: string } | undefined;
+      const end = p.end as { x?: number; y?: number; boundShapeId?: string } | undefined;
+      // arrow が他 shape にバインドされていれば anchor ref を優先、
+      // そうでなければ絶対座標にフォールバック。
+      return {
+        ...base,
+        type: "connector",
+        width: 0,
+        height: 0,
+        from: start?.boundShapeId
+          ? { shapeId: start.boundShapeId.replace(/^shape:/, "") }
+          : { x: start?.x ?? 0, y: start?.y ?? 0 },
+        to: end?.boundShapeId
+          ? { shapeId: end.boundShapeId.replace(/^shape:/, "") }
+          : { x: end?.x ?? 0, y: end?.y ?? 0 },
+      } as ShapeData;
+    }
+    case "image": {
+      const url = assetMap.get((p.assetId as string) ?? "");
+      if (!url) return null;
+      return {
+        ...base,
+        type: "image",
+        width: (p.w as number) ?? 200,
+        height: (p.h as number) ?? 150,
+        src: url,
+      } as ShapeData;
+    }
+    default:
+      console.warn(`Skipping unsupported tldraw shape type: ${rec.type}`);
+      return null;
+  }
+}
+
+export function migrateTldrawSnapshot(snapshot: TLRecord[], yDoc: Y.Doc): number {
+  const shapesMap = yDoc.getMap<Record<string, unknown>>("shapes");
+  // 1st pass: 画像 asset URL を id で集める。
+  const assetMap = new Map<string, string>();
+  for (const rec of snapshot) {
+    if (rec.typeName === "asset" && (rec as TLRecord & { type?: string }).type === "image") {
+      const src = (rec.props as Record<string, unknown> | undefined)?.src;
+      if (typeof src === "string") assetMap.set(rec.id, src);
+    }
+  }
+  // 2nd pass: 1 トランザクション内で shape を Y.Map に移行。
+  let written = 0;
+  yDoc.transact(() => {
+    for (const rec of snapshot) {
+      const shape = migrateRecord(rec, assetMap);
+      if (!shape) continue;
+      shapesMap.set(shape.id, JSON.parse(JSON.stringify(shape)));
+      written++;
+    }
+  });
+  return written;
+}
+```
+
+実行手順: tldraw snapshot を読み込み（通常 tldraw の `getSnapshot(store)` か、export した `.tldr` JSON）、新しい `Y.Doc` を作って `migrateTldrawSnapshot` を呼び、`usketch-plugin-sync-localstorage-yjs` の `createYjsSync` で uSketch にアタッチする。sync plugin が `Y.Map` を観察して shape を `BoardStore` に流し込む。
+
+> **画像 asset について。** tldraw snapshot で画像バイトが `TLAsset.src` に base64 で残っている場合、移行後の `image` shape は `data.src` にバイトをインライン保持する。動作はするが document が肥大化するので、先に asset を CDN へアップロードして解決済み URL を asset map に書く方が良い。
+
+## External Content
+
+tldraw は drop / paste を `editor.registerExternalContentHandler(kind, fn)` で扱い、7 kind（`text | files | url | svg-text | tldraw | excalidraw | embeds`）を持つ。uSketch は 3 kind（`file | url | text`）に正規化し、predicate で match する:
+
+| tldraw kind | uSketch handler |
+| ----------- | --------------- |
+| `text` | `kind: "text"` |
+| `files` | `kind: "file"` |
+| `url` | `kind: "url"` |
+| `svg-text` | `kind: "text"` + `match: ({ html, text }) => (html ?? text).trim().startsWith("<svg")` |
+| `embeds`（YouTube 等） | `kind: "url"` + host 名による `match` |
+| `tldraw` / `excalidraw` document import | native handler 無し — `kind: "text"` 経由で dispatch し、JSON 形状を検出してコンバーターを走らせる |
+
+例: YouTube embed handler。
+
+```tsx
+import type { UsketchPlugin } from "@edv4h/usketch-shared";
+
+export const youtubeEmbedPlugin: UsketchPlugin = {
+  id: "youtube-embed",
+  name: "YouTube embed",
+  setup(ctx) {
+    const off = ctx.externalContent.register({
+      id: "youtube-embed:url",
+      kind: "url",
+      order: 50,
+      match: (content) => {
+        try {
+          const u = new URL(content.url);
+          return u.hostname === "youtube.com" || u.hostname === "www.youtube.com";
+        } catch {
+          return false;
+        }
+      },
+      handle: async (content, hctx) => {
+        const shape = makeYoutubeShape(content.url);
+        hctx.commands.execute({
+          execute: () => hctx.store.addShape(shape),
+          undo: () => hctx.store.deleteShape(shape.id),
+        });
+      },
+    });
+    (this as UsketchPlugin).teardown = () => off();
+  },
+};
+```
+
+解決は single-winner ルール（`order` 最大が勝ち、同値は last-registered が勝つ）。詳しくは [External Content](./external-content) を参照。
+
+## Selection UI の差し替え
+
+tldraw では selection UI が `SelectTool`（バウンディングボックスとハンドルを描く `StateNode`）と shape ごとの `Indicator` コンポーネントに分かれている。差し替えるには tool を subclass し、新しい indicator を登録し、`SelectTool` 内部 state との結合をある程度受け入れる必要がある。
+
+uSketch は shape 描画と selection chrome を完全に分離している。selection foreground 全体 — バウンディングボックス、8 個のリサイズハンドル、回転ハンドル、マーキー矩形 — は 1 つの React コンポーネントとして登録する:
+
+```ts
+const app = await createApp({
+  store,
+  plugins,
+  selectionForeground: {
+    render: (ctx) => <MySelectionForeground ctx={ctx} />,
+  },
+});
+```
+
+プラグインも `ctx.ui.registerSelectionForeground({ id, priority, render })` で opt-in できる。registry は priority 最大のエントリを選び、同値は last-registered が勝つ。`usketch-plugin-tool-select` が priority 0 でデフォルトを自己登録する。詳しくは [Selection Foreground](./selection-foreground) を参照。
+
+## よくある落とし穴
+
+tldraw からの移植で遭遇しやすい問題。移植開始前にざっと目を通しておくと、後のデバッグ時間を節約できる。
+
+### 1. 自動リアクティビティが無い
+
+`track()` は無い。`useStoreSubscribe` の外で `app.store` を読むコンポーネントは初回のみレンダーされて以後更新されない。reactive read はすべて selector でラップし、**primitive または安定した参照を返す**。コンポーネントが derived 値に依存している場合、selector 内で計算すれば React は derived 値が変わったときだけ再レンダーする。
+
+### 2. Editor が registrar に分散している
+
+`editor.X()` を適切な registry method に置換する:
+
+| tldraw | uSketch |
+| ------ | ------- |
+| `editor.createShape(...)` | `app.commands.execute(createAddShapeCommand(app.store, shape))` |
+| `editor.deleteShapes(ids)` | `app.commands.execute(createDeleteShapeCommand(app.store, id))` |
+| `editor.select(...ids)` | `app.store.setSelection(ids)` |
+| `editor.getCurrentPageShapes()` | `Array.from(app.store.getShapes().values())` |
+
+ロジック移植の前に search-and-replace のパスとして処理しておく。
+
+### 3. `editor.run(fn)` バッチラッパーが無い
+
+tldraw の `editor.run(fn)` は複数 mutation を 1 つの undo エントリにまとめる。uSketch には直接対応する API がまだない — すべての mutation を `execute` で実行し、逆操作を `undo` で行う合成 `Command` を 1 つ作って `commands.execute` に渡す。
+
+native の `commands.batch(fn)` API はロードマップにある。実装されても workaround は引き続き有効。
+
+### 4. `sideEffects.registerBeforeCreateHandler` が無い
+
+tldraw は `editor.sideEffects.registerBeforeCreateHandler` / `BeforeChange` 等で record を commit 前に変更・veto できる。uSketch には現状 pre-mutation hook がない。最も近い workaround:
+
+- **post-mutation 反応**: `store.onMutation((event) => …)` が各 mutation 後に型付き payload で発火する。cleanup、sync、audit ログに向く。
+- **pre-mutation 検証**: `addShape` / `updateShape` 呼び出しを、`execute` 前に検証する自作 `Command` でラップする。検証責任を呼び出し側に押し付ける設計 — プラグインが裏でこっそりミューテーションを変えることはできない。
+
+pre-mutation hook API は設計中。必要なら対応する issue を追跡してほしい。
+
+### 5. WeakMapCache / createComputedCache
+
+uSketch 内に signia は無い。2 つの置換パターン:
+
+- React 内: `useMemo` を shape そのものでキー化（Zustand は更新ごとに新しい shape 参照を返す）。
+- React 外: 通常 `Map<id, Cached>` を `store.onMutation` で無効化。signia の再現を試みないこと — primitive を返す selector は再実行が軽く、引き起こされる再レンダーも通常問題にならない。
+
+### 6. Props フラット化での衝突
+
+`ShapeData` の予約コアフィールド: `id`、`type`、`x`、`y`、`width`、`height`、`rotation`、`zIndex`、`style`、`meta`、`parentId`、`createdAt`、`updatedAt`。tldraw shape が `props.x` / `props.y` / `props.w` / `props.h` を持っていたらコアフィールドに潰れる。アプリケーションドメイン値 — `employeeId`、内部 `versionId`、`featureFlag` 等 — は `meta` に入れる。`x-*` エスケープハッチは一回限りの移行用。
+
+### 7. TLAsset（画像・動画）
+
+tldraw は asset registry を `assetId` 経由で間接参照するが、uSketch は URL を shape に直接持つ（`data.src`）。移行時に asset-id → URL リゾルバが必要（migration script に含めた）。動画 asset 用のビルトイン shape は無い — 独自 shape plugin を書くか該当 record をスキップする。
+
+### 8. `zoomToFit` API シグネチャ
+
+tldraw では `editor.zoomToFit()` は引数なし。uSketch では:
+
+```ts
+app.store.fitToBounds(bounds, { width, height }, padding?);
+```
+
+呼び出し側が bounds と viewport ピクセルサイズを渡す。bounds は shape をイテレートして計算する:
+
+```ts
+import type { BoundingBox, ShapeData } from "@edv4h/usketch-shared";
+
+function unionBounds(shapes: Iterable<ShapeData>): BoundingBox | null {
+  let result: BoundingBox | null = null;
+  for (const s of shapes) {
+    const b = { x: s.x, y: s.y, width: s.width, height: s.height };
+    if (!result) {
+      result = b;
+    } else {
+      const right = Math.max(result.x + result.width, b.x + b.width);
+      const bottom = Math.max(result.y + result.height, b.y + b.height);
+      result = {
+        x: Math.min(result.x, b.x),
+        y: Math.min(result.y, b.y),
+        width: right - Math.min(result.x, b.x),
+        height: bottom - Math.min(result.y, b.y),
+      };
+    }
+  }
+  return result;
+}
+```
+
+### 9. shape 削除時の関連オブジェクトクリーンアップ
+
+tldraw は `editor.sideEffects.registerAfterDeleteHandler('shape', fn)` で connector cleanup 等を行う。uSketch プラグインは `store.onMutation` で `shape:removed` event を listen し、フォローアップ command を自分で発行する:
+
+```ts
+ctx.store.onMutation((event) => {
+  if (event.type === "shape:removed") {
+    const id = event.payload?.id;
+    // `id` を参照する connector を探して削除する。
+  }
+});
+```
+
+group 化された shape の親 / 子 / connector cleanup はすでに `@edv4h/usketch-store` の `createDeleteWithChildrenCommand` が処理している — まずそれを使う。
+
+## 次に読むもの
+
+- [Shape プラグイン作成ガイド](./shape-plugin) — `ShapeDefinition` と描画 tool パターンの正典リファレンス
+- [Tool プラグイン作成ガイド](./tool-plugin) — phase 変数、ライフサイクル、`@edv4h/usketch-tool-helpers` セッション
+- [Selection Foreground](./selection-foreground) — selection chrome を独自 React コンポーネントで差し替え
+- [External Content](./external-content) — drop / paste / URL ハンドラを priority 解決で登録
+- [Third-Party Plugin Authoring](./third-party-plugin) — uSketch plugin を独立 npm パッケージとして配布
+
+このガイドでカバーしていない tldraw 概念があれば issue / pull request を歓迎する — 読者からの移行ノートがこのドキュメントを精度高く保つ最良の手段。

--- a/apps/docs/src/content/docs-ja/guides/shape-plugin.mdx
+++ b/apps/docs/src/content/docs-ja/guides/shape-plugin.mdx
@@ -190,3 +190,15 @@ export const rectPlugin: UsketchPlugin = {
 - ライブプレビューには**ストアを直接変更**、確定アクションには**コマンド**を使う。
 - ユーザーが少しだけドラッグしたケース（width/height が閾値未満）を必ず扱う。
 - 描画後は選択ツールに戻す — これが期待される UX。
+
+## tldraw からの移行
+
+`class MyShapeUtil extends ShapeUtil<TMyShape>` を書いていた人向け。uSketch では `ctx.shapes.register()` に渡すただのオブジェクトで同じことを表現します:
+
+- `component(shape)` → `render(data)`
+- `getGeometry(shape)` → `getBounds(data)` + `hitTest(data, point)`
+- `onResize(info)` → `resize(data, handle, delta)`
+- `getDefaultProps()` + `TLBaseShape` の入れ物 → `createDefault(params)`（戻り値は `extends ShapeData` の独自型）
+- `shape.props.foo` → `data.foo`（フラット — `width` / `height` / `x` / `y` はコアフィールド）
+
+API 対応表・Yjs データ移行・落とし穴の詳細は [tldraw からの移行](./migrate-from-tldraw) を参照。

--- a/apps/docs/src/content/docs-ja/guides/tool-plugin.mdx
+++ b/apps/docs/src/content/docs-ja/guides/tool-plugin.mdx
@@ -178,3 +178,14 @@ ctx.tools.register("stamp-and-drag", {
 - ツールの状態はプラグインオブジェクトではなく、`setup()` 内の**クロージャ**に保持する。これにより共有可変状態の問題を避けられる。
 - 他プラグインが反応する必要があるなら `ctx.events.emit()` でイベントを発行する。
 - `order` は慎重に設定する — ツールバーでは `order` の昇順で左から右に並ぶ。
+
+## tldraw からの移行
+
+`class MyTool extends StateNode` は `ctx.tools.register()` に渡す `ToolDefinition` オブジェクトに置き換わります:
+
+- ルート state の `onEnter` / `onExit` → `onActivate` / `onDeactivate`
+- 子 `StateNode` + `transition("…")` → `setup()` 内クロージャの `phase` 変数
+- `editor.inputs.currentPagePoint` → `event.worldPoint`
+- `editor.createShape(...)` → `ctx.commands.execute(createAddShapeCommand(store, shape))`
+
+内部状態はプラグインオブジェクトではなく `setup()` のクロージャに保持してください。`StateNode` の子階層・`track()` リアクティビティを含むフル比較は [tldraw からの移行](./migrate-from-tldraw) を参照。

--- a/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
@@ -374,7 +374,7 @@ function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
 }
 ```
 
-If your tool has many transitions or you want to share drag / resize / rotate behaviour with the built-in select tool, reach for [`@edv4h/usketch-tool-helpers`](../../reference/tool-helpers). Its `startDragSession` / `startResizeSession` / `startRotateSession` / `startMarqueeSession` helpers cover most of what tldraw's `StateNode` library provides out of the box; see the **Reusable Session Helpers** section of [Building a Tool Plugin](./tool-plugin) for the patterns.
+If your tool has many transitions or you want to share drag / resize / rotate behaviour with the built-in select tool, reach for `@edv4h/usketch-tool-helpers`. Its `startDragSession` / `startResizeSession` / `startRotateSession` / `startMarqueeSession` helpers cover most of what tldraw's `StateNode` library provides out of the box; see the [Reusable Session Helpers](./tool-plugin#reusable-session-helpers) section of *Building a Tool Plugin* for the patterns.
 
 ### Step 3. Inputs API
 
@@ -500,7 +500,7 @@ Three key differences:
 | ----------------------- | -------------- | ------------- | ----- |
 | `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`; resolve color | Use the rectangle plugin from `usketch-plugin-shape-basic`. |
 | `geo` + `props.geo = "ellipse"` | `ellipse` | same | Same plugin. |
-| `arrow` | `connector` | `props.start/end → from/to` anchor refs | If anchors don't resolve, fall back to absolute points. uSketch has no `arrow` shape — the closest match is `usketch-plugin-shape-connector`. |
+| `arrow` | `connector` | `props.start.boundShapeId → sourceId` (else `sourcePoint`); `props.end.boundShapeId → targetId` (else `targetPoint`) | uSketch has no `arrow` shape. The closest match is `usketch-plugin-shape-connector`, whose `ConnectorShapeData` requires `sourceAnchor` / `targetAnchor` / `arrowHead` / `pathType` defaults — use `createDefaultConnector` from that plugin and override the endpoint fields. |
 | `text` | `text` | `props.text → text`; size enum (`s/m/l/xl`) → px (`12/16/24/36`); font enum → CSS family | Width / height from the tldraw record itself. |
 | `image` | `image` | `props.assetId → src` (via asset map); `props.w/h → width/height` | tldraw stores image bytes in a separate `TLAsset` record — collect those in a first pass and resolve URLs before migrating shapes. |
 
@@ -570,30 +570,41 @@ function migrateRecord(rec: TLRecord, assetMap: Map<string, string>): ShapeData 
       } as ShapeData;
     }
     case "text":
+      // TextShapeData requires text / fontSize / fontFamily / isEditing,
+      // and the text plugin draws over a transparent background — so
+      // override base.style to match what createDefault would produce.
       return {
         ...base,
         type: "text",
         width: (p.w as number) ?? 200,
         height: 40,
+        style: { ...base.style, fill: "transparent", strokeWidth: 0 },
         text: (p.text as string) ?? "",
         fontSize: FONT_SIZE_PX[(p.size as string) ?? "m"] ?? 16,
+        fontFamily: "system-ui, sans-serif",
+        isEditing: false,
       } as ShapeData;
     case "arrow": {
       const start = p.start as { x?: number; y?: number; boundShapeId?: string } | undefined;
       const end = p.end as { x?: number; y?: number; boundShapeId?: string } | undefined;
-      // If the arrow is bound to other shapes, prefer anchor references;
-      // otherwise fall back to absolute points.
+      const sourceId = start?.boundShapeId?.replace(/^shape:/, "");
+      const targetId = end?.boundShapeId?.replace(/^shape:/, "");
+      // ConnectorShapeData requires every field below — sourcePoint / targetPoint
+      // act as the fallback when sourceId / targetId aren't bound. Anchor /
+      // arrowHead / pathType inherit the connector plugin's defaults.
       return {
         ...base,
         type: "connector",
         width: 0,
         height: 0,
-        from: start?.boundShapeId
-          ? { shapeId: start.boundShapeId.replace(/^shape:/, "") }
-          : { x: start?.x ?? 0, y: start?.y ?? 0 },
-        to: end?.boundShapeId
-          ? { shapeId: end.boundShapeId.replace(/^shape:/, "") }
-          : { x: end?.x ?? 0, y: end?.y ?? 0 },
+        sourceId,
+        targetId,
+        sourceAnchor: "auto",
+        targetAnchor: "auto",
+        arrowHead: "forward",
+        pathType: "straight",
+        sourcePoint: { x: start?.x ?? base.x, y: start?.y ?? base.y },
+        targetPoint: { x: end?.x ?? base.x + 100, y: end?.y ?? base.y },
       } as ShapeData;
     }
     case "image": {

--- a/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
@@ -510,7 +510,7 @@ The function below is illustrative — verify it against your own snapshot shape
 
 ```ts
 import * as Y from "yjs";
-import { type ShapeData, DEFAULT_STYLE, generateId } from "@edv4h/usketch-shared";
+import { type ShapeData, DEFAULT_STYLE } from "@edv4h/usketch-shared";
 
 type TLRecord = {
   id: string;

--- a/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
@@ -498,9 +498,9 @@ Three key differences:
 
 | tldraw `type` + `props` | uSketch `type` | Field mapping | Notes |
 | ----------------------- | -------------- | ------------- | ----- |
-| `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`; resolve color | Use the rectangle plugin from `usketch-plugin-shape-basic`. |
+| `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`; resolve color | Use the rectangle plugin from `@edv4h/usketch-plugin-shape-basic`. |
 | `geo` + `props.geo = "ellipse"` | `ellipse` | same | Same plugin. |
-| `arrow` | `connector` | `props.start.boundShapeId → sourceId` (else `sourcePoint`); `props.end.boundShapeId → targetId` (else `targetPoint`) | uSketch has no `arrow` shape. The closest match is `usketch-plugin-shape-connector`, whose `ConnectorShapeData` requires `sourceAnchor` / `targetAnchor` / `arrowHead` / `pathType` defaults — use `createDefaultConnector` from that plugin and override the endpoint fields. |
+| `arrow` | `connector` | `props.start.boundShapeId → sourceId` (else `sourcePoint`); `props.end.boundShapeId → targetId` (else `targetPoint`) | uSketch has no `arrow` shape. The closest match is `@edv4h/usketch-plugin-shape-connector`, whose `ConnectorShapeData` requires `sourceAnchor` / `targetAnchor` / `arrowHead` / `pathType` defaults — use `createDefaultConnector` from that plugin and override the endpoint fields. |
 | `text` | `text` | `props.text → text`; size enum (`s/m/l/xl`) → px (`12/16/24/36`); font enum → CSS family | Width / height from the tldraw record itself. |
 | `image` | `image` | `props.assetId → src` (via asset map); `props.w/h → width/height` | tldraw stores image bytes in a separate `TLAsset` record — collect those in a first pass and resolve URLs before migrating shapes. |
 
@@ -648,7 +648,7 @@ export function migrateTldrawSnapshot(snapshot: TLRecord[], yDoc: Y.Doc): number
 }
 ```
 
-To run the migration, load the tldraw snapshot (typically via `getSnapshot(store)` in tldraw or by reading the `.tldr` JSON file you exported), construct a fresh `Y.Doc`, call `migrateTldrawSnapshot`, then attach the doc to uSketch through `createYjsSync` from `usketch-plugin-sync-localstorage-yjs`. The sync plugin observes the `Y.Map` and feeds shapes into `BoardStore` as they arrive.
+To run the migration, load the tldraw snapshot (typically via `getSnapshot(store)` in tldraw or by reading the `.tldr` JSON file you exported), construct a fresh `Y.Doc`, call `migrateTldrawSnapshot`, then attach the doc to uSketch through `createYjsSync` from `@edv4h/usketch-plugin-sync-localstorage-yjs`. The sync plugin observes the `Y.Map` and feeds shapes into `BoardStore` as they arrive.
 
 > **Image assets.** If your tldraw snapshot still stores image bytes as base64 in `TLAsset.src`, the `image` shapes after migration will carry those bytes inline in `data.src`. That works but bloats the document; consider uploading the assets to a CDN first and writing the resolved URLs into the asset map.
 
@@ -717,7 +717,7 @@ const app = await createApp({
 });
 ```
 
-Plugins can also opt in via `ctx.ui.registerSelectionForeground({ id, priority, render })`. The registry picks the highest-priority entry, with last-registered winning ties; `usketch-plugin-tool-select` self-registers a default at priority 0. See [Selection Foreground](./selection-foreground) for the full API.
+Plugins can also opt in via `ctx.ui.registerSelectionForeground({ id, priority, render })`. The registry picks the highest-priority entry, with last-registered winning ties; `@edv4h/usketch-plugin-tool-select` self-registers a default at priority 0. See [Selection Foreground](./selection-foreground) for the full API.
 
 ## Common pitfalls
 

--- a/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
+++ b/apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx
@@ -1,0 +1,820 @@
+---
+title: Migrating from tldraw
+description: Port a tldraw v2 app to uSketch — API correspondence table, code examples for shape/tool/Yjs migration, and common pitfalls.
+order: 30
+---
+
+If you have built a tldraw v2 app and want to move to uSketch — perhaps because tldraw's v2 license tier no longer fits your use case, or because you want a smaller, MIT-licensed canvas runtime — this guide is the shortest path. The two libraries share many concepts (shape utilities, tools, an immutable record store, a Yjs adapter) but they package them differently. Read this guide once before you start porting; it will save you re-discovering each delta through trial and error.
+
+## Why this guide
+
+tldraw v2 introduced a non-free license layer in 2024, and a number of teams have asked for a clear migration path to a permissively licensed canvas runtime. uSketch v2 is MIT-licensed, ships an explicit plugin API, and reuses several primitives that will look familiar (`ShapeData` is a flatter cousin of `TLBaseShape`, `Yjs` syncing works through a similar `Y.Map`-of-shapes layout, and so on).
+
+This guide assumes you have written at least one of:
+
+- `class MyShapeUtil extends ShapeUtil<TMyShape>` to add a custom shape,
+- `class MyTool extends StateNode` for a custom tool,
+- code that calls `editor.createShape(...)` / `editor.updateShapes(...)`.
+
+It is **not** a tutorial — start with [Building a Shape Plugin](./shape-plugin) and [Building a Tool Plugin](./tool-plugin) if you have never written uSketch code before. It is also **not** a comparison of features the two libraries don't share: tldraw's collaborative presence avatars, AI agents, and document import for the proprietary `.tldr` format are out of scope.
+
+## Conceptual mapping
+
+Three mental-model shifts cover 80% of the migration work. Internalize these first and the API-level translations below will feel mechanical.
+
+### The single `Editor` becomes `useApp()` plus five registrars
+
+tldraw centralizes everything on the `Editor` instance: `editor.createShape`, `editor.select`, `editor.zoomToFit`, `editor.sideEffects.registerBeforeCreateHandler` all hang off the same object. uSketch splits these responsibilities into a few cooperating registries that you reach through `useApp()`:
+
+| Concern | uSketch entry point |
+| ------- | ------------------- |
+| Read / mutate shapes, viewport, selection | `app.store` (`BoardStore`) |
+| Undo / redo, batched operations | `app.commands` |
+| Register / look up shape definitions | `app.shapes` |
+| Register / activate tools | `app.tools` |
+| Emit / listen to events | `app.events` |
+| Drop / paste / URL handlers | `app.externalContent` |
+| Selection-UI override | `app.ui` |
+
+Inside a plugin's `setup(ctx)`, those same registries are reachable as `ctx.store`, `ctx.commands`, etc.
+
+### `track()` becomes `useStoreSubscribe(store, selector)`
+
+tldraw uses signia signals: a `track(Component)` HOC subscribes to every reactive read the component made, and re-renders automatically. uSketch uses Zustand under the hood; React components subscribe **explicitly** by calling `useStoreSubscribe(store, selector)` and the selector should return either a primitive or a stable reference. The trade-off is a tiny bit more boilerplate per component in exchange for explicit, debuggable subscriptions.
+
+### Classes become objects
+
+`ShapeUtil` and `StateNode` are abstract classes you extend; uSketch `ShapeDefinition` and `ToolDefinition` are plain objects with method-shaped properties. There is no inheritance — composition is done with helper functions (`@edv4h/usketch-shape-utils`, `@edv4h/usketch-tool-helpers`), and "child states" inside a tool become closure variables inside `setup()`.
+
+### Nested `props` flatten into `ShapeData`
+
+In tldraw a shape's intrinsic data lives at `shape.props.w`, `shape.props.text`, etc. In uSketch, `width`, `height`, `x`, `y`, `rotation`, `zIndex`, `style`, `parentId`, `meta`, `createdAt`, `updatedAt` are reserved **core fields** on `ShapeData`. Plugin-specific fields (a sticky note's `text`, an image shape's `src`) sit at the same top level — no `data.props` wrapper. Application data that has no geometry meaning goes into `meta`.
+
+## API correspondence
+
+| tldraw concept | uSketch equivalent |
+| -------------- | ------------------ |
+| `ShapeUtil.component(shape)` | `ShapeDefinition.render(data)` |
+| `ShapeUtil.getGeometry(shape)` | `ShapeDefinition.getBounds(data)` + `hitTest(data, point)` |
+| `ShapeUtil.onResize(info)` | `ShapeDefinition.resize(data, handle, delta)` |
+| `ShapeUtil.getDefaultProps()` | `ShapeDefinition.createDefault({ id, x, y })` |
+| `TLBaseShape<T, Props>` | `ShapeData & { type: T; ...intrinsicFields }` (flat) |
+| `Editor.createShapes([...])` | `store.addShape(shape)` wrapped in `commands.execute({ execute, undo })` |
+| `track(Component)` | `useStoreSubscribe(store, selector)` inside the component |
+| `class extends StateNode` | `ToolDefinition` object + closure state inside `setup()` |
+| `editor.registerExternalContentHandler(kind, fn)` | `ctx.externalContent.register({ id, kind, match, handle })` |
+| `useEditor()` | `useApp()` |
+| `WeakMapCache` / `createComputedCache` | Plain `Map<id, T>` invalidated via `store.onMutation`, or `useMemo` |
+
+The remainder of this guide expands each row with code.
+
+## Shape migration
+
+### Step 1. ShapeUtil class → ShapeDefinition object
+
+A tldraw shape util looks like this:
+
+```tsx
+// ─── tldraw v2 (before) ───────────────────────────────────────────────
+import { BaseBoxShapeUtil, HTMLContainer, type TLBaseShape } from "tldraw";
+
+type CardShape = TLBaseShape<"card", { w: number; h: number; title: string }>;
+
+class CardShapeUtil extends BaseBoxShapeUtil<CardShape> {
+  static override type = "card" as const;
+
+  override getDefaultProps(): CardShape["props"] {
+    return { w: 240, h: 120, title: "New card" };
+  }
+
+  override component(shape: CardShape) {
+    return (
+      <HTMLContainer
+        style={{ width: shape.props.w, height: shape.props.h, padding: 8 }}
+      >
+        <strong>{shape.props.title}</strong>
+      </HTMLContainer>
+    );
+  }
+  // getGeometry / onResize provided by BaseBoxShapeUtil
+}
+```
+
+The uSketch equivalent is a set of plain functions registered through `ctx.shapes.register()`:
+
+```tsx
+// ─── uSketch v2 (after) ───────────────────────────────────────────────
+import type {
+  BoundingBox,
+  Point,
+  ResizeHandle,
+  ShapeData,
+  PluginContext,
+  UsketchPlugin,
+} from "@edv4h/usketch-shared";
+import { DEFAULT_STYLE } from "@edv4h/usketch-shared";
+
+export interface CardShapeData extends ShapeData {
+  title: string;
+}
+
+function render(shape: ShapeData) {
+  const data = shape as CardShapeData;
+  return (
+    <foreignObject x={data.x} y={data.y} width={data.width} height={data.height}>
+      <div
+        xmlns="http://www.w3.org/1999/xhtml"
+        style={{ width: "100%", height: "100%", padding: 8, boxSizing: "border-box" }}
+      >
+        <strong>{data.title}</strong>
+      </div>
+    </foreignObject>
+  );
+}
+
+function getBounds(data: ShapeData): BoundingBox {
+  return { x: data.x, y: data.y, width: data.width, height: data.height };
+}
+
+function hitTest(data: ShapeData, point: Point): boolean {
+  return (
+    point.x >= data.x &&
+    point.x <= data.x + data.width &&
+    point.y >= data.y &&
+    point.y <= data.y + data.height
+  );
+}
+
+function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
+  // Same eight-direction switch as the rectangle plugin —
+  // see Building a Shape Plugin → "Implement Resize Logic".
+  return data;
+}
+
+function createDefault(params: { id: string; x: number; y: number }): CardShapeData {
+  return {
+    id: params.id,
+    type: "card",
+    x: params.x,
+    y: params.y,
+    width: 240,
+    height: 120,
+    style: { ...DEFAULT_STYLE },
+    title: "New card",
+  };
+}
+
+export const cardPlugin: UsketchPlugin = {
+  id: "card-shape",
+  name: "Card",
+  setup(ctx: PluginContext) {
+    ctx.shapes.register("card", { render, getBounds, hitTest, resize, createDefault });
+  },
+};
+```
+
+Two patterns to internalize:
+
+- **No wrapper class.** `ShapeDefinition` is the object literal; there is no `this`. State (caches, timers) belongs in the `setup()` closure.
+- **Cast `ShapeData` to your extension interface** inside `render` / `hitTest` / `resize` so plugin-specific fields are type-safe. This mirrors the `as RectangleShapeData` pattern in [Building a Shape Plugin](./shape-plugin).
+
+### Step 2. TLBaseShape props → flat ShapeData
+
+tldraw envelopes intrinsic data in `props`:
+
+```ts
+type CardShape = TLBaseShape<"card", { w: number; h: number; title: string }>;
+// Access: shape.props.w, shape.props.title
+```
+
+uSketch reuses **core fields** (`width`, `height`, `x`, `y`, `rotation`, …) and puts plugin-specific fields at the same level:
+
+```ts
+interface CardShapeData extends ShapeData {
+  title: string;
+}
+// Access: data.width, data.title
+```
+
+The reserved core fields you must not redefine:
+
+| Field | Type | Notes |
+| ----- | ---- | ----- |
+| `id` | `string` | Unique within the board. |
+| `type` | `string` | Matches the `ShapeRegistry` key. |
+| `x`, `y` | `number` | Top-left in world coordinates. |
+| `width`, `height` | `number` | Always present (no `props.w`). |
+| `rotation` | `number?` | Radians; `undefined` ≡ 0. |
+| `zIndex` | `string?` | Fractional index; same encoding as tldraw's `index`. |
+| `style` | `ShapeStyle` | `{ fill, stroke, strokeWidth, opacity }`. |
+| `parentId` | `string?` | For grouped / framed shapes. |
+| `meta` | `TMeta` | Application data — see below. |
+| `createdAt`, `updatedAt` | `number?` | Optional millisecond timestamps. |
+
+Anything that isn't geometry (an `employeeId`, an external `versionId`) belongs in `meta`. There is also an `x-*` escape hatch for legacy migrations, but new code should use `meta`. See [Shape System → Extending shapes](/docs/concepts/shape-system/#extending-shapes).
+
+### Step 3. createShapes → store.addShape + commands
+
+tldraw batches mutations in `editor.run`:
+
+```ts
+editor.run(() => {
+  editor.createShapes([{ id, type: "card", x: 100, y: 100, props: { /*…*/ } }]);
+});
+```
+
+uSketch separates the store mutation from undo bookkeeping. The store mutates immediately; commands give you undo:
+
+```ts
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+
+ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
+```
+
+`createAddShapeCommand` wraps `{ execute: () => store.addShape(shape), undo: () => store.deleteShape(shape.id) }`. The full set of helpers in `@edv4h/usketch-store` covers the operations you would do with `editor.X`:
+
+| Operation | Helper |
+| --------- | ------ |
+| Create a shape | `createAddShapeCommand(store, shape)` |
+| Delete a shape | `createDeleteShapeCommand(store, id)` |
+| Update a shape (with from / to snapshots) | `createUpdateShapeCommand(store, id, from, to)` |
+| Move many shapes | `createMoveShapesCommand(store, beforeMap, afterMap)` |
+| Batch updates | `createBatchUpdateShapesCommand(store, updates)` |
+| Group / ungroup | `createGroupCommand`, `createUngroupCommand` |
+| Z-order operations | `createBringToFrontCommand`, `createSendToBackCommand`, … |
+
+There is no `commands.batch(fn)` wrapper today — to batch multiple operations into a single undo step, build one composite `Command` object whose `execute` runs all mutations and whose `undo` reverses them.
+
+## Tool migration
+
+### Step 1. StateNode → ToolDefinition
+
+tldraw tools are class hierarchies:
+
+```tsx
+// ─── tldraw v2 (before) ───────────────────────────────────────────────
+import { StateNode, type TLPointerEventInfo } from "tldraw";
+
+class CardTool extends StateNode {
+  static override id = "card";
+  static override initial = "idle";
+  static override children = () => [Idle, Drawing];
+}
+
+class Idle extends StateNode {
+  static override id = "idle";
+  override onPointerDown = () => this.parent.transition("drawing");
+}
+
+class Drawing extends StateNode {
+  static override id = "drawing";
+  override onEnter = () => {
+    const { currentPagePoint } = this.editor.inputs;
+    this.editor.createShape({
+      type: "card",
+      x: currentPagePoint.x,
+      y: currentPagePoint.y,
+    });
+  };
+  override onPointerUp = () => this.parent.transition("idle");
+}
+```
+
+In uSketch the tool is a single object literal. Sub-states collapse into a closure variable — typically a `phase` discriminator plus any phase-local data:
+
+```tsx
+// ─── uSketch v2 (after) ───────────────────────────────────────────────
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import {
+  generateId,
+  type CanvasPointerEvent,
+  type PluginContext,
+  type ToolContext,
+  type UsketchPlugin,
+} from "@edv4h/usketch-shared";
+
+function CardIcon() {
+  return <svg width="20" height="20" viewBox="0 0 20 20" /* … */ />;
+}
+
+export const cardToolPlugin: UsketchPlugin = {
+  id: "card-tool",
+  name: "Card tool",
+  setup(ctx: PluginContext) {
+    // Replaces tldraw's child-state hierarchy.
+    // These live inside the setup() closure — not on the plugin object —
+    // so each plugin instance has its own state.
+    type Phase = "idle" | "drawing";
+    let phase: Phase = "idle";
+    let drawingId: string | null = null;
+
+    function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+      const id = generateId();
+      drawingId = id;
+      phase = "drawing";
+      const shape = toolCtx.shapes
+        .get("card")!
+        .createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+      // Temporary store mutation for live preview.
+      toolCtx.store.addShape(shape);
+    }
+
+    function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+      if (phase !== "drawing" || !drawingId) return;
+      const start = toolCtx.store.getShape(drawingId);
+      if (!start) return;
+      toolCtx.store.updateShape(drawingId, {
+        width: Math.max(1, event.worldPoint.x - start.x),
+        height: Math.max(1, event.worldPoint.y - start.y),
+      });
+    }
+
+    function onPointerUp(toolCtx: ToolContext) {
+      if (phase !== "drawing" || !drawingId) return;
+      const shape = toolCtx.store.getShape(drawingId);
+      if (shape) {
+        // Swap the temp shape for an undoable command.
+        toolCtx.store.deleteShape(drawingId);
+        toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+      }
+      drawingId = null;
+      phase = "idle";
+      toolCtx.store.setActiveToolId("select");
+    }
+
+    ctx.tools.register("card-draw", {
+      icon: CardIcon,
+      cursor: "crosshair",
+      shortcut: "c",
+      order: 12,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+    });
+  },
+};
+```
+
+### Step 2. Child states → phase variables
+
+tldraw `StateNode` child states inherit `editor` and can `transition("name")` to siblings. In uSketch, the same shape is achieved with a discriminated union:
+
+```ts
+type Phase =
+  | { kind: "idle" }
+  | { kind: "drawing"; shapeId: string; startPoint: Point }
+  | { kind: "rotating"; shapeId: string; pivot: Point };
+
+let phase: Phase = { kind: "idle" };
+
+function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+  // Transition into the "drawing" phase carrying phase-local data
+  phase = { kind: "drawing", shapeId: generateId(), startPoint: event.worldPoint };
+  // …
+}
+```
+
+If your tool has many transitions or you want to share drag / resize / rotate behaviour with the built-in select tool, reach for [`@edv4h/usketch-tool-helpers`](../../reference/tool-helpers). Its `startDragSession` / `startResizeSession` / `startRotateSession` / `startMarqueeSession` helpers cover most of what tldraw's `StateNode` library provides out of the box; see the **Reusable Session Helpers** section of [Building a Tool Plugin](./tool-plugin) for the patterns.
+
+### Step 3. Inputs API
+
+tldraw reads input state from `editor.inputs.*`; uSketch passes it on each event:
+
+| tldraw | uSketch |
+| ------ | ------- |
+| `editor.inputs.currentPagePoint` | `event.worldPoint` (passed to every handler) |
+| `editor.inputs.currentScreenPoint` | `event.screenPoint` |
+| `editor.inputs.shiftKey` | `event.shiftKey` |
+| `editor.inputs.ctrlKey` / `altKey` / `metaKey` | `event.ctrlKey` / `event.altKey` / `event.metaKey` |
+| `editor.inputs.isDragging` | Derived from your `phase` variable |
+| `editor.getSelectedShapeIds()` | `app.store.getSelection()` (returns `ReadonlySet<string>`) |
+
+`CanvasPointerEvent` is a plain object — no globals, no need to query the editor between events.
+
+## Reactivity and selectors
+
+### track() → useStoreSubscribe
+
+In tldraw:
+
+```tsx
+import { useEditor, track } from "tldraw";
+
+const SelectionCount = track(function SelectionCount() {
+  const editor = useEditor();
+  const count = editor.getSelectedShapeIds().length;
+  return <div>{count} selected</div>;
+});
+```
+
+In uSketch you subscribe explicitly. The selector is a function that takes the store and returns a value; the component re-renders whenever the selector's return changes by `Object.is`:
+
+```tsx
+import { useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
+import type { BoardStore } from "@edv4h/usketch-shared";
+
+const selectSelectionCount = (s: BoardStore) => s.getSelection().size;
+
+function SelectionCount() {
+  const app = useApp();
+  // Returning a primitive keeps the equality check cheap and stable.
+  const count = useStoreSubscribe(app.store, selectSelectionCount);
+  return <div>{count} selected</div>;
+}
+```
+
+> **Selector hygiene.** Selectors must return stable references so subscription comparisons don't thrash. Returning `Array.from(s.getSelection())` allocates a fresh array on every read and will trigger a re-render every store tick — return the underlying `ReadonlySet` (stable identity), a primitive derived from it, or memoize the result.
+
+### useEditor → useApp
+
+`useEditor()` in tldraw becomes `useApp()` in uSketch and gives you the same access. The pattern shift is that you call into different registries instead of methods on one object:
+
+```tsx
+function CreateCard() {
+  const app = useApp();
+  const handleClick = () => {
+    const shape = app.shapes.get("card")!.createDefault({ id: generateId(), x: 0, y: 0 });
+    app.commands.execute(createAddShapeCommand(app.store, shape));
+  };
+  return <button onClick={handleClick}>Add card</button>;
+}
+```
+
+For non-React consumers (event sources, debug panels) the lower-level subscription is `store.subscribe(listener)` for general "something changed" notifications and `store.onMutation((event) => …)` for typed mutation events.
+
+### createComputedCache → useMemo or onMutation
+
+tldraw's `createComputedCache` keeps a value derived from one or more records in sync with their identity. The two natural replacements are:
+
+- **Inside a React component**: `useMemo(() => derive(shape), [shape])`. Zustand re-runs your selector with the new shape reference, React invalidates the memo.
+- **Outside React**: a plain `Map<id, Cached>` invalidated via `store.onMutation`. The mutation event includes the affected shape ID; clear the cache entry, recompute lazily.
+
+`WeakMapCache` has no direct uSketch counterpart because plain `ShapeData` objects don't carry stable identity across updates (updating returns a new object). Key your cache by `shape.id`.
+
+## Yjs data migration
+
+Both libraries persist shapes in a Yjs `Y.Map`, but the record shape differs. tldraw stores a `TLRecord` per shape:
+
+```json
+{
+  "id": "shape:abc",
+  "type": "geo",
+  "typeName": "shape",
+  "x": 100,
+  "y": 200,
+  "rotation": 0,
+  "index": "a1",
+  "parentId": "page:page",
+  "isLocked": false,
+  "opacity": 1,
+  "props": { "geo": "rectangle", "w": 200, "h": 100, "color": "blue", "fill": "solid" },
+  "meta": {}
+}
+```
+
+The uSketch equivalent is a flatter `ShapeData`:
+
+```json
+{
+  "id": "abc",
+  "type": "rectangle",
+  "x": 100,
+  "y": 200,
+  "width": 200,
+  "height": 100,
+  "rotation": 0,
+  "zIndex": "a1",
+  "style": { "fill": "#3b82f6", "stroke": "#0f172a", "strokeWidth": 2, "opacity": 1 }
+}
+```
+
+Three key differences:
+
+- `props.w` / `props.h` collapse to top-level `width` / `height`.
+- `index` (fractional index) renames to `zIndex` — the encoding is identical so the string can be reused 1:1.
+- tldraw color enums (`"blue"`, `"red"`, …) resolve to hex tokens.
+
+### Per-shape field mapping
+
+| tldraw `type` + `props` | uSketch `type` | Field mapping | Notes |
+| ----------------------- | -------------- | ------------- | ----- |
+| `geo` + `props.geo = "rectangle"` | `rectangle` | `props.w/h → width/height`; resolve color | Use the rectangle plugin from `usketch-plugin-shape-basic`. |
+| `geo` + `props.geo = "ellipse"` | `ellipse` | same | Same plugin. |
+| `arrow` | `connector` | `props.start/end → from/to` anchor refs | If anchors don't resolve, fall back to absolute points. uSketch has no `arrow` shape — the closest match is `usketch-plugin-shape-connector`. |
+| `text` | `text` | `props.text → text`; size enum (`s/m/l/xl`) → px (`12/16/24/36`); font enum → CSS family | Width / height from the tldraw record itself. |
+| `image` | `image` | `props.assetId → src` (via asset map); `props.w/h → width/height` | tldraw stores image bytes in a separate `TLAsset` record — collect those in a first pass and resolve URLs before migrating shapes. |
+
+### A migration script
+
+The function below is illustrative — verify it against your own snapshot shape (tldraw evolves between minor versions). Treat it as a starting point and adapt color/font enums to match your tldraw configuration.
+
+```ts
+import * as Y from "yjs";
+import { type ShapeData, DEFAULT_STYLE, generateId } from "@edv4h/usketch-shared";
+
+type TLRecord = {
+  id: string;
+  typeName: string;
+  type?: string;
+  x?: number;
+  y?: number;
+  rotation?: number;
+  index?: string;
+  parentId?: string;
+  opacity?: number;
+  props?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
+};
+
+const COLOR_HEX: Record<string, string> = {
+  blue: "#3b82f6",
+  red: "#ef4444",
+  green: "#22c55e",
+  yellow: "#eab308",
+  black: "#0f172a",
+  grey: "#64748b",
+  "light-blue": "#93c5fd",
+};
+
+const FONT_SIZE_PX: Record<string, number> = { s: 12, m: 16, l: 24, xl: 36 };
+
+function resolveColor(name: unknown): string {
+  return (typeof name === "string" && COLOR_HEX[name]) || "#0f172a";
+}
+
+function migrateRecord(rec: TLRecord, assetMap: Map<string, string>): ShapeData | null {
+  if (rec.typeName !== "shape") return null;
+
+  const base = {
+    id: rec.id.replace(/^shape:/, ""),
+    x: rec.x ?? 0,
+    y: rec.y ?? 0,
+    rotation: rec.rotation ?? 0,
+    zIndex: rec.index, // 1:1 reuse — same fractional-index encoding
+    parentId: rec.parentId === "page:page" ? undefined : rec.parentId,
+    style: { ...DEFAULT_STYLE, opacity: rec.opacity ?? 1 },
+  };
+  const p = (rec.props ?? {}) as Record<string, unknown>;
+
+  switch (rec.type) {
+    case "geo": {
+      const geo = (p.geo as string | undefined) ?? "rectangle";
+      const type = geo === "ellipse" ? "ellipse" : "rectangle";
+      const color = resolveColor(p.color);
+      return {
+        ...base,
+        type,
+        width: (p.w as number) ?? 100,
+        height: (p.h as number) ?? 100,
+        style: { ...base.style, fill: color, stroke: "#0f172a", strokeWidth: 2 },
+      } as ShapeData;
+    }
+    case "text":
+      return {
+        ...base,
+        type: "text",
+        width: (p.w as number) ?? 200,
+        height: 40,
+        text: (p.text as string) ?? "",
+        fontSize: FONT_SIZE_PX[(p.size as string) ?? "m"] ?? 16,
+      } as ShapeData;
+    case "arrow": {
+      const start = p.start as { x?: number; y?: number; boundShapeId?: string } | undefined;
+      const end = p.end as { x?: number; y?: number; boundShapeId?: string } | undefined;
+      // If the arrow is bound to other shapes, prefer anchor references;
+      // otherwise fall back to absolute points.
+      return {
+        ...base,
+        type: "connector",
+        width: 0,
+        height: 0,
+        from: start?.boundShapeId
+          ? { shapeId: start.boundShapeId.replace(/^shape:/, "") }
+          : { x: start?.x ?? 0, y: start?.y ?? 0 },
+        to: end?.boundShapeId
+          ? { shapeId: end.boundShapeId.replace(/^shape:/, "") }
+          : { x: end?.x ?? 0, y: end?.y ?? 0 },
+      } as ShapeData;
+    }
+    case "image": {
+      const url = assetMap.get((p.assetId as string) ?? "");
+      if (!url) return null;
+      return {
+        ...base,
+        type: "image",
+        width: (p.w as number) ?? 200,
+        height: (p.h as number) ?? 150,
+        src: url,
+      } as ShapeData;
+    }
+    default:
+      console.warn(`Skipping unsupported tldraw shape type: ${rec.type}`);
+      return null;
+  }
+}
+
+export function migrateTldrawSnapshot(snapshot: TLRecord[], yDoc: Y.Doc): number {
+  const shapesMap = yDoc.getMap<Record<string, unknown>>("shapes");
+  // First pass: collect image asset URLs by id.
+  const assetMap = new Map<string, string>();
+  for (const rec of snapshot) {
+    if (rec.typeName === "asset" && (rec as TLRecord & { type?: string }).type === "image") {
+      const src = (rec.props as Record<string, unknown> | undefined)?.src;
+      if (typeof src === "string") assetMap.set(rec.id, src);
+    }
+  }
+  // Second pass: migrate shapes into the Y.Map in a single transaction.
+  let written = 0;
+  yDoc.transact(() => {
+    for (const rec of snapshot) {
+      const shape = migrateRecord(rec, assetMap);
+      if (!shape) continue;
+      shapesMap.set(shape.id, JSON.parse(JSON.stringify(shape)));
+      written++;
+    }
+  });
+  return written;
+}
+```
+
+To run the migration, load the tldraw snapshot (typically via `getSnapshot(store)` in tldraw or by reading the `.tldr` JSON file you exported), construct a fresh `Y.Doc`, call `migrateTldrawSnapshot`, then attach the doc to uSketch through `createYjsSync` from `usketch-plugin-sync-localstorage-yjs`. The sync plugin observes the `Y.Map` and feeds shapes into `BoardStore` as they arrive.
+
+> **Image assets.** If your tldraw snapshot still stores image bytes as base64 in `TLAsset.src`, the `image` shapes after migration will carry those bytes inline in `data.src`. That works but bloats the document; consider uploading the assets to a CDN first and writing the resolved URLs into the asset map.
+
+## External content
+
+tldraw routes drop / paste through `editor.registerExternalContentHandler(kind, fn)` with seven kinds: `text | files | url | svg-text | tldraw | excalidraw | embeds`. uSketch normalises these to three kinds (`file | url | text`) and matches via predicate:
+
+| tldraw kind | uSketch handler |
+| ----------- | --------------- |
+| `text` | `kind: "text"` |
+| `files` | `kind: "file"` |
+| `url` | `kind: "url"` |
+| `svg-text` | `kind: "text"` with `match: ({ html, text }) => (html ?? text).trim().startsWith("<svg")` |
+| `embeds` (YouTube etc.) | `kind: "url"` with a host-name `match` |
+| `tldraw` / `excalidraw` document import | No native handler — dispatch through `kind: "text"`, detect the JSON shape, run a converter |
+
+Example: a YouTube embed handler.
+
+```tsx
+import type { UsketchPlugin } from "@edv4h/usketch-shared";
+
+export const youtubeEmbedPlugin: UsketchPlugin = {
+  id: "youtube-embed",
+  name: "YouTube embed",
+  setup(ctx) {
+    const off = ctx.externalContent.register({
+      id: "youtube-embed:url",
+      kind: "url",
+      order: 50,
+      match: (content) => {
+        try {
+          const u = new URL(content.url);
+          return u.hostname === "youtube.com" || u.hostname === "www.youtube.com";
+        } catch {
+          return false;
+        }
+      },
+      handle: async (content, hctx) => {
+        const shape = makeYoutubeShape(content.url);
+        hctx.commands.execute({
+          execute: () => hctx.store.addShape(shape),
+          undo: () => hctx.store.deleteShape(shape.id),
+        });
+      },
+    });
+    (this as UsketchPlugin).teardown = () => off();
+  },
+};
+```
+
+Resolution follows a single-winner rule (highest `order` wins, last-registered breaks ties). See [External Content](./external-content) for the full contract.
+
+## Selection UI replacement
+
+In tldraw the selection UI is split between `SelectTool` (a `StateNode` that renders the bounding box and handles) and per-shape `Indicator` components. Replacing it usually means subclassing the tool, registering new indicator components, and accepting some coupling to internal `SelectTool` states.
+
+uSketch keeps shape rendering completely separate from selection chrome. The whole selection foreground — bounding box, eight resize handles, rotation handle, marquee rectangle — is registered as a single React component:
+
+```ts
+const app = await createApp({
+  store,
+  plugins,
+  selectionForeground: {
+    render: (ctx) => <MySelectionForeground ctx={ctx} />,
+  },
+});
+```
+
+Plugins can also opt in via `ctx.ui.registerSelectionForeground({ id, priority, render })`. The registry picks the highest-priority entry, with last-registered winning ties; `usketch-plugin-tool-select` self-registers a default at priority 0. See [Selection Foreground](./selection-foreground) for the full API.
+
+## Common pitfalls
+
+These are the issues teams hit most often when porting from tldraw. Skim them before you start — they will save hours of debugging later.
+
+### 1. No automatic reactivity
+
+`track()` is gone. Components that read `app.store` outside of `useStoreSubscribe` will render once and never update. Wrap every reactive read in a selector and **return primitives or stable references**. If your component depends on a derived value, compute it inside the selector so React only re-renders when the derived value changes.
+
+### 2. The Editor is dispersed across registrars
+
+Replace `editor.X()` with the right registry method:
+
+| tldraw | uSketch |
+| ------ | ------- |
+| `editor.createShape(...)` | `app.commands.execute(createAddShapeCommand(app.store, shape))` |
+| `editor.deleteShapes(ids)` | `app.commands.execute(createDeleteShapeCommand(app.store, id))` |
+| `editor.select(...ids)` | `app.store.setSelection(ids)` |
+| `editor.getCurrentPageShapes()` | `Array.from(app.store.getShapes().values())` |
+
+Treat it as a search-and-replace pass before you start porting logic.
+
+### 3. No `editor.run(fn)` batch wrapper
+
+tldraw's `editor.run(fn)` rolls multiple mutations into one undo entry. uSketch has no direct equivalent yet — build a single composite `Command` whose `execute` runs every mutation and whose `undo` reverses them, then pass it to `commands.execute` once.
+
+A native `commands.batch(fn)` API is on the roadmap; the workaround stays sound after it lands.
+
+### 4. No `sideEffects.registerBeforeCreateHandler`
+
+tldraw lets you mutate or veto records before they are committed via `editor.sideEffects.registerBeforeCreateHandler` / `BeforeChange` / etc. uSketch has no built-in pre-mutation hook today. The closest workarounds:
+
+- **After-mutation reactions**: `store.onMutation((event) => …)` fires after each mutation with a typed payload. Good for cleanup, sync, audit logging.
+- **Pre-mutation validation**: wrap your `addShape` / `updateShape` calls in a custom `Command` whose `execute` runs validation before calling the store. This pushes the responsibility onto every call site, which is by design — there's no way to silently mutate behind a plugin's back.
+
+A pre-mutation hook API is being designed; track the corresponding issue on the repo if you need this.
+
+### 5. WeakMapCache / createComputedCache
+
+There's no signia inside uSketch. Two replacement patterns:
+
+- Inside React: `useMemo` keyed on the shape itself (Zustand returns a new shape reference on every update).
+- Outside React: a plain `Map<id, Cached>` invalidated via `store.onMutation`. Don't try to recreate signia — selectors that return primitives re-run cheaply and the re-render they trigger is usually fine.
+
+### 6. Props flattening collisions
+
+Reserved core fields on `ShapeData`: `id`, `type`, `x`, `y`, `width`, `height`, `rotation`, `zIndex`, `style`, `meta`, `parentId`, `createdAt`, `updatedAt`. If your tldraw shape had `props.x`, `props.y`, `props.w`, `props.h` they collapse onto the core fields. Anything application-domain — `employeeId`, internal `versionId`, a `featureFlag` — goes into `meta`. The legacy `x-*` escape hatch is for one-off migrations only.
+
+### 7. TLAsset (images / videos)
+
+tldraw indirects through an asset registry keyed by `assetId`; uSketch stores the URL directly on the shape (`data.src`). During migration you need an asset-id → URL resolver step (already shown in the migration script). For video assets there is no built-in uSketch shape today — write your own shape plugin or skip those records.
+
+### 8. `zoomToFit` API shape
+
+In tldraw, `editor.zoomToFit()` takes no arguments. In uSketch:
+
+```ts
+app.store.fitToBounds(bounds, { width, height }, padding?);
+```
+
+The caller passes the bounds and the viewport pixel size. Compute the bounds by iterating shapes:
+
+```ts
+import type { BoundingBox, ShapeData } from "@edv4h/usketch-shared";
+
+function unionBounds(shapes: Iterable<ShapeData>): BoundingBox | null {
+  let result: BoundingBox | null = null;
+  for (const s of shapes) {
+    const b = { x: s.x, y: s.y, width: s.width, height: s.height };
+    if (!result) {
+      result = b;
+    } else {
+      const right = Math.max(result.x + result.width, b.x + b.width);
+      const bottom = Math.max(result.y + result.height, b.y + b.height);
+      result = {
+        x: Math.min(result.x, b.x),
+        y: Math.min(result.y, b.y),
+        width: right - Math.min(result.x, b.x),
+        height: bottom - Math.min(result.y, b.y),
+      };
+    }
+  }
+  return result;
+}
+```
+
+### 9. Cleanup of related shapes on delete
+
+tldraw's connector cleanup runs through `editor.sideEffects.registerAfterDeleteHandler('shape', fn)`. uSketch plugins listen on `store.onMutation` for `shape:removed` events and issue follow-up commands themselves:
+
+```ts
+ctx.store.onMutation((event) => {
+  if (event.type === "shape:removed") {
+    const id = event.payload?.id;
+    // Find connectors that reference `id` and delete them.
+  }
+});
+```
+
+`createDeleteWithChildrenCommand` from `@edv4h/usketch-store` already handles parent / child / connector cleanup for grouped shapes — reach for it first.
+
+## Where to go next
+
+- [Building a Shape Plugin](./shape-plugin) — the canonical reference for `ShapeDefinition` and the drawing-tool pattern.
+- [Building a Tool Plugin](./tool-plugin) — phase variables, lifecycle, and the `@edv4h/usketch-tool-helpers` sessions.
+- [Selection Foreground](./selection-foreground) — replace the default selection chrome with your own React component.
+- [External Content](./external-content) — register drop / paste / URL handlers with priority resolution.
+- [Third-Party Plugin Authoring](./third-party-plugin) — ship a uSketch plugin as a standalone npm package.
+- [Domain Design Plugin](./domain-design-plugin) — a built-in plugin that demonstrates the patterns end-to-end.
+
+Found a tldraw concept this guide didn't cover? Open an issue or send a pull request — migration notes contributed by readers are the best way to keep this document accurate.

--- a/apps/docs/src/content/docs/guides/shape-plugin.mdx
+++ b/apps/docs/src/content/docs/guides/shape-plugin.mdx
@@ -230,3 +230,15 @@ See [Shape System → Extending shapes](/docs/concepts/shape-system/#extending-s
 - Always handle the case where the user barely drags (width/height < threshold).
 - Switch back to the select tool after drawing — this is the expected UX.
 - Declare an `extends ShapeData` interface for your plugin's intrinsic fields; put application data in `meta`.
+
+## Coming from tldraw?
+
+If you previously wrote `class MyShapeUtil extends ShapeUtil<TMyShape>`, the uSketch equivalent is the plain object passed to `ctx.shapes.register()`:
+
+- `component(shape)` → `render(data)`
+- `getGeometry(shape)` → `getBounds(data)` + `hitTest(data, point)`
+- `onResize(info)` → `resize(data, handle, delta)`
+- `getDefaultProps()` + the `TLBaseShape` envelope → `createDefault(params)` returning your `extends ShapeData` type
+- `shape.props.foo` → `data.foo` (flat — `width` / `height` / `x` / `y` are core fields)
+
+For the full API table, Yjs data migration, and common pitfalls, see [Migrating from tldraw](./migrate-from-tldraw).

--- a/apps/docs/src/content/docs/guides/tool-plugin.mdx
+++ b/apps/docs/src/content/docs/guides/tool-plugin.mdx
@@ -178,3 +178,14 @@ For static "click to place" tools, you don't need a session at all; the eraser e
 - Keep tool state in **closures** within `setup()`, not on the plugin object. This avoids shared mutable state issues.
 - Emit events via `ctx.events.emit()` if other plugins need to react to your tool's actions.
 - Set `order` thoughtfully — tools appear left-to-right in the toolbar sorted by `order`.
+
+## Coming from tldraw?
+
+`class MyTool extends StateNode` becomes a `ToolDefinition` object registered via `ctx.tools.register()`. The conversion:
+
+- `onEnter` / `onExit` on the root state → `onActivate` / `onDeactivate`
+- Child `StateNode`s with `transition("…")` → a `phase` closure variable inside `setup()`
+- `editor.inputs.currentPagePoint` → `event.worldPoint`
+- `editor.createShape(...)` → `ctx.commands.execute(createAddShapeCommand(store, shape))`
+
+Keep all internal state in `setup()` closures — never on the plugin object — so each plugin instance has its own state. See [Migrating from tldraw](./migrate-from-tldraw) for the full mapping including `StateNode` child hierarchies and `track()` reactivity.


### PR DESCRIPTION
## Summary

Issue #579 の対応。tldraw v2 アプリを uSketch v2 へ移植するための包括的な移行ガイドを en / ja の両方で追加。

### 新規ファイル

- \`apps/docs/src/content/docs/guides/migrate-from-tldraw.mdx\` (en, ~600 行)
- \`apps/docs/src/content/docs-ja/guides/migrate-from-tldraw.mdx\` (ja, ~600 行)

### 既存 guide への追記

- \`shape-plugin.mdx\` (en/ja) 末尾に「Coming from tldraw?」フッター
- \`tool-plugin.mdx\` (en/ja) 末尾に同様のフッター

### 章立て (en/ja 共通)

1. Why this guide
2. Conceptual mapping (Editor → useApp + 5 registrars / signals → Zustand / class → object / nested props → flat)
3. API correspondence table (Issue 本文 11 行を網羅)
4. Shape migration (ShapeUtil → ShapeDefinition / TLBaseShape → flat ShapeData / createShapes → store.addShape + commands)
5. Tool migration (StateNode → ToolDefinition + closure / child states → phase variables / inputs API map)
6. Reactivity & selectors (track → useStoreSubscribe / useEditor → useApp / createComputedCache 代替)
7. Yjs data migration (TLRecord JSON 例 + ShapeData JSON 例 + 5 shape mapping + migrate スクリプト)
8. External content (tldraw 7 kind → uSketch 3 kind + YouTube サンプル)
9. Selection UI replacement (selection-foreground API への cross-link)
10. Common pitfalls (9 項目: 自動 reactivity 無し / Editor 分散 / batch 無し / pre-mutation hook 無し / WeakMapCache 代替 / props 衝突 / TLAsset / zoomToFit / cleanup on delete)
11. Where to go next (関連 guide への cross-links)

### Issue Acceptance チェック

- [x] 英語 + 日本語の移行ガイド公開
- [x] docs の guides カタログから参照可能 (order: 30、external-content と domain-design の間)
- [x] 既存 \`shape-plugin.mdx\` / \`tool-plugin.mdx\` (en/ja) にコード例 + cross-link 追加

## Test plan

- [x] \`pnpm --filter @edv4h/usketch-docs build\` — 100 ページ build 成功 (/docs/guides/migrate-from-tldraw, /docs/ja/guides/migrate-from-tldraw を含む)
- [x] \`pnpm --filter @edv4h/usketch-docs check\` — 0 errors / 0 warnings / 0 hints
- [x] \`pnpm -r typecheck\` — 全 package パス
- [x] \`pnpm biome check .\` — errors なし (warnings は既存のもの)
- [ ] 手動: dev server で sidebar 順序、内部リンク、表レンダリングを目視確認

## Notes

- changeset は不要 (docs のみ、package 公開なし)
- Yjs migration スクリプトは「説明用コード例」として記載 (runtime 検証はせず、読者が自分の snapshot に合わせて adapt する前提)
- tldraw の \`arrow\` shape は uSketch \`connector\` plugin にマッピング (アンカー未解決時は絶対座標 fallback、制限を明記)
- pitfall 9 項目 (Issue 本文 6 項目 + Plan agent 提案 3 項目 = batch / pre-mutation hook / cleanup on delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)