### PR TITLE
✨ feat(openui): server-proxy provider で本番デプロイ対応

### DIFF
--- a/.changeset/openui-server-proxy.md
+++ b/.changeset/openui-server-proxy.md
@@ -1,0 +1,11 @@
+---
+"@edv4h/usketch-plugin-tool-openui": minor
+"@edv4h/usketch-plugin-server-ai": minor
+---
+
+OpenUI: make production-deployable via a server-side proxy.
+
+- `@edv4h/usketch-plugin-tool-openui` adds `createServerProxyProvider`, which routes LLM calls through your own `/api/ai/openui` endpoint with cookie-based auth (`credentials: "include"`). The existing OpenAI-compatible provider also gains an opt-in `credentials` option.
+- `@edv4h/usketch-plugin-server-ai` adds `registerOpenUIRoute` (mounted at `POST /api/ai/openui`), an OpenAI-compatible Chat Completions proxy that reuses the worker's `OPENAI_API_KEY` secret, enforces board access control when `?boardId=...` is supplied, and streams SSE pass-through.
+
+`apps/web` now uses `createServerProxyProvider` exclusively, so the OpenAI API key no longer ships in the browser bundle.

--- a/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs-ja/guides/openui-generative-ui.mdx
@@ -21,25 +21,18 @@ UX は tldraw の "Make Real" と同じ流儀ですが、生 Tailwind HTML で�
 pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
 ```
 
-`apps/web` のデフォルト provider は `http://localhost:7878/v1` の OpenAI 互換 Chat Completions endpoint を叩きます。任意の互換サーバが使えます — Ollama、LiteLLM、vLLM、自前の LLM proxy、あるいは手早くコンテナを立てたいなら [wandb/openui](https://github.com/wandb/openui) sandbox も選択肢:
+`apps/web` の OpenUI 呼び出しは `/api/ai/openui` のサーバ側プロキシ (`@edv4h/usketch-plugin-server-ai` 提供) を経由します。OpenAI API key は Workers Secret にのみ保管され、ブラウザ bundle には絶対に含まれません。
 
-```bash
-# 任意: 汎用 OpenAI 互換 Docker (wandb/openui はあくまで一例。
-# 独自 model server に置き換えてください)
-docker run -p 7878:7878 -e OPENAI_API_KEY=sk-... ghcr.io/wandb/openui:latest
-```
+build 時に設定できる env var は任意で 1 つ:
 
-ローカルサーバを使わず OpenAI を直接叩く場合:
+- `VITE_OPENUI_MODEL` — model 名のデフォルト。未指定で `gpt-4o`
 
-```env
-VITE_OPENUI_PROVIDER=openai
-VITE_OPENAI_API_KEY=sk-...
-```
+> **本番安全策:** Cloudflare Pages の build env vars に `VITE_OPENAI_API_KEY` / `VITE_OPENUI_BASE_URL` / `VITE_OPENUI_PROVIDER` を**設定しないでください**。現在のコードはこれらを参照しませんが、Vite の `import.meta.env` の性質上、過去設定が残っていると将来再導入された際に漏洩する経路になり得ます。API key はサーバ側の `OPENAI_API_KEY` Workers Secret にのみ置きます。
 
-その他の env vars (`apps/web` が読む):
+### デプロイ手順
 
-- `VITE_OPENUI_BASE_URL` — OpenAI 互換 endpoint を上書き (Azure, Ollama, LiteLLM, …)
-- `VITE_OPENUI_MODEL` — model 名を指定。default `gpt-4o`
+1. **Server** (Cloudflare Workers): `OPENAI_API_KEY` を secret として設定 (`wrangler secret put OPENAI_API_KEY` — `/api/ai/complete` で既に必要)。OpenUI route は同じ secret を再利用します。
+2. **Web** (Cloudflare Pages): `VITE_API_URL` を worker URL に設定。任意で `VITE_OPENUI_MODEL`。切替時は **サーバを先にデプロイ** してください。route 未着の古い worker に新 web が当たると 404 になります。
 
 ## createApp への組み込み
 
@@ -48,8 +41,8 @@ import { createApp } from "@edv4h/usketch-core";
 import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
 import { openUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
 import {
-	createOpenAIProvider,
 	createOpenUIToolPlugin,
+	createServerProxyProvider,
 } from "@edv4h/usketch-plugin-tool-openui";
 
 const app = await createApp({
@@ -59,7 +52,11 @@ const app = await createApp({
 		createSidePanelPlugin(),
 		openUIShapePlugin,
 		createOpenUIToolPlugin({
-			provider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY! }),
+			provider: createServerProxyProvider({
+				apiUrl: import.meta.env.VITE_API_URL,
+				boardId,
+				// extraHeaders: { "X-User-Id": "dev-user" }, // dev のみ bypass
+			}),
 		}),
 	],
 });
@@ -111,34 +108,47 @@ system prompt は毎リクエスト時に `library.prompt(...)` から再生成�
 
 ```ts
 import {
+	createServerProxyProvider,
 	createOpenAIProvider,
 	createOpenAICompatibleProvider,
 } from "@edv4h/usketch-plugin-tool-openui";
 
-// OpenAI を直接叩く:
-createOpenAIProvider({ apiKey: "sk-..." });
+// 本番安全: 自前サーバプロキシ経由 (推奨)
+createServerProxyProvider({
+	apiUrl: "https://api.usketch.app",
+	boardId: "board-abc",
+});
 
-// OpenAI 互換 endpoint (Ollama / vLLM / LiteLLM / Azure / OpenUI server / …):
+// サードパーティ host で独自バックエンドを持つ場合は OpenAI 直接接続もできるが、
+// ブラウザ bundle に本物の API key を焼き込んではいけない:
+createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY! });
+
+// OpenAI 互換 endpoint (Ollama / vLLM / LiteLLM / Azure / …):
 createOpenAICompatibleProvider({
 	baseURL: "http://localhost:11434/v1", // Ollama
 	defaultModel: "llama3.2:vision",
 });
 ```
 
-Anthropic 直接接続は v1 ではサポートしません — browser CORS + クライアント側 API key 露出のトレードオフから、server-side proxy 経由が望ましいためです。必要であれば follow-up issue を立ててください。
+`createOpenAIProvider` / `createOpenAICompatibleProvider` は third-party host 向けに引き続き export していますが、本リポジトリの `apps/web` ではどちらも `createServerProxyProvider` に置き換え済みです。
+
+Anthropic 直接接続は v1 ではサポートしません — server-side proxy で SSE を正規化する形が想定されています。必要であれば follow-up issue を立ててください。
 
 ## セキュリティモデル
 
 - `@openuidev/react-lang` の `<Renderer>` は parse した statement を library の Zod schema に対して validate します。library にない component / prop は render 前に拒否されるため、`dangerouslySetInnerHTML` も script 実行経路も存在しません。
-- API key は host option (`createOpenAIProvider({ apiKey })`) 経由で渡します。プラグインが直接 env vars を読むことはありません。
-- Make Real の vision request は canvas snapshot を base64 data URL として送信します。機密性の高い board では、識別情報を strip してから転送する server-side proxy をデプロイすることを推奨します。
+- デフォルトの `createServerProxyProvider` は OpenAI API key をブラウザ bundle に一切含めません。認証はセッション cookie (`credentials: "include"`) に依存します。dev モードの `X-User-Id` ヘッダは bypass であり本番では使えません。
+- サーバ route は `boardId` 指定時に board アクセス制御を行います (メンバーシップまたは `isPublic`)。
+- Make Real の vision request は canvas snapshot を最大 10 MB の base64 data URL として送信し、サーバ route が転送前にサイズを検証します。機密性の高い board では、転送前に識別情報を strip する middleware の追加を検討してください。
 
 ## トラブルシューティング
 
 | 症状 | 原因 |
 | --- | --- |
 | Shape が "OpenUI library not configured" の fallback で表示される | `createOpenUIToolPlugin` (または `setOpenUILibrary` を呼ぶ host コード) が `createApp({ plugins })` に登録されていない。plugin の順序は関係ない (`createApp` は全 plugin の `setup()` を終えてから canvas を描画する) が、library を渡す caller が居ないと shape は fallback を表示する |
-| `OpenUI provider 401:` | API key が未設定または不正。`VITE_OPENAI_API_KEY` を設定するか、provider factory に `apiKey` を渡す |
+| `OpenUI provider 401:` | セッション cookie が無効・期限切れ。サインインし直す。dev では `extraHeaders` で `X-User-Id` を渡す |
+| `OpenUI provider 404:` | 指定した `boardId` のメンバーではなく、board が非公開。`boardId` を外すか board を共有する |
+| `OpenUI provider 502:` | サーバプロキシが OpenAI に到達できない。worker のログと `OPENAI_API_KEY` Workers Secret 設定を確認 |
 | `Empty response from model` | LLM が fence や prose だけ返した。プラグインは典型的な artifact を除去するが、それでも発生する場合は prompt を refine するか強い model を選ぶ |
 | `done` 後も shape が空に見える | LLM が library にない component を出力した。browser console を確認 — `Renderer error:` で拒否された statement が出る |
 

--- a/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
+++ b/apps/docs/src/content/docs/guides/openui-generative-ui.mdx
@@ -21,25 +21,18 @@ Both plugins ship with the monorepo and are wired into `apps/web` for cloud boar
 pnpm add @edv4h/usketch-plugin-shape-openui @edv4h/usketch-plugin-tool-openui
 ```
 
-The default provider in `apps/web` talks to an OpenAI-compatible Chat Completions endpoint at `http://localhost:7878/v1`. Any compatible server works — Ollama, LiteLLM, vLLM, a local LLM proxy, or even the [wandb/openui](https://github.com/wandb/openui) sandbox if you want a quick container:
+In `apps/web`, OpenUI LLM calls go through the server-side proxy at `/api/ai/openui` (provided by `@edv4h/usketch-plugin-server-ai`). The OpenAI API key lives only in the server's Workers Secret store — it never ships in the browser bundle.
 
-```bash
-# Optional: a generic OpenAI-compatible Docker (wandb/openui is one option;
-# substitute your own model server)
-docker run -p 7878:7878 -e OPENAI_API_KEY=sk-... ghcr.io/wandb/openui:latest
-```
+The only build-time env var you can optionally set:
 
-Or skip the local server entirely and point directly at OpenAI:
+- `VITE_OPENUI_MODEL` — pick a default model name. Defaults to `gpt-4o`.
 
-```env
-VITE_OPENUI_PROVIDER=openai
-VITE_OPENAI_API_KEY=sk-...
-```
+> **Production safety:** Do **not** set `VITE_OPENAI_API_KEY`, `VITE_OPENUI_BASE_URL`, or `VITE_OPENUI_PROVIDER` in Cloudflare Pages build env vars. They are no longer read by the app, but historical configs may still leak via Vite's `import.meta.env` if you re-introduce them. The API key must only live in the server's `OPENAI_API_KEY` Workers Secret.
 
-Other useful env vars (`apps/web` reads these):
+### Deploying
 
-- `VITE_OPENUI_BASE_URL` — override the OpenAI-compatible endpoint (Azure, Ollama, LiteLLM, …).
-- `VITE_OPENUI_MODEL` — pick a model name. Defaults to `gpt-4o`.
+1. **Server** (Cloudflare Workers): make sure `OPENAI_API_KEY` is set as a secret (`wrangler secret put OPENAI_API_KEY` — already required by `/api/ai/complete`). The OpenUI route reuses the same secret.
+2. **Web** (Cloudflare Pages): set `VITE_API_URL` to your worker URL. Optionally set `VITE_OPENUI_MODEL`. Deploy the server **before** the web app on cutover — old web builds pointing at a worker without the route will see 404s.
 
 ## Wiring it into createApp
 
@@ -48,8 +41,8 @@ import { createApp } from "@edv4h/usketch-core";
 import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
 import { openUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
 import {
-	createOpenAIProvider,
 	createOpenUIToolPlugin,
+	createServerProxyProvider,
 } from "@edv4h/usketch-plugin-tool-openui";
 
 const app = await createApp({
@@ -59,7 +52,11 @@ const app = await createApp({
 		createSidePanelPlugin(),
 		openUIShapePlugin,
 		createOpenUIToolPlugin({
-			provider: createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY! }),
+			provider: createServerProxyProvider({
+				apiUrl: import.meta.env.VITE_API_URL,
+				boardId,
+				// extraHeaders: { "X-User-Id": "dev-user" }, // dev-mode bypass only
+			}),
 		}),
 	],
 });
@@ -111,34 +108,47 @@ The system prompt is regenerated from the library on every request via `library.
 
 ```ts
 import {
+	createServerProxyProvider,
 	createOpenAIProvider,
 	createOpenAICompatibleProvider,
 } from "@edv4h/usketch-plugin-tool-openui";
 
-// Direct OpenAI:
-createOpenAIProvider({ apiKey: "sk-..." });
+// Production-safe: route through your own server proxy (recommended).
+createServerProxyProvider({
+	apiUrl: "https://api.usketch.app",
+	boardId: "board-abc",
+});
 
-// Anything OpenAI-compatible (Ollama, vLLM, LiteLLM, Azure OpenAI, OpenUI server, …):
+// Third-party hosts that already have a server-side proxy can talk to OpenAI
+// directly — but never bake a real API key into a browser bundle:
+createOpenAIProvider({ apiKey: process.env.OPENAI_API_KEY! });
+
+// Anything OpenAI-compatible (Ollama, vLLM, LiteLLM, Azure OpenAI, …):
 createOpenAICompatibleProvider({
 	baseURL: "http://localhost:11434/v1",  // Ollama
 	defaultModel: "llama3.2:vision",
 });
 ```
 
-Anthropic is not directly supported in v1 — browser CORS plus key-in-client trade-offs make it best served via a server-side proxy. Track the follow-up issue if you need it.
+`createOpenAIProvider` and `createOpenAICompatibleProvider` remain exported for third-party hosts that have their own backend; in this repo's `apps/web`, both have been replaced by `createServerProxyProvider`.
+
+Anthropic is not directly supported in v1 — server-side proxying with a normalized SSE format is the planned approach. Track the follow-up issue if you need it.
 
 ## Security model
 
 - The `<Renderer>` from `@openuidev/react-lang` validates every parsed statement against the library's Zod schemas. Components or props the library doesn't declare are rejected before they render — there is no `dangerouslySetInnerHTML` and no script execution surface.
-- API keys are passed via host options (`createOpenAIProvider({ apiKey })`). The plugin never reads env vars directly.
-- Vision requests for Make Real send the canvas snapshot as a base64 data URL; for sensitive boards, deploy a server-side proxy that strips identifiers before forwarding.
+- The default `createServerProxyProvider` keeps the OpenAI API key out of the browser bundle entirely. Authentication relies on the session cookie (`credentials: "include"`); the dev-mode `X-User-Id` header is a bypass that should never be enabled in production.
+- The server route enforces board access control when a `boardId` is supplied (membership or `isPublic`).
+- Vision requests for Make Real send the canvas snapshot as a base64 data URL up to 10 MB; the server route validates the payload size before forwarding. For sensitive boards, deploy a middleware that strips identifiers before the proxy forwards to OpenAI.
 
 ## Troubleshooting
 
 | Symptom | Likely cause |
 | --- | --- |
 | Shape mounts as "OpenUI library not configured" fallback | `createOpenUIToolPlugin` (or another caller of `setOpenUILibrary`) is not registered in `createApp({ plugins })`. Plugin ordering doesn't matter — `createApp` finishes every plugin's `setup()` before the canvas paints — but if no caller wires up a library, the shape renders the fallback. |
-| `OpenUI provider 401:` | Missing or invalid API key. Set `VITE_OPENAI_API_KEY` or pass `apiKey` to the provider factory. |
+| `OpenUI provider 401:` | The session cookie is missing or expired. Sign in again. In dev, set the `X-User-Id` header through `extraHeaders`. |
+| `OpenUI provider 404:` | The user is not a member of the supplied `boardId`, and the board is private. Either omit `boardId` or share the board. |
+| `OpenUI provider 502:` | The server proxy was unable to reach OpenAI. Check the worker logs and that `OPENAI_API_KEY` is set as a Workers Secret. |
 | `Empty response from model` | The LLM returned only fences / prose. The plugin strips common artifacts; if it still triggers, refine the prompt or pick a stronger model. |
 | The shape renders empty even after `done` | The LLM emitted a component name the library doesn't define. Open the browser console — `Renderer error:` logs the rejected statement. |
 

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -41,9 +41,8 @@ import {
 	UnconfirmedOverlay,
 } from "@edv4h/usketch-plugin-sync-ywebsocket";
 import {
-	createOpenAICompatibleProvider,
-	createOpenAIProvider,
 	createOpenUIToolPlugin,
+	createServerProxyProvider,
 } from "@edv4h/usketch-plugin-tool-openui";
 import { panToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
 import { selectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
@@ -244,25 +243,16 @@ export function App() {
 			extraPlugins.push(createAiImagePlugin({ boardId }));
 			extraPlugins.push(createAiRecognizePlugin({ boardId }));
 
-			// OpenUI Generative UI (experimental). Defaults to a self-hosted OpenUI
-			// server at http://localhost:7878; set VITE_OPENUI_PROVIDER=openai +
-			// VITE_OPENAI_API_KEY to use OpenAI directly.
-			const openuiProviderName = import.meta.env.VITE_OPENUI_PROVIDER ?? "openui-server";
-			const openaiKey = import.meta.env.VITE_OPENAI_API_KEY;
-			const openuiBaseURL = import.meta.env.VITE_OPENUI_BASE_URL;
+			// OpenUI Generative UI. Routes LLM calls through the server's
+			// `/api/ai/openui` proxy so the OpenAI API key never reaches the
+			// browser bundle.
 			const openuiModel = import.meta.env.VITE_OPENUI_MODEL;
-			const openuiProvider =
-				openuiProviderName === "openai" && openaiKey
-					? createOpenAIProvider({
-							apiKey: openaiKey,
-							defaultModel: openuiModel,
-						})
-					: createOpenAICompatibleProvider({
-							baseURL: openuiBaseURL ?? "http://localhost:7878/v1",
-							apiKey: openaiKey,
-							defaultModel: openuiModel,
-							label: "OpenUI server",
-						});
+			const openuiProvider = createServerProxyProvider({
+				apiUrl,
+				extraHeaders: aiHeaders,
+				boardId,
+				defaultModel: openuiModel,
+			});
 			extraPlugins.push(openUIShapePlugin);
 			extraPlugins.push(createOpenUIToolPlugin({ provider: openuiProvider }));
 

--- a/plugins/usketch-plugin-server-ai/src/__tests__/openui-route.test.ts
+++ b/plugins/usketch-plugin-server-ai/src/__tests__/openui-route.test.ts
@@ -1,0 +1,236 @@
+import type { HonoEnv } from "@edv4h/usketch-server-core";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerOpenUIRoute } from "../openui-route.js";
+
+/**
+ * Fake drizzle query chain. The real `registerOpenUIRoute` calls:
+ *   db.select(...).from(boards).leftJoin(...).where(...).limit(1)
+ * so each method just returns the same object until `limit()` resolves to
+ * the rows we want for this test case.
+ */
+function makeFakeDb(rows: Array<{ isPublic: boolean; role: string | null }>) {
+	const chain = {
+		select: () => chain,
+		from: () => chain,
+		leftJoin: () => chain,
+		where: () => chain,
+		limit: async () => rows,
+	};
+	return chain;
+}
+
+const SCHEMA = {
+	boards: { id: "boards.id", isPublic: "boards.isPublic" } as any,
+	boardMembers: {
+		boardId: "boardMembers.boardId",
+		userId: "boardMembers.userId",
+		role: "boardMembers.role",
+	} as any,
+};
+
+function buildApp(opts: {
+	userId?: string;
+	apiKey?: string;
+	db?: ReturnType<typeof makeFakeDb>;
+	upstreamUrl?: string;
+}) {
+	const { userId, db, upstreamUrl = "https://upstream.test/v1/chat/completions" } = opts;
+	const app = new Hono<HonoEnv>();
+	// inject fake auth + db middleware to mimic the real server pipeline
+	app.use("*", async (c, next) => {
+		if (userId) c.set("userId", userId);
+		if (db) c.set("db", db as never);
+		await next();
+	});
+	registerOpenUIRoute(app, { schema: SCHEMA, upstreamUrl });
+	return app;
+}
+
+async function requestApp(
+	app: Hono<HonoEnv>,
+	path: string,
+	body: unknown,
+	apiKey: string | undefined,
+) {
+	const env = apiKey ? { OPENAI_API_KEY: apiKey } : {};
+	return app.request(
+		path,
+		{
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+		},
+		env,
+	);
+}
+
+const VALID_BODY = {
+	model: "gpt-4o",
+	stream: true,
+	messages: [{ role: "user" as const, content: "hello" }],
+};
+
+describe("registerOpenUIRoute", () => {
+	const fetchMock = vi.fn();
+	const originalFetch = globalThis.fetch;
+	beforeEach(() => {
+		fetchMock.mockReset();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("returns 401 when there is no userId", async () => {
+		const app = buildApp({ apiKey: "sk-x" });
+		const res = await requestApp(app, "/openui", VALID_BODY, "sk-x");
+		expect(res.status).toBe(401);
+	});
+
+	it("returns 500 when OPENAI_API_KEY is not configured", async () => {
+		const app = buildApp({ userId: "u-1" });
+		const res = await requestApp(app, "/openui", VALID_BODY, undefined);
+		expect(res.status).toBe(500);
+		expect(await res.json()).toMatchObject({ error: expect.stringMatching(/OPENAI_API_KEY/) });
+	});
+
+	it("forwards stream=true upstream and pass-throughs SSE bytes", async () => {
+		const sse = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('data: {"x":1}\n\n'));
+				controller.close();
+			},
+		});
+		fetchMock.mockResolvedValueOnce(new Response(sse, { status: 200 }));
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+
+		const res = await requestApp(app, "/openui", VALID_BODY, "sk-x");
+		expect(res.status).toBe(200);
+		expect(res.headers.get("content-type")).toMatch(/text\/event-stream/);
+		const text = await res.text();
+		expect(text).toBe('data: {"x":1}\n\n');
+
+		// Upstream call used our key + url + forwarded body
+		const [url, init] = fetchMock.mock.calls[0] ?? [];
+		expect(url).toBe("https://upstream.test/v1/chat/completions");
+		const initHeaders = (init as RequestInit).headers as Record<string, string>;
+		expect(initHeaders.Authorization).toBe("Bearer sk-x");
+		expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+			model: "gpt-4o",
+			stream: true,
+		});
+	});
+
+	it("returns upstream JSON verbatim for stream=false", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(JSON.stringify({ choices: [{ message: { content: "done" } }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+		const res = await requestApp(app, "/openui", { ...VALID_BODY, stream: false }, "sk-x");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toMatchObject({ choices: [{ message: { content: "done" } }] });
+	});
+
+	it("checks board access when boardId is provided (non-member, non-public → 404)", async () => {
+		const db = makeFakeDb([{ isPublic: false, role: null }]);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x", db });
+		const res = await requestApp(app, "/openui?boardId=b-1", VALID_BODY, "sk-x");
+		expect(res.status).toBe(404);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("allows access when boardId points at a public board (non-member)", async () => {
+		const db = makeFakeDb([{ isPublic: true, role: null }]);
+		fetchMock.mockResolvedValueOnce(
+			new Response(new ReadableStream({ start: (c) => c.close() }), { status: 200 }),
+		);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x", db });
+		const res = await requestApp(app, "/openui?boardId=b-1", VALID_BODY, "sk-x");
+		expect(res.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("allows access when boardId points at a board the user is a member of", async () => {
+		const db = makeFakeDb([{ isPublic: false, role: "editor" }]);
+		fetchMock.mockResolvedValueOnce(
+			new Response(new ReadableStream({ start: (c) => c.close() }), { status: 200 }),
+		);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x", db });
+		const res = await requestApp(app, "/openui?boardId=b-1", VALID_BODY, "sk-x");
+		expect(res.status).toBe(200);
+	});
+
+	it("returns 404 when boardId does not exist", async () => {
+		const db = makeFakeDb([]);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x", db });
+		const res = await requestApp(app, "/openui?boardId=b-missing", VALID_BODY, "sk-x");
+		expect(res.status).toBe(404);
+	});
+
+	it("skips board access check when boardId is omitted", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(new ReadableStream({ start: (c) => c.close() }), { status: 200 }),
+		);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+		const res = await requestApp(app, "/openui", VALID_BODY, "sk-x");
+		expect(res.status).toBe(200);
+	});
+
+	it("returns 502 on upstream 5xx", async () => {
+		fetchMock.mockResolvedValueOnce(new Response("rate limited", { status: 503 }));
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+		const res = await requestApp(app, "/openui", VALID_BODY, "sk-x");
+		expect(res.status).toBe(502);
+	});
+
+	it("returns 502 when upstream fetch throws", async () => {
+		fetchMock.mockRejectedValueOnce(new Error("ECONNRESET"));
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+		const res = await requestApp(app, "/openui", VALID_BODY, "sk-x");
+		expect(res.status).toBe(502);
+		expect(await res.json()).toMatchObject({ error: expect.stringMatching(/ECONNRESET/) });
+	});
+
+	it("rejects bodies with no messages (zod 400)", async () => {
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+		const res = await requestApp(app, "/openui", { messages: [] }, "sk-x");
+		expect(res.status).toBe(400);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects oversized image_url payloads (>10MB)", async () => {
+		const huge = "x".repeat(10_000_001);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+		const res = await requestApp(
+			app,
+			"/openui",
+			{
+				messages: [{ role: "user", content: [{ type: "image_url", image_url: { url: huge } }] }],
+			},
+			"sk-x",
+		);
+		expect(res.status).toBe(400);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("strips unknown extra fields like `tools` from the forwarded body", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(new ReadableStream({ start: (c) => c.close() }), { status: 200 }),
+		);
+		const app = buildApp({ userId: "u-1", apiKey: "sk-x" });
+		const res = await requestApp(
+			app,
+			"/openui",
+			{ ...VALID_BODY, tools: [{ type: "function", function: { name: "x" } }] },
+			"sk-x",
+		);
+		expect(res.status).toBe(200);
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		const forwarded = JSON.parse(init.body as string);
+		expect(forwarded.tools).toBeUndefined();
+	});
+});

--- a/plugins/usketch-plugin-server-ai/src/index.ts
+++ b/plugins/usketch-plugin-server-ai/src/index.ts
@@ -1,2 +1,8 @@
+export type {
+	OpenUICompletionBody,
+	OpenUIRouteSchema,
+	RegisterOpenUIRouteOptions,
+} from "./openui-route.js";
+export { openuiCompletionSchema, registerOpenUIRoute } from "./openui-route.js";
 export type { AiPluginSchema } from "./plugin.js";
 export { createAiPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-server-ai/src/openui-route.ts
+++ b/plugins/usketch-plugin-server-ai/src/openui-route.ts
@@ -1,0 +1,140 @@
+import type { HonoEnv } from "@edv4h/usketch-server-core";
+import { zValidator } from "@hono/zod-validator";
+import { and, eq } from "drizzle-orm";
+import type { SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";
+import type { Hono } from "hono";
+import { z } from "zod";
+
+/**
+ * Schema for board access control (re-used from the AI plugin). We only
+ * need the `boards` / `boardMembers` tables to enforce membership when
+ * the client supplies a `?boardId=...` query.
+ */
+export interface OpenUIRouteSchema {
+	boards: SQLiteTableWithColumns<any>;
+	boardMembers: SQLiteTableWithColumns<any>;
+}
+
+/**
+ * Max bytes for a single `image_url.url` payload. Matches the existing
+ * `/api/ai/complete` `image` limit so vision attachments behave the same
+ * across all AI endpoints.
+ */
+const MAX_IMAGE_URL_BYTES = 10_000_000;
+
+const messageContentPart = z.union([
+	z.object({ type: z.literal("text"), text: z.string().max(40_000) }),
+	z.object({
+		type: z.literal("image_url"),
+		image_url: z.object({
+			url: z.string().max(MAX_IMAGE_URL_BYTES),
+			detail: z.enum(["low", "high", "auto"]).optional(),
+		}),
+	}),
+]);
+
+export const openuiCompletionSchema = z.object({
+	model: z.string().min(1).max(64).default("gpt-4o"),
+	stream: z.boolean().optional().default(true),
+	temperature: z.number().min(0).max(2).optional(),
+	messages: z
+		.array(
+			z.object({
+				role: z.enum(["system", "user", "assistant"]),
+				content: z.union([z.string().max(40_000), z.array(messageContentPart).max(8)]),
+			}),
+		)
+		.min(1)
+		.max(16),
+});
+
+export type OpenUICompletionBody = z.infer<typeof openuiCompletionSchema>;
+
+export interface RegisterOpenUIRouteOptions {
+	schema: OpenUIRouteSchema;
+	/**
+	 * Override the upstream Chat Completions endpoint. Defaults to OpenAI.
+	 * Useful for tests (point at a mock) or self-hosted gateways.
+	 */
+	upstreamUrl?: string;
+}
+
+const DEFAULT_UPSTREAM = "https://api.openai.com/v1/chat/completions";
+
+/**
+ * Mount `POST /openui` on the provided AI sub-app. The route is an
+ * OpenAI-compatible Chat Completions proxy: it validates the incoming
+ * body, enforces board access control when `?boardId=...` is supplied,
+ * and forwards the request to OpenAI using the server's `OPENAI_API_KEY`
+ * secret. SSE responses are streamed back to the client as-is.
+ */
+export function registerOpenUIRoute(app: Hono<HonoEnv>, options: RegisterOpenUIRouteOptions): void {
+	const { schema, upstreamUrl = DEFAULT_UPSTREAM } = options;
+	const { boards, boardMembers } = schema;
+
+	app.post("/openui", zValidator("json", openuiCompletionSchema), async (c) => {
+		const userId = c.get("userId");
+		if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+		const apiKey = (c.env as { OPENAI_API_KEY?: string }).OPENAI_API_KEY;
+		if (!apiKey) return c.json({ error: "OPENAI_API_KEY is not configured" }, 500);
+
+		const boardId = c.req.query("boardId");
+		if (boardId) {
+			const db = c.get("db");
+			if (!db) return c.json({ error: "Internal error" }, 500);
+			const rows = await db
+				.select({ isPublic: boards.isPublic, role: boardMembers.role })
+				.from(boards)
+				.leftJoin(
+					boardMembers,
+					and(eq(boards.id, boardMembers.boardId), eq(boardMembers.userId, userId)),
+				)
+				.where(eq(boards.id, boardId))
+				.limit(1);
+			if (rows.length === 0 || (rows[0].role === null && !rows[0].isPublic)) {
+				return c.json({ error: "Not found" }, 404);
+			}
+		}
+
+		const body = c.req.valid("json");
+
+		let upstream: Response;
+		try {
+			upstream = await fetch(upstreamUrl, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
+				},
+				body: JSON.stringify(body),
+				signal: c.req.raw.signal,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Unknown error";
+			return c.json({ error: `OpenAI upstream fetch failed: ${message}` }, 502);
+		}
+
+		if (!upstream.ok) {
+			const errText = await upstream.text().catch(() => "");
+			return c.json(
+				{ error: `OpenAI upstream error: ${upstream.status} ${errText.slice(0, 500)}` },
+				502,
+			);
+		}
+
+		if (!body.stream) {
+			const json = await upstream.json();
+			return c.json(json as Record<string, unknown>);
+		}
+
+		return new Response(upstream.body, {
+			status: 200,
+			headers: {
+				"Content-Type": "text/event-stream; charset=utf-8",
+				"Cache-Control": "no-cache, no-transform",
+				Connection: "keep-alive",
+			},
+		});
+	});
+}

--- a/plugins/usketch-plugin-server-ai/src/plugin.ts
+++ b/plugins/usketch-plugin-server-ai/src/plugin.ts
@@ -5,6 +5,7 @@ import type { SQLiteTableWithColumns } from "drizzle-orm/sqlite-core";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { z } from "zod";
+import { registerOpenUIRoute } from "./openui-route.js";
 
 /** AI プラグインが必要とするスキーマテーブル */
 export interface AiPluginSchema {
@@ -718,6 +719,8 @@ export function createAiPlugin(schema: AiPluginSchema): ServerPlugin {
 					}
 				});
 			});
+
+			registerOpenUIRoute(aiApp, { schema: { boards, boardMembers } });
 
 			ctx.routes.register({ path: "/api/ai", app: aiApp });
 		},

--- a/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
+++ b/plugins/usketch-plugin-tool-openui/src/__tests__/providers/openai-compatible.test.ts
@@ -173,4 +173,27 @@ describe("createOpenAICompatibleProvider", () => {
 		for await (const c of provider.generate("hi", { stream: false })) chunks.push(c);
 		expect(chunks).toEqual(["final answer"]);
 	});
+
+	it("forwards `credentials` to fetch when specified", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createOpenAICompatibleProvider({
+			apiKey: "sk-x",
+			credentials: "include",
+		});
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(init?.credentials).toBe("include");
+	});
+
+	it("omits `credentials` from fetch init when unspecified (preserves default behavior)", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createOpenAICompatibleProvider({ apiKey: "sk-x" });
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+		expect(init?.credentials).toBeUndefined();
+	});
 });

--- a/plugins/usketch-plugin-tool-openui/src/__tests__/providers/server-proxy.test.ts
+++ b/plugins/usketch-plugin-tool-openui/src/__tests__/providers/server-proxy.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createServerProxyProvider } from "../../providers/server-proxy.js";
+
+function sseStream(chunks: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	let i = 0;
+	return new ReadableStream({
+		pull(controller) {
+			const chunk = chunks[i];
+			if (chunk === undefined) {
+				controller.close();
+				return;
+			}
+			controller.enqueue(encoder.encode(chunk));
+			i++;
+		},
+	});
+}
+
+describe("createServerProxyProvider", () => {
+	const fetchMock = vi.fn();
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		fetchMock.mockReset();
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+	});
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("POSTs to <apiUrl>/api/ai/openui with credentials: include", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createServerProxyProvider({ apiUrl: "https://api.example.test" });
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const [url, init] = fetchMock.mock.calls[0] ?? [];
+		expect(url).toBe("https://api.example.test/api/ai/openui");
+		expect((init as RequestInit).method).toBe("POST");
+		expect((init as RequestInit).credentials).toBe("include");
+	});
+
+	it("forwards boardId as a query parameter when provided", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createServerProxyProvider({
+			apiUrl: "https://api.example.test",
+			boardId: "board-123",
+		});
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const url = fetchMock.mock.calls[0]?.[0];
+		expect(url).toBe("https://api.example.test/api/ai/openui?boardId=board-123");
+	});
+
+	it("omits the boardId query when not provided", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createServerProxyProvider({ apiUrl: "https://api.example.test" });
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const url = fetchMock.mock.calls[0]?.[0] as string;
+		expect(url.includes("boardId")).toBe(false);
+	});
+
+	it("merges extraHeaders into the fetch headers", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createServerProxyProvider({
+			apiUrl: "https://api.example.test",
+			extraHeaders: { "X-User-Id": "user-42" },
+		});
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		const headers = init.headers as Record<string, string>;
+		expect(headers["X-User-Id"]).toBe("user-42");
+		expect(headers["Content-Type"]).toBe("application/json");
+		// No Authorization header — the server attaches it.
+		expect(headers.Authorization).toBeUndefined();
+	});
+
+	it("sends an OpenAI-compatible body shape", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createServerProxyProvider({
+			apiUrl: "https://api.example.test",
+			defaultModel: "gpt-4o-mini",
+		});
+		for await (const _ of provider.generate("hello", { systemPrompt: "be brief" })) {
+			// no-op
+		}
+		const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+		const body = JSON.parse(init.body as string);
+		expect(body.model).toBe("gpt-4o-mini");
+		expect(body.stream).toBe(true);
+		expect(body.messages).toEqual([
+			{ role: "system", content: "be brief" },
+			{ role: "user", content: "hello" },
+		]);
+	});
+
+	it("streams SSE deltas as an AsyncIterable<string>", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response(
+				sseStream([
+					`data: ${JSON.stringify({ choices: [{ delta: { content: "Hello" } }] })}\n\n`,
+					`data: ${JSON.stringify({ choices: [{ delta: { content: ", world" } }] })}\n\n`,
+					"data: [DONE]\n\n",
+				]),
+				{ status: 200 },
+			),
+		);
+		const provider = createServerProxyProvider({ apiUrl: "https://api.example.test" });
+		const chunks: string[] = [];
+		for await (const c of provider.generate("hi", {})) chunks.push(c);
+		expect(chunks.join("")).toBe("Hello, world");
+	});
+
+	it("throws when the server returns a 4xx response", async () => {
+		fetchMock.mockResolvedValueOnce(
+			new Response("Unauthorized", { status: 401, statusText: "Unauthorized" }),
+		);
+		const provider = createServerProxyProvider({ apiUrl: "https://api.example.test" });
+		await expect(async () => {
+			for await (const _ of provider.generate("hi", {})) {
+				// no-op
+			}
+		}).rejects.toThrow(/401/);
+	});
+
+	it("supports a custom routePath override", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createServerProxyProvider({
+			apiUrl: "https://api.example.test",
+			routePath: "/v2/ai/openui",
+		});
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const url = fetchMock.mock.calls[0]?.[0];
+		expect(url).toBe("https://api.example.test/v2/ai/openui");
+	});
+
+	it("tolerates apiUrl with a trailing slash", async () => {
+		fetchMock.mockResolvedValueOnce(new Response(sseStream(["data: [DONE]\n\n"]), { status: 200 }));
+		const provider = createServerProxyProvider({ apiUrl: "https://api.example.test/" });
+		for await (const _ of provider.generate("hi", {})) {
+			// no-op
+		}
+		const url = fetchMock.mock.calls[0]?.[0];
+		expect(url).toBe("https://api.example.test/api/ai/openui");
+	});
+
+	it("exposes id: 'server-proxy'", () => {
+		const provider = createServerProxyProvider({ apiUrl: "https://api.example.test" });
+		expect(provider.id).toBe("server-proxy");
+	});
+});

--- a/plugins/usketch-plugin-tool-openui/src/index.ts
+++ b/plugins/usketch-plugin-tool-openui/src/index.ts
@@ -2,6 +2,7 @@ export { OPENUI_DEFAULT_LIBRARY_ID, openuiDefaultLibrary } from "./default-libra
 export { createOpenUIToolPlugin } from "./plugin.js";
 export { createOpenAIProvider } from "./providers/openai.js";
 export { createOpenAICompatibleProvider } from "./providers/openai-compatible.js";
+export { createServerProxyProvider } from "./providers/server-proxy.js";
 export type {
 	GenerateOptions,
 	OpenUIProvider,

--- a/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/openai-compatible.ts
@@ -22,6 +22,14 @@ export interface OpenAICompatibleProviderOptions {
 	extraHeaders?: Record<string, string>;
 	supportsVision?: boolean;
 	label?: string;
+	/**
+	 * `RequestCredentials` for the fetch call. Set to `"include"` for
+	 * cookie-authenticated proxies (e.g. uSketch's own `/api/ai/openui`
+	 * route). Defaults to `undefined`, which means fetch's default
+	 * (`"same-origin"`) applies — that's what you want for direct OpenAI
+	 * calls because the request goes cross-origin anyway with no cookies.
+	 */
+	credentials?: RequestCredentials;
 }
 
 /**
@@ -47,6 +55,7 @@ export function createOpenAICompatibleProvider(
 		extraHeaders,
 		supportsVision = true,
 		label = "OpenAI-compatible",
+		credentials,
 	} = options;
 	// Resolve a stable URL once at factory time. URL handles trailing slashes,
 	// allows future query-param overrides, and rejects malformed inputs early.
@@ -83,6 +92,7 @@ export function createOpenAICompatibleProvider(
 			const response = await fetch(resolvedEndpoint, {
 				method: "POST",
 				headers,
+				credentials,
 				signal: opts.signal,
 				body: JSON.stringify({
 					model: opts.model ?? defaultModel,

--- a/plugins/usketch-plugin-tool-openui/src/providers/server-proxy.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/server-proxy.ts
@@ -1,0 +1,66 @@
+import { createOpenAICompatibleProvider } from "./openai-compatible.js";
+import type { OpenUIProvider } from "./types.js";
+
+export interface ServerProxyProviderOptions {
+	/**
+	 * API origin (no trailing `/api`). e.g. `https://api.usketch.app` or
+	 * `http://localhost:8787`. The provider POSTs to
+	 * `${apiUrl}${routePath}` (default route: `/api/ai/openui`).
+	 */
+	apiUrl: string;
+	/**
+	 * Extra request headers. Used for the dev `X-User-Id` shim; production
+	 * relies on the session cookie sent via `credentials: "include"`.
+	 */
+	extraHeaders?: Record<string, string>;
+	/** Forwarded as `?boardId=...` for board-scoped access control. */
+	boardId?: string;
+	defaultModel?: string;
+	label?: string;
+	availableModels?: string[];
+	supportsVision?: boolean;
+	/** Override the route path. Defaults to `"/api/ai/openui"`. */
+	routePath?: string;
+}
+
+/**
+ * Server-proxy provider: route LLM calls through uSketch's own
+ * `/api/ai/openui` endpoint instead of calling OpenAI from the browser.
+ *
+ * Production-safe because the OpenAI API key lives only in the Workers
+ * Secret store on the server — the browser bundle never sees it. Auth is
+ * delegated to better-auth's session cookie (`credentials: "include"`),
+ * with `X-User-Id` accepted as a dev-mode bypass.
+ *
+ * Internally this is a thin wrapper around `createOpenAICompatibleProvider`
+ * because the server route is intentionally OpenAI-API-compatible.
+ */
+export function createServerProxyProvider(options: ServerProxyProviderOptions): OpenUIProvider {
+	const {
+		apiUrl,
+		extraHeaders,
+		boardId,
+		defaultModel = "gpt-4o",
+		label = "uSketch server",
+		availableModels,
+		supportsVision = true,
+		routePath = "/api/ai/openui",
+	} = options;
+
+	const base = apiUrl.replace(/\/+$/, "");
+	const url = new URL(`${base}${routePath}`);
+	if (boardId) url.searchParams.set("boardId", boardId);
+
+	const provider = createOpenAICompatibleProvider({
+		endpoint: url.toString(),
+		// No `apiKey` — the server attaches the OpenAI bearer token from its
+		// own secret store.
+		extraHeaders,
+		defaultModel,
+		availableModels,
+		supportsVision,
+		label,
+		credentials: "include",
+	});
+	return { ...provider, id: "server-proxy" };
+}

--- a/plugins/usketch-plugin-tool-openui/src/providers/types.ts
+++ b/plugins/usketch-plugin-tool-openui/src/providers/types.ts
@@ -20,7 +20,7 @@ export interface GenerateOptions {
 	systemPrompt?: string;
 }
 
-export type ProviderId = "openai" | "openai-compatible";
+export type ProviderId = "openai" | "openai-compatible" | "server-proxy";
 
 /**
  * Provider abstraction. All implementations expose a single async-iterable


### PR DESCRIPTION
## Summary

OpenUI plugin の本番デプロイ可能化。`VITE_OPENAI_API_KEY` がブラウザ bundle に焼き込まれていた構造を廃し、サーバ側 `/api/ai/openui` プロキシ経由に統一する。

- **`@edv4h/usketch-plugin-tool-openui`** (minor)
  - 新規 `createServerProxyProvider({ apiUrl, boardId?, extraHeaders?, ... })` — cookie auth (`credentials: "include"`) で自前 `/api/ai/openui` route を叩く薄い wrapper
  - `createOpenAICompatibleProvider` に opt-in `credentials` option を追加 (後方互換)
  - `ProviderId` に `"server-proxy"` を追加
- **`@edv4h/usketch-plugin-server-ai`** (minor)
  - 新規 `registerOpenUIRoute(app, { schema })` — `POST /openui` を AI sub-app に mount
  - body は OpenAI 互換 Chat Completions、`image_url` 10MB 上限、unknown フィールド (`tools` 等) は strip
  - `?boardId=...` 指定時は board メンバーシップ / `isPublic` で access control (`/api/ai/complete` と同じパターン)
  - SSE は upstream の bytes をそのまま `text/event-stream` で pass-through
  - upstream `OPENAI_API_KEY` は既存 Workers Secret を再利用
- **`apps/web`**: `createOpenAI(Compatible)Provider` 参照を完全削除し `createServerProxyProvider` に統一。`VITE_OPENAI_API_KEY` / `VITE_OPENUI_BASE_URL` / `VITE_OPENUI_PROVIDER` は読み取らない
- **docs (en/ja)**: セットアップ手順をサーバプロキシ前提に書き換え、Cloudflare Pages の build env に絶対に key を入れないよう注意書きを追加

`createOpenAIProvider` / `createOpenAICompatibleProvider` は third-party host 向けに引き続き export。

## Test plan

- [x] `pnpm --filter @edv4h/usketch-plugin-tool-openui test` — 20 tests pass (10 既存 + 10 新規)
- [x] `pnpm --filter @edv4h/usketch-plugin-server-ai test` — 14 tests pass (新規)
- [x] `pnpm --filter @edv4h/usketch-plugin-tool-openui typecheck` / `build` — clean
- [x] `pnpm --filter @edv4h/usketch-plugin-server-ai typecheck` / `build` — clean
- [x] `pnpm --filter @edv4h/usketch-web typecheck` / `build` — clean
- [x] `pnpm biome check .` — errors なし (warning のみ既存パターン)
- [x] `grep -r "VITE_OPENAI\|localhost:7878" apps/web/dist` — 0 件 (本番 bundle に焼き込み無し)
- [ ] cloud board での手動 happy path 確認 (wrangler dev + web dev)
- [ ] Preview deploy で疎通確認

## Deploy 順序

1. Server を先にデプロイ (`/api/ai/openui` route が landed)
2. Web を後でデプロイ

逆順だと一時的に新 web が古 server の 404 を踏む。

## Breaking changes

なし。新規 export 追加と `apps/web` internal の差替えのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)