### PR TITLE
✨ feat(plugins): OpenUI Generative UI ウィジェット (experimental)

### DIFF
--- a/.changeset/plugin-shape-openui.md
+++ b/.changeset/plugin-shape-openui.md
@@ -1,0 +1,11 @@
+---
+"@edv4h/usketch-plugin-shape-openui": minor
+"@edv4h/usketch-plugin-tool-openui": minor
+---
+
+✨ OpenUI Generative UI ウィジェットプラグインを追加 (experimental, requires @openuidev/* 0.2.x):
+
+- `usketch-plugin-shape-openui`: `openui` shape を `@openuidev/react-lang` の `<Renderer>` でマウント。Zod schema 駆動の library に対して validate された OpenUI Lang のみが render される。
+- `usketch-plugin-tool-openui`: toolbar tool + side-panel prompt UI + 選択上の「Make Real」ボタン (`@edv4h/usketch-plugin-export` の `exportCanvas` で PNG snapshot)。OpenAI 直接と OpenAI 互換 endpoint (Azure / Ollama / LiteLLM / OpenUI server) の 2 provider。
+- デフォルト library に 12 汎用 component (Stack / Heading / Text / Card / Button / Input / Badge / Avatar / Image / List / Row / Spacer) を同梱、host が `defineComponent` + `createLibrary` でブランド component を追加可能。
+- `apps/web` に統合 (default: `http://localhost:7878/v1`、`VITE_OPENUI_PROVIDER=openai` で OpenAI 直叩き)。

--- a/.changeset/plugin-shape-openui.md
+++ b/.changeset/plugin-shape-openui.md
@@ -1,6 +1,6 @@
 ---
-"@edv4h/usketch-plugin-shape-openui": minor
-"@edv4h/usketch-plugin-tool-openui": minor
+"@edv4h/usketch-plugin-shape-openui": patch
+"@edv4h/usketch-plugin-tool-openui": patch
 ---
 
 ✨ OpenUI Generative UI ウィジェットプラグインを追加 (experimental, requires @openuidev/* 0.2.x):

--- a/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
@@ -137,7 +137,7 @@ Anthropic 直接接続は v1 ではサポートしません — browser CORS + �
 
 | 症状 | 原因 |
 | --- | --- |
-| Shape が "OpenUI library not configured" の fallback で表示される | `createOpenUIToolPlugin` が登録されていない、または shape plugin より前に走った。`openUIShapePlugin` を先に追加する |
+| Shape が "OpenUI library not configured" の fallback で表示される | `createOpenUIToolPlugin` (または `setOpenUILibrary` を呼ぶ host コード) が `createApp({ plugins })` に登録されていない。plugin の順序は関係ない (`createApp` は全 plugin の `setup()` を終えてから canvas を描画する) が、library を渡す caller が居ないと shape は fallback を表示する |
 | `OpenUI provider 401:` | API key が未設定または不正。`VITE_OPENAI_API_KEY` を設定するか、provider factory に `apiKey` を渡す |
 | `Empty response from model` | LLM が fence や prose だけ返した。プラグインは典型的な artifact を除去するが、それでも発生する場合は prompt を refine するか強い model を選ぶ |
 | `done` 後も shape が空に見える | LLM が library にない component を出力した。browser console を確認 — `Renderer error:` で拒否された statement が出る |

--- a/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
@@ -21,13 +21,15 @@ UX は tldraw の "Make Real" と同じ流儀ですが、生 Tailwind HTML で�
 pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
 ```
 
-デフォルト provider は localhost:7878 の OpenUI セルフホストサーバを叩きます。Docker で起動:
+`apps/web` のデフォルト provider は `http://localhost:7878/v1` の OpenAI 互換 Chat Completions endpoint を叩きます。任意の互換サーバが使えます — Ollama、LiteLLM、vLLM、自前の LLM proxy、あるいは手早くコンテナを立てたいなら [wandb/openui](https://github.com/wandb/openui) sandbox も選択肢:
 
 ```bash
+# 任意: 汎用 OpenAI 互換 Docker (wandb/openui はあくまで一例。
+# 独自 model server に置き換えてください)
 docker run -p 7878:7878 -e OPENAI_API_KEY=sk-... ghcr.io/wandb/openui:latest
 ```
 
-OpenAI を直接叩く場合:
+ローカルサーバを使わず OpenAI を直接叩く場合:
 
 ```env
 VITE_OPENUI_PROVIDER=openai
@@ -81,7 +83,7 @@ const app = await createApp({
 2. 画像 + 「このスケッチに対応する real UI を作って」プロンプトを provider に送信
 3. 結果を元 shape の右側に配置
 
-Make Real には `@edv4h/usketch-plugin-export` が必要です。export plugin を読み込んでいない場合はボタンが silent に無効化されます。
+`@edv4h/usketch-plugin-export` は tool plugin の hard な runtime 依存です (package の `dependencies` に列挙され、`exportCanvas` が直接 import される)。host 側でインストールを忘れないでください。プラグインは export がない場合に gracefully fall back しません — Make Real ボタン押下時に throw し、エラーは標準の `ai:status` event 経由で side panel にエラーバナーとして表示されます。
 
 ## Library のカスタマイズ
 

--- a/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
@@ -1,0 +1,147 @@
+---
+title: "OpenUI: Generative UI ウィジェット (実験的)"
+description: LLM 生成した UI ウィジェットを OpenUI Lang と @openuidev/react-lang の Renderer 経由で canvas 上の first-class shape として描画する。
+order: 26
+---
+
+> **実験的機能。** 依存先の `@openuidev/*` パッケージはまだ 0.x の頻繁リリース中で、API が変わる可能性があります。バージョンを pin し、`@openuidev` が 1.0 に到達したタイミングで再評価してください。
+
+uSketch では AI 生成の UI ウィジェット (料金プラン表 / 問い合わせフォーム / 統計ダッシュボード等) を canvas 上の first-class shape として配置できます。本リポジトリの 2 つのプラグインが往復をカバーします:
+
+- **`@edv4h/usketch-plugin-shape-openui`** — `openui` shape の定義。`@openuidev/react-lang` の `<Renderer>` で [OpenUI Lang](https://www.openui.com/docs/openui-lang) を描画。
+- **`@edv4h/usketch-plugin-tool-openui`** — toolbar tool / side-panel prompt UI / 選択上の「Make Real」ボタン / LLM provider (OpenAI 直接 / OpenAI 互換 endpoint) を提供。
+
+UX は tldraw の "Make Real" と同じ流儀ですが、生 Tailwind HTML ではなく OpenUI Lang を出力するため、Zod schema 駆動の component library に対して validate されてから DOM に流れます — 悪意ある LLM が任意 script を注入する経路はありません。
+
+## セットアップ
+
+両プラグインはこのモノレポに同梱されており、`apps/web` ではデフォルトで wire 済みです。独自 host で使う場合:
+
+```bash
+pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
+```
+
+デフォルト provider は localhost:7878 の OpenUI セルフホストサーバを叩きます。Docker で起動:
+
+```bash
+docker run -p 7878:7878 -e OPENAI_API_KEY=sk-... ghcr.io/wandb/openui:latest
+```
+
+OpenAI を直接叩く場合:
+
+```env
+VITE_OPENUI_PROVIDER=openai
+VITE_OPENAI_API_KEY=sk-...
+```
+
+その他の env vars (`apps/web` が読む):
+
+- `VITE_OPENUI_BASE_URL` — OpenAI 互換 endpoint を上書き (Azure, Ollama, LiteLLM, …)
+- `VITE_OPENUI_MODEL` — model 名を指定。default `gpt-4o`
+
+## createApp への組み込み
+
+```ts
+import { createApp } from "@edv4h/usketch-core";
+import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
+import { openUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
+import {
+	createOpenAIProvider,
+	createOpenUIToolPlugin,
+} from "@edv4h/usketch-plugin-tool-openui";
+
+const app = await createApp({
+	store,
+	plugins: [
+		// tool plugin の前に side panel を入れる (タブ登録 event を受けるため)。
+		createSidePanelPlugin(),
+		openUIShapePlugin,
+		createOpenUIToolPlugin({
+			provider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY! }),
+		}),
+	],
+});
+```
+
+## 使い方
+
+### Toolbar ツール
+
+1. ✨ OpenUI tool をクリック (またはショートカット `U`)。OpenUI タブの side panel が開きます。
+2. プロンプトを入力。例: *"a pricing card with three tiers and CTA buttons"*
+3. **Generate** ボタン (または `⌘+Enter`) を押すと、LLM 出力を stream で受け取り、library schema で validate しながら新規 `openui` shape を viewport 中央に配置します。
+
+ステータス行に streaming 進捗が出ます。**Cancel** ボタンで in-flight request を中断できます。
+
+### Make Real
+
+任意の shape (フリーハンドスケッチ / 付箋の山 / 矩形でラフ書きしたワイヤフレーム等) を選択し、選択上に浮かぶ **✨ Make Real** ボタンをクリック。プラグインは:
+
+1. `@edv4h/usketch-plugin-export` の `exportCanvas` で選択範囲を PNG にスナップショット
+2. 画像 + 「このスケッチに対応する real UI を作って」プロンプトを provider に送信
+3. 結果を元 shape の右側に配置
+
+Make Real には `@edv4h/usketch-plugin-export` が必要です。export plugin を読み込んでいない場合はボタンが silent に無効化されます。
+
+## Library のカスタマイズ
+
+Library は LLM が出せる component セットを定義します。デフォルト library には 12 個の汎用 primitive (Stack / Heading / Text / Card / Button / Input / Badge / Avatar / Image / List / Row / Spacer) が同梱されています。ブランド component を入れたい場合は独自 library を渡します:
+
+```ts
+import { createLibrary, defineComponent } from "@openuidev/react-lang";
+import { z } from "zod/v4";
+
+const BrandHero = defineComponent({
+	name: "BrandHero",
+	description: "Acme 風のヒーローバナー。",
+	props: z.object({ title: z.string(), subtitle: z.string().default("") }),
+	component: ({ props }) => <header className="acme-hero">…</header>,
+});
+
+const library = createLibrary({ components: [BrandHero /* + その他 */] });
+
+createOpenUIToolPlugin({ provider, library, libraryId: "acme-1" });
+```
+
+system prompt は毎リクエスト時に `library.prompt(...)` から再生成されます。LLM は常に library の component と Zod 型 props を正確に知った状態で応答します。
+
+## Provider の切り替え
+
+```ts
+import {
+	createOpenAIProvider,
+	createOpenAICompatibleProvider,
+} from "@edv4h/usketch-plugin-tool-openui";
+
+// OpenAI を直接叩く:
+createOpenAIProvider({ apiKey: "sk-..." });
+
+// OpenAI 互換 endpoint (Ollama / vLLM / LiteLLM / Azure / OpenUI server / …):
+createOpenAICompatibleProvider({
+	baseURL: "http://localhost:11434/v1", // Ollama
+	defaultModel: "llama3.2:vision",
+});
+```
+
+Anthropic 直接接続は v1 ではサポートしません — browser CORS + クライアント側 API key 露出のトレードオフから、server-side proxy 経由が望ましいためです。必要であれば follow-up issue を立ててください。
+
+## セキュリティモデル
+
+- `@openuidev/react-lang` の `<Renderer>` は parse した statement を library の Zod schema に対して validate します。library にない component / prop は render 前に拒否されるため、`dangerouslySetInnerHTML` も script 実行経路も存在しません。
+- API key は host option (`createOpenAIProvider({ apiKey })`) 経由で渡します。プラグインが直接 env vars を読むことはありません。
+- Make Real の vision request は canvas snapshot を base64 data URL として送信します。機密性の高い board では、識別情報を strip してから転送する server-side proxy をデプロイすることを推奨します。
+
+## トラブルシューティング
+
+| 症状 | 原因 |
+| --- | --- |
+| Shape が "OpenUI library not configured" の fallback で表示される | `createOpenUIToolPlugin` が登録されていない、または shape plugin より前に走った。`openUIShapePlugin` を先に追加する |
+| `OpenUI provider 401:` | API key が未設定または不正。`VITE_OPENAI_API_KEY` を設定するか、provider factory に `apiKey` を渡す |
+| `Empty response from model` | LLM が fence や prose だけ返した。プラグインは典型的な artifact を除去するが、それでも発生する場合は prompt を refine するか強い model を選ぶ |
+| `done` 後も shape が空に見える | LLM が library にない component を出力した。browser console を確認 — `Renderer error:` で拒否された statement が出る |
+
+## 制約
+
+- **静的ウィジェットのみ。** OpenUI Lang の `Action()` (event hook) は未配線。button は render されるが実 event は発火しない。Follow-up で改善予定。
+- **canvas 上での progressive streaming は未対応。** 完全な応答を buffer してから shape を配置する。partial UI は side panel ステータスでのみ表示。tldraw "Make Real" と同じトレードオフ。
+- **app instance ごとに 1 library。** shape plugin は単一の active `Library` reference を保持。複数 library が必要な場合は issue を立ててください。

--- a/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
@@ -15,7 +15,7 @@ UX は tldraw の "Make Real" と同じ流儀ですが、生 Tailwind HTML で�
 
 ## セットアップ
 
-両プラグインはこのモノレポに同梱されており、`apps/web` ではデフォルトで wire 済みです。独自 host で使う場合:
+両プラグインはこのモノレポに同梱されており、`apps/web` ではクラウドボード (`/boards/...`) でのみ wire 済みです (ローカルボードでは読み込まれません)。独自 host で使う場合:
 
 ```bash
 pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
@@ -71,7 +71,7 @@ const app = await createApp({
 
 1. ✨ OpenUI tool をクリック (またはショートカット `U`)。OpenUI タブの side panel が開きます。
 2. プロンプトを入力。例: *"a pricing card with three tiers and CTA buttons"*
-3. **Generate** ボタン (または `⌘+Enter`) を押すと、LLM 出力を stream で受け取り、library schema で validate しながら新規 `openui` shape を viewport 中央に配置します。
+3. **Generate** ボタン (または `⌘+Enter`) を押すと、LLM 出力を stream で buffer に貯め、完了時点で新規 `openui` shape を viewport 中央に配置します。library の Zod schema による validate は `<Renderer>` 側の render 時に行われます — library にない component は描画から落とされ (console に `Renderer error:` が出る) ますが、shape 自体は作成されます。
 
 ステータス行に streaming 進捗が出ます。**Cancel** ボタンで in-flight request を中断できます。
 

--- a/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
@@ -1,0 +1,147 @@
+---
+title: "OpenUI: Generative UI widgets (experimental)"
+description: Render LLM-generated UI widgets as first-class shapes on the canvas via OpenUI Lang and the Renderer from @openuidev/react-lang.
+order: 26
+---
+
+> **Experimental.** This guide describes a freshly landed plugin pair that depends on `@openuidev/*` packages still on a 0.x release cadence. APIs may shift; pin versions and re-evaluate when `@openuidev` ships 1.0.
+
+uSketch can host AI-generated UI widgets — a pricing card, a contact form, a stat dashboard — as first-class shapes on the canvas. Two plugins from this repo cover the round-trip:
+
+- **`@edv4h/usketch-plugin-shape-openui`** — defines the `openui` shape and renders [OpenUI Lang](https://www.openui.com/docs/openui-lang) snippets via `<Renderer>` from `@openuidev/react-lang`.
+- **`@edv4h/usketch-plugin-tool-openui`** — registers a toolbar tool, a side-panel prompt UI, a "Make Real" button on selection, and the LLM provider plumbing (OpenAI / OpenAI-compatible).
+
+The flow is tldraw's "Make Real" pattern but with OpenUI Lang instead of raw Tailwind HTML: outputs are validated against a Zod-schema-defined component library before they hit the DOM, so a malicious LLM cannot inject arbitrary script tags.
+
+## Setup
+
+Both plugins ship with the monorepo and are wired into `apps/web` by default. For a standalone host:
+
+```bash
+pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
+```
+
+The default provider talks to a self-hosted [wandb/openui](https://github.com/wandb/openui) server at `http://localhost:7878`. Start one with Docker:
+
+```bash
+docker run -p 7878:7878 -e OPENAI_API_KEY=sk-... ghcr.io/wandb/openui:latest
+```
+
+Or point directly at OpenAI:
+
+```env
+VITE_OPENUI_PROVIDER=openai
+VITE_OPENAI_API_KEY=sk-...
+```
+
+Other useful env vars (`apps/web` reads these):
+
+- `VITE_OPENUI_BASE_URL` — override the OpenAI-compatible endpoint (Azure, Ollama, LiteLLM, …).
+- `VITE_OPENUI_MODEL` — pick a model name. Defaults to `gpt-4o`.
+
+## Wiring it into createApp
+
+```ts
+import { createApp } from "@edv4h/usketch-core";
+import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
+import { openUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
+import {
+	createOpenAIProvider,
+	createOpenUIToolPlugin,
+} from "@edv4h/usketch-plugin-tool-openui";
+
+const app = await createApp({
+	store,
+	plugins: [
+		// Side panel must come BEFORE the tool plugin so its tab registration is received.
+		createSidePanelPlugin(),
+		openUIShapePlugin,
+		createOpenUIToolPlugin({
+			provider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY! }),
+		}),
+	],
+});
+```
+
+## Usage
+
+### Toolbar tool
+
+1. Click the ✨ OpenUI tool (or press `U`) — the side panel opens to the OpenUI tab.
+2. Type a description, e.g. *"a pricing card with three tiers and CTA buttons"*.
+3. Hit **Generate** (or `⌘+Enter`). The plugin streams LLM output, validates each statement against the library schema, and places a new `openui` shape at the viewport center.
+
+The status row reports streaming progress; the **Cancel** button aborts in-flight requests cleanly.
+
+### Make Real
+
+Select any shapes (a freehand sketch, a stack of stickies, a wireframe drawn with rectangles), then click **✨ Make Real** in the floating button above the selection. The plugin:
+
+1. Snapshots the selection as a PNG via `exportCanvas` from `@edv4h/usketch-plugin-export`.
+2. Sends the image plus a "build a real UI matching this sketch" prompt to the provider.
+3. Places the result to the right of the source bounds.
+
+`@edv4h/usketch-plugin-export` is required for this feature. If the export plugin is not loaded, the button silently disables itself.
+
+## Customizing the library
+
+The library defines what components the LLM is allowed to emit. The default library ships 12 generic primitives (Stack, Heading, Text, Card, Button, Input, Badge, Avatar, Image, List, Row, Spacer). Pass a custom one if you need branded components:
+
+```ts
+import { createLibrary, defineComponent } from "@openuidev/react-lang";
+import { z } from "zod/v4";
+
+const BrandHero = defineComponent({
+	name: "BrandHero",
+	description: "Hero banner with the Acme brand colors.",
+	props: z.object({ title: z.string(), subtitle: z.string().default("") }),
+	component: ({ props }) => <header className="acme-hero">…</header>,
+});
+
+const library = createLibrary({ components: [BrandHero /* + your other components */] });
+
+createOpenUIToolPlugin({ provider, library, libraryId: "acme-1" });
+```
+
+The system prompt is regenerated from the library on every request via `library.prompt(...)`, so the LLM is always told the exact set of components and their Zod-typed props.
+
+## Provider abstraction
+
+```ts
+import {
+	createOpenAIProvider,
+	createOpenAICompatibleProvider,
+} from "@edv4h/usketch-plugin-tool-openui";
+
+// Direct OpenAI:
+createOpenAIProvider({ apiKey: "sk-..." });
+
+// Anything OpenAI-compatible (Ollama, vLLM, LiteLLM, Azure OpenAI, OpenUI server, …):
+createOpenAICompatibleProvider({
+	baseURL: "http://localhost:11434/v1",  // Ollama
+	defaultModel: "llama3.2:vision",
+});
+```
+
+Anthropic is not directly supported in v1 — browser CORS plus key-in-client trade-offs make it best served via a server-side proxy. Track the follow-up issue if you need it.
+
+## Security model
+
+- The `<Renderer>` from `@openuidev/react-lang` validates every parsed statement against the library's Zod schemas. Components or props the library doesn't declare are rejected before they render — there is no `dangerouslySetInnerHTML` and no script execution surface.
+- API keys are passed via host options (`createOpenAIProvider({ apiKey })`). The plugin never reads env vars directly.
+- Vision requests for Make Real send the canvas snapshot as a base64 data URL; for sensitive boards, deploy a server-side proxy that strips identifiers before forwarding.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Shape mounts as "OpenUI library not configured" fallback | `createOpenUIToolPlugin` was not registered, or it ran before the shape plugin loaded. Add `openUIShapePlugin` before the tool plugin. |
+| `OpenUI provider 401:` | Missing or invalid API key. Set `VITE_OPENAI_API_KEY` or pass `apiKey` to the provider factory. |
+| `Empty response from model` | The LLM returned only fences / prose. The plugin strips common artifacts; if it still triggers, refine the prompt or pick a stronger model. |
+| The shape renders empty even after `done` | The LLM emitted a component name the library doesn't define. Open the browser console — `Renderer error:` logs the rejected statement. |
+
+## Limitations
+
+- **Static widgets only.** `Action()` (OpenUI Lang's event hook) is not wired through — buttons render but don't fire real events. Follow-up tracks deeper integration.
+- **No streaming progressive render in the canvas.** The plugin buffers the entire response before placing the shape; partial UI is reported only in the side panel status. tldraw "Make Real" makes the same trade-off.
+- **One library per app instance.** The shape plugin holds a single active `Library` reference. Hosts that want multiple libraries should file an issue describing the use case.

--- a/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
@@ -21,13 +21,15 @@ Both plugins ship with the monorepo and are wired into `apps/web` by default. Fo
 pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
 ```
 
-The default provider talks to a self-hosted [wandb/openui](https://github.com/wandb/openui) server at `http://localhost:7878`. Start one with Docker:
+The default provider in `apps/web` talks to an OpenAI-compatible Chat Completions endpoint at `http://localhost:7878/v1`. Any compatible server works — Ollama, LiteLLM, vLLM, a local LLM proxy, or even the [wandb/openui](https://github.com/wandb/openui) sandbox if you want a quick container:
 
 ```bash
+# Optional: a generic OpenAI-compatible Docker (wandb/openui is one option;
+# substitute your own model server)
 docker run -p 7878:7878 -e OPENAI_API_KEY=sk-... ghcr.io/wandb/openui:latest
 ```
 
-Or point directly at OpenAI:
+Or skip the local server entirely and point directly at OpenAI:
 
 ```env
 VITE_OPENUI_PROVIDER=openai
@@ -81,7 +83,7 @@ Select any shapes (a freehand sketch, a stack of stickies, a wireframe drawn wit
 2. Sends the image plus a "build a real UI matching this sketch" prompt to the provider.
 3. Places the result to the right of the source bounds.
 
-`@edv4h/usketch-plugin-export` is required for this feature. If the export plugin is not loaded, the button silently disables itself.
+`@edv4h/usketch-plugin-export` is a hard runtime dependency of the tool plugin (the package is listed under `dependencies` and `exportCanvas` is imported directly), so make sure your host installs it. The plugin does *not* gracefully fall back if you skip it — the Make Real button will throw when clicked, and the error surfaces via the standard `ai:status` channel as a side-panel error banner.
 
 ## Customizing the library
 

--- a/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
@@ -15,7 +15,7 @@ The flow is tldraw's "Make Real" pattern but with OpenUI Lang instead of raw Tai
 
 ## Setup
 
-Both plugins ship with the monorepo and are wired into `apps/web` by default. For a standalone host:
+Both plugins ship with the monorepo and are wired into `apps/web` for cloud boards (`/boards/...`); local boards don't load them. For a standalone host:
 
 ```bash
 pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
@@ -71,7 +71,7 @@ const app = await createApp({
 
 1. Click the ✨ OpenUI tool (or press `U`) — the side panel opens to the OpenUI tab.
 2. Type a description, e.g. *"a pricing card with three tiers and CTA buttons"*.
-3. Hit **Generate** (or `⌘+Enter`). The plugin streams LLM output, validates each statement against the library schema, and places a new `openui` shape at the viewport center.
+3. Hit **Generate** (or `⌘+Enter`). The plugin streams LLM output into a buffer, then places a new `openui` shape at the viewport center once the response completes. Zod-schema validation against the library happens at render time inside `<Renderer>` — invalid components are dropped from the rendered output (and surfaced as `Renderer error:` in the console), but the shape itself is still created.
 
 The status row reports streaming progress; the **Cancel** button aborts in-flight requests cleanly.
 

--- a/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
@@ -137,7 +137,7 @@ Anthropic is not directly supported in v1 — browser CORS plus key-in-client tr
 
 | Symptom | Likely cause |
 | --- | --- |
-| Shape mounts as "OpenUI library not configured" fallback | `createOpenUIToolPlugin` was not registered, or it ran before the shape plugin loaded. Add `openUIShapePlugin` before the tool plugin. |
+| Shape mounts as "OpenUI library not configured" fallback | `createOpenUIToolPlugin` (or another caller of `setOpenUILibrary`) is not registered in `createApp({ plugins })`. Plugin ordering doesn't matter — `createApp` finishes every plugin's `setup()` before the canvas paints — but if no caller wires up a library, the shape renders the fallback. |
 | `OpenUI provider 401:` | Missing or invalid API key. Set `VITE_OPENAI_API_KEY` or pass `apiKey` to the provider factory. |
 | `Empty response from model` | The LLM returned only fences / prose. The plugin strips common artifacts; if it still triggers, refine the prompt or pick a stronger model. |
 | The shape renders empty even after `done` | The LLM emitted a component name the library doesn't define. Open the browser console — `Renderer error:` logs the rejected statement. |

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,8 @@
 		"@edv4h/usketch-plugin-canvas-filter": "workspace:*",
 		"@edv4h/usketch-plugin-shape-island": "workspace:*",
 		"@edv4h/usketch-plugin-shape-image": "workspace:*",
+		"@edv4h/usketch-plugin-shape-openui": "workspace:*",
+		"@edv4h/usketch-plugin-tool-openui": "workspace:*",
 		"@edv4h/usketch-plugin-export": "workspace:*",
 		"@edv4h/usketch-plugin-follow-me": "workspace:*",
 		"@edv4h/usketch-plugin-keyboard-shortcuts": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -27,6 +27,7 @@ import { framePlugin } from "@edv4h/usketch-plugin-shape-frame";
 import { freedrawPlugin } from "@edv4h/usketch-plugin-shape-freedraw";
 import { groupPlugin } from "@edv4h/usketch-plugin-shape-group";
 import { imageShapePlugin } from "@edv4h/usketch-plugin-shape-image";
+import { openUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
 import { stickyPlugin } from "@edv4h/usketch-plugin-shape-sticky";
 import { textPlugin } from "@edv4h/usketch-plugin-shape-text";
 import { wireframePlugin } from "@edv4h/usketch-plugin-shape-wireframe";
@@ -39,6 +40,11 @@ import {
 	type DivergenceTrackerHandle,
 	UnconfirmedOverlay,
 } from "@edv4h/usketch-plugin-sync-ywebsocket";
+import {
+	createOpenAICompatibleProvider,
+	createOpenAIProvider,
+	createOpenUIToolPlugin,
+} from "@edv4h/usketch-plugin-tool-openui";
 import { panToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
 import { selectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
 import { viewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
@@ -237,6 +243,29 @@ export function App() {
 			extraPlugins.push(createAiVoicePlugin({ boardId }));
 			extraPlugins.push(createAiImagePlugin({ boardId }));
 			extraPlugins.push(createAiRecognizePlugin({ boardId }));
+
+			// OpenUI Generative UI (experimental). Defaults to a self-hosted OpenUI
+			// server at http://localhost:7878; set VITE_OPENUI_PROVIDER=openai +
+			// VITE_OPENAI_API_KEY to use OpenAI directly.
+			const openuiProviderName = import.meta.env.VITE_OPENUI_PROVIDER ?? "openui-server";
+			const openaiKey = import.meta.env.VITE_OPENAI_API_KEY;
+			const openuiBaseURL = import.meta.env.VITE_OPENUI_BASE_URL;
+			const openuiModel = import.meta.env.VITE_OPENUI_MODEL;
+			const openuiProvider =
+				openuiProviderName === "openai" && openaiKey
+					? createOpenAIProvider({
+							apiKey: openaiKey,
+							defaultModel: openuiModel,
+						})
+					: createOpenAICompatibleProvider({
+							baseURL: openuiBaseURL ?? "http://localhost:7878/v1",
+							apiKey: openaiKey,
+							defaultModel: openuiModel,
+							label: "OpenUI server",
+						});
+			extraPlugins.push(openUIShapePlugin);
+			extraPlugins.push(createOpenUIToolPlugin({ provider: openuiProvider }));
+
 			extraPlugins.push(createWhistlePlugin(wsProvider));
 			extraPlugins.push(createActivityFeedPlugin({ wsProvider, boardId, apiUrl }));
 		} else {

--- a/plugins/usketch-plugin-shape-openui/package.json
+++ b/plugins/usketch-plugin-shape-openui/package.json
@@ -25,7 +25,7 @@
 	"peerDependencies": {
 		"@modelcontextprotocol/sdk": ">=1.0.0",
 		"react": ">=19",
-		"zod": ">=3.25.0"
+		"zod": "^4.0.0 || >=3.25.0 <4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@modelcontextprotocol/sdk": {

--- a/plugins/usketch-plugin-shape-openui/package.json
+++ b/plugins/usketch-plugin-shape-openui/package.json
@@ -1,0 +1,52 @@
+{
+	"name": "@edv4h/usketch-plugin-shape-openui",
+	"version": "0.1.0",
+	"description": "Experimental OpenUI shape plugin: render Generative UI (OpenUI Lang) as a uSketch shape via @openuidev/react-lang's Renderer.",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shared": "workspace:*",
+		"@openuidev/react-lang": "0.2.5"
+	},
+	"peerDependencies": {
+		"@modelcontextprotocol/sdk": ">=1.0.0",
+		"react": ">=19",
+		"zod": "^3.25.0 || ^4.0.0"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.14",
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-openui"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-shape-openui/package.json
+++ b/plugins/usketch-plugin-shape-openui/package.json
@@ -25,7 +25,12 @@
 	"peerDependencies": {
 		"@modelcontextprotocol/sdk": ">=1.0.0",
 		"react": ">=19",
-		"zod": "^3.25.0 || ^4.0.0"
+		"zod": ">=3.25.0"
+	},
+	"peerDependenciesMeta": {
+		"@modelcontextprotocol/sdk": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@types/react": "19.2.14",

--- a/plugins/usketch-plugin-shape-openui/src/__tests__/plugin.test.tsx
+++ b/plugins/usketch-plugin-shape-openui/src/__tests__/plugin.test.tsx
@@ -1,0 +1,121 @@
+import type { ShapeData, ShapeRegistry } from "@edv4h/usketch-shared";
+import { describe, expect, it, vi } from "vitest";
+import { openUIShapePlugin } from "../plugin.js";
+import type { OpenUIShapeData } from "../types.js";
+
+interface CapturedDefinition {
+	render: (data: ShapeData) => unknown;
+	getBounds: (data: ShapeData) => unknown;
+	hitTest: (data: ShapeData, point: { x: number; y: number }) => boolean;
+	resize: (
+		data: ShapeData,
+		handle: "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw",
+		delta: { x: number; y: number },
+	) => ShapeData;
+	createDefault: (params: { id: string; x: number; y: number }) => ShapeData;
+	serializeForAi?: (shape: ShapeData) => Record<string, unknown>;
+	debugFields?: (shape: ShapeData) => Record<string, unknown>;
+}
+
+function setupPlugin(): CapturedDefinition {
+	let captured: CapturedDefinition | undefined;
+	const shapes = {
+		register: vi.fn((_type: string, def: CapturedDefinition) => {
+			captured = def;
+		}),
+	} as unknown as ShapeRegistry;
+	openUIShapePlugin.setup({ shapes } as never);
+	if (!captured) throw new Error("ShapeDefinition was not registered");
+	return captured;
+}
+
+describe("openUIShapePlugin", () => {
+	it("registers the `openui` shape", () => {
+		const shapes = { register: vi.fn() } as unknown as ShapeRegistry;
+		openUIShapePlugin.setup({ shapes } as never);
+		expect(shapes.register).toHaveBeenCalledWith("openui", expect.any(Object));
+	});
+
+	it("createDefault produces a valid OpenUIShapeData with empty langSource", () => {
+		const def = setupPlugin();
+		const shape = def.createDefault({ id: "test-1", x: 10, y: 20 }) as OpenUIShapeData;
+		expect(shape).toMatchObject({
+			id: "test-1",
+			type: "openui",
+			x: 10,
+			y: 20,
+			width: 480,
+			height: 360,
+			langSource: "",
+			prompt: "",
+			model: "",
+			libraryId: "openui-default",
+		});
+	});
+
+	it("getBounds returns the shape rectangle", () => {
+		const def = setupPlugin();
+		const shape = def.createDefault({ id: "t", x: 5, y: 7 });
+		expect(def.getBounds(shape)).toEqual({ x: 5, y: 7, width: 480, height: 360 });
+	});
+
+	it("hitTest is true inside, false outside", () => {
+		const def = setupPlugin();
+		const shape = def.createDefault({ id: "t", x: 0, y: 0 });
+		expect(def.hitTest(shape, { x: 100, y: 100 })).toBe(true);
+		expect(def.hitTest(shape, { x: 1000, y: 1000 })).toBe(false);
+	});
+
+	it("resize clamps width/height to minSize", () => {
+		const def = setupPlugin();
+		const shape = def.createDefault({ id: "t", x: 0, y: 0 });
+		const resized = def.resize(shape, "se", { x: -10000, y: -10000 });
+		expect(resized.width).toBeGreaterThanOrEqual(160);
+		expect(resized.height).toBeGreaterThanOrEqual(100);
+	});
+
+	it("resize handles all eight directions", () => {
+		const def = setupPlugin();
+		const shape = def.createDefault({ id: "t", x: 0, y: 0 });
+		for (const handle of ["n", "s", "e", "w", "ne", "nw", "se", "sw"] as const) {
+			const r = def.resize(shape, handle, { x: 5, y: 5 });
+			expect(r.width).toBeGreaterThanOrEqual(160);
+			expect(r.height).toBeGreaterThanOrEqual(100);
+		}
+	});
+
+	it("serializeForAi omits langSource body but keeps metadata", () => {
+		const def = setupPlugin();
+		const shape: OpenUIShapeData = {
+			...(def.createDefault({ id: "t", x: 0, y: 0 }) as OpenUIShapeData),
+			prompt: "a pricing card",
+			model: "gpt-4o",
+			langSource: "root = Stack()",
+		};
+		const out = def.serializeForAi?.(shape);
+		expect(out).toMatchObject({
+			prompt: "a pricing card",
+			model: "gpt-4o",
+			libraryId: "openui-default",
+			langLength: "root = Stack()".length,
+		});
+		expect(out).not.toHaveProperty("langSource");
+	});
+
+	it("debugFields surfaces the same metadata", () => {
+		const def = setupPlugin();
+		const shape: OpenUIShapeData = {
+			...(def.createDefault({ id: "t", x: 0, y: 0 }) as OpenUIShapeData),
+			prompt: "p",
+			model: "m",
+			langSource: "x",
+		};
+		const out = def.debugFields?.(shape);
+		expect(out).toMatchObject({
+			prompt: "p",
+			model: "m",
+			libraryId: "openui-default",
+			langLength: 1,
+		});
+	});
+});

--- a/plugins/usketch-plugin-shape-openui/src/__tests__/sanitize.test.ts
+++ b/plugins/usketch-plugin-shape-openui/src/__tests__/sanitize.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeLangSource } from "../sanitize.js";
+
+describe("sanitizeLangSource", () => {
+	it("returns empty string for blank input", () => {
+		expect(sanitizeLangSource("")).toBe("");
+		expect(sanitizeLangSource("   \n  ")).toBe("");
+	});
+
+	it("strips a leading ```openui-lang fence", () => {
+		const input = '```openui-lang\nroot = Stack({direction: "column"})\n```';
+		expect(sanitizeLangSource(input)).toBe('root = Stack({direction: "column"})');
+	});
+
+	it("strips a leading ``` fence with no language tag", () => {
+		const input = "```\nroot = Stack()\n```";
+		expect(sanitizeLangSource(input)).toBe("root = Stack()");
+	});
+
+	it("strips a leading ```ts fence (some models pick the wrong tag)", () => {
+		const input = "```ts\nroot = Stack()\n```";
+		expect(sanitizeLangSource(input)).toBe("root = Stack()");
+	});
+
+	it("leaves clean lang source untouched", () => {
+		const input = 'root = Stack({direction: "column"})\nchild = Button({label: "OK"})';
+		expect(sanitizeLangSource(input)).toBe(input);
+	});
+
+	it("strips a leading prose preface line ending with a colon", () => {
+		const input = "Here is the UI:\nroot = Stack()";
+		expect(sanitizeLangSource(input)).toBe("root = Stack()");
+	});
+
+	it("does NOT strip a first line that looks like an assignment", () => {
+		const input = 'root = Stack()\nchild = Button({label: "OK"})';
+		expect(sanitizeLangSource(input)).toBe(input);
+	});
+
+	it("strips a leading comment-style preface", () => {
+		const input = "// Generated UI\nroot = Stack()";
+		expect(sanitizeLangSource(input)).toBe("root = Stack()");
+	});
+});

--- a/plugins/usketch-plugin-shape-openui/src/index.ts
+++ b/plugins/usketch-plugin-shape-openui/src/index.ts
@@ -1,0 +1,4 @@
+export { getOpenUILibrary, setOpenUILibrary } from "./library-registry.js";
+export { openUIShapePlugin } from "./plugin.js";
+export { sanitizeLangSource } from "./sanitize.js";
+export type { OpenUIShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-openui/src/library-registry.ts
+++ b/plugins/usketch-plugin-shape-openui/src/library-registry.ts
@@ -1,0 +1,25 @@
+import type { Library } from "@openuidev/react-lang";
+
+/**
+ * Module-scoped registry for the active OpenUI component library.
+ *
+ * The shape plugin needs a `Library` at render time to pass to `<Renderer>`,
+ * but the library is configured by the *tool* plugin (which knows what
+ * components the host wants to expose to the LLM). To avoid a circular
+ * dependency between the two plugins, the shape plugin exports
+ * `setOpenUILibrary` and the tool plugin calls it during `setup`.
+ *
+ * This pattern assumes the two plugins live in the same process (true for
+ * a single `createApp(...)` invocation). It does NOT support multiple
+ * `createApp` instances with different libraries — file a follow-up if that
+ * matters.
+ */
+let activeLibrary: Library | null = null;
+
+export function setOpenUILibrary(library: Library | null): void {
+	activeLibrary = library;
+}
+
+export function getOpenUILibrary(): Library | null {
+	return activeLibrary;
+}

--- a/plugins/usketch-plugin-shape-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-openui/src/plugin.tsx
@@ -56,6 +56,13 @@ function render(shape: ShapeData) {
 				padding: 8,
 				boxSizing: "border-box",
 				fontFamily: "system-ui, -apple-system, sans-serif",
+				// The widget is a static preview — disable pointer events and text
+				// selection so canvas drag/select/resize behave normally. (A future
+				// "focus mode" interaction is tracked as a follow-up; until then,
+				// clicking through to the underlying button/input is intentionally
+				// blocked to match shape-text / shape-image conventions.)
+				pointerEvents: "none",
+				userSelect: "none",
 			}}
 		>
 			<Renderer

--- a/plugins/usketch-plugin-shape-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-openui/src/plugin.tsx
@@ -1,0 +1,184 @@
+import {
+	type BoundingBox,
+	DEFAULT_STYLE,
+	type PluginContext,
+	type Point,
+	type ResizeHandle,
+	type ShapeData,
+	type UsketchPlugin,
+	withRotation,
+} from "@edv4h/usketch-shared";
+import { Renderer } from "@openuidev/react-lang";
+import { getOpenUILibrary } from "./library-registry.js";
+import type { OpenUIShapeData } from "./types.js";
+
+function FallbackBox({ message }: { message: string }) {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: 16,
+				background: "#fafafa",
+				border: "1px dashed #d4d4d8",
+				borderRadius: 6,
+				color: "#71717a",
+				fontFamily: "system-ui, -apple-system, sans-serif",
+				fontSize: 13,
+				textAlign: "center",
+			}}
+		>
+			{message}
+		</div>
+	);
+}
+
+function render(shape: ShapeData) {
+	const data = shape as OpenUIShapeData;
+	const library = getOpenUILibrary();
+	if (!library) {
+		return (
+			<FallbackBox message="OpenUI library not configured — install usketch-plugin-tool-openui" />
+		);
+	}
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				overflow: "auto",
+				border: `${data.style.strokeWidth}px solid ${data.style.stroke}`,
+				borderRadius: 6,
+				background: data.style.fill,
+				padding: 8,
+				boxSizing: "border-box",
+				fontFamily: "system-ui, -apple-system, sans-serif",
+			}}
+		>
+			<Renderer
+				response={data.langSource}
+				library={library}
+				isStreaming={false}
+				onError={(err) => {
+					// biome-ignore lint/suspicious/noConsole: surface render errors to host
+					console.warn("[usketch-plugin-shape-openui] Renderer error:", err);
+				}}
+			/>
+		</div>
+	);
+}
+
+function getBounds(data: ShapeData): BoundingBox {
+	return { x: data.x, y: data.y, width: data.width, height: data.height };
+}
+
+function hitTest(data: ShapeData, point: Point): boolean {
+	return (
+		point.x >= data.x &&
+		point.x <= data.x + data.width &&
+		point.y >= data.y &&
+		point.y <= data.y + data.height
+	);
+}
+
+function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
+	let { x, y, width, height } = data;
+	switch (handle) {
+		case "se":
+			width += delta.x;
+			height += delta.y;
+			break;
+		case "nw":
+			x += delta.x;
+			y += delta.y;
+			width -= delta.x;
+			height -= delta.y;
+			break;
+		case "ne":
+			y += delta.y;
+			width += delta.x;
+			height -= delta.y;
+			break;
+		case "sw":
+			x += delta.x;
+			width -= delta.x;
+			height += delta.y;
+			break;
+		case "e":
+			width += delta.x;
+			break;
+		case "w":
+			x += delta.x;
+			width -= delta.x;
+			break;
+		case "n":
+			y += delta.y;
+			height -= delta.y;
+			break;
+		case "s":
+			height += delta.y;
+			break;
+	}
+	return { ...data, x, y, width: Math.max(160, width), height: Math.max(100, height) };
+}
+
+function createDefault(params: { id: string; x: number; y: number }): OpenUIShapeData {
+	return {
+		id: params.id,
+		type: "openui",
+		x: params.x,
+		y: params.y,
+		width: 480,
+		height: 360,
+		style: { ...DEFAULT_STYLE, fill: "#ffffff", stroke: "#e5e7eb", strokeWidth: 1 },
+		langSource: "",
+		prompt: "",
+		model: "",
+		libraryId: "openui-default",
+	};
+}
+
+function serializeForAi(shape: ShapeData): Record<string, unknown> {
+	const data = shape as OpenUIShapeData;
+	return {
+		prompt: data.prompt,
+		model: data.model,
+		libraryId: data.libraryId,
+		langLength: data.langSource.length,
+		// langSource body intentionally omitted: it is too large for AI prompts
+		// and re-feeding generated UI to other AI plugins risks self-referential
+		// loops.
+	};
+}
+
+function debugFields(shape: ShapeData): Record<string, unknown> {
+	const data = shape as OpenUIShapeData;
+	return {
+		prompt: data.prompt,
+		model: data.model,
+		libraryId: data.libraryId,
+		langLength: data.langSource.length,
+	};
+}
+
+export const openUIShapePlugin: UsketchPlugin = {
+	id: "usketch-plugin-shape-openui",
+	name: "OpenUI",
+
+	setup(ctx: PluginContext) {
+		ctx.shapes.register("openui", {
+			render,
+			getBounds,
+			hitTest: withRotation(hitTest),
+			resize,
+			createDefault,
+			renderTarget: "html",
+			minSize: { width: 160, height: 100 },
+			serializeForAi,
+			debugFields,
+		});
+	},
+};

--- a/plugins/usketch-plugin-shape-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-openui/src/plugin.tsx
@@ -63,7 +63,6 @@ function render(shape: ShapeData) {
 				library={library}
 				isStreaming={false}
 				onError={(err) => {
-					// biome-ignore lint/suspicious/noConsole: surface render errors to host
 					console.warn("[usketch-plugin-shape-openui] Renderer error:", err);
 				}}
 			/>

--- a/plugins/usketch-plugin-shape-openui/src/sanitize.ts
+++ b/plugins/usketch-plugin-shape-openui/src/sanitize.ts
@@ -1,0 +1,26 @@
+/**
+ * Strip markdown fences and common LLM artifacts that creep into OpenUI Lang
+ * output despite an explicit "no markdown" system prompt.
+ *
+ * The Renderer's parser is forgiving but rejects entire responses on a
+ * trailing ``` — easier to clean up at the dispatch boundary than trust the
+ * model to behave.
+ */
+export function sanitizeLangSource(raw: string): string {
+	let s = raw.trim();
+	// Leading opening fence: ```openui-lang / ```ts / ```
+	s = s.replace(/^```[a-zA-Z0-9_-]*\s*\n/, "");
+	// Trailing closing fence
+	s = s.replace(/\n```\s*$/, "");
+	// Some models add "Here is the UI:" or similar — strip a single leading
+	// line that does not start with an identifier=Component( pattern.
+	// Conservative: only strip if the first non-empty line clearly is prose.
+	const lines = s.split("\n");
+	if (lines.length > 1 && lines[0] && !/^[a-zA-Z_][\w$]*\s*=/.test(lines[0])) {
+		const trimmed = lines[0].trim();
+		if (trimmed.endsWith(":") || trimmed.endsWith(".") || trimmed.startsWith("//")) {
+			s = lines.slice(1).join("\n").trimStart();
+		}
+	}
+	return s.trim();
+}

--- a/plugins/usketch-plugin-shape-openui/src/types.ts
+++ b/plugins/usketch-plugin-shape-openui/src/types.ts
@@ -1,0 +1,25 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/**
+ * Intrinsic data for the `openui` shape — a Generative UI widget rendered
+ * via `@openuidev/react-lang`'s `Renderer` from a snippet of OpenUI Lang.
+ *
+ * The lang source is plain text (OpenUI Lang DSL). The Renderer validates it
+ * against the active library's Zod schemas at mount time, so invalid LLM
+ * output cannot inject arbitrary HTML or scripts.
+ */
+export interface OpenUIShapeData extends ShapeData {
+	/** Full OpenUI Lang DSL source for this widget. */
+	langSource: string;
+	/** Original user prompt that produced this widget. Useful for iterate / debug. */
+	prompt: string;
+	/** Model identifier that generated the response (e.g. `"gpt-4o"`). */
+	model: string;
+	/**
+	 * Identifier of the library used to render this widget. Hosts that swap
+	 * libraries between sessions can use this to warn or fall back when a
+	 * persisted shape was generated against a different component set.
+	 * Defaults to `"openui-default"`.
+	 */
+	libraryId: string;
+}

--- a/plugins/usketch-plugin-shape-openui/tsconfig.json
+++ b/plugins/usketch-plugin-shape-openui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/plugins/usketch-plugin-tool-openui/package.json
+++ b/plugins/usketch-plugin-tool-openui/package.json
@@ -29,7 +29,7 @@
 	"peerDependencies": {
 		"@modelcontextprotocol/sdk": ">=1.0.0",
 		"react": ">=19",
-		"zod": ">=3.25.0"
+		"zod": "^4.0.0 || >=3.25.0 <4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@modelcontextprotocol/sdk": {

--- a/plugins/usketch-plugin-tool-openui/package.json
+++ b/plugins/usketch-plugin-tool-openui/package.json
@@ -1,0 +1,56 @@
+{
+	"name": "@edv4h/usketch-plugin-tool-openui",
+	"version": "0.1.0",
+	"description": "Experimental OpenUI tool plugin: prompt → OpenUI Lang → openui shape. Provides a toolbar tool, a side-panel prompt UI, a Make Real button on selection, and OpenAI / OpenAI-compatible providers.",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-canvas-engine": "workspace:*",
+		"@edv4h/usketch-plugin-export": "workspace:*",
+		"@edv4h/usketch-plugin-shape-openui": "workspace:*",
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*",
+		"@openuidev/react-lang": "0.2.5"
+	},
+	"peerDependencies": {
+		"@modelcontextprotocol/sdk": ">=1.0.0",
+		"react": ">=19",
+		"zod": "^3.25.0 || ^4.0.0"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.14",
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-tool-openui"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-tool-openui/package.json
+++ b/plugins/usketch-plugin-tool-openui/package.json
@@ -29,7 +29,12 @@
 	"peerDependencies": {
 		"@modelcontextprotocol/sdk": ">=1.0.0",
 		"react": ">=19",
-		"zod": "^3.25.0 || ^4.0.0"
+		"zod": ">=3.25.0"
+	},
+	"peerDependenciesMeta": {
+		"@modelcontextprotocol/sdk": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"@types/react": "19.2.14",

--- a/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
+++ b/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
@@ -7,11 +7,12 @@ function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
 	let i = 0;
 	return new ReadableStream({
 		pull(controller) {
-			if (i >= chunks.length) {
+			const chunk = chunks[i];
+			if (chunk === undefined) {
 				controller.close();
 				return;
 			}
-			controller.enqueue(encoder.encode(chunks[i]!));
+			controller.enqueue(encoder.encode(chunk));
 			i++;
 		},
 	});
@@ -53,7 +54,9 @@ describe("createOpenAICompatibleProvider", () => {
 		expect(chunks.join("")).toBe("ok");
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
-		const [url, init] = fetchMock.mock.calls[0]!;
+		const firstCall = fetchMock.mock.calls[0];
+		if (!firstCall) throw new Error("fetch was not called");
+		const [url, init] = firstCall;
 		expect(url).toBe("https://example.test/v1/chat/completions");
 		expect((init as RequestInit).method).toBe("POST");
 		const headers = (init as RequestInit).headers as Record<string, string>;
@@ -78,7 +81,9 @@ describe("createOpenAICompatibleProvider", () => {
 		for await (const _ of iter) {
 			// no-op
 		}
-		const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+		const visionCall = fetchMock.mock.calls[0];
+		if (!visionCall) throw new Error("fetch was not called");
+		const body = JSON.parse((visionCall[1] as RequestInit).body as string);
 		expect(body.messages[0].content).toEqual([
 			{ type: "text", text: "make real" },
 			{ type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },

--- a/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
+++ b/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
@@ -133,6 +133,35 @@ describe("createOpenAICompatibleProvider", () => {
 		expect(all).toEqual(["tail"]);
 	});
 
+	it("tolerates baseURL with a trailing slash without producing a double-slash URL", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createOpenAICompatibleProvider({
+			baseURL: "https://api.example.test/v1/",
+			apiKey: "sk-x",
+		});
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const url = fetchMock.mock.calls[0]?.[0];
+		expect(url).toBe("https://api.example.test/v1/chat/completions");
+	});
+
+	it("honors a full `endpoint` override (e.g. Azure-style URL with query params)", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createOpenAICompatibleProvider({
+			endpoint:
+				"https://acme.openai.azure.com/openai/deployments/gpt4/chat/completions?api-version=2024-02-01",
+			apiKey: "sk-x",
+		});
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const url = fetchMock.mock.calls[0]?.[0];
+		expect(url).toBe(
+			"https://acme.openai.azure.com/openai/deployments/gpt4/chat/completions?api-version=2024-02-01",
+		);
+	});
+
 	it("returns a single chunk when stream=false", async () => {
 		fetchMock.mockResolvedValueOnce(
 			new Response(JSON.stringify({ choices: [{ message: { content: "final answer" } }] }), {

--- a/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
+++ b/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createOpenAICompatibleProvider } from "../../providers/openai-compatible.js";
+
+/** Build a ReadableStream from a sequence of SSE bytes. */
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	let i = 0;
+	return new ReadableStream({
+		pull(controller) {
+			if (i >= chunks.length) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(encoder.encode(chunks[i]!));
+			i++;
+		},
+	});
+}
+
+describe("createOpenAICompatibleProvider", () => {
+	const fetchMock = vi.fn();
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		fetchMock.mockReset();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("posts to <baseURL>/chat/completions with Authorization and JSON body", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				sseStream([
+					`data: ${JSON.stringify({ choices: [{ delta: { content: "ok" } }] })}\n\n`,
+					"data: [DONE]\n\n",
+				]),
+				{
+					status: 200,
+				},
+			),
+		);
+		const provider = createOpenAICompatibleProvider({
+			baseURL: "https://example.test/v1",
+			apiKey: "sk-test",
+			defaultModel: "test-model",
+		});
+		const chunks: string[] = [];
+		for await (const c of provider.generate("hello", { stream: true, systemPrompt: "be brief" })) {
+			chunks.push(c);
+		}
+		expect(chunks.join("")).toBe("ok");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0]!;
+		expect(url).toBe("https://example.test/v1/chat/completions");
+		expect((init as RequestInit).method).toBe("POST");
+		const headers = (init as RequestInit).headers as Record<string, string>;
+		expect(headers.Authorization).toBe("Bearer sk-test");
+		expect(headers["Content-Type"]).toBe("application/json");
+		const body = JSON.parse((init as RequestInit).body as string);
+		expect(body.model).toBe("test-model");
+		expect(body.stream).toBe(true);
+		expect(body.messages).toEqual([
+			{ role: "system", content: "be brief" },
+			{ role: "user", content: "hello" },
+		]);
+	});
+
+	it("attaches image content for vision input", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createOpenAICompatibleProvider({ apiKey: "sk-x", supportsVision: true });
+		const iter = provider.generate("make real", {
+			vision: { imageDataUrl: "data:image/png;base64,AAA" },
+		});
+		// drain
+		for await (const _ of iter) {
+			// no-op
+		}
+		const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+		expect(body.messages[0].content).toEqual([
+			{ type: "text", text: "make real" },
+			{ type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+		]);
+	});
+
+	it("accumulates content across multiple SSE chunks", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				sseStream([
+					`data: ${JSON.stringify({ choices: [{ delta: { content: "Hello, " } }] })}\n\n`,
+					`data: ${JSON.stringify({ choices: [{ delta: { content: "world!" } }] })}\n\n`,
+					"data: [DONE]\n\n",
+				]),
+				{ status: 200 },
+			),
+		);
+		const provider = createOpenAICompatibleProvider({ apiKey: "sk-x" });
+		const all: string[] = [];
+		for await (const c of provider.generate("hi", {})) all.push(c);
+		expect(all).toEqual(["Hello, ", "world!"]);
+	});
+
+	it("throws on non-2xx response with body", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response("rate limit", { status: 429, statusText: "Too Many Requests" }),
+		);
+		const provider = createOpenAICompatibleProvider({ apiKey: "sk-x" });
+		await expect(async () => {
+			for await (const _ of provider.generate("hi", {})) {
+				// no-op
+			}
+		}).rejects.toThrow(/429/);
+	});
+
+	it("returns a single chunk when stream=false", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ choices: [{ message: { content: "final answer" } }] }), {
+				status: 200,
+			}),
+		);
+		const provider = createOpenAICompatibleProvider({ apiKey: "sk-x" });
+		const chunks: string[] = [];
+		for await (const c of provider.generate("hi", { stream: false })) chunks.push(c);
+		expect(chunks).toEqual(["final answer"]);
+	});
+});

--- a/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
+++ b/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
@@ -119,6 +119,20 @@ describe("createOpenAICompatibleProvider", () => {
 		}).rejects.toThrow(/429/);
 	});
 
+	it("flushes the final SSE line when the stream ends without a trailing newline", async () => {
+		// Some servers omit the closing `\n\n` after the last `data:` event.
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				sseStream([`data: ${JSON.stringify({ choices: [{ delta: { content: "tail" } }] })}`]),
+				{ status: 200 },
+			),
+		);
+		const provider = createOpenAICompatibleProvider({ apiKey: "sk-x" });
+		const all: string[] = [];
+		for await (const c of provider.generate("hi", {})) all.push(c);
+		expect(all).toEqual(["tail"]);
+	});
+
 	it("returns a single chunk when stream=false", async () => {
 		fetchMock.mockResolvedValueOnce(
 			new Response(JSON.stringify({ choices: [{ message: { content: "final answer" } }] }), {

--- a/plugins/usketch-plugin-tool-openui/src/default-library.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/default-library.tsx
@@ -1,5 +1,5 @@
 import { createLibrary, defineComponent, useRenderNode } from "@openuidev/react-lang";
-import type { CSSProperties, ReactNode } from "react";
+import { type CSSProperties, Fragment, type ReactNode } from "react";
 import { z } from "zod/v4";
 
 /**
@@ -18,9 +18,12 @@ function renderArray(
 	render: ReturnType<typeof useRenderNode>,
 ): ReactNode {
 	if (!values) return null;
+	// Use Fragment, not <div>, so flex-child semantics (e.g. Spacer's flex: 1)
+	// apply to the actual rendered component instead of being trapped by a
+	// wrapper element.
 	return values.map((v, i) => (
 		// biome-ignore lint/suspicious/noArrayIndexKey: OpenUI Lang nodes are positional and stable
-		<div key={i}>{render(v)}</div>
+		<Fragment key={i}>{render(v)}</Fragment>
 	));
 }
 

--- a/plugins/usketch-plugin-tool-openui/src/default-library.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/default-library.tsx
@@ -1,0 +1,312 @@
+import { createLibrary, defineComponent, useRenderNode } from "@openuidev/react-lang";
+import type { CSSProperties, ReactNode } from "react";
+import { z } from "zod/v4";
+
+/**
+ * Bundled `Library` for the OpenUI tool plugin. A deliberately small set of
+ * generic UI primitives that the LLM can compose into widgets without
+ * needing host-app context. Hosts that want richer or branded components
+ * should pass their own `createLibrary(...)` via `createOpenUIToolPlugin`.
+ *
+ * Container components (Stack, Card, List, Row) accept a `children` prop that
+ * is an array of nested component values. The OpenUI Lang DSL writes them as
+ * positional arguments: `Stack([Heading("Hi"), Text("body")])`.
+ */
+
+function renderArray(
+	values: readonly unknown[] | undefined,
+	render: ReturnType<typeof useRenderNode>,
+): ReactNode {
+	if (!values) return null;
+	return values.map((v, i) => (
+		// biome-ignore lint/suspicious/noArrayIndexKey: OpenUI Lang nodes are positional and stable
+		<div key={i}>{render(v)}</div>
+	));
+}
+
+const Stack = defineComponent({
+	name: "Stack",
+	description: "Vertical or horizontal flex container that groups children with a consistent gap.",
+	props: z.object({
+		direction: z.enum(["column", "row"]).default("column"),
+		gap: z.number().default(8),
+		align: z.enum(["start", "center", "end", "stretch"]).default("stretch"),
+		padding: z.number().default(0),
+		children: z.array(z.unknown()).default([]),
+	}),
+	component: ({ props }) => {
+		const render = useRenderNode();
+		return (
+			<div
+				style={{
+					display: "flex",
+					flexDirection: props.direction,
+					gap: props.gap,
+					alignItems: props.align,
+					padding: props.padding,
+				}}
+			>
+				{renderArray(props.children, render)}
+			</div>
+		);
+	},
+});
+
+const Heading = defineComponent({
+	name: "Heading",
+	description: "Headline text used for widget titles and section labels.",
+	props: z.object({
+		text: z.string(),
+		level: z.enum(["h1", "h2", "h3", "h4"]).default("h2"),
+	}),
+	component: ({ props }) => {
+		const size = { h1: 28, h2: 22, h3: 18, h4: 16 }[props.level];
+		return (
+			<div style={{ fontSize: size, fontWeight: 600, lineHeight: 1.2, color: "#0f172a" }}>
+				{props.text}
+			</div>
+		);
+	},
+});
+
+const Text = defineComponent({
+	name: "Text",
+	description: "Body text or paragraph content.",
+	props: z.object({
+		text: z.string(),
+		muted: z.boolean().default(false),
+	}),
+	component: ({ props }) => (
+		<div style={{ fontSize: 14, lineHeight: 1.5, color: props.muted ? "#71717a" : "#1f2937" }}>
+			{props.text}
+		</div>
+	),
+});
+
+const Card = defineComponent({
+	name: "Card",
+	description:
+		"Padded surface with a subtle border. Use as the outer container of self-contained widgets.",
+	props: z.object({
+		padding: z.number().default(16),
+		children: z.array(z.unknown()).default([]),
+	}),
+	component: ({ props }) => {
+		const render = useRenderNode();
+		return (
+			<div
+				style={{
+					background: "#ffffff",
+					border: "1px solid #e5e7eb",
+					borderRadius: 8,
+					padding: props.padding,
+					boxShadow: "0 1px 2px rgba(15, 23, 42, 0.04)",
+				}}
+			>
+				{renderArray(props.children, render)}
+			</div>
+		);
+	},
+});
+
+const buttonVariants: Record<string, CSSProperties> = {
+	primary: { background: "#0f172a", color: "#ffffff", border: "1px solid #0f172a" },
+	secondary: { background: "#ffffff", color: "#0f172a", border: "1px solid #cbd5e1" },
+	ghost: { background: "transparent", color: "#0f172a", border: "1px solid transparent" },
+};
+
+const Button = defineComponent({
+	name: "Button",
+	description:
+		"Primary or secondary call-to-action button. Static — does not invoke real handlers.",
+	props: z.object({
+		label: z.string(),
+		variant: z.enum(["primary", "secondary", "ghost"]).default("primary"),
+	}),
+	component: ({ props }) => (
+		<button
+			type="button"
+			style={{
+				...buttonVariants[props.variant],
+				padding: "8px 14px",
+				borderRadius: 6,
+				fontSize: 14,
+				fontWeight: 500,
+				cursor: "pointer",
+			}}
+		>
+			{props.label}
+		</button>
+	),
+});
+
+const Input = defineComponent({
+	name: "Input",
+	description: "Single-line text input. Static preview — no controlled value.",
+	props: z.object({
+		placeholder: z.string().default(""),
+		label: z.string().default(""),
+	}),
+	component: ({ props }) => (
+		<label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+			{props.label && <span style={{ fontSize: 13, color: "#374151" }}>{props.label}</span>}
+			<input
+				type="text"
+				placeholder={props.placeholder}
+				style={{
+					padding: "8px 10px",
+					border: "1px solid #cbd5e1",
+					borderRadius: 6,
+					fontSize: 14,
+					background: "#ffffff",
+				}}
+			/>
+		</label>
+	),
+});
+
+const badgeTones: Record<string, { bg: string; fg: string }> = {
+	neutral: { bg: "#f1f5f9", fg: "#0f172a" },
+	success: { bg: "#dcfce7", fg: "#166534" },
+	warn: { bg: "#fef3c7", fg: "#92400e" },
+	danger: { bg: "#fee2e2", fg: "#991b1b" },
+};
+
+const Badge = defineComponent({
+	name: "Badge",
+	description: "Compact pill used to highlight a tag, count, or status.",
+	props: z.object({
+		text: z.string(),
+		tone: z.enum(["neutral", "success", "warn", "danger"]).default("neutral"),
+	}),
+	component: ({ props }) => {
+		const t = badgeTones[props.tone];
+		return (
+			<span
+				style={{
+					display: "inline-flex",
+					alignItems: "center",
+					padding: "2px 8px",
+					borderRadius: 999,
+					background: t.bg,
+					color: t.fg,
+					fontSize: 12,
+					fontWeight: 500,
+				}}
+			>
+				{props.text}
+			</span>
+		);
+	},
+});
+
+const Avatar = defineComponent({
+	name: "Avatar",
+	description: "Circular avatar with initials. Use when a real image is not available.",
+	props: z.object({
+		initials: z.string(),
+		size: z.number().default(32),
+		color: z.string().default("#0ea5e9"),
+	}),
+	component: ({ props }) => (
+		<div
+			style={{
+				width: props.size,
+				height: props.size,
+				borderRadius: "50%",
+				background: props.color,
+				color: "#ffffff",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				fontSize: Math.round(props.size * 0.4),
+				fontWeight: 600,
+			}}
+		>
+			{props.initials}
+		</div>
+	),
+});
+
+const Image = defineComponent({
+	name: "Image",
+	description: "External image element. Use when a real source URL is provided in the prompt.",
+	props: z.object({
+		src: z.string(),
+		alt: z.string().default(""),
+		fit: z.enum(["cover", "contain"]).default("cover"),
+	}),
+	component: ({ props }) => (
+		<img
+			src={props.src}
+			alt={props.alt}
+			style={{ width: "100%", height: "100%", objectFit: props.fit, borderRadius: 6 }}
+		/>
+	),
+});
+
+const List = defineComponent({
+	name: "List",
+	description: "Vertical list. Children are rendered as separate rows.",
+	props: z.object({
+		divided: z.boolean().default(true),
+		children: z.array(z.unknown()).default([]),
+	}),
+	component: ({ props }) => {
+		const render = useRenderNode();
+		return (
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					gap: props.divided ? 0 : 8,
+				}}
+			>
+				{renderArray(props.children, render)}
+			</div>
+		);
+	},
+});
+
+const Row = defineComponent({
+	name: "Row",
+	description: "Horizontal row primitive used inside List or as a layout helper.",
+	props: z.object({
+		gap: z.number().default(8),
+		align: z.enum(["start", "center", "end"]).default("center"),
+		children: z.array(z.unknown()).default([]),
+	}),
+	component: ({ props }) => {
+		const render = useRenderNode();
+		return (
+			<div
+				style={{
+					display: "flex",
+					gap: props.gap,
+					alignItems: props.align,
+					padding: "8px 0",
+					borderBottom: "1px solid #f1f5f9",
+				}}
+			>
+				{renderArray(props.children, render)}
+			</div>
+		);
+	},
+});
+
+const Spacer = defineComponent({
+	name: "Spacer",
+	description: "Flexible empty space used to push siblings apart in a Row or Stack.",
+	props: z.object({ size: z.number().default(8) }),
+	component: ({ props }) => (
+		<div style={{ flex: 1, minWidth: props.size, minHeight: props.size }} />
+	),
+});
+
+/** Bundled OpenUI library shipped with `usketch-plugin-tool-openui`. */
+export const openuiDefaultLibrary = createLibrary({
+	components: [Stack, Heading, Text, Card, Button, Input, Badge, Avatar, Image, List, Row, Spacer],
+	root: "Stack",
+});
+
+export const OPENUI_DEFAULT_LIBRARY_ID = "openui-default";

--- a/plugins/usketch-plugin-tool-openui/src/index.ts
+++ b/plugins/usketch-plugin-tool-openui/src/index.ts
@@ -1,0 +1,12 @@
+export { OPENUI_DEFAULT_LIBRARY_ID, openuiDefaultLibrary } from "./default-library.js";
+export { createOpenUIToolPlugin } from "./plugin.js";
+export { createOpenAIProvider } from "./providers/openai.js";
+export { createOpenAICompatibleProvider } from "./providers/openai-compatible.js";
+export type {
+	GenerateOptions,
+	OpenUIProvider,
+	ProviderId,
+	VisionInput,
+} from "./providers/types.js";
+export { buildSystemPrompt } from "./system-prompt.js";
+export type { OpenUIGenerateRequest, OpenUIToolOptions } from "./types.js";

--- a/plugins/usketch-plugin-tool-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/plugin.tsx
@@ -1,0 +1,462 @@
+import { ShapeAnchorOverlay, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
+import { exportCanvas } from "@edv4h/usketch-plugin-export";
+import { sanitizeLangSource, setOpenUILibrary } from "@edv4h/usketch-plugin-shape-openui";
+import {
+	type BoundingBox,
+	DEFAULT_STYLE,
+	generateId,
+	type PluginContext,
+	type ShapeData,
+	type UsketchPlugin,
+} from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { OPENUI_DEFAULT_LIBRARY_ID, openuiDefaultLibrary } from "./default-library.js";
+import { buildSystemPrompt } from "./system-prompt.js";
+import type { OpenUIGenerateRequest, OpenUIToolOptions } from "./types.js";
+
+const TOOL_ID = "openui";
+const SIDE_PANEL_TAB_ID = "openui";
+const MAKE_REAL_LAYER_ID = "openui-make-real";
+const GENERATE_EVENT = "openui:generate-request";
+const AI_STATUS_EVENT = "ai:status";
+
+interface AiStatusPayload {
+	status: "thinking" | "placing" | "done" | "error";
+	message?: string;
+	shapeCount?: number;
+	source?: string;
+}
+
+function viewportCenterToWorld(viewport: { x: number; y: number; zoom: number }): {
+	x: number;
+	y: number;
+} {
+	if (typeof window === "undefined") return { x: 0, y: 0 };
+	return {
+		x: (window.innerWidth / 2 - viewport.x) / viewport.zoom,
+		y: (window.innerHeight / 2 - viewport.y) / viewport.zoom,
+	};
+}
+
+function unionBounds(shapes: ShapeData[]): BoundingBox | null {
+	if (shapes.length === 0) return null;
+	const first = shapes[0]!;
+	let minX = first.x;
+	let minY = first.y;
+	let maxX = first.x + first.width;
+	let maxY = first.y + first.height;
+	for (let i = 1; i < shapes.length; i++) {
+		const s = shapes[i]!;
+		if (s.x < minX) minX = s.x;
+		if (s.y < minY) minY = s.y;
+		if (s.x + s.width > maxX) maxX = s.x + s.width;
+		if (s.y + s.height > maxY) maxY = s.y + s.height;
+	}
+	return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
+	const {
+		provider,
+		library = openuiDefaultLibrary,
+		libraryId = OPENUI_DEFAULT_LIBRARY_ID,
+		model,
+		enableMakeReal = provider.supportsVision,
+		systemPrompt,
+		timeoutMs = 60_000,
+	} = opts;
+
+	let cleanup: (() => void) | undefined;
+
+	return {
+		id: "usketch-plugin-tool-openui",
+		name: "OpenUI Tool",
+
+		setup(ctx: PluginContext) {
+			setOpenUILibrary(library);
+			let activeController: AbortController | null = null;
+			let placementBase: { x: number; y: number } | null = null;
+
+			const emitStatus = (payload: AiStatusPayload): void => {
+				ctx.events.emit(AI_STATUS_EVENT, { ...payload, source: "openui" });
+			};
+
+			async function runGenerate(req: OpenUIGenerateRequest): Promise<void> {
+				if (activeController) activeController.abort();
+				const controller = new AbortController();
+				activeController = controller;
+				const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
+
+				emitStatus({ status: "thinking", message: "Generating UI…" });
+				let buffer = "";
+				let lastReport = 0;
+				try {
+					for await (const chunk of provider.generate(req.prompt, {
+						stream: true,
+						model,
+						vision: req.vision,
+						signal: controller.signal,
+						systemPrompt: systemPrompt ?? buildSystemPrompt(library),
+					})) {
+						buffer += chunk;
+						const now = Date.now();
+						if (now - lastReport > 200) {
+							lastReport = now;
+							emitStatus({
+								status: "thinking",
+								message: `Streaming… (${buffer.length} chars)`,
+							});
+						}
+					}
+
+					const cleaned = sanitizeLangSource(buffer);
+					if (!cleaned) throw new Error("Empty response from model");
+
+					emitStatus({ status: "placing", message: "Creating shape…", shapeCount: 1 });
+
+					const viewport = ctx.store.getViewport();
+					const base = placementBase ?? viewportCenterToWorld(viewport);
+					placementBase = null;
+					const id = generateId();
+					const shape = {
+						id,
+						type: "openui",
+						x: Math.round(base.x - 240),
+						y: Math.round(base.y - 180),
+						width: 480,
+						height: 360,
+						style: { ...DEFAULT_STYLE, fill: "#ffffff", stroke: "#e5e7eb", strokeWidth: 1 },
+						langSource: cleaned,
+						prompt: req.prompt,
+						model: model ?? provider.defaultModel,
+						libraryId,
+					} as ShapeData;
+					ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
+					ctx.store.setSelection([id]);
+
+					emitStatus({ status: "done", shapeCount: 1, message: "Created!" });
+				} catch (err) {
+					if (controller.signal.aborted) return;
+					emitStatus({
+						status: "error",
+						message: err instanceof Error ? err.message : "Generation failed",
+					});
+				} finally {
+					window.clearTimeout(timeoutId);
+					if (activeController === controller) activeController = null;
+				}
+			}
+
+			ctx.tools.register(TOOL_ID, {
+				icon: SparkleIcon,
+				cursor: "default",
+				shortcut: "u",
+				order: 30,
+				onActivate: () => {
+					ctx.events.emit("side-panel:open", { tabId: SIDE_PANEL_TAB_ID });
+				},
+				onPointerDown: () => {
+					// Prompt-driven, not pointer-driven.
+				},
+			});
+
+			ctx.events.emit("side-panel:register-tab", {
+				tab: {
+					id: SIDE_PANEL_TAB_ID,
+					label: "OpenUI",
+					icon: "✨",
+					order: 25,
+					render: () => (
+						<OpenUISidePanel
+							events={ctx.events}
+							provider={provider}
+							model={model}
+							onCancel={() => activeController?.abort()}
+						/>
+					),
+				},
+			});
+
+			if (enableMakeReal && provider.supportsVision) {
+				ctx.layers.register({
+					id: MAKE_REAL_LAYER_ID,
+					order: 86,
+					fixed: true,
+					render: () => (
+						<MakeRealButton
+							ctx={ctx}
+							onTrigger={(bounds) => {
+								// Place the new shape to the right of the source selection.
+								placementBase = bounds
+									? { x: bounds.x + bounds.width + 280, y: bounds.y + bounds.height / 2 }
+									: null;
+							}}
+						/>
+					),
+				});
+			}
+
+			const offGenerate = ctx.events.on(GENERATE_EVENT, (data: unknown) => {
+				void runGenerate(data as OpenUIGenerateRequest);
+			});
+
+			cleanup = () => {
+				offGenerate();
+				ctx.events.emit("side-panel:unregister-tab", { tabId: SIDE_PANEL_TAB_ID });
+				if (enableMakeReal && provider.supportsVision) {
+					ctx.layers.unregister(MAKE_REAL_LAYER_ID);
+				}
+				setOpenUILibrary(null);
+				activeController?.abort();
+			};
+		},
+
+		teardown() {
+			cleanup?.();
+		},
+	};
+}
+
+function SparkleIcon() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+			<path d="M10 2l1.8 4.2L16 8l-4.2 1.8L10 14l-1.8-4.2L4 8l4.2-1.8L10 2z" fill="currentColor" />
+		</svg>
+	);
+}
+
+// ─── Side panel UI ──────────────────────────────────────────────────────
+
+interface SidePanelProps {
+	events: import("@edv4h/usketch-shared").EventBus;
+	provider: import("./providers/types.js").OpenUIProvider;
+	model?: string;
+	onCancel: () => void;
+}
+
+function OpenUISidePanel({ events, provider, model, onCancel }: SidePanelProps) {
+	const [prompt, setPrompt] = useState("");
+	const [status, setStatus] = useState<AiStatusPayload | null>(null);
+	const isComposingRef = useRef(false);
+	const selectedModel = model ?? provider.defaultModel;
+
+	useEffect(() => {
+		const off = events.on(AI_STATUS_EVENT, (data: unknown) => {
+			const payload = data as AiStatusPayload;
+			if (payload.source !== "openui") return;
+			setStatus(payload);
+			if (payload.status === "done" || payload.status === "error") {
+				window.setTimeout(() => setStatus(null), 3000);
+			}
+		});
+		return off;
+	}, [events]);
+
+	const isBusy = status?.status === "thinking" || status?.status === "placing";
+
+	const handleSubmit = useCallback(() => {
+		const trimmed = prompt.trim();
+		if (!trimmed || isBusy) return;
+		events.emit(GENERATE_EVENT, { prompt: trimmed });
+	}, [prompt, isBusy, events]);
+
+	return (
+		<div style={{ display: "flex", flexDirection: "column", gap: 12, padding: 16 }}>
+			<div style={{ fontSize: 13, color: "#71717a" }}>
+				Describe the UI widget to add to the canvas. Generated via <strong>{provider.label}</strong>
+				{selectedModel ? (
+					<>
+						{" · "}
+						<code style={{ fontSize: 12 }}>{selectedModel}</code>
+					</>
+				) : null}
+				.
+			</div>
+			<textarea
+				value={prompt}
+				onChange={(e) => setPrompt(e.target.value)}
+				onCompositionStart={() => {
+					isComposingRef.current = true;
+				}}
+				onCompositionEnd={() => {
+					isComposingRef.current = false;
+				}}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !isComposingRef.current) {
+						e.preventDefault();
+						handleSubmit();
+					}
+				}}
+				placeholder="e.g. a pricing card with three tiers"
+				rows={5}
+				disabled={isBusy}
+				style={{
+					width: "100%",
+					padding: 10,
+					border: "1px solid #cbd5e1",
+					borderRadius: 6,
+					fontSize: 14,
+					fontFamily: "inherit",
+					resize: "vertical",
+					background: isBusy ? "#f4f4f5" : "#ffffff",
+				}}
+			/>
+			<div style={{ display: "flex", gap: 8 }}>
+				<button
+					type="button"
+					onClick={handleSubmit}
+					disabled={isBusy || !prompt.trim()}
+					style={{
+						flex: 1,
+						padding: "8px 14px",
+						borderRadius: 6,
+						border: "1px solid #0f172a",
+						background: isBusy || !prompt.trim() ? "#94a3b8" : "#0f172a",
+						color: "#ffffff",
+						cursor: isBusy || !prompt.trim() ? "not-allowed" : "pointer",
+						fontSize: 14,
+						fontWeight: 500,
+					}}
+				>
+					{isBusy ? "Generating…" : "Generate (⌘+Enter)"}
+				</button>
+				{isBusy ? (
+					<button
+						type="button"
+						onClick={onCancel}
+						style={{
+							padding: "8px 14px",
+							borderRadius: 6,
+							border: "1px solid #cbd5e1",
+							background: "#ffffff",
+							cursor: "pointer",
+							fontSize: 14,
+						}}
+					>
+						Cancel
+					</button>
+				) : null}
+			</div>
+			{status ? (
+				<div
+					style={{
+						padding: 8,
+						borderRadius: 6,
+						background:
+							status.status === "error"
+								? "#fee2e2"
+								: status.status === "done"
+									? "#dcfce7"
+									: "#f1f5f9",
+						color:
+							status.status === "error"
+								? "#991b1b"
+								: status.status === "done"
+									? "#166534"
+									: "#0f172a",
+						fontSize: 13,
+					}}
+				>
+					{status.message ?? status.status}
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+// ─── Make Real button ────────────────────────────────────────────────────
+
+interface MakeRealProps {
+	ctx: PluginContext;
+	onTrigger: (bounds: BoundingBox | null) => void;
+}
+
+function MakeRealButton({ ctx, onTrigger }: MakeRealProps) {
+	const selection = useStoreSubscribe(ctx.store, (s) => s.getSelection());
+	const [busy, setBusy] = useState(false);
+
+	if (selection.size === 0) return null;
+
+	const ids = [...selection];
+	const shapes = ids.map((id) => ctx.store.getShape(id)).filter((s): s is ShapeData => Boolean(s));
+	if (shapes.length === 0) return null;
+	if (shapes.some((s) => s.type === "openui")) return null;
+
+	const handleClick = async (): Promise<void> => {
+		setBusy(true);
+		try {
+			const selectionMap = new Map<string, ShapeData>();
+			for (const s of shapes) selectionMap.set(s.id, s);
+			const blob = await exportCanvas(selectionMap, ctx.shapes, {
+				format: "png",
+				pixelRatio: 2,
+				background: "#ffffff",
+			});
+			const imageDataUrl: string = await new Promise((resolve, reject) => {
+				const reader = new FileReader();
+				reader.onload = () => resolve(reader.result as string);
+				reader.onerror = () => reject(new Error("Failed to read screenshot"));
+				reader.readAsDataURL(blob);
+			});
+			onTrigger(unionBounds(shapes));
+			ctx.events.emit(GENERATE_EVENT, {
+				prompt: "Build a real, polished UI that faithfully matches this sketch.",
+				vision: { imageDataUrl },
+			});
+		} catch (err) {
+			ctx.events.emit(AI_STATUS_EVENT, {
+				status: "error",
+				message: err instanceof Error ? err.message : "Make Real failed",
+				source: "openui",
+			});
+		} finally {
+			setBusy(false);
+		}
+	};
+
+	return (
+		<ShapeAnchorOverlay
+			shapeIds={ids}
+			position="top"
+			fallback="bottom"
+			style={{ pointerEvents: "auto" }}
+		>
+			<div
+				style={{
+					display: "inline-flex",
+					alignItems: "center",
+					gap: 6,
+					background: "#ffffff",
+					border: "1px solid #e5e7eb",
+					borderRadius: 8,
+					padding: "4px 8px",
+					boxShadow: "0 2px 8px rgba(15, 23, 42, 0.08)",
+					fontSize: 13,
+					fontFamily: "system-ui, -apple-system, sans-serif",
+				}}
+				onPointerDown={(e) => e.stopPropagation()}
+			>
+				<button
+					type="button"
+					onClick={handleClick}
+					disabled={busy}
+					style={{
+						display: "inline-flex",
+						alignItems: "center",
+						gap: 4,
+						padding: "4px 8px",
+						border: "none",
+						background: "transparent",
+						cursor: busy ? "wait" : "pointer",
+						fontSize: 13,
+						fontWeight: 500,
+						color: "#0f172a",
+					}}
+				>
+					{busy ? "…" : "✨ Make Real"}
+				</button>
+			</div>
+		</ShapeAnchorOverlay>
+	);
+}

--- a/plugins/usketch-plugin-tool-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/plugin.tsx
@@ -350,7 +350,7 @@ function OpenUISidePanel({ events, provider, model, onCancel }: SidePanelProps) 
 						fontWeight: 500,
 					}}
 				>
-					{isBusy ? "Generating…" : "Generate (⌘+Enter)"}
+					{isBusy ? "Generating…" : "Generate (Ctrl/⌘+Enter)"}
 				</button>
 				{isBusy ? (
 					<button

--- a/plugins/usketch-plugin-tool-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/plugin.tsx
@@ -63,6 +63,7 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 		enableMakeReal = provider.supportsVision,
 		systemPrompt,
 		timeoutMs = 60_000,
+		stream: defaultStream = true,
 	} = opts;
 
 	let cleanup: (() => void) | undefined;
@@ -95,27 +96,43 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 				};
 
 				safeEmit({ status: "thinking", message: "Generating UI…" });
-				let buffer = "";
-				let lastReport = 0;
-				try {
+				const resolvedSystemPrompt = systemPrompt ?? buildSystemPrompt(library);
+
+				const collect = async (stream: boolean): Promise<string> => {
+					let buf = "";
+					let lastReport = 0;
 					for await (const chunk of provider.generate(req.prompt, {
-						stream: true,
+						stream,
 						model,
 						vision: req.vision,
 						signal: controller.signal,
-						systemPrompt: systemPrompt ?? buildSystemPrompt(library),
+						systemPrompt: resolvedSystemPrompt,
 					})) {
-						buffer += chunk;
+						buf += chunk;
 						const now = Date.now();
 						if (now - lastReport > 200) {
 							lastReport = now;
 							safeEmit({
 								status: "thinking",
-								message: `Streaming… (${buffer.length} chars)`,
+								message: stream
+									? `Streaming… (${buf.length} chars)`
+									: `Receiving… (${buf.length} chars)`,
 							});
 						}
 					}
+					return buf;
+				};
 
+				let buffer = "";
+				try {
+					buffer = await collect(defaultStream);
+					// Some OpenAI-compatible endpoints accept `stream: true` but
+					// reply with a plain JSON body — the streaming parser yields no
+					// deltas and we end up here with an empty buffer. Retry once
+					// in non-streaming mode before giving up.
+					if (defaultStream && sanitizeLangSource(buffer).length === 0) {
+						buffer = await collect(false);
+					}
 					const cleaned = sanitizeLangSource(buffer);
 					if (!cleaned) throw new Error("Empty response from model");
 

--- a/plugins/usketch-plugin-tool-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/plugin.tsx
@@ -86,7 +86,15 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 				activeController = controller;
 				const timeoutId = window.setTimeout(() => controller.abort(), timeoutMs);
 
-				emitStatus({ status: "thinking", message: "Generating UI…" });
+				// Gate every emit on this generation still being the active one.
+				// Without this, a slow-to-unwind cancelled generation could overwrite
+				// the "thinking" status of a freshly-started one.
+				const safeEmit = (payload: AiStatusPayload): void => {
+					if (activeController !== controller) return;
+					emitStatus(payload);
+				};
+
+				safeEmit({ status: "thinking", message: "Generating UI…" });
 				let buffer = "";
 				let lastReport = 0;
 				try {
@@ -101,7 +109,7 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 						const now = Date.now();
 						if (now - lastReport > 200) {
 							lastReport = now;
-							emitStatus({
+							safeEmit({
 								status: "thinking",
 								message: `Streaming… (${buffer.length} chars)`,
 							});
@@ -111,7 +119,7 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 					const cleaned = sanitizeLangSource(buffer);
 					if (!cleaned) throw new Error("Empty response from model");
 
-					emitStatus({ status: "placing", message: "Creating shape…", shapeCount: 1 });
+					safeEmit({ status: "placing", message: "Creating shape…", shapeCount: 1 });
 
 					const viewport = ctx.store.getViewport();
 					const base = placementBase ?? viewportCenterToWorld(viewport);
@@ -133,15 +141,15 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 					ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
 					ctx.store.setSelection([id]);
 
-					emitStatus({ status: "done", shapeCount: 1, message: "Created!" });
+					safeEmit({ status: "done", shapeCount: 1, message: "Created!" });
 				} catch (err) {
 					if (controller.signal.aborted) {
 						// User-initiated cancel or timeout — release the busy state
 						// so the side panel doesn't stay disabled forever.
-						emitStatus({ status: "done", message: "Cancelled" });
+						safeEmit({ status: "done", message: "Cancelled" });
 						return;
 					}
-					emitStatus({
+					safeEmit({
 						status: "error",
 						message: err instanceof Error ? err.message : "Generation failed",
 					});
@@ -252,11 +260,15 @@ function OpenUISidePanel({ events, provider, model, onCancel }: SidePanelProps) 
 		const off = events.on(AI_STATUS_EVENT, (data: unknown) => {
 			const payload = data as AiStatusPayload;
 			if (payload.source !== "openui") return;
+			// Cancel any pending auto-clear on EVERY status update — otherwise a
+			// "done" status quickly followed by a new "thinking" would let the
+			// old 3s timer fire and clear the busy state mid-generation.
+			if (clearTimeoutRef.current !== null) {
+				window.clearTimeout(clearTimeoutRef.current);
+				clearTimeoutRef.current = null;
+			}
 			setStatus(payload);
 			if (payload.status === "done" || payload.status === "error") {
-				if (clearTimeoutRef.current !== null) {
-					window.clearTimeout(clearTimeoutRef.current);
-				}
 				clearTimeoutRef.current = window.setTimeout(() => {
 					setStatus(null);
 					clearTimeoutRef.current = null;

--- a/plugins/usketch-plugin-tool-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/plugin.tsx
@@ -40,19 +40,17 @@ function viewportCenterToWorld(viewport: { x: number; y: number; zoom: number })
 }
 
 function unionBounds(shapes: ShapeData[]): BoundingBox | null {
-	if (shapes.length === 0) return null;
-	const first = shapes[0]!;
-	let minX = first.x;
-	let minY = first.y;
-	let maxX = first.x + first.width;
-	let maxY = first.y + first.height;
-	for (let i = 1; i < shapes.length; i++) {
-		const s = shapes[i]!;
+	let minX = Number.POSITIVE_INFINITY;
+	let minY = Number.POSITIVE_INFINITY;
+	let maxX = Number.NEGATIVE_INFINITY;
+	let maxY = Number.NEGATIVE_INFINITY;
+	for (const s of shapes) {
 		if (s.x < minX) minX = s.x;
 		if (s.y < minY) minY = s.y;
 		if (s.x + s.width > maxX) maxX = s.x + s.width;
 		if (s.y + s.height > maxY) maxY = s.y + s.height;
 	}
+	if (minX === Number.POSITIVE_INFINITY) return null;
 	return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
 }
 
@@ -137,7 +135,12 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 
 					emitStatus({ status: "done", shapeCount: 1, message: "Created!" });
 				} catch (err) {
-					if (controller.signal.aborted) return;
+					if (controller.signal.aborted) {
+						// User-initiated cancel or timeout — release the busy state
+						// so the side panel doesn't stay disabled forever.
+						emitStatus({ status: "done", message: "Cancelled" });
+						return;
+					}
 					emitStatus({
 						status: "error",
 						message: err instanceof Error ? err.message : "Generation failed",
@@ -239,6 +242,10 @@ function OpenUISidePanel({ events, provider, model, onCancel }: SidePanelProps) 
 	const [prompt, setPrompt] = useState("");
 	const [status, setStatus] = useState<AiStatusPayload | null>(null);
 	const isComposingRef = useRef(false);
+	// Track the pending auto-clear timeout so we can cancel it on unmount or
+	// when a new terminal status arrives. Otherwise React fires `setStatus(null)`
+	// after the panel has been torn down and we leak setTimeout handles.
+	const clearTimeoutRef = useRef<number | null>(null);
 	const selectedModel = model ?? provider.defaultModel;
 
 	useEffect(() => {
@@ -247,10 +254,22 @@ function OpenUISidePanel({ events, provider, model, onCancel }: SidePanelProps) 
 			if (payload.source !== "openui") return;
 			setStatus(payload);
 			if (payload.status === "done" || payload.status === "error") {
-				window.setTimeout(() => setStatus(null), 3000);
+				if (clearTimeoutRef.current !== null) {
+					window.clearTimeout(clearTimeoutRef.current);
+				}
+				clearTimeoutRef.current = window.setTimeout(() => {
+					setStatus(null);
+					clearTimeoutRef.current = null;
+				}, 3000);
 			}
 		});
-		return off;
+		return () => {
+			off();
+			if (clearTimeoutRef.current !== null) {
+				window.clearTimeout(clearTimeoutRef.current);
+				clearTimeoutRef.current = null;
+			}
+		};
 	}, [events]);
 
 	const isBusy = status?.status === "thinking" || status?.status === "placing";

--- a/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
@@ -91,7 +91,9 @@ export function createOpenAICompatibleProvider(
 /**
  * Parse an OpenAI-style SSE stream into a flat sequence of content deltas.
  * Handles partial lines across chunk boundaries and stops cleanly on
- * `data: [DONE]`.
+ * `data: [DONE]`. After the read loop ends, flushes any residual `data:` line
+ * that wasn't followed by a trailing newline — some servers terminate the
+ * stream without a final `\n\n`.
  */
 async function* parseOpenAIStream(response: Response): AsyncIterable<string> {
 	const body = response.body;
@@ -99,6 +101,23 @@ async function* parseOpenAIStream(response: Response): AsyncIterable<string> {
 	const reader = body.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
+
+	/** Try to interpret one trimmed line as an OpenAI SSE delta. */
+	function extractDelta(line: string): { content?: string; done: boolean } {
+		if (!line.startsWith("data:")) return { done: false };
+		const data = line.slice(5).trimStart();
+		if (data === "[DONE]") return { done: true };
+		if (!data) return { done: false };
+		try {
+			const parsed = JSON.parse(data) as {
+				choices?: { delta?: { content?: string } }[];
+			};
+			return { content: parsed.choices?.[0]?.delta?.content, done: false };
+		} catch {
+			return { done: false };
+		}
+	}
+
 	try {
 		while (true) {
 			const { done, value } = await reader.read();
@@ -109,19 +128,17 @@ async function* parseOpenAIStream(response: Response): AsyncIterable<string> {
 				const line = buffer.slice(0, nl).trimEnd();
 				buffer = buffer.slice(nl + 1);
 				nl = buffer.indexOf("\n");
-				if (!line.startsWith("data:")) continue;
-				const data = line.slice(5).trimStart();
-				if (data === "[DONE]") return;
-				if (!data) continue;
-				let parsed: { choices?: { delta?: { content?: string } }[] };
-				try {
-					parsed = JSON.parse(data);
-				} catch {
-					continue;
-				}
-				const content = parsed.choices?.[0]?.delta?.content;
+				const { content, done: terminated } = extractDelta(line);
+				if (terminated) return;
 				if (typeof content === "string" && content.length > 0) yield content;
 			}
+		}
+		// Flush the final un-newline-terminated line, if any.
+		const tail = buffer.trim();
+		if (tail.length > 0) {
+			const { content, done: terminated } = extractDelta(tail);
+			if (terminated) return;
+			if (typeof content === "string" && content.length > 0) yield content;
 		}
 	} finally {
 		reader.releaseLock();

--- a/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
@@ -1,8 +1,20 @@
 import type { GenerateOptions, OpenUIProvider } from "./types.js";
 
 export interface OpenAICompatibleProviderOptions {
-	/** Default `"https://api.openai.com/v1"`. Override for Ollama, LiteLLM, Azure, etc. */
+	/**
+	 * Base URL, with or without a trailing slash. Defaults to
+	 * `https://api.openai.com/v1`. By default the request is sent to
+	 * `<baseURL>/chat/completions` using `Authorization: Bearer <apiKey>`.
+	 * Override `endpoint` if your server uses a different path or query string,
+	 * and pass `extraHeaders` to swap the auth header.
+	 */
 	baseURL?: string;
+	/**
+	 * Full chat-completions URL (overrides `baseURL`-based construction).
+	 * Use this for endpoints that require query parameters such as Azure
+	 * OpenAI (`https://<resource>.openai.azure.com/openai/deployments/<dep>/chat/completions?api-version=2024-...`).
+	 */
+	endpoint?: string;
 	/** Sent as `Authorization: Bearer <apiKey>`. Optional for self-hosted endpoints. */
 	apiKey?: string;
 	defaultModel?: string;
@@ -14,14 +26,21 @@ export interface OpenAICompatibleProviderOptions {
 
 /**
  * Generic provider for any OpenAI-compatible Chat Completions endpoint
- * (api.openai.com, Azure OpenAI, Ollama, vLLM, LiteLLM, a self-hosted
- * OpenUI server, …). Streams SSE deltas as `AsyncIterable<string>`.
+ * (api.openai.com, Ollama, vLLM, LiteLLM, a self-hosted OpenUI server,
+ * …). Streams SSE deltas as `AsyncIterable<string>`.
+ *
+ * **Not fully covered**: Azure OpenAI needs a different URL shape
+ * (`/openai/deployments/<name>/chat/completions?api-version=...`) plus an
+ * `api-key` header instead of `Authorization: Bearer`. Pass the full URL via
+ * `endpoint` and the auth header via `extraHeaders` if you need that
+ * variant — a dedicated factory may land later.
  */
 export function createOpenAICompatibleProvider(
 	options: OpenAICompatibleProviderOptions = {},
 ): OpenUIProvider {
 	const {
 		baseURL = "https://api.openai.com/v1",
+		endpoint,
 		apiKey,
 		defaultModel = "gpt-4o",
 		availableModels,
@@ -29,6 +48,10 @@ export function createOpenAICompatibleProvider(
 		supportsVision = true,
 		label = "OpenAI-compatible",
 	} = options;
+	// Resolve a stable URL once at factory time. URL handles trailing slashes,
+	// allows future query-param overrides, and rejects malformed inputs early.
+	const resolvedEndpoint =
+		endpoint ?? new URL("chat/completions", ensureTrailingSlash(baseURL)).toString();
 
 	return {
 		id: "openai-compatible",
@@ -57,7 +80,7 @@ export function createOpenAICompatibleProvider(
 				{ role: "user", content: userContent },
 			];
 
-			const response = await fetch(`${baseURL}/chat/completions`, {
+			const response = await fetch(resolvedEndpoint, {
 				method: "POST",
 				headers,
 				signal: opts.signal,
@@ -143,4 +166,10 @@ async function* parseOpenAIStream(response: Response): AsyncIterable<string> {
 	} finally {
 		reader.releaseLock();
 	}
+}
+
+/** Append a trailing slash if missing; `new URL("chat/completions", base)`
+ *  drops the last path segment of `base` when it doesn't end with `/`. */
+function ensureTrailingSlash(url: string): string {
+	return url.endsWith("/") ? url : `${url}/`;
 }

--- a/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
@@ -1,0 +1,129 @@
+import type { GenerateOptions, OpenUIProvider } from "./types.js";
+
+export interface OpenAICompatibleProviderOptions {
+	/** Default `"https://api.openai.com/v1"`. Override for Ollama, LiteLLM, Azure, etc. */
+	baseURL?: string;
+	/** Sent as `Authorization: Bearer <apiKey>`. Optional for self-hosted endpoints. */
+	apiKey?: string;
+	defaultModel?: string;
+	availableModels?: string[];
+	extraHeaders?: Record<string, string>;
+	supportsVision?: boolean;
+	label?: string;
+}
+
+/**
+ * Generic provider for any OpenAI-compatible Chat Completions endpoint
+ * (api.openai.com, Azure OpenAI, Ollama, vLLM, LiteLLM, a self-hosted
+ * OpenUI server, …). Streams SSE deltas as `AsyncIterable<string>`.
+ */
+export function createOpenAICompatibleProvider(
+	options: OpenAICompatibleProviderOptions = {},
+): OpenUIProvider {
+	const {
+		baseURL = "https://api.openai.com/v1",
+		apiKey,
+		defaultModel = "gpt-4o",
+		availableModels,
+		extraHeaders,
+		supportsVision = true,
+		label = "OpenAI-compatible",
+	} = options;
+
+	return {
+		id: "openai-compatible",
+		label,
+		defaultModel,
+		availableModels,
+		supportsVision,
+		async *generate(prompt: string, opts: GenerateOptions): AsyncIterable<string> {
+			const stream = opts.stream ?? true;
+			const headers: Record<string, string> = {
+				"Content-Type": "application/json",
+				...extraHeaders,
+			};
+			if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+			const userContent =
+				opts.vision && supportsVision
+					? [
+							{ type: "text", text: prompt },
+							{ type: "image_url", image_url: { url: opts.vision.imageDataUrl } },
+						]
+					: prompt;
+
+			const messages = [
+				...(opts.systemPrompt ? [{ role: "system", content: opts.systemPrompt }] : []),
+				{ role: "user", content: userContent },
+			];
+
+			const response = await fetch(`${baseURL}/chat/completions`, {
+				method: "POST",
+				headers,
+				signal: opts.signal,
+				body: JSON.stringify({
+					model: opts.model ?? defaultModel,
+					stream,
+					temperature: 0.2,
+					messages,
+				}),
+			});
+
+			if (!response.ok) {
+				const body = await response.text().catch(() => "");
+				throw new Error(`OpenUI provider ${response.status}: ${body || response.statusText}`);
+			}
+
+			if (!stream) {
+				const data = (await response.json()) as {
+					choices?: { message?: { content?: string } }[];
+				};
+				const text = data.choices?.[0]?.message?.content ?? "";
+				if (text) yield text;
+				return;
+			}
+
+			yield* parseOpenAIStream(response);
+		},
+	};
+}
+
+/**
+ * Parse an OpenAI-style SSE stream into a flat sequence of content deltas.
+ * Handles partial lines across chunk boundaries and stops cleanly on
+ * `data: [DONE]`.
+ */
+async function* parseOpenAIStream(response: Response): AsyncIterable<string> {
+	const body = response.body;
+	if (!body) return;
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			let nl = buffer.indexOf("\n");
+			while (nl !== -1) {
+				const line = buffer.slice(0, nl).trimEnd();
+				buffer = buffer.slice(nl + 1);
+				nl = buffer.indexOf("\n");
+				if (!line.startsWith("data:")) continue;
+				const data = line.slice(5).trimStart();
+				if (data === "[DONE]") return;
+				if (!data) continue;
+				let parsed: { choices?: { delta?: { content?: string } }[] };
+				try {
+					parsed = JSON.parse(data);
+				} catch {
+					continue;
+				}
+				const content = parsed.choices?.[0]?.delta?.content;
+				if (typeof content === "string" && content.length > 0) yield content;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}

--- a/plugins/usketch-plugin-tool-openui/src/providers/openai.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/openai.ts
@@ -1,0 +1,33 @@
+import { createOpenAICompatibleProvider } from "./openai-compatible.js";
+import type { OpenUIProvider } from "./types.js";
+
+export interface OpenAIProviderOptions {
+	apiKey: string;
+	baseURL?: string;
+	defaultModel?: string;
+	availableModels?: string[];
+}
+
+/**
+ * Thin wrapper around {@link createOpenAICompatibleProvider} pre-configured for
+ * `api.openai.com`. Exists as a separate factory so the side panel can list
+ * "OpenAI" with a recognizable label without exposing the host to the
+ * compatibility plumbing.
+ */
+export function createOpenAIProvider(options: OpenAIProviderOptions): OpenUIProvider {
+	const {
+		apiKey,
+		baseURL = "https://api.openai.com/v1",
+		defaultModel = "gpt-4o",
+		availableModels = ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"],
+	} = options;
+	const provider = createOpenAICompatibleProvider({
+		baseURL,
+		apiKey,
+		defaultModel,
+		availableModels,
+		supportsVision: true,
+		label: "OpenAI",
+	});
+	return { ...provider, id: "openai" };
+}

--- a/plugins/usketch-plugin-tool-openui/src/providers/types.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/types.ts
@@ -28,10 +28,14 @@ export type ProviderId = "openai" | "openai-compatible";
  */
 export interface OpenUIProvider {
 	id: ProviderId;
-	/** Display label (used in the side-panel model selector). */
+	/** Human-readable label (e.g. shown next to "Generated via …" in the side panel). */
 	label: string;
 	defaultModel: string;
-	/** Optional list of additional model names to expose in the UI selector. */
+	/**
+	 * Optional list of additional model names. Reserved for a future side-panel
+	 * model selector — not consumed by the current UI, but providers should
+	 * still populate it accurately so hosts can build their own selector.
+	 */
 	availableModels?: string[];
 	supportsVision: boolean;
 	/**

--- a/plugins/usketch-plugin-tool-openui/src/providers/types.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Image input for vision-capable providers (e.g. used by the "Make Real" flow
+ * which snapshots the canvas selection and feeds it to a multimodal model).
+ */
+export interface VisionInput {
+	/** `data:image/png;base64,…` style URL preferred. Remote `https://` URLs also work for OpenAI. */
+	imageDataUrl: string;
+	width?: number;
+	height?: number;
+}
+
+export interface GenerateOptions {
+	/** When `true`, return token-by-token deltas. When `false`, yield one chunk. Defaults to `true`. */
+	stream?: boolean;
+	model?: string;
+	vision?: VisionInput;
+	/** Caller-controlled abort signal so the side-panel "Cancel" button can interrupt. */
+	signal?: AbortSignal;
+	/** Override the system prompt for this single request. */
+	systemPrompt?: string;
+}
+
+export type ProviderId = "openai" | "openai-compatible";
+
+/**
+ * Provider abstraction. All implementations expose a single async-iterable
+ * `generate()` so the calling code is uniform regardless of streaming mode.
+ */
+export interface OpenUIProvider {
+	id: ProviderId;
+	/** Display label (used in the side-panel model selector). */
+	label: string;
+	defaultModel: string;
+	/** Optional list of additional model names to expose in the UI selector. */
+	availableModels?: string[];
+	supportsVision: boolean;
+	/**
+	 * Generate text deltas (OpenUI Lang source) for a user prompt. Always
+	 * returns an async iterable, even for non-streaming providers (which
+	 * yield a single chunk with the full response).
+	 */
+	generate(prompt: string, options: GenerateOptions): AsyncIterable<string>;
+}

--- a/plugins/usketch-plugin-tool-openui/src/system-prompt.ts
+++ b/plugins/usketch-plugin-tool-openui/src/system-prompt.ts
@@ -1,0 +1,25 @@
+import type { Library } from "@openuidev/react-lang";
+import { openuiDefaultLibrary } from "./default-library.js";
+
+/**
+ * Build the system prompt for OpenUI Lang generation. Delegates to the
+ * library's own `prompt()` builder, which injects the component grammar,
+ * Zod schema-derived prop docs, and reserved keywords automatically.
+ *
+ * Adding rules here is preferred over overriding the whole prompt because
+ * the library-generated parts must stay in sync with the active component
+ * set — drift causes the LLM to emit components the Renderer rejects.
+ */
+export function buildSystemPrompt(library: Library = openuiDefaultLibrary): string {
+	return library.prompt({
+		preamble:
+			"You are a UI engineer building widget previews for a digital whiteboard. " +
+			"Generate one self-contained widget per request — a single root component with sensible defaults.",
+		additionalRules: [
+			"- Output OpenUI Lang only. No prose, no markdown fences.",
+			"- Prefer concrete copy and realistic placeholder content over Lorem Ipsum.",
+			"- If a reference image is supplied, reproduce its structure, content, and color palette faithfully.",
+			"- Default to compact widgets that fit comfortably in a 480x360 canvas card.",
+		],
+	});
+}

--- a/plugins/usketch-plugin-tool-openui/src/types.ts
+++ b/plugins/usketch-plugin-tool-openui/src/types.ts
@@ -1,0 +1,40 @@
+import type { Library } from "@openuidev/react-lang";
+import type { OpenUIProvider } from "./providers/types.js";
+
+/**
+ * Options for {@link createOpenUIToolPlugin}.
+ *
+ * The plugin connects the host to an LLM provider, registers a toolbar tool
+ * plus a side-panel tab for prompt input, and (optionally) a "Make Real"
+ * button anchored to the current selection.
+ */
+export interface OpenUIToolOptions {
+	/** Concrete provider (created via one of the `createXxxProvider` helpers). */
+	provider: OpenUIProvider;
+	/**
+	 * Override the default component library that defines what UI primitives
+	 * the LLM is allowed to emit. Pass `createLibrary([...])` from
+	 * `@openuidev/react-lang`. When omitted, the plugin uses its bundled
+	 * default library (~12 generic components).
+	 */
+	library?: Library;
+	/** Identifier persisted alongside generated shapes. Defaults to `"openui-default"`. */
+	libraryId?: string;
+	/** Override the provider's default model. */
+	model?: string;
+	/**
+	 * Show the "Make Real" button on the current selection. Requires the
+	 * provider to support vision input. Defaults to `provider.supportsVision`.
+	 */
+	enableMakeReal?: boolean;
+	/** Replace the generated system prompt with a custom one. Advanced. */
+	systemPrompt?: string;
+	/** Hard timeout for in-flight generation, in milliseconds. Defaults to 60_000. */
+	timeoutMs?: number;
+}
+
+/** Payload of the internal `openui:generate-request` event. */
+export interface OpenUIGenerateRequest {
+	prompt: string;
+	vision?: { imageDataUrl: string; width?: number; height?: number };
+}

--- a/plugins/usketch-plugin-tool-openui/src/types.ts
+++ b/plugins/usketch-plugin-tool-openui/src/types.ts
@@ -31,6 +31,14 @@ export interface OpenUIToolOptions {
 	systemPrompt?: string;
 	/** Hard timeout for in-flight generation, in milliseconds. Defaults to 60_000. */
 	timeoutMs?: number;
+	/**
+	 * Whether to request streaming responses. Defaults to `true`. Set to
+	 * `false` for OpenAI-compatible endpoints that don't implement SSE
+	 * (some local LLM proxies). When streaming yields zero deltas, the
+	 * plugin retries once with `stream: false` automatically regardless of
+	 * this setting.
+	 */
+	stream?: boolean;
 }
 
 /** Payload of the internal `openui:generate-request` event. */

--- a/plugins/usketch-plugin-tool-openui/tsconfig.json
+++ b/plugins/usketch-plugin-tool-openui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,7 +1622,7 @@ importers:
         specifier: 19.2.4
         version: 19.2.4
       zod:
-        specifier: '>=3.25.0'
+        specifier: ^4.0.0 || >=3.25.0 <4.0.0
         version: 3.25.76
     devDependencies:
       '@types/react':
@@ -1884,7 +1884,7 @@ importers:
         specifier: 19.2.4
         version: 19.2.4
       zod:
-        specifier: '>=3.25.0'
+        specifier: ^4.0.0 || >=3.25.0 <4.0.0
         version: 3.25.76
     devDependencies:
       '@types/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,7 +1622,7 @@ importers:
         specifier: 19.2.4
         version: 19.2.4
       zod:
-        specifier: ^3.25.0 || ^4.0.0
+        specifier: '>=3.25.0'
         version: 3.25.76
     devDependencies:
       '@types/react':
@@ -1884,7 +1884,7 @@ importers:
         specifier: 19.2.4
         version: 19.2.4
       zod:
-        specifier: ^3.25.0 || ^4.0.0
+        specifier: '>=3.25.0'
         version: 3.25.76
     devDependencies:
       '@types/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@edv4h/usketch-plugin-shape-island':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-island
+      '@edv4h/usketch-plugin-shape-openui':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-shape-openui
       '@edv4h/usketch-plugin-shape-sticky':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-sticky
@@ -330,6 +333,9 @@ importers:
       '@edv4h/usketch-plugin-sync-ywebsocket':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-sync-ywebsocket
+      '@edv4h/usketch-plugin-tool-openui':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-tool-openui
       '@edv4h/usketch-plugin-tool-pan':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-tool-pan
@@ -1840,6 +1846,46 @@ importers:
       yjs:
         specifier: ^13.6.0
         version: 13.6.30
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  plugins/usketch-plugin-tool-openui:
+    dependencies:
+      '@edv4h/usketch-canvas-engine':
+        specifier: workspace:*
+        version: link:../../packages/canvas-engine
+      '@edv4h/usketch-plugin-export':
+        specifier: workspace:*
+        version: link:../usketch-plugin-export
+      '@edv4h/usketch-plugin-shape-openui':
+        specifier: workspace:*
+        version: link:../usketch-plugin-shape-openui
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@modelcontextprotocol/sdk':
+        specifier: '>=1.0.0'
+        version: 1.27.1(zod@3.25.76)
+      '@openuidev/react-lang':
+        specifier: 0.2.5
+        version: 0.2.5(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react@19.2.4)(zod@3.25.76)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      zod:
+        specifier: ^3.25.0 || ^4.0.0
+        version: 3.25.76
     devDependencies:
       '@types/react':
         specifier: 19.2.14
@@ -6566,7 +6612,7 @@ packages:
       zod: ^3
 
   zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==, tarball: https://registry.npmjs.org/zod/-/zod-3.25.76.tgz}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1601,6 +1601,34 @@ importers:
         specifier: 3.2.4
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  plugins/usketch-plugin-shape-openui:
+    dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@modelcontextprotocol/sdk':
+        specifier: '>=1.0.0'
+        version: 1.27.1(zod@3.25.76)
+      '@openuidev/react-lang':
+        specifier: 0.2.5
+        version: 0.2.5(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react@19.2.4)(zod@3.25.76)
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+      zod:
+        specifier: ^3.25.0 || ^4.0.0
+        version: 3.25.76
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
+
   plugins/usketch-plugin-shape-sticky:
     dependencies:
       '@edv4h/usketch-core':
@@ -2960,7 +2988,7 @@ packages:
     resolution: {integrity: sha512-ULgJLBVJEBIKBddVFla4PiOCHM4a7wjThS9FtMbmc9YehcYmnuMtF8/mi9ItZobHpQGwChzF/7ujoUTs+cYbZw==, tarball: https://registry.npmjs.org/@fontsource/ibm-plex-sans-jp/-/ibm-plex-sans-jp-5.2.8.tgz}
 
   '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==, tarball: https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -3167,7 +3195,7 @@ packages:
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==, tarball: https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz}
 
   '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==, tarball: https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -3198,6 +3226,25 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==, tarball: https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz}
     engines: {node: '>= 8'}
+
+  '@openuidev/lang-core@0.2.5':
+    resolution: {integrity: sha512-cL01txOXWeDdOJY83F8R0QR7F1FPEsuUFft/8uRYiaN8LozKySNonc1g5nhreYKjcQ2YvvyvwHZn/AQZCaFtDQ==, tarball: https://registry.npmjs.org/@openuidev/lang-core/-/lang-core-0.2.5.tgz}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.0.0'
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@openuidev/react-lang@0.2.5':
+    resolution: {integrity: sha512-OImhBXUQoIOlHEGc308e0BaJGVHrEA6qWv76xqc71sSQUoaWjn0zhCaGA8qcXGhqYVak4bzIbLikgO+L0Kf3tQ==, tarball: https://registry.npmjs.org/@openuidev/react-lang/-/react-lang-0.2.5.tgz}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.0.0'
+      react: 19.2.4
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -3782,7 +3829,7 @@ packages:
     resolution: {integrity: sha512-2k3KME2WXRqqR8MRi09UWExcaZx8Y1050fGYxqL4KfOZaXPDNMfiQChEAMU9atdudnzx//HcxEl/orZU8G+qFg==}
 
   accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==, tarball: https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz}
     engines: {node: '>= 0.6'}
 
   acorn-jsx@5.3.2:
@@ -3804,7 +3851,7 @@ packages:
         optional: true
 
   ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==, tarball: https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -3812,7 +3859,7 @@ packages:
         optional: true
 
   ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==, tarball: https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -3985,7 +4032,7 @@ packages:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==, tarball: https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz}
     engines: {node: '>=18'}
 
   boolbase@1.0.0:
@@ -4020,7 +4067,7 @@ packages:
     engines: {node: '>=18'}
 
   bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==, tarball: https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz}
     engines: {node: '>= 0.8'}
 
   cac@6.7.14:
@@ -4028,11 +4075,11 @@ packages:
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==, tarball: https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==, tarball: https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz}
     engines: {node: '>= 0.4'}
 
   camelcase@8.0.0:
@@ -4138,11 +4185,11 @@ packages:
     engines: {node: '> 0.10'}
 
   content-disposition@1.0.1:
-    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==, tarball: https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz}
     engines: {node: '>=18'}
 
   content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==, tarball: https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz}
     engines: {node: '>= 0.6'}
 
   convert-source-map@2.0.0:
@@ -4152,11 +4199,11 @@ packages:
     resolution: {integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==}
 
   cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==, tarball: https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz}
     engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==, tarball: https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz}
     engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
@@ -4164,11 +4211,11 @@ packages:
     engines: {node: '>=18'}
 
   cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==, tarball: https://registry.npmjs.org/cors/-/cors-2.8.6.tgz}
     engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==, tarball: https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz}
     engines: {node: '>= 8'}
 
   crossws@0.3.5:
@@ -4257,7 +4304,7 @@ packages:
     engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==, tarball: https://registry.npmjs.org/depd/-/depd-2.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
@@ -4413,14 +4460,14 @@ packages:
     engines: {node: '>=4'}
 
   dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==, tarball: https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   easy-table@1.1.0:
     resolution: {integrity: sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==}
 
   ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==, tarball: https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz}
 
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
@@ -4439,7 +4486,7 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==, tarball: https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   enquirer@2.4.1:
@@ -4458,18 +4505,18 @@ packages:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==, tarball: https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==, tarball: https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==, tarball: https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz}
     engines: {node: '>= 0.4'}
 
   es-set-tostringtag@2.1.0:
@@ -4507,7 +4554,7 @@ packages:
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==, tarball: https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==, tarball: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz}
@@ -4543,18 +4590,18 @@ packages:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==, tarball: https://registry.npmjs.org/etag/-/etag-1.8.1.tgz}
     engines: {node: '>= 0.6'}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==, tarball: https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==, tarball: https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz}
     engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
@@ -4562,13 +4609,13 @@ packages:
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.1:
-    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
+    resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==, tarball: https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
 
   express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==, tarball: https://registry.npmjs.org/express/-/express-5.2.1.tgz}
     engines: {node: '>= 18'}
 
   extend@3.0.2:
@@ -4582,14 +4629,14 @@ packages:
     engines: {node: '>=18'}
 
   fast-deep-equal@3.1.3:
-    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==, tarball: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==, tarball: https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz}
     engines: {node: '>=8.6.0'}
 
   fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==, tarball: https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==, tarball: https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz}
@@ -4611,7 +4658,7 @@ packages:
     engines: {node: '>=8'}
 
   finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==, tarball: https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz}
     engines: {node: '>= 18.0.0'}
 
   find-up@4.1.0:
@@ -4643,7 +4690,7 @@ packages:
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==, tarball: https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz}
     engines: {node: '>= 0.6'}
 
   fractional-indexing@3.2.0:
@@ -4651,7 +4698,7 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
 
   fresh@2.0.0:
-    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==, tarball: https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   fs-extra@7.0.1:
@@ -4673,7 +4720,7 @@ packages:
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==, tarball: https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -4688,7 +4735,7 @@ packages:
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==, tarball: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz}
     engines: {node: '>= 0.4'}
 
   get-nonce@1.0.1:
@@ -4696,7 +4743,7 @@ packages:
     engines: {node: '>=6'}
 
   get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==, tarball: https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   get-tsconfig@4.13.6:
@@ -4718,7 +4765,7 @@ packages:
     engines: {node: '>=10'}
 
   gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==, tarball: https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
@@ -4728,7 +4775,7 @@ packages:
     resolution: {integrity: sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==}
 
   has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==, tarball: https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz}
     engines: {node: '>= 0.4'}
 
   has-tostringtag@1.0.2:
@@ -4736,7 +4783,7 @@ packages:
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==, tarball: https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz}
     engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
@@ -4785,10 +4832,6 @@ packages:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
 
-  hono@4.12.8:
-    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
-    engines: {node: '>=16.9.0'}
-
   hono@4.12.9:
     resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
     engines: {node: '>=16.9.0'}
@@ -4803,7 +4846,7 @@ packages:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
   http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==, tarball: https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz}
     engines: {node: '>= 0.8'}
 
   human-id@4.1.3:
@@ -4811,7 +4854,7 @@ packages:
     hasBin: true
 
   iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==, tarball: https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -4822,17 +4865,17 @@ packages:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, tarball: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==, tarball: https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz}
 
   ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==, tarball: https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==, tarball: https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz}
     engines: {node: '>= 0.10'}
 
   iron-webcrypto@1.2.1:
@@ -4885,7 +4928,7 @@ packages:
     engines: {node: '>=12'}
 
   is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==, tarball: https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==, tarball: https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz}
@@ -4900,13 +4943,13 @@ packages:
     engines: {node: '>=16'}
 
   isexe@2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==, tarball: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz}
 
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
   jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==, tarball: https://registry.npmjs.org/jose/-/jose-6.2.2.tgz}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz}
@@ -4928,10 +4971,10 @@ packages:
     hasBin: true
 
   json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz}
 
   json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==, tarball: https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -5001,7 +5044,7 @@ packages:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==, tarball: https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz}
 
   math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==, tarball: https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz}
     engines: {node: '>= 0.4'}
 
   mdast-util-definitions@6.0.0:
@@ -5062,14 +5105,14 @@ packages:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==, tarball: https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz}
     engines: {node: '>= 0.8'}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==, tarball: https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz}
 
   merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==, tarball: https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz}
     engines: {node: '>=18'}
 
   merge2@1.4.1:
@@ -5186,19 +5229,19 @@ packages:
     engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==, tarball: https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz}
     engines: {node: '>= 0.6'}
 
   mime-db@1.54.0:
-    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==, tarball: https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==, tarball: https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==, tarball: https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz}
     engines: {node: '>=18'}
 
   miniflare@4.20260317.1:
@@ -5272,7 +5315,7 @@ packages:
     engines: {node: ^20.0.0 || >=22.0.0}
 
   negotiator@1.0.0:
-    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==, tarball: https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz}
     engines: {node: '>= 0.6'}
 
   neotraverse@0.6.18:
@@ -5299,11 +5342,11 @@ packages:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==, tarball: https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz}
     engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==, tarball: https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz}
     engines: {node: '>= 0.4'}
 
   ofetch@1.5.1:
@@ -5313,11 +5356,11 @@ packages:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==, tarball: https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==, tarball: https://registry.npmjs.org/once/-/once-1.4.0.tgz}
 
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
@@ -5389,7 +5432,7 @@ packages:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==, tarball: https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz}
     engines: {node: '>= 0.8'}
 
   path-browserify@1.0.1:
@@ -5400,7 +5443,7 @@ packages:
     engines: {node: '>=8'}
 
   path-key@3.1.1:
-    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==, tarball: https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz}
     engines: {node: '>=8'}
 
   path-scurry@2.0.2:
@@ -5411,7 +5454,7 @@ packages:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==, tarball: https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==, tarball: https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz}
@@ -5443,7 +5486,7 @@ packages:
     engines: {node: '>=6'}
 
   pkce-challenge@5.0.1:
-    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==, tarball: https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz}
     engines: {node: '>=16.20.0'}
 
   playwright-core@1.58.2:
@@ -5489,7 +5532,7 @@ packages:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==, tarball: https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz}
     engines: {node: '>= 0.10'}
 
   proxy-compare@3.0.1:
@@ -5503,7 +5546,7 @@ packages:
     engines: {node: '>=6'}
 
   qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==, tarball: https://registry.npmjs.org/qs/-/qs-6.15.0.tgz}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -5516,11 +5559,11 @@ packages:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
   range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==, tarball: https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz}
     engines: {node: '>= 0.6'}
 
   raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==, tarball: https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz}
     engines: {node: '>= 0.10'}
 
   react-dom@19.2.4:
@@ -5662,7 +5705,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==, tarball: https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz}
     engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
@@ -5702,7 +5745,7 @@ packages:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
   router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==, tarball: https://registry.npmjs.org/router/-/router-2.2.0.tgz}
     engines: {node: '>= 18'}
 
   run-applescript@7.1.0:
@@ -5713,7 +5756,7 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==, tarball: https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz}
 
   safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==, tarball: https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz}
 
   satori@0.26.0:
     resolution: {integrity: sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==}
@@ -5736,11 +5779,11 @@ packages:
     hasBin: true
 
   send@1.2.1:
-    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==, tarball: https://registry.npmjs.org/send/-/send-1.2.1.tgz}
     engines: {node: '>= 18'}
 
   serve-static@2.2.1:
-    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==, tarball: https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz}
     engines: {node: '>= 18'}
 
   set-cookie-parser@2.7.2:
@@ -5750,37 +5793,37 @@ packages:
     resolution: {integrity: sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==}
 
   setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==, tarball: https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==, tarball: https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz}
     engines: {node: '>=8'}
 
   shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==, tarball: https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz}
     engines: {node: '>=8'}
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==, tarball: https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==, tarball: https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz}
     engines: {node: '>= 0.4'}
 
   side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==, tarball: https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz}
     engines: {node: '>= 0.4'}
 
   side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==, tarball: https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -5832,7 +5875,7 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==, tarball: https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz}
 
   statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==, tarball: https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz}
     engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
@@ -5920,7 +5963,7 @@ packages:
     engines: {node: '>=8.0'}
 
   toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==, tarball: https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz}
     engines: {node: '>=0.6'}
 
   tr46@5.1.1:
@@ -5964,7 +6007,7 @@ packages:
     engines: {node: '>=16'}
 
   type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==, tarball: https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz}
     engines: {node: '>= 0.6'}
 
   typesafe-path@0.2.2:
@@ -6041,7 +6084,7 @@ packages:
     engines: {node: '>= 4.0.0'}
 
   unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==, tarball: https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz}
     engines: {node: '>= 0.8'}
 
   unstorage@1.17.4:
@@ -6133,7 +6176,7 @@ packages:
         optional: true
 
   vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==, tarball: https://registry.npmjs.org/vary/-/vary-1.1.2.tgz}
     engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
@@ -6377,7 +6420,7 @@ packages:
     engines: {node: '>=4'}
 
   which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==, tarball: https://registry.npmjs.org/which/-/which-2.0.2.tgz}
     engines: {node: '>= 8'}
     hasBin: true
 
@@ -6414,7 +6457,7 @@ packages:
     engines: {node: '>=18'}
 
   wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==, tarball: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz}
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
@@ -6512,7 +6555,7 @@ packages:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==, tarball: https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz}
     peerDependencies:
       zod: ^3.25 || ^4
 
@@ -7384,9 +7427,9 @@ snapshots:
 
   '@fontsource/ibm-plex-sans-jp@5.2.8': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.8)':
+  '@hono/node-server@1.19.11(hono@4.12.9)':
     dependencies:
-      hono: 4.12.8
+      hono: 4.12.9
 
   '@hono/zod-validator@0.7.6(hono@4.12.9)(zod@4.3.6)':
     dependencies:
@@ -7578,7 +7621,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.8)
+      '@hono/node-server': 1.19.11(hono@4.12.9)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -7588,7 +7631,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.8
+      hono: 4.12.9
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7617,6 +7660,20 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@openuidev/lang-core@0.2.5(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+
+  '@openuidev/react-lang@0.2.5(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(react@19.2.4)(zod@3.25.76)':
+    dependencies:
+      '@openuidev/lang-core': 0.2.5(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))(zod@3.25.76)
+      react: 19.2.4
+      zod: 3.25.76
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -9304,8 +9361,6 @@ snapshots:
       space-separated-tokens: 2.0.2
 
   hex-rgb@4.3.0: {}
-
-  hono@4.12.8: {}
 
   hono@4.12.9: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,12 @@ packages:
 
 onlyBuiltDependencies:
   - "@j178/prek"
+
+# @openuidev/* (thesysdev) is on a rapid 0.x cadence (new minors every few days).
+# The global ~/.npmrc default `min-release-age` blocks installation of those
+# fresh versions. Bypass the gate for this scope so the OpenUI shape plugin
+# can pin to a verified release. Re-evaluate when @openuidev hits 1.0.
+minimumReleaseAgeExclude:
+  - "@openuidev/react-lang"
+  - "@openuidev/react-headless"
+  - "@openuidev/lang-core"


### PR DESCRIPTION
## Summary

[OpenUI](https://www.openui.com/) (thesysdev / Thesys Inc., MIT) ベースの Generative UI ウィジェットプラグインを 2 つ追加。自然言語 prompt から OpenUI Lang を生成し、Zod schema 駆動の component library 経由で **first-class shape として canvas に配置**します。tldraw "Make Real" の uSketch 版で、Tailwind HTML + iframe ではなく OpenUI Lang + Renderer 直接マウントで実装。

### 新規パッケージ

- **\`@edv4h/usketch-plugin-shape-openui\`** — \`openui\` shape を \`@openuidev/react-lang\` の \`<Renderer>\` でマウント。library Zod schema が validator なので任意 HTML / script の混入経路なし。
- **\`@edv4h/usketch-plugin-tool-openui\`** — toolbar tool + side-panel prompt UI + 選択上の "Make Real" ボタン + 2 つの provider (OpenAI 直接、OpenAI 互換)。

### 主な設計判断

| 論点 | 採用 |
| --- | --- |
| OpenUI 実装 | **thesysdev/openui** (www.openui.com 本家、MIT)。wandb/openui ではない |
| Shape render | \`<Renderer />\` を直接マウント (iframe 不要) |
| LLM 呼び出し | plugin が自前 fetch + SSE 自前パース (\`@openuidev/react-headless\` の ChatProvider は使わない) |
| Provider | OpenAI 直接 + OpenAI 互換 endpoint (Azure / Ollama / LiteLLM / OpenUI server)。**Anthropic は v1 未対応** (browser CORS) |
| Make Real | \`@edv4h/usketch-plugin-export\` の \`exportCanvas\` で PNG snapshot → vision provider |
| Library scope | 12 汎用 component (Stack / Heading / Text / Card / Button / Input / Badge / Avatar / Image / List / Row / Spacer) をデフォルト同梱、host が \`defineComponent\` + \`createLibrary\` で override 可 |

### apps/web 統合

デフォルト provider は \`http://localhost:7878/v1\` の OpenUI セルフホストサーバ。\`VITE_OPENUI_PROVIDER=openai\` + \`VITE_OPENAI_API_KEY\` で OpenAI 直叩きに切替可能。\`VITE_OPENUI_BASE_URL\` で任意 OpenAI 互換 endpoint へ切替。

### Tests

- **shape-openui**: 16 unit tests (8 sanitize + 8 shape contract)
- **tool-openui**: 5 provider unit tests (request shape / vision payload / SSE accumulation / 4xx error mapping / non-streaming fallback)

### Pnpm workspace 設定

\`@openuidev/*\` (0.x rapid cadence) はグローバル \`min-release-age=5d\` でブロックされるため、\`pnpm-workspace.yaml\` に \`minimumReleaseAgeExclude\` を追加 (shape-openui PR の commit \`810d84a3\` 時点)。

## Experimental note

\`@openuidev/react-lang\` 0.2.5 / \`@openuidev/lang-core\` 0.2.5 を pin 依存。0.x の間は minor が頻繁に変わるため、本プラグインも \`0.1.0\` で同レーンに乗せる。1.0 到達時に再評価。

## Test plan

- [x] \`pnpm --filter @edv4h/usketch-plugin-shape-openui typecheck && test && build\`
- [x] \`pnpm --filter @edv4h/usketch-plugin-tool-openui typecheck && test && build\`
- [x] \`pnpm --filter @edv4h/usketch-web typecheck && build\` (apps/web 統合)
- [x] \`pnpm --filter @edv4h/usketch-docs build\` (en + ja guide 含む)
- [x] \`pnpm biome check .\` (新規 file は clean、既存 warnings は触らず)
- [ ] 手動: OpenAI API key で prompt → shape 生成
- [ ] 手動: sketch 選択 → Make Real → vision request → 右側に shape
- [ ] 手動: API key 未設定 → 401 error event → guide 案内

## Follow-ups (out of scope)

1. Anthropic provider (server-side proxy 経由)
2. Iterative edit (既存 openui shape を refine)
3. OpenUI Action() 統合 (button click → uSketch event)
4. Progressive streaming render (canvas 上で partial Lang を ghost shape に)

🤖 Generated with [Claude Code](https://claude.com/claude-code)