### PR TITLE
🐛 fix: StrictMode-safe plugin lifecycle (closes #609)

### DIFF
--- a/.changeset/strict-mode-safe-plugin-lifecycle.md
+++ b/.changeset/strict-mode-safe-plugin-lifecycle.md
@@ -1,0 +1,91 @@
+---
+"@edv4h/usketch-shared": major
+"@edv4h/usketch-core": major
+"@edv4h/usketch-dom-renderer": major
+"@edv4h/usketch-gpu-renderer": major
+"@edv4h/usketch-plugin-activity-feed": major
+"@edv4h/usketch-plugin-ai-actions": major
+"@edv4h/usketch-plugin-ai-agent": major
+"@edv4h/usketch-plugin-ai-chat": major
+"@edv4h/usketch-plugin-ai-copilot": major
+"@edv4h/usketch-plugin-ai-image": major
+"@edv4h/usketch-plugin-ai-recognize": major
+"@edv4h/usketch-plugin-ai-voice": major
+"@edv4h/usketch-plugin-avatar": major
+"@edv4h/usketch-plugin-bg-dots": major
+"@edv4h/usketch-plugin-bg-grid": major
+"@edv4h/usketch-plugin-board-info-panel": major
+"@edv4h/usketch-plugin-canvas-filter": major
+"@edv4h/usketch-plugin-comments": major
+"@edv4h/usketch-plugin-community-chat": major
+"@edv4h/usketch-plugin-debug-hud": major
+"@edv4h/usketch-plugin-domain-design": major
+"@edv4h/usketch-plugin-effect-ripple": major
+"@edv4h/usketch-plugin-export": major
+"@edv4h/usketch-plugin-follow-me": major
+"@edv4h/usketch-plugin-keyboard-shortcuts": major
+"@edv4h/usketch-plugin-laser": major
+"@edv4h/usketch-plugin-presence-cursor": major
+"@edv4h/usketch-plugin-presence-enhanced": major
+"@edv4h/usketch-plugin-presentation": major
+"@edv4h/usketch-plugin-reactions": major
+"@edv4h/usketch-plugin-shape-basic": major
+"@edv4h/usketch-plugin-shape-community-region": major
+"@edv4h/usketch-plugin-shape-connector": major
+"@edv4h/usketch-plugin-shape-counter": major
+"@edv4h/usketch-plugin-shape-frame": major
+"@edv4h/usketch-plugin-shape-freedraw": major
+"@edv4h/usketch-plugin-shape-group": major
+"@edv4h/usketch-plugin-shape-image": major
+"@edv4h/usketch-plugin-shape-island": major
+"@edv4h/usketch-plugin-shape-openui": major
+"@edv4h/usketch-plugin-shape-sticky": major
+"@edv4h/usketch-plugin-shape-text": major
+"@edv4h/usketch-plugin-shape-wireframe": major
+"@edv4h/usketch-plugin-side-panel": major
+"@edv4h/usketch-plugin-snap": major
+"@edv4h/usketch-plugin-spatial-chat": major
+"@edv4h/usketch-plugin-spotlight": major
+"@edv4h/usketch-plugin-sync-localstorage-yjs": major
+"@edv4h/usketch-plugin-sync-ywebsocket": major
+"@edv4h/usketch-plugin-tool-openui": major
+"@edv4h/usketch-plugin-tool-pan": major
+"@edv4h/usketch-plugin-tool-select": major
+"@edv4h/usketch-plugin-viewport-nav": major
+"@edv4h/usketch-plugin-voting": major
+"@edv4h/usketch-plugin-whistle": major
+---
+
+**BREAKING**: Plugin lifecycle reworked for React StrictMode safety. Fixes #609.
+
+`UsketchPlugin.setup(ctx)` now returns the teardown function directly; the `teardown` property on `UsketchPlugin` has been removed. All plugins that previously exported a module-level singleton object (e.g. `selectToolPlugin`, `panToolPlugin`, `gridBgPlugin`) are now factory functions (`createSelectToolPlugin()`, `createPanToolPlugin()`, `createGridBgPlugin()`). Each `createApp` call now owns its own plugin instance and teardown closure, so a second mount cannot overwrite the first's cleanup state.
+
+`createApp` collects per-instance teardowns and runs them in LIFO order on `destroy()`. `destroy()` is idempotent — repeated calls are no-ops. If a later plugin's `setup` throws, the teardowns collected so far roll back in LIFO order.
+
+**Migration**:
+
+1. Replace singleton imports with factory calls at the call site:
+   ```diff
+   - import { selectToolPlugin, panToolPlugin, gridBgPlugin } from "@edv4h/usketch-plugin-...";
+   + import { createSelectToolPlugin, createPanToolPlugin, createGridBgPlugin } from "@edv4h/usketch-plugin-...";
+
+     const app = await createApp({
+       store,
+   -   plugins: [selectToolPlugin, panToolPlugin, gridBgPlugin],
+   +   plugins: [createSelectToolPlugin(), createPanToolPlugin(), createGridBgPlugin()],
+     });
+   ```
+
+2. When authoring a custom plugin, return the cleanup from `setup` instead of assigning it to `this.teardown`:
+   ```diff
+     setup(ctx) {
+       const off = ctx.events.on("…", handler);
+   -   (this as UsketchPlugin).teardown = () => off();
+   +   return () => off();
+     },
+   - teardown() { … },
+   ```
+
+3. Build plugin arrays inside `useEffect` (or any per-mount scope), not at module level — even with factory functions, sharing a single instance across mounts undoes StrictMode safety.
+
+Plugins that already shipped as `createXxxPlugin()` (e.g. `createDomRendererPlugin`, `createPresenceCursorPlugin`) keep their factory names; only the `teardown` property has moved to the `setup` return value.

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -10,30 +10,30 @@ import { createAiCopilotPlugin } from "@edv4h/usketch-plugin-ai-copilot";
 import { createAiImagePlugin } from "@edv4h/usketch-plugin-ai-image";
 import { createAiRecognizePlugin } from "@edv4h/usketch-plugin-ai-recognize";
 import { createAiVoicePlugin } from "@edv4h/usketch-plugin-ai-voice";
-import { dotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
-import { gridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
+import { createDotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
+import { createGridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
-import { domainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
-import { exportPlugin } from "@edv4h/usketch-plugin-export";
+import { createDomainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
+import { createExportPlugin } from "@edv4h/usketch-plugin-export";
 import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
-import { createLaserPlugin, laserPlugin } from "@edv4h/usketch-plugin-laser";
+import { createLaserPlugin } from "@edv4h/usketch-plugin-laser";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
 import { createPresenceEnhancedPlugin } from "@edv4h/usketch-plugin-presence-enhanced";
 import { createPresentationPlugin } from "@edv4h/usketch-plugin-presentation";
-import { basicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
-import { connectorPlugin } from "@edv4h/usketch-plugin-shape-connector";
-import { counterPlugin } from "@edv4h/usketch-plugin-shape-counter";
-import { framePlugin } from "@edv4h/usketch-plugin-shape-frame";
-import { freedrawPlugin } from "@edv4h/usketch-plugin-shape-freedraw";
-import { groupPlugin } from "@edv4h/usketch-plugin-shape-group";
-import { imageShapePlugin } from "@edv4h/usketch-plugin-shape-image";
-import { openUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
-import { stickyPlugin } from "@edv4h/usketch-plugin-shape-sticky";
-import { textPlugin } from "@edv4h/usketch-plugin-shape-text";
-import { wireframePlugin } from "@edv4h/usketch-plugin-shape-wireframe";
+import { createBasicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
+import { createConnectorPlugin } from "@edv4h/usketch-plugin-shape-connector";
+import { createCounterPlugin } from "@edv4h/usketch-plugin-shape-counter";
+import { createFramePlugin } from "@edv4h/usketch-plugin-shape-frame";
+import { createFreedrawPlugin } from "@edv4h/usketch-plugin-shape-freedraw";
+import { createGroupPlugin } from "@edv4h/usketch-plugin-shape-group";
+import { createImageShapePlugin } from "@edv4h/usketch-plugin-shape-image";
+import { createOpenUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
+import { createStickyPlugin } from "@edv4h/usketch-plugin-shape-sticky";
+import { createTextPlugin } from "@edv4h/usketch-plugin-shape-text";
+import { createWireframePlugin } from "@edv4h/usketch-plugin-shape-wireframe";
 import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
-import { snapPlugin } from "@edv4h/usketch-plugin-snap";
-import { createSpotlightPlugin, spotlightPlugin } from "@edv4h/usketch-plugin-spotlight";
+import { createSnapPlugin } from "@edv4h/usketch-plugin-snap";
+import { createSpotlightPlugin } from "@edv4h/usketch-plugin-spotlight";
 import { createYjsSync } from "@edv4h/usketch-plugin-sync-localstorage-yjs";
 import {
 	createDivergenceTracker,
@@ -44,10 +44,10 @@ import {
 	createOpenUIToolPlugin,
 	createServerProxyProvider,
 } from "@edv4h/usketch-plugin-tool-openui";
-import { panToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
-import { selectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
-import { viewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
-import { createWhistlePlugin, whistlePlugin } from "@edv4h/usketch-plugin-whistle";
+import { createPanToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
+import { createSelectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
+import { createViewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
+import { createWhistlePlugin } from "@edv4h/usketch-plugin-whistle";
 import type { UsketchPlugin } from "@edv4h/usketch-shared";
 import { createBoardStore } from "@edv4h/usketch-store";
 import {
@@ -90,34 +90,36 @@ function readPresentationMode(search: string): PresentationMode {
 	return params.get("mode") === "present" ? "present" : "edit";
 }
 
-const basePlugins: UsketchPlugin[] = [
-	gridBgPlugin,
-	dotsBgPlugin,
-	selectToolPlugin,
-	panToolPlugin,
-	viewportNavPlugin,
-	basicShapePlugin,
-	groupPlugin,
-	framePlugin,
-	connectorPlugin,
-	freedrawPlugin,
-	textPlugin,
-	stickyPlugin,
-	imageShapePlugin,
-	counterPlugin,
-	wireframePlugin,
-	domainDesignPlugin,
-	snapPlugin,
-	exportPlugin,
-	createGpuRendererPlugin(),
-	createDomRendererPlugin(),
-];
+function createBasePlugins(): UsketchPlugin[] {
+	return [
+		createGridBgPlugin(),
+		createDotsBgPlugin(),
+		createSelectToolPlugin(),
+		createPanToolPlugin(),
+		createViewportNavPlugin(),
+		createBasicShapePlugin(),
+		createGroupPlugin(),
+		createFramePlugin(),
+		createConnectorPlugin(),
+		createFreedrawPlugin(),
+		createTextPlugin(),
+		createStickyPlugin(),
+		createImageShapePlugin(),
+		createCounterPlugin(),
+		createWireframePlugin(),
+		createDomainDesignPlugin(),
+		createSnapPlugin(),
+		createExportPlugin(),
+		createGpuRendererPlugin(),
+		createDomRendererPlugin(),
+	];
+}
 
 async function loadPlugins(extra: UsketchPlugin[]): Promise<UsketchPlugin[]> {
-	const plugins = [...basePlugins, ...extra];
+	const plugins = [...createBasePlugins(), ...extra];
 	if (import.meta.env.DEV) {
-		const { debugHudPlugin } = await import("@edv4h/usketch-plugin-debug-hud");
-		return [...plugins, debugHudPlugin];
+		const { createDebugHudPlugin } = await import("@edv4h/usketch-plugin-debug-hud");
+		return [...plugins, createDebugHudPlugin()];
 	}
 	return plugins;
 }
@@ -253,15 +255,15 @@ export function App() {
 				boardId,
 				defaultModel: openuiModel,
 			});
-			extraPlugins.push(openUIShapePlugin);
+			extraPlugins.push(createOpenUIShapePlugin());
 			extraPlugins.push(createOpenUIToolPlugin({ provider: openuiProvider }));
 
 			extraPlugins.push(createWhistlePlugin(wsProvider));
 			extraPlugins.push(createActivityFeedPlugin({ wsProvider, boardId, apiUrl }));
 		} else {
-			extraPlugins.push(laserPlugin);
-			extraPlugins.push(spotlightPlugin);
-			extraPlugins.push(whistlePlugin);
+			extraPlugins.push(createLaserPlugin());
+			extraPlugins.push(createSpotlightPlugin());
+			extraPlugins.push(createWhistlePlugin());
 		}
 
 		// プレゼンテーション: ローカル/Cloud 共通で常にロードし、`?present=1` が付いた時だけ UI を出す。

--- a/apps/web/src/pages/benchmark/benchmark-canvas.tsx
+++ b/apps/web/src/pages/benchmark/benchmark-canvas.tsx
@@ -2,7 +2,7 @@ import { AppProvider, Canvas } from "@edv4h/usketch-canvas-engine";
 import { type AppInstance, createApp, createShapeCountLodPolicy } from "@edv4h/usketch-core";
 import { createDomRendererPlugin } from "@edv4h/usketch-dom-renderer";
 import { createGpuRendererPlugin } from "@edv4h/usketch-gpu-renderer";
-import { basicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
+import { createBasicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
 import type { BoardStore, ShapeData, UsketchPlugin } from "@edv4h/usketch-shared";
 import { createBoardStore } from "@edv4h/usketch-store";
 import { useEffect, useRef, useState } from "react";
@@ -35,7 +35,7 @@ export function BenchmarkCanvas({ mode, onReady, onDestroy }: BenchmarkCanvasPro
 		const store = createBoardStore();
 
 		const plugins: UsketchPlugin[] = [
-			basicShapePlugin,
+			createBasicShapePlugin(),
 			createGpuRendererPlugin(),
 			createDomRendererPlugin(),
 		];

--- a/apps/web/src/pages/community/community-page.tsx
+++ b/apps/web/src/pages/community/community-page.tsx
@@ -3,32 +3,32 @@ import { type AppInstance, createApp } from "@edv4h/usketch-core";
 import { createDomRendererPlugin } from "@edv4h/usketch-dom-renderer";
 import { createActivityFeedPlugin } from "@edv4h/usketch-plugin-activity-feed";
 import { createAvatarPlugin } from "@edv4h/usketch-plugin-avatar";
-import { dotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
-import { gridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
+import { createDotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
+import { createGridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createBoardInfoPanelPlugin } from "@edv4h/usketch-plugin-board-info-panel";
 import { createFilterPlugin } from "@edv4h/usketch-plugin-canvas-filter";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
 import { createCommunityChatPlugin } from "@edv4h/usketch-plugin-community-chat";
-import { createRippleEffectPlugin, rippleEffectPlugin } from "@edv4h/usketch-plugin-effect-ripple";
+import { createRippleEffectPlugin } from "@edv4h/usketch-plugin-effect-ripple";
 import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
 import { createKeyboardShortcutsPlugin } from "@edv4h/usketch-plugin-keyboard-shortcuts";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
-import { createReactionsPlugin, reactionsPlugin } from "@edv4h/usketch-plugin-reactions";
+import { createReactionsPlugin } from "@edv4h/usketch-plugin-reactions";
 import {
 	type BoardPortalShapeData,
 	createBoardPortalPlugin,
 } from "@edv4h/usketch-plugin-shape-board-portal";
-import { groupPlugin } from "@edv4h/usketch-plugin-shape-group";
-import { islandPlugin } from "@edv4h/usketch-plugin-shape-island";
+import { createGroupPlugin } from "@edv4h/usketch-plugin-shape-group";
+import { createIslandPlugin } from "@edv4h/usketch-plugin-shape-island";
 import { createSidePanelPlugin } from "@edv4h/usketch-plugin-side-panel";
-import { createSpatialChatPlugin, spatialChatPlugin } from "@edv4h/usketch-plugin-spatial-chat";
-import { createSpotlightPlugin, spotlightPlugin } from "@edv4h/usketch-plugin-spotlight";
+import { createSpatialChatPlugin } from "@edv4h/usketch-plugin-spatial-chat";
+import { createSpotlightPlugin } from "@edv4h/usketch-plugin-spotlight";
 import { createYjsSync } from "@edv4h/usketch-plugin-sync-localstorage-yjs";
-import { panToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
-import { selectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
-import { viewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
-import { createVotingPlugin, votingPlugin } from "@edv4h/usketch-plugin-voting";
-import { createWhistlePlugin, whistlePlugin } from "@edv4h/usketch-plugin-whistle";
+import { createPanToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
+import { createSelectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
+import { createViewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
+import { createVotingPlugin } from "@edv4h/usketch-plugin-voting";
+import { createWhistlePlugin } from "@edv4h/usketch-plugin-whistle";
 import type { UsketchPlugin } from "@edv4h/usketch-shared";
 import { createBoardStore } from "@edv4h/usketch-store";
 import { createWsProvider, type WsProviderHandle } from "@edv4h/usketch-sync";
@@ -188,25 +188,25 @@ export function CommunityPage() {
 						}),
 					);
 				} else {
-					extraPlugins.push(rippleEffectPlugin);
-					extraPlugins.push(reactionsPlugin);
-					extraPlugins.push(spatialChatPlugin);
-					extraPlugins.push(votingPlugin);
-					extraPlugins.push(spotlightPlugin);
+					extraPlugins.push(createRippleEffectPlugin());
+					extraPlugins.push(createReactionsPlugin());
+					extraPlugins.push(createSpatialChatPlugin());
+					extraPlugins.push(createVotingPlugin());
+					extraPlugins.push(createSpotlightPlugin());
 					extraPlugins.push(createKeyboardShortcutsPlugin());
-					extraPlugins.push(whistlePlugin);
+					extraPlugins.push(createWhistlePlugin());
 					extraPlugins.push(createFilterPlugin());
 				}
 
 				const basePlugins: UsketchPlugin[] = [
-					gridBgPlugin,
-					dotsBgPlugin,
-					selectToolPlugin,
-					panToolPlugin,
-					viewportNavPlugin,
+					createGridBgPlugin(),
+					createDotsBgPlugin(),
+					createSelectToolPlugin(),
+					createPanToolPlugin(),
+					createViewportNavPlugin(),
 					portalPlugin,
-					groupPlugin,
-					islandPlugin,
+					createGroupPlugin(),
+					createIslandPlugin(),
 					createDomRendererPlugin(),
 				];
 

--- a/apps/web/src/pages/world-map.tsx
+++ b/apps/web/src/pages/world-map.tsx
@@ -5,9 +5,9 @@ import {
 	type CommunityRegionShapeData,
 	createCommunityRegionPlugin,
 } from "@edv4h/usketch-plugin-shape-community-region";
-import { panToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
-import { selectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
-import { viewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
+import { createPanToolPlugin } from "@edv4h/usketch-plugin-tool-pan";
+import { createSelectToolPlugin } from "@edv4h/usketch-plugin-tool-select";
+import { createViewportNavPlugin } from "@edv4h/usketch-plugin-viewport-nav";
 import { createBoardStore } from "@edv4h/usketch-store";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
@@ -157,9 +157,9 @@ export function WorldMapPage() {
 
 				// 4. キャンバス初期化
 				const plugins = [
-					selectToolPlugin,
-					panToolPlugin,
-					viewportNavPlugin,
+					createSelectToolPlugin(),
+					createPanToolPlugin(),
+					createViewportNavPlugin(),
 					createCommunityRegionPlugin({
 						onRegionClick: (regionSlug: string) => {
 							navigate(`/community/${regionSlug}`);

--- a/docs/plugin-system-design.md
+++ b/docs/plugin-system-design.md
@@ -80,6 +80,8 @@ interface LayerManager {
 /**
  * 全プラグイン共通の基本型
  */
+type PluginTeardown = () => void | Promise<void>
+
 interface UsketchPlugin {
   /** プラグインの一意識別子（例: "usketch-plugin-shape-rect"） */
   id: string
@@ -93,11 +95,14 @@ interface UsketchPlugin {
   /** プラグインの設定スキーマ（Zod） */
   configSchema?: z.ZodType
 
-  /** プラグイン初期化 */
-  setup(ctx: PluginContext): void | Promise<void>
-
-  /** プラグイン破棄 */
-  teardown?(): void
+  /**
+   * プラグイン初期化
+   *
+   * 戻り値で teardown 関数を返すことで、createApp().destroy() 時に
+   * per-instance のクリーンアップを行える。`this` への代入は React StrictMode
+   * 下で 2 回目の setup が 1 回目の closure を上書きしてしまうため禁止。
+   */
+  setup(ctx: PluginContext): PluginTeardown | void | Promise<PluginTeardown | void>
 }
 
 /**
@@ -139,45 +144,58 @@ interface ToolPlugin extends UsketchPlugin {
 
 **例: 選択ツールプラグイン**
 
+プラグインは **必ずファクトリ関数で公開する**（`createXxxPlugin()`）。同一 plugin instance が複数の `createApp` に渡されると React StrictMode の二重マウントで teardown closure が破壊されるため、毎回 fresh な instance を返す形に統一する。
+
 ```typescript
 // plugins/usketch-plugin-tool-select/src/index.ts
 import { selectToolMachine } from './machine'
 import { SelectIcon } from './icon'
 
-export const selectToolPlugin: ToolPlugin = {
-  id: 'usketch-plugin-tool-select',
-  name: '選択',
-  type: 'tool',
-  machine: selectToolMachine,
-  icon: SelectIcon,
-  shortcut: 'v',
-  order: 0,
+export function createSelectToolPlugin(): ToolPlugin {
+  return {
+    id: 'usketch-plugin-tool-select',
+    name: '選択',
+    type: 'tool',
+    machine: selectToolMachine,
+    icon: SelectIcon,
+    shortcut: 'v',
+    order: 0,
 
-  setup(ctx) {
-    // 選択UIレイヤーを登録
-    ctx.layers.register({
-      id: 'select-handles',
-      order: 70,
-      render: (renderCtx) => <SelectionHandles {...renderCtx} />,
-      interactable: true,
-    })
+    setup(ctx) {
+      // 選択UIレイヤーを登録
+      ctx.layers.register({
+        id: 'select-handles',
+        order: 70,
+        render: (renderCtx) => <SelectionHandles {...renderCtx} />,
+        interactable: true,
+      })
 
-    // ドラッグ選択レイヤーを登録
-    ctx.layers.register({
-      id: 'drag-selection',
-      order: 75,
-      render: (renderCtx) => <DragSelectionBox {...renderCtx} />,
-    })
+      // ドラッグ選択レイヤーを登録
+      ctx.layers.register({
+        id: 'drag-selection',
+        order: 75,
+        render: (renderCtx) => <DragSelectionBox {...renderCtx} />,
+      })
 
-    // コマンド登録
-    ctx.commands.register('select-all', selectAllCommand)
-    ctx.commands.register('delete-selected', deleteSelectedCommand)
+      // コマンド登録
+      ctx.commands.register('select-all', selectAllCommand)
+      ctx.commands.register('delete-selected', deleteSelectedCommand)
 
-    // ショートカット登録
-    ctx.shortcuts.register('Ctrl+A', 'select-all')
-    ctx.shortcuts.register('Delete', 'delete-selected')
-    ctx.shortcuts.register('Backspace', 'delete-selected')
-  },
+      // ショートカット登録
+      const offSelectAll = ctx.shortcuts.register('Ctrl+A', 'select-all')
+      const offDelete = ctx.shortcuts.register('Delete', 'delete-selected')
+      const offBackspace = ctx.shortcuts.register('Backspace', 'delete-selected')
+
+      // teardown を return する（this.teardown への代入は禁止）
+      return () => {
+        offSelectAll()
+        offDelete()
+        offBackspace()
+        ctx.layers.unregister('select-handles')
+        ctx.layers.unregister('drag-selection')
+      }
+    },
+  }
 }
 ```
 
@@ -393,36 +411,48 @@ export const snapPlugin: FeaturePlugin = {
 // apps/web/src/main.tsx
 import { createApp } from '@usketch/core'
 
-// コアプラグイン（MVPに必須）
-import { selectToolPlugin } from 'usketch-plugin-tool-select'
-import { panToolPlugin } from 'usketch-plugin-tool-pan'
-import { rectPlugin } from 'usketch-plugin-shape-rect'
-import { ellipsePlugin } from 'usketch-plugin-shape-ellipse'
-import { freedrawPlugin } from 'usketch-plugin-shape-freedraw'
-import { textPlugin } from 'usketch-plugin-shape-text'
-import { gridBgPlugin } from 'usketch-plugin-bg-grid'
-import { snapPlugin } from 'usketch-plugin-snap'
-import { exportPlugin } from 'usketch-plugin-export'
+// コアプラグイン（MVPに必須）— 全て factory 関数として import
+import { createSelectToolPlugin } from 'usketch-plugin-tool-select'
+import { createPanToolPlugin } from 'usketch-plugin-tool-pan'
+import { createBasicShapePlugin } from 'usketch-plugin-shape-basic'
+import { createTextPlugin } from 'usketch-plugin-shape-text'
+import { createGridBgPlugin } from 'usketch-plugin-bg-grid'
+import { createSnapPlugin } from 'usketch-plugin-snap'
+import { createExportPlugin } from 'usketch-plugin-export'
 
-const app = createApp({
-  plugins: [
-    // ツール
-    selectToolPlugin,
-    panToolPlugin,
-    // シェイプ（ツール付き）
-    rectPlugin,
-    ellipsePlugin,
-    freedrawPlugin,
-    textPlugin,
-    // 背景
-    gridBgPlugin,
-    // 機能
-    snapPlugin,
-    exportPlugin,
-  ],
-})
+// 重要: plugin 配列は useEffect 等の per-mount スコープで毎回組み立てる
+// （モジュールトップで const にすると StrictMode 二重マウントで instance が共有され危険）
+useEffect(() => {
+  let app: AppInstance | null = null
+  let cancelled = false
 
-app.mount(document.getElementById('root')!)
+  createApp({
+    plugins: [
+      // ツール
+      createSelectToolPlugin(),
+      createPanToolPlugin(),
+      // シェイプ
+      createBasicShapePlugin(),
+      createTextPlugin(),
+      // 背景
+      createGridBgPlugin(),
+      // 機能
+      createSnapPlugin(),
+      createExportPlugin(),
+    ],
+  }).then((instance) => {
+    if (cancelled) {
+      instance.destroy()
+      return
+    }
+    app = instance
+  })
+
+  return () => {
+    cancelled = true
+    app?.destroy()
+  }
+}, [])
 ```
 
 ### 4.2 ライフサイクル
@@ -437,7 +467,8 @@ createApp({ plugins })
   │     ├─ ツール登録
   │     ├─ シェイプ登録
   │     ├─ コマンド登録
-  │     └─ イベント購読
+  │     ├─ イベント購読
+  │     └─ setup の戻り値 (teardown 関数) を per-instance に蓄積
   │
   ├─ 3. React ツリーのマウント
   │     ├─ Canvas コンポーネント
@@ -445,9 +476,12 @@ createApp({ plugins })
   │     ├─ Toolbar（登録されたツールを表示）
   │     └─ PropertyPanel（選択シェイプに応じたパネル表示）
   │
-  └─ [アンマウント時]
-      └─ 各プラグインの teardown() を呼び出し
+  └─ [destroy() 時 / アンマウント時]
+      ├─ destroyed フラグで idempotent 化 (2 回目以降の destroy() は no-op)
+      └─ 蓄積された teardown を LIFO 順 (逆順) で実行
 ```
+
+> setup が throw した場合、それまでに収集した teardown を LIFO 順でロールバック実行する（partial set-up を leak させない）。
 
 ### 4.3 動的ロード（将来対応）
 

--- a/packages/core/src/__tests__/create-app-external-content.test.ts
+++ b/packages/core/src/__tests__/create-app-external-content.test.ts
@@ -46,15 +46,11 @@ function createStubStore(): BoardStore {
 }
 
 function registeringPlugin(handler: ExternalContentHandler): UsketchPlugin {
-	let off: (() => void) | undefined;
 	return {
 		id: "test-external-content-plugin",
 		name: "test external content",
 		setup(ctx: PluginContext) {
-			off = ctx.externalContent.register(handler);
-		},
-		teardown() {
-			off?.();
+			return ctx.externalContent.register(handler);
 		},
 	};
 }

--- a/packages/core/src/__tests__/create-app-selection-foreground.test.ts
+++ b/packages/core/src/__tests__/create-app-selection-foreground.test.ts
@@ -46,15 +46,11 @@ function createStubStore(): BoardStore {
 }
 
 function defaultPlugin(entry: SelectionForeground): UsketchPlugin {
-	let off: (() => void) | undefined;
 	return {
 		id: "test-default-plugin",
 		name: "test default",
 		setup(ctx: PluginContext) {
-			off = ctx.ui.registerSelectionForeground(entry);
-		},
-		teardown() {
-			off?.();
+			return ctx.ui.registerSelectionForeground(entry);
 		},
 	};
 }

--- a/packages/core/src/__tests__/create-app-strict-mode.test.ts
+++ b/packages/core/src/__tests__/create-app-strict-mode.test.ts
@@ -1,0 +1,176 @@
+import type { BoardStore, PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { createApp } from "../create-app.js";
+
+function createStubStore(): BoardStore {
+	const listeners = new Set<() => void>();
+	return {
+		getShapes: () => new Map(),
+		getShapesSorted: () => [],
+		getShape: () => undefined,
+		addShape() {},
+		updateShape() {},
+		deleteShape() {},
+		ensureZIndex() {},
+		getSelection: () => new Set(),
+		setSelection() {},
+		addToSelection() {},
+		removeFromSelection() {},
+		clearSelection() {},
+		getActiveToolId: () => "select",
+		setActiveToolId() {},
+		getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+		setViewport() {},
+		panBy() {},
+		zoomTo() {},
+		fitToBounds() {},
+		getStyleSettings: () => ({
+			fill: "#ffffff",
+			stroke: "#1e1e1e",
+			strokeWidth: 2,
+			opacity: 1,
+		}),
+		setStyleSettings() {},
+		getVisibleShapeIds: () => [],
+		subscribe(listener: () => void) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		onMutation: () => () => {},
+	} as unknown as BoardStore;
+}
+
+/**
+ * Reproduces the bug from Issue #609: under React StrictMode, `useEffect` runs
+ * setup → cleanup → setup. If a plugin is a module-level singleton that stashes
+ * its teardown on `this`, the second setup overwrites the first instance's
+ * closure — and when the first `createApp`'s `destroy()` later fires, it tears
+ * down the live second instance instead.
+ *
+ * The factory-function form (each `createApp` gets its own plugin object via
+ * `createXxxPlugin()`) plus `setup` returning the teardown closure makes this
+ * impossible at the type level. These tests pin that contract.
+ */
+describe("createApp — strict-mode safety", () => {
+	it("destroying app1 does not affect app2's registry when both use a fresh plugin instance", async () => {
+		// Factory: each call returns an independent plugin object (the recommended pattern).
+		function createTestPlugin(): UsketchPlugin {
+			return {
+				id: "test-plugin",
+				name: "test",
+				setup(ctx: PluginContext) {
+					const off = ctx.ui.registerSelectionForeground({
+						id: "test-foreground",
+						priority: 0,
+						render: () => null,
+					});
+					return () => off();
+				},
+			};
+		}
+
+		const app1 = await createApp({
+			store: createStubStore(),
+			plugins: [createTestPlugin()],
+		});
+		const app2 = await createApp({
+			store: createStubStore(),
+			plugins: [createTestPlugin()],
+		});
+
+		// Both apps see their own registration.
+		expect(app1.selectionForeground.getActive()?.id).toBe("test-foreground");
+		expect(app2.selectionForeground.getActive()?.id).toBe("test-foreground");
+
+		// Destroying app1 must not unregister app2's entry — the per-instance
+		// teardown closure is owned by app1's plugin instance only.
+		app1.destroy();
+		expect(app2.selectionForeground.getActive()?.id).toBe("test-foreground");
+
+		app2.destroy();
+		expect(app2.selectionForeground.getActive()).toBeNull();
+	});
+
+	it("destroy() is idempotent — teardown only runs once even if destroy is called twice", async () => {
+		let teardownCount = 0;
+		const plugin: UsketchPlugin = {
+			id: "idempotent-test",
+			name: "idempotent",
+			setup() {
+				return () => {
+					teardownCount += 1;
+				};
+			},
+		};
+
+		const app = await createApp({ store: createStubStore(), plugins: [plugin] });
+		app.destroy();
+		app.destroy();
+		app.destroy();
+		expect(teardownCount).toBe(1);
+	});
+
+	it("setup throw triggers LIFO rollback of teardowns from previously-set-up plugins", async () => {
+		const order: string[] = [];
+		const pluginA: UsketchPlugin = {
+			id: "A",
+			name: "A",
+			setup() {
+				return () => order.push("teardown-A");
+			},
+		};
+		const pluginB: UsketchPlugin = {
+			id: "B",
+			name: "B",
+			setup() {
+				return () => order.push("teardown-B");
+			},
+		};
+		const pluginC: UsketchPlugin = {
+			id: "C",
+			name: "C",
+			setup() {
+				throw new Error("C failed");
+			},
+		};
+
+		await expect(
+			createApp({ store: createStubStore(), plugins: [pluginA, pluginB, pluginC] }),
+		).rejects.toThrow("C failed");
+
+		// LIFO: B was set up after A, so B's teardown should run first.
+		expect(order).toEqual(["teardown-B", "teardown-A"]);
+	});
+
+	it("teardowns run in LIFO order on destroy", async () => {
+		const order: string[] = [];
+		const make = (id: string): UsketchPlugin => ({
+			id,
+			name: id,
+			setup() {
+				return () => order.push(id);
+			},
+		});
+
+		const app = await createApp({
+			store: createStubStore(),
+			plugins: [make("first"), make("second"), make("third")],
+		});
+
+		app.destroy();
+		expect(order).toEqual(["third", "second", "first"]);
+	});
+
+	it("plugins that return nothing from setup are skipped during teardown (no error)", async () => {
+		const plugin: UsketchPlugin = {
+			id: "no-teardown",
+			name: "no teardown",
+			setup() {
+				// returns void
+			},
+		};
+
+		const app = await createApp({ store: createStubStore(), plugins: [plugin] });
+		expect(() => app.destroy()).not.toThrow();
+	});
+});

--- a/packages/core/src/create-app.ts
+++ b/packages/core/src/create-app.ts
@@ -6,6 +6,7 @@ import type {
 	LayerManager,
 	LodPolicy,
 	PluginContext,
+	PluginTeardown,
 	RenderMode,
 	SelectionForeground,
 	SelectionForegroundRegistry,
@@ -131,13 +132,28 @@ export async function createApp(options: CreateAppOptions): Promise<AppInstance>
 		events.emit(event.type, event.payload);
 	});
 
-	// Register and setup plugins
+	// Register and setup plugins.
+	// Each plugin's setup may return a per-instance teardown closure; we collect
+	// them here and run them in LIFO order on destroy. If a later setup throws,
+	// we run the teardowns we already collected (also LIFO) so partially-set-up
+	// plugins don't leak state.
+	const teardowns: PluginTeardown[] = [];
 	try {
 		for (const plugin of plugins) {
 			pluginRegistry.register(plugin);
-			await plugin.setup(ctx);
+			const teardown = await plugin.setup(ctx);
+			if (typeof teardown === "function") {
+				teardowns.push(teardown);
+			}
 		}
 	} catch (error) {
+		for (const teardown of [...teardowns].reverse()) {
+			try {
+				await teardown();
+			} catch (teardownError) {
+				console.error("[usketch] plugin teardown failed during setup rollback", teardownError);
+			}
+		}
 		unsubMutation();
 		throw error;
 	}
@@ -159,6 +175,7 @@ export async function createApp(options: CreateAppOptions): Promise<AppInstance>
 		});
 	}
 
+	let destroyed = false;
 	return {
 		store,
 		layers,
@@ -174,8 +191,19 @@ export async function createApp(options: CreateAppOptions): Promise<AppInstance>
 		externalContent,
 		plugins: pluginRegistry.getAll(),
 		destroy() {
-			for (const plugin of plugins) {
-				plugin.teardown?.();
+			if (destroyed) return;
+			destroyed = true;
+			for (const teardown of [...teardowns].reverse()) {
+				try {
+					const result = teardown();
+					if (result && typeof (result as Promise<unknown>).catch === "function") {
+						(result as Promise<unknown>).catch((error) => {
+							console.error("[usketch] async plugin teardown rejected", error);
+						});
+					}
+				} catch (error) {
+					console.error("[usketch] plugin teardown threw", error);
+				}
 			}
 			lod.destroy();
 			unsubMutation();

--- a/packages/dom-renderer/src/plugin.tsx
+++ b/packages/dom-renderer/src/plugin.tsx
@@ -2,8 +2,6 @@ import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
 import { DomShapeLayer } from "./dom-shape-layer.js";
 
 export function createDomRendererPlugin(): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-dom-renderer",
 		name: "DOM Renderer",
@@ -63,15 +61,11 @@ export function createDomRendererPlugin(): UsketchPlugin {
 				),
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubClaim();
 				unsubDropTarget();
 				ctx.layers.unregister("dom-shapes");
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/packages/gpu-renderer/src/plugin.tsx
+++ b/packages/gpu-renderer/src/plugin.tsx
@@ -7,7 +7,6 @@ export interface GpuRendererPluginOptions {
 
 export function createGpuRendererPlugin(options?: GpuRendererPluginOptions): UsketchPlugin {
 	const mode = options?.mode ?? "auto";
-	let cleanup: (() => void) | undefined;
 
 	return {
 		id: "usketch-gpu-renderer",
@@ -31,13 +30,9 @@ export function createGpuRendererPlugin(options?: GpuRendererPluginOptions): Usk
 				),
 			});
 
-			cleanup = () => {
+			return () => {
 				ctx.layers.unregister("gpu-shapes");
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,7 @@ export type {
 	LayerManager,
 	LayerRenderContext,
 	PluginContext,
+	PluginTeardown,
 	RenderTarget,
 	SelectionForeground,
 	SelectionForegroundRegistry,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -499,9 +499,28 @@ export interface PluginContext {
 	externalContent: ExternalContentRegistry;
 }
 
+/**
+ * Cleanup function returned from {@link UsketchPlugin.setup}.
+ *
+ * Called by `createApp().destroy()` (and as part of setup-rollback when a later
+ * plugin throws). May be sync or async — `destroy()` itself stays sync and any
+ * async teardown is fire-and-forget with errors logged.
+ */
+export type PluginTeardown = () => void | Promise<void>;
+
 export interface UsketchPlugin {
 	readonly id: string;
 	readonly name: string;
-	setup(ctx: PluginContext): void | Promise<void>;
-	teardown?(): void;
+	/**
+	 * Initialize the plugin. Return a teardown function to release resources
+	 * when the app is destroyed; return `void` (or omit a return) if the plugin
+	 * has nothing to clean up.
+	 *
+	 * The previous `plugin.teardown` property has been removed: stashing the
+	 * cleanup on `this` is unsafe under React StrictMode (a second `setup` call
+	 * silently overwrites the first plugin instance's teardown closure). Always
+	 * return the cleanup from setup instead — each `createApp` call owns its
+	 * own closure.
+	 */
+	setup(ctx: PluginContext): PluginTeardown | void | Promise<PluginTeardown | void>;
 }

--- a/plugins/usketch-plugin-activity-feed/src/plugin.tsx
+++ b/plugins/usketch-plugin-activity-feed/src/plugin.tsx
@@ -132,8 +132,6 @@ export interface ActivityFeedOptions {
 export function createActivityFeedPlugin(options: ActivityFeedOptions): UsketchPlugin {
 	const { boardId, apiUrl } = options;
 
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-activity-feed",
 		name: "アクティビティフィード",
@@ -150,13 +148,9 @@ export function createActivityFeedPlugin(options: ActivityFeedOptions): UsketchP
 				},
 			});
 
-			cleanup = () => {
+			return () => {
 				ctx.events.emit("side-panel:unregister-tab", { tabId: "activity" });
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-ai-actions/src/plugin.tsx
+++ b/plugins/usketch-plugin-ai-actions/src/plugin.tsx
@@ -17,10 +17,10 @@ export function createAiActionsPlugin(options: AiActionsOptions): UsketchPlugin 
 				fixed: true,
 				render: () => <ActionBar store={ctx.store} events={ctx.events} boardId={options.boardId} />,
 			});
-		},
 
-		teardown() {
-			// Layer is automatically cleaned up when the app is destroyed
+			return () => {
+				ctx.layers.unregister("ai-action-bar");
+			};
 		},
 	};
 }

--- a/plugins/usketch-plugin-ai-agent/src/plugin.ts
+++ b/plugins/usketch-plugin-ai-agent/src/plugin.ts
@@ -31,7 +31,6 @@ const ACTION_PROMPTS: Record<
 export function createAiAgentPlugin(options: AiAgentOptions): UsketchPlugin {
 	const { apiUrl, extraHeaders } = options;
 	let busy = false;
-	let cleanup: (() => void) | undefined;
 
 	return {
 		id: "usketch-plugin-ai-agent",
@@ -102,14 +101,10 @@ export function createAiAgentPlugin(options: AiAgentOptions): UsketchPlugin {
 				},
 			);
 
-			cleanup = () => {
+			return () => {
 				unsubRequest();
 				unsubSmartAction();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-ai-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-ai-chat/src/plugin.tsx
@@ -30,7 +30,6 @@ export interface AiChatOptions {
 }
 
 export function createAiChatPlugin(options: AiChatOptions): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
 	const paletteEnabled = options.enableCommandPalette !== false;
 
 	return {
@@ -73,14 +72,10 @@ export function createAiChatPlugin(options: AiChatOptions): UsketchPlugin {
 				},
 			});
 
-			cleanup = () => {
+			return () => {
 				paletteCleanup?.();
 				ctx.events.emit("side-panel:unregister-tab", { tabId: "ai-chat" });
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-ai-copilot/src/plugin.tsx
+++ b/plugins/usketch-plugin-ai-copilot/src/plugin.tsx
@@ -30,7 +30,6 @@ Rules:
 export function createAiCopilotPlugin(options: CopilotOptions): UsketchPlugin {
 	const { apiUrl, boardId, extraHeaders, debounceMs = 2000, maxSuggestions = 3 } = options;
 
-	let cleanup: (() => void) | undefined;
 	let enabled = options.enabled ?? false;
 
 	return {
@@ -298,7 +297,7 @@ export function createAiCopilotPlugin(options: CopilotOptions): UsketchPlugin {
 				}
 			});
 
-			cleanup = () => {
+			return () => {
 				if (debounceTimer) clearTimeout(debounceTimer);
 				abortActiveRequest();
 				dismissAll();
@@ -310,10 +309,6 @@ export function createAiCopilotPlugin(options: CopilotOptions): UsketchPlugin {
 				const styleEl = document.getElementById(STYLE_ID);
 				if (styleEl) styleEl.remove();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-ai-image/src/plugin.ts
+++ b/plugins/usketch-plugin-ai-image/src/plugin.ts
@@ -5,7 +5,6 @@ import type { ImageOptions } from "./types.js";
 
 export function createAiImagePlugin(options: ImageOptions): UsketchPlugin {
 	const { maxSizeMB = 4, maxDimension = 2048 } = options;
-	let cleanup: (() => void) | undefined;
 
 	return {
 		id: "usketch-plugin-ai-image",
@@ -97,13 +96,9 @@ export function createAiImagePlugin(options: ImageOptions): UsketchPlugin {
 			// owns the explicit `image:upload` event (file picker entry point).
 			const unsubUpload = ctx.events.on("image:upload", handleUpload);
 
-			cleanup = () => {
+			return () => {
 				unsubUpload();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-ai-recognize/src/plugin.ts
+++ b/plugins/usketch-plugin-ai-recognize/src/plugin.ts
@@ -8,8 +8,6 @@ export interface RecognizeOptions {
 }
 
 export function createAiRecognizePlugin(options: RecognizeOptions): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-ai-recognize",
 		name: "AI Recognize",
@@ -133,14 +131,10 @@ IMPORTANT:
 				});
 			}
 
-			cleanup = () => {
+			return () => {
 				unsubRecognize();
 				cleanupListeners();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-ai-voice/src/plugin.ts
+++ b/plugins/usketch-plugin-ai-voice/src/plugin.ts
@@ -4,8 +4,6 @@ import type { VoiceOptions, VoiceStatusEvent } from "./types.js";
 import { createVoiceIndicator } from "./voice-indicator.js";
 
 export function createAiVoicePlugin(options: VoiceOptions): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-ai-voice",
 		name: "AI Voice",
@@ -17,7 +15,6 @@ export function createAiVoicePlugin(options: VoiceOptions): UsketchPlugin {
 
 			if (!SpeechRecognitionCtor) {
 				// Browser doesn't support Speech API - plugin is a no-op
-				cleanup = () => {};
 				return;
 			}
 
@@ -91,15 +88,11 @@ export function createAiVoicePlugin(options: VoiceOptions): UsketchPlugin {
 				startListening();
 			});
 
-			cleanup = () => {
+			return () => {
 				stopListening();
 				unsubToggle();
 				indicator.destroy();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-avatar/src/plugin.tsx
+++ b/plugins/usketch-plugin-avatar/src/plugin.tsx
@@ -51,8 +51,6 @@ export function createAvatarPlugin(options: AvatarPluginOptions): UsketchPlugin 
 	const { wsProvider, userId, userName, userImage } = options;
 	const { awareness } = wsProvider;
 
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-avatar",
 		name: "アバター",
@@ -291,7 +289,7 @@ export function createAvatarPlugin(options: AvatarPluginOptions): UsketchPlugin 
 			// 遅延チェックでavatar情報の更新を拾う
 			const delayedCheck = setTimeout(() => onAwarenessChange(), 2000);
 
-			cleanup = () => {
+			return () => {
 				clearTimeout(delayedCheck);
 				awareness.off("change", onAwarenessChange);
 				unsubStore();
@@ -299,10 +297,6 @@ export function createAvatarPlugin(options: AvatarPluginOptions): UsketchPlugin 
 				hideRadialMenu();
 				ctx.layers.unregister("avatar-self");
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-bg-dots/src/index.ts
+++ b/plugins/usketch-plugin-bg-dots/src/index.ts
@@ -1,2 +1,2 @@
 export const PLUGIN_NAME = "usketch-plugin-bg-dots" as const;
-export { dotsBgPlugin } from "./plugin.js";
+export { createDotsBgPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-bg-dots/src/plugin.tsx
+++ b/plugins/usketch-plugin-bg-dots/src/plugin.tsx
@@ -60,32 +60,30 @@ function DotsBackground({ viewport }: { viewport: LayerRenderContext["viewport"]
 
 // ── Plugin ──
 
-export const dotsBgPlugin: UsketchPlugin = {
-	id: "usketch-plugin-bg-dots",
-	name: "Dots Background",
+export function createDotsBgPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-bg-dots",
+		name: "Dots Background",
 
-	setup(ctx: PluginContext) {
-		// Reset to default hidden state
-		visible = false;
+		setup(ctx: PluginContext) {
+			// Reset to default hidden state
+			visible = false;
 
-		ctx.layers.register({
-			id: "bg-dots",
-			order: 10,
-			fixed: true,
-			render: (renderCtx) => <DotsBackground viewport={renderCtx.viewport} />,
-		});
+			ctx.layers.register({
+				id: "bg-dots",
+				order: 10,
+				fixed: true,
+				render: (renderCtx) => <DotsBackground viewport={renderCtx.viewport} />,
+			});
 
-		const off = ctx.events.on<{ type: string }>("bg:set", ({ type }) => {
-			setVisible(type === "dots");
-		});
+			const off = ctx.events.on<{ type: string }>("bg:set", ({ type }) => {
+				setVisible(type === "dots");
+			});
 
-		(this as unknown as { _cleanup: () => void })._cleanup = () => {
-			off();
-			ctx.layers.unregister("bg-dots");
-		};
-	},
-
-	teardown() {
-		(this as unknown as { _cleanup?: () => void })._cleanup?.();
-	},
-};
+			return () => {
+				off();
+				ctx.layers.unregister("bg-dots");
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-bg-grid/src/index.ts
+++ b/plugins/usketch-plugin-bg-grid/src/index.ts
@@ -1,2 +1,2 @@
 export const PLUGIN_NAME = "usketch-plugin-bg-grid" as const;
-export { gridBgPlugin } from "./plugin.js";
+export { createGridBgPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-bg-grid/src/plugin.tsx
+++ b/plugins/usketch-plugin-bg-grid/src/plugin.tsx
@@ -64,32 +64,30 @@ function GridBackground({ viewport }: { viewport: LayerRenderContext["viewport"]
 
 // ── Plugin ──
 
-export const gridBgPlugin: UsketchPlugin = {
-	id: "usketch-plugin-bg-grid",
-	name: "Grid Background",
+export function createGridBgPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-bg-grid",
+		name: "Grid Background",
 
-	setup(ctx: PluginContext) {
-		// Reset to default visible state
-		visible = true;
+		setup(ctx: PluginContext) {
+			// Reset to default visible state
+			visible = true;
 
-		ctx.layers.register({
-			id: "bg-grid",
-			order: 10,
-			fixed: true,
-			render: (renderCtx) => <GridBackground viewport={renderCtx.viewport} />,
-		});
+			ctx.layers.register({
+				id: "bg-grid",
+				order: 10,
+				fixed: true,
+				render: (renderCtx) => <GridBackground viewport={renderCtx.viewport} />,
+			});
 
-		const off = ctx.events.on<{ type: string }>("bg:set", ({ type }) => {
-			setVisible(type === "grid");
-		});
+			const off = ctx.events.on<{ type: string }>("bg:set", ({ type }) => {
+				setVisible(type === "grid");
+			});
 
-		(this as unknown as { _cleanup: () => void })._cleanup = () => {
-			off();
-			ctx.layers.unregister("bg-grid");
-		};
-	},
-
-	teardown() {
-		(this as unknown as { _cleanup?: () => void })._cleanup?.();
-	},
-};
+			return () => {
+				off();
+				ctx.layers.unregister("bg-grid");
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-board-info-panel/src/plugin.tsx
+++ b/plugins/usketch-plugin-board-info-panel/src/plugin.tsx
@@ -12,7 +12,6 @@ export interface BoardInfoPanelPluginOptions {
 
 export function createBoardInfoPanelPlugin(options: BoardInfoPanelPluginOptions): UsketchPlugin {
 	const { apiUrl, extraHeaders, onOpenBoard } = options;
-	let cleanup: (() => void) | undefined;
 
 	return {
 		id: "usketch-plugin-board-info-panel",
@@ -79,14 +78,10 @@ export function createBoardInfoPanelPlugin(options: BoardInfoPanelPluginOptions)
 				checkSelection();
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubMutation();
 				ctx.events.emit("side-panel:unregister-tab", { tabId: "board-info" });
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-canvas-filter/src/plugin.tsx
+++ b/plugins/usketch-plugin-canvas-filter/src/plugin.tsx
@@ -203,36 +203,36 @@ export function createFilterPlugin(_options?: FilterPluginOptions): UsketchPlugi
 					},
 				});
 			}
-		},
 
-		teardown() {
-			for (const cleanup of cleanups) cleanup();
-			cleanups.length = 0;
+			return () => {
+				for (const cleanup of cleanups) cleanup();
+				cleanups.length = 0;
 
-			if (ctx) {
-				ctx.layers.unregister("filter-palette");
-				ctx.layers.unregister("filter-indicator");
-				ctx.layers.unregister("time-travel-banner");
-				ctx.events.emit("side-panel:unregister-tab", { tabId: "time-travel" });
+				if (ctx) {
+					ctx.layers.unregister("filter-palette");
+					ctx.layers.unregister("filter-indicator");
+					ctx.layers.unregister("time-travel-banner");
+					ctx.events.emit("side-panel:unregister-tab", { tabId: "time-travel" });
 
-				if (currentConfig) {
-					ctx.events.emit<FilterChangedEvent>("filter:changed", {
-						predicate: null,
-						config: null,
-					});
+					if (currentConfig) {
+						ctx.events.emit<FilterChangedEvent>("filter:changed", {
+							predicate: null,
+							config: null,
+						});
+					}
+
+					if (timeTravelShapes) {
+						ctx.events.emit("time-travel:exit", {});
+					}
 				}
 
-				if (timeTravelShapes) {
-					ctx.events.emit("time-travel:exit", {});
-				}
-			}
-
-			currentConfig = null;
-			paletteOpen = false;
-			timeTravelTs = null;
-			timeTravelShapes = null;
-			listeners.clear();
-			ctx = null;
+				currentConfig = null;
+				paletteOpen = false;
+				timeTravelTs = null;
+				timeTravelShapes = null;
+				listeners.clear();
+				ctx = null;
+			};
 		},
 	};
 }

--- a/plugins/usketch-plugin-comments/src/plugin.tsx
+++ b/plugins/usketch-plugin-comments/src/plugin.tsx
@@ -30,7 +30,6 @@ export interface CommentsPluginOptions {
 
 export function createCommentsPlugin(options: CommentsPluginOptions): UsketchPlugin {
 	const { boardId, apiUrl, extraHeaders } = options;
-	let cleanup: (() => void) | undefined;
 
 	return {
 		id: "usketch-plugin-comments",
@@ -85,15 +84,11 @@ export function createCommentsPlugin(options: CommentsPluginOptions): UsketchPlu
 				},
 			);
 
-			cleanup = () => {
+			return () => {
 				unsubStartThread();
 				ctx.events.emit("side-panel:unregister-tab", { tabId: "comments" });
 				ctx.layers.unregister("comment-badges");
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-community-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-community-chat/src/plugin.tsx
@@ -380,8 +380,6 @@ function ChatIcon() {
 // ── プラグイン ──
 
 export function createCommunityChatPlugin(options: CommunityChatOptions): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	const client = createChatClient({
 		apiUrl: options.apiUrl,
 		extraHeaders: options.extraHeaders,
@@ -567,16 +565,12 @@ export function createCommunityChatPlugin(options: CommunityChatOptions): Usketc
 				},
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubMutation();
 				unsubNewMessage();
 				unsubShapeAdd();
 				ctx.events.emit("side-panel:unregister-tab", { tabId: "community-chat" });
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-debug-hud/src/index.ts
+++ b/plugins/usketch-plugin-debug-hud/src/index.ts
@@ -1,1 +1,1 @@
-export { debugHudPlugin } from "./plugin.js";
+export { createDebugHudPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-debug-hud/src/plugin.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/plugin.tsx
@@ -19,75 +19,72 @@ function formatEventLabel(event: string, data: unknown): string {
 	return event;
 }
 
-export const debugHudPlugin: UsketchPlugin = {
-	id: "debug-hud",
-	name: "Debug HUD",
+export function createDebugHudPlugin(): UsketchPlugin {
+	return {
+		id: "debug-hud",
+		name: "Debug HUD",
 
-	setup(ctx) {
-		const fpsCounter = new FpsCounter();
-		const eventLogger = new EventLogger();
-		const pointerTracker = new PointerTracker();
-		const visibility = createVisibilityStore(VISIBILITY_STORAGE_KEY);
+		setup(ctx) {
+			const fpsCounter = new FpsCounter();
+			const eventLogger = new EventLogger();
+			const pointerTracker = new PointerTracker();
+			const visibility = createVisibilityStore(VISIBILITY_STORAGE_KEY);
 
-		// Start FPS counter
-		fpsCounter.start();
+			// Start FPS counter
+			fpsCounter.start();
 
-		// Monkey-patch emit to capture events. Push is skipped while the HUD is hidden
-		// so the drag path stays free of EventLogger work when no UI is observing it.
-		const originalEmit = ctx.events.emit.bind(ctx.events);
-		(ctx.events as { emit: EventBus["emit"] }).emit = <T = unknown>(event: string, data: T) => {
-			if (visibility.get() && !EXCLUDED_EVENTS.has(event)) {
-				const label = formatEventLabel(event, data);
-				eventLogger.push({ event: label, timestamp: Date.now() });
-			}
-			originalEmit(event, data);
-		};
+			// Monkey-patch emit to capture events. Push is skipped while the HUD is hidden
+			// so the drag path stays free of EventLogger work when no UI is observing it.
+			const originalEmit = ctx.events.emit.bind(ctx.events);
+			(ctx.events as { emit: EventBus["emit"] }).emit = <T = unknown>(event: string, data: T) => {
+				if (visibility.get() && !EXCLUDED_EVENTS.has(event)) {
+					const label = formatEventLabel(event, data);
+					eventLogger.push({ event: label, timestamp: Date.now() });
+				}
+				originalEmit(event, data);
+			};
 
-		// Track pointer coordinates
-		const unsubPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointermove", (data) => {
-			pointerTracker.update(data.worldPoint, data.screenPoint);
-		});
+			// Track pointer coordinates
+			const unsubPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointermove", (data) => {
+				pointerTracker.update(data.worldPoint, data.screenPoint);
+			});
 
-		// Pick up sync status tracker from window (set by app.tsx)
-		const syncStatus = (globalThis as Record<string, unknown>).__usketchSyncStatus as
-			| import("./sync-status-types.js").SyncStatusTrackerLike
-			| undefined;
+			// Pick up sync status tracker from window (set by app.tsx)
+			const syncStatus = (globalThis as Record<string, unknown>).__usketchSyncStatus as
+				| import("./sync-status-types.js").SyncStatusTrackerLike
+				| undefined;
 
-		// Register the fixed layer — always renders, visibility toggled inside component
-		ctx.layers.register({
-			id: "debug-hud",
-			order: 9999,
-			fixed: true,
-			render: (renderCtx) => (
-				<DebugHud
-					store={ctx.store}
-					fpsCounter={fpsCounter}
-					eventLogger={eventLogger}
-					pointerTracker={pointerTracker}
-					commands={ctx.commands}
-					tools={ctx.tools}
-					layers={ctx.layers}
-					shapes={ctx.shapes}
-					syncStatus={syncStatus}
-					events={ctx.events}
-					ctx={renderCtx}
-					visibility={visibility}
-				/>
-			),
-		});
+			// Register the fixed layer — always renders, visibility toggled inside component
+			ctx.layers.register({
+				id: "debug-hud",
+				order: 9999,
+				fixed: true,
+				render: (renderCtx) => (
+					<DebugHud
+						store={ctx.store}
+						fpsCounter={fpsCounter}
+						eventLogger={eventLogger}
+						pointerTracker={pointerTracker}
+						commands={ctx.commands}
+						tools={ctx.tools}
+						layers={ctx.layers}
+						shapes={ctx.shapes}
+						syncStatus={syncStatus}
+						events={ctx.events}
+						ctx={renderCtx}
+						visibility={visibility}
+					/>
+				),
+			});
 
-		// Store teardown in closure — no module-level state
-		this.teardown = () => {
-			fpsCounter.stop();
-			pointerTracker.dispose();
-			eventLogger.dispose();
-			(ctx.events as { emit: EventBus["emit"] }).emit = originalEmit;
-			unsubPointer();
-			ctx.layers.unregister("debug-hud");
-		};
-	},
-
-	teardown() {
-		// overwritten by setup()
-	},
-};
+			return () => {
+				fpsCounter.stop();
+				pointerTracker.dispose();
+				eventLogger.dispose();
+				(ctx.events as { emit: EventBus["emit"] }).emit = originalEmit;
+				unsubPointer();
+				ctx.layers.unregister("debug-hud");
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
+++ b/plugins/usketch-plugin-domain-design/src/__tests__/plugin.test.ts
@@ -1,6 +1,6 @@
 import type { PluginContext, ShapeData, ShapeDefinition } from "@edv4h/usketch-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { domainDesignPlugin } from "../plugin.js";
+import { createDomainDesignPlugin } from "../plugin.js";
 import { DOMAIN_TYPES } from "../types.js";
 
 type EventHandler = (data: unknown) => void;
@@ -115,7 +115,7 @@ function createMockContext() {
 	return { ctx, shapeRegistrations, toolRegistrations, eventHandlers };
 }
 
-describe("domainDesignPlugin", () => {
+describe("createDomainDesignPlugin", () => {
 	let restoreWindow: () => void;
 	beforeEach(() => {
 		restoreWindow = installWindowMock();
@@ -125,13 +125,15 @@ describe("domainDesignPlugin", () => {
 	});
 
 	it("has stable id and Japanese display name", () => {
-		expect(domainDesignPlugin.id).toBe("usketch-plugin-domain-design");
-		expect(domainDesignPlugin.name).toBe("ドメイン設計");
+		const plugin = createDomainDesignPlugin();
+		expect(plugin.id).toBe("usketch-plugin-domain-design");
+		expect(plugin.name).toBe("ドメイン設計");
 	});
 
 	it("registers 4 domain shape types (3 containers + 1 connector)", async () => {
 		const { ctx, shapeRegistrations } = createMockContext();
-		await domainDesignPlugin.setup(ctx);
+		const plugin = createDomainDesignPlugin();
+		const teardown = await plugin.setup(ctx);
 		const types = Array.from(shapeRegistrations.keys()).sort();
 		expect(types).toEqual(
 			[
@@ -141,32 +143,35 @@ describe("domainDesignPlugin", () => {
 				DOMAIN_TYPES.connector,
 			].sort(),
 		);
-		domainDesignPlugin.teardown?.();
+		teardown?.();
 	});
 
 	it("registers a property bar layer for domain-connector", async () => {
 		const { ctx } = createMockContext();
 		const layerRegister = ctx.layers.register as ReturnType<typeof vi.fn>;
-		await domainDesignPlugin.setup(ctx);
+		const plugin = createDomainDesignPlugin();
+		const teardown = await plugin.setup(ctx);
 		const layerIds = layerRegister.mock.calls.map((call: [{ id: string }]) => call[0].id);
 		expect(layerIds).toContain("domain-connector-properties");
-		domainDesignPlugin.teardown?.();
+		teardown?.();
 	});
 
 	it("registers the domain-draw tool with shortcut 'd'", async () => {
 		const { ctx, toolRegistrations } = createMockContext();
-		await domainDesignPlugin.setup(ctx);
+		const plugin = createDomainDesignPlugin();
+		const teardown = await plugin.setup(ctx);
 		const tool = toolRegistrations.get("domain-draw") as { shortcut?: string } | undefined;
 		expect(tool).toBeDefined();
 		expect(tool?.shortcut).toBe("d");
-		domainDesignPlugin.teardown?.();
+		teardown?.();
 	});
 
 	it("teardown unregisters listeners (does not throw on second call)", async () => {
 		const { ctx } = createMockContext();
-		await domainDesignPlugin.setup(ctx);
-		expect(() => domainDesignPlugin.teardown?.()).not.toThrow();
+		const plugin = createDomainDesignPlugin();
+		const teardown = await plugin.setup(ctx);
+		expect(() => teardown?.()).not.toThrow();
 		// 2 度目の teardown も安全であること
-		expect(() => domainDesignPlugin.teardown?.()).not.toThrow();
+		expect(() => teardown?.()).not.toThrow();
 	});
 });

--- a/plugins/usketch-plugin-domain-design/src/index.ts
+++ b/plugins/usketch-plugin-domain-design/src/index.ts
@@ -1,4 +1,4 @@
-export { domainDesignPlugin } from "./plugin.js";
+export { createDomainDesignPlugin } from "./plugin.js";
 export { DOMAIN_SUBTYPES, type DomainSubtype } from "./registry.js";
 export {
 	type AggregateMeta,

--- a/plugins/usketch-plugin-domain-design/src/plugin.tsx
+++ b/plugins/usketch-plugin-domain-design/src/plugin.tsx
@@ -78,246 +78,244 @@ function DomainDrawIcon() {
 	);
 }
 
-export const domainDesignPlugin: UsketchPlugin = {
-	id: "usketch-plugin-domain-design",
-	name: "ドメイン設計",
+export function createDomainDesignPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-domain-design",
+		name: "ドメイン設計",
 
-	setup(ctx: PluginContext) {
-		const cleanups: Array<() => void> = [];
+		setup(ctx: PluginContext) {
+			const cleanups: Array<() => void> = [];
 
-		// ── Container shape 登録 (BoundedContext / Aggregate / ClassBox) ──
-		for (const subtype of DOMAIN_SUBTYPES) {
-			if (subtype.kind !== "shape") continue;
-			const renderer = SHAPE_RENDERERS[subtype.type];
-			const hitTestFn = SHAPE_HIT_TESTS[subtype.type];
-			if (!renderer || !hitTestFn) continue;
-			ctx.shapes.register(subtype.type, {
-				render: renderer,
-				getBounds,
-				hitTest: hitTestFn,
-				resize: createResize(
-					MIN_SIZE_BY_TYPE[subtype.type]?.width ?? 1,
-					MIN_SIZE_BY_TYPE[subtype.type]?.height ?? 1,
-				),
-				createDefault: subtype.createDefault,
-				renderTarget: RENDER_TARGET_BY_TYPE[subtype.type],
-				minSize: MIN_SIZE_BY_TYPE[subtype.type],
+			// ── Container shape 登録 (BoundedContext / Aggregate / ClassBox) ──
+			for (const subtype of DOMAIN_SUBTYPES) {
+				if (subtype.kind !== "shape") continue;
+				const renderer = SHAPE_RENDERERS[subtype.type];
+				const hitTestFn = SHAPE_HIT_TESTS[subtype.type];
+				if (!renderer || !hitTestFn) continue;
+				ctx.shapes.register(subtype.type, {
+					render: renderer,
+					getBounds,
+					hitTest: hitTestFn,
+					resize: createResize(
+						MIN_SIZE_BY_TYPE[subtype.type]?.width ?? 1,
+						MIN_SIZE_BY_TYPE[subtype.type]?.height ?? 1,
+					),
+					createDefault: subtype.createDefault,
+					renderTarget: RENDER_TARGET_BY_TYPE[subtype.type],
+					minSize: MIN_SIZE_BY_TYPE[subtype.type],
+				});
+			}
+
+			// ── DDD Connector shape 登録 ──
+			// Anchor / hit-test / bounds は `@edv4h/usketch-connector-anchor` のロジックを直接利用。
+			// renderer のみ DDD 専用 (relation badge / 矢頭 / multiplicity を上書き)。
+			// `createDefault` は draw tool 以外のパス (AI copilot 等が
+			// `ctx.shapes.get(type).createDefault(...)` を呼ぶケース) でも有効な
+			// `DomainConnectorShape` を返すよう、専用ファクトリを再利用する。
+			ctx.shapes.register(DOMAIN_TYPES.connector, {
+				render: renderDomainConnector,
+				getBounds: getBoundsConnector,
+				hitTest: hitTestConnector,
+				resize: (data) => ({ ...data }),
+				resizable: false,
+				createDefault: ({ id, x, y }) =>
+					createDefaultDomainConnector({
+						id,
+						x,
+						y,
+						domainKind: "context-map",
+						relation: "customer-supplier",
+					}),
+				renderTarget: "svg",
 			});
-		}
 
-		// ── DDD Connector shape 登録 ──
-		// Anchor / hit-test / bounds は `@edv4h/usketch-connector-anchor` のロジックを直接利用。
-		// renderer のみ DDD 専用 (relation badge / 矢頭 / multiplicity を上書き)。
-		// `createDefault` は draw tool 以外のパス (AI copilot 等が
-		// `ctx.shapes.get(type).createDefault(...)` を呼ぶケース) でも有効な
-		// `DomainConnectorShape` を返すよう、専用ファクトリを再利用する。
-		ctx.shapes.register(DOMAIN_TYPES.connector, {
-			render: renderDomainConnector,
-			getBounds: getBoundsConnector,
-			hitTest: hitTestConnector,
-			resize: (data) => ({ ...data }),
-			resizable: false,
-			createDefault: ({ id, x, y }) =>
-				createDefaultDomainConnector({
+			// ── Connector tracking & cascade delete ──
+			const isDomainConnectorType = (t: string) => t === DOMAIN_TYPES.connector;
+			const stopTracker = createConnectorTracker({
+				store: ctx.store,
+				isConnectorType: isDomainConnectorType,
+			});
+			const stopCascade = createCascadeDelete({
+				store: ctx.store,
+				isConnectorType: isDomainConnectorType,
+			});
+			cleanups.push(stopTracker, stopCascade);
+
+			// ── DDD connector property bar ──
+			// shape-connector の `connector-properties` (order 82) のすぐ上に積む。
+			// 同時に表示されることはない (それぞれ自分の type のときだけ render される)
+			// が、order 値を分けておくことでレイヤーリストでの並びが安定する。
+			ctx.layers.register({
+				id: "domain-connector-properties",
+				order: 84,
+				fixed: true,
+				render: () => <DomainConnectorPropertyBar />,
+			});
+			cleanups.push(() => ctx.layers.unregister("domain-connector-properties"));
+
+			// ── Tool: subtype 切り替え ──
+			let currentSubtype = DOMAIN_SUBTYPES[0]?.type ?? DOMAIN_TYPES.boundedContext;
+			const offSubtype = ctx.events.on<{ type: string }>("domain-design:select-subtype", (data) => {
+				currentSubtype = data.type;
+			});
+			cleanups.push(offSubtype);
+
+			// Connector draw tool（subtype 切替で domainKind / relation が変わる）
+			const connectorTool: DomainConnectorDrawTool = createDomainConnectorDrawTool(() => {
+				const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
+				if (subtype?.kind === "connector") {
+					return { domainKind: subtype.domainKind, relation: subtype.defaultRelation };
+				}
+				return { domainKind: "context-map", relation: "customer-supplier" as ContextMapRelation };
+			});
+
+			// Container shape draw 用の state（drag で rect を生成）
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+
+			function isConnectorSubtype() {
+				const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
+				return subtype?.kind === "connector";
+			}
+
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (isConnectorSubtype()) {
+					connectorTool.onPointerDown(toolCtx, event);
+					return;
+				}
+				const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
+				if (!subtype || subtype.kind !== "shape") return;
+				const id = generateId();
+				drawState = {
+					startX: event.worldPoint.x,
+					startY: event.worldPoint.y,
+					shapeId: id,
+				};
+				const shape = subtype.createDefault({
 					id,
-					x,
-					y,
-					domainKind: "context-map",
-					relation: "customer-supplier",
-				}),
-			renderTarget: "svg",
-		});
-
-		// ── Connector tracking & cascade delete ──
-		const isDomainConnectorType = (t: string) => t === DOMAIN_TYPES.connector;
-		const stopTracker = createConnectorTracker({
-			store: ctx.store,
-			isConnectorType: isDomainConnectorType,
-		});
-		const stopCascade = createCascadeDelete({
-			store: ctx.store,
-			isConnectorType: isDomainConnectorType,
-		});
-		cleanups.push(stopTracker, stopCascade);
-
-		// ── DDD connector property bar ──
-		// shape-connector の `connector-properties` (order 82) のすぐ上に積む。
-		// 同時に表示されることはない (それぞれ自分の type のときだけ render される)
-		// が、order 値を分けておくことでレイヤーリストでの並びが安定する。
-		ctx.layers.register({
-			id: "domain-connector-properties",
-			order: 84,
-			fixed: true,
-			render: () => <DomainConnectorPropertyBar />,
-		});
-		cleanups.push(() => ctx.layers.unregister("domain-connector-properties"));
-
-		// ── Tool: subtype 切り替え ──
-		let currentSubtype = DOMAIN_SUBTYPES[0]?.type ?? DOMAIN_TYPES.boundedContext;
-		const offSubtype = ctx.events.on<{ type: string }>("domain-design:select-subtype", (data) => {
-			currentSubtype = data.type;
-		});
-		cleanups.push(offSubtype);
-
-		// Connector draw tool（subtype 切替で domainKind / relation が変わる）
-		const connectorTool: DomainConnectorDrawTool = createDomainConnectorDrawTool(() => {
-			const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
-			if (subtype?.kind === "connector") {
-				return { domainKind: subtype.domainKind, relation: subtype.defaultRelation };
+					x: event.worldPoint.x,
+					y: event.worldPoint.y,
+				});
+				shape.width = 0;
+				shape.height = 0;
+				toolCtx.store.addShape(shape);
 			}
-			return { domainKind: "context-map", relation: "customer-supplier" as ContextMapRelation };
-		});
 
-		// Container shape draw 用の state（drag で rect を生成）
-		let drawState: { startX: number; startY: number; shapeId: string } | null = null;
-
-		function isConnectorSubtype() {
-			const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
-			return subtype?.kind === "connector";
-		}
-
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (isConnectorSubtype()) {
-				connectorTool.onPointerDown(toolCtx, event);
-				return;
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (isConnectorSubtype()) {
+					connectorTool.onPointerMove(toolCtx, event);
+					return;
+				}
+				if (!drawState) return;
+				const x = Math.min(drawState.startX, event.worldPoint.x);
+				const y = Math.min(drawState.startY, event.worldPoint.y);
+				const width = Math.abs(event.worldPoint.x - drawState.startX);
+				const height = Math.abs(event.worldPoint.y - drawState.startY);
+				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
 			}
-			const subtype = DOMAIN_SUBTYPES.find((s) => s.type === currentSubtype);
-			if (!subtype || subtype.kind !== "shape") return;
-			const id = generateId();
-			drawState = {
-				startX: event.worldPoint.x,
-				startY: event.worldPoint.y,
-				shapeId: id,
-			};
-			const shape = subtype.createDefault({
-				id,
-				x: event.worldPoint.x,
-				y: event.worldPoint.y,
-			});
-			shape.width = 0;
-			shape.height = 0;
-			toolCtx.store.addShape(shape);
-		}
 
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (isConnectorSubtype()) {
-				connectorTool.onPointerMove(toolCtx, event);
-				return;
-			}
-			if (!drawState) return;
-			const x = Math.min(drawState.startX, event.worldPoint.x);
-			const y = Math.min(drawState.startY, event.worldPoint.y);
-			const width = Math.abs(event.worldPoint.x - drawState.startX);
-			const height = Math.abs(event.worldPoint.y - drawState.startY);
-			toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
-		}
-
-		function onPointerUp(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (isConnectorSubtype()) {
-				connectorTool.onPointerUp(toolCtx, event);
-				return;
-			}
-			if (!drawState) return;
-			const shape = toolCtx.store.getShape(drawState.shapeId);
-			const minDim = 2;
-			const length = Math.min(Math.abs(shape?.width ?? 0), Math.abs(shape?.height ?? 0));
-			if (shape && length > minDim) {
-				toolCtx.store.deleteShape(drawState.shapeId);
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-			} else {
-				toolCtx.store.deleteShape(drawState.shapeId);
-			}
-			drawState = null;
-			toolCtx.store.setActiveToolId("select");
-		}
-
-		ctx.tools.register("domain-draw", {
-			icon: DomainDrawIcon,
-			cursor: "crosshair",
-			shortcut: "d",
-			order: 12,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-			onDeactivate(toolCtx: ToolContext) {
-				connectorTool.onDeactivate(toolCtx);
-				if (drawState) {
+			function onPointerUp(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (isConnectorSubtype()) {
+					connectorTool.onPointerUp(toolCtx, event);
+					return;
+				}
+				if (!drawState) return;
+				const shape = toolCtx.store.getShape(drawState.shapeId);
+				const minDim = 2;
+				const length = Math.min(Math.abs(shape?.width ?? 0), Math.abs(shape?.height ?? 0));
+				if (shape && length > minDim) {
 					toolCtx.store.deleteShape(drawState.shapeId);
-					drawState = null;
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+				} else {
+					toolCtx.store.deleteShape(drawState.shapeId);
 				}
-			},
-		});
-
-		// ── インライン編集（state machine + custom events） ──
-		const editingService = createDomainEditingService(ctx);
-		const { send, stop: stopMachine } = editingService;
-		cleanups.push(stopMachine);
-
-		const onCommit = (e: Event) => {
-			const detail = (e as CustomEvent).detail as {
-				id: string;
-				nextMeta: Record<string, unknown>;
-			};
-			send({ type: "COMMIT", id: detail.id, nextMeta: detail.nextMeta });
-		};
-		const onCancel = (e: Event) => {
-			const detail = (e as CustomEvent).detail as { id: string };
-			send({ type: "CANCEL", id: detail.id });
-		};
-		window.addEventListener("usketch:domain-design:commit", onCommit);
-		window.addEventListener("usketch:domain-design:cancel", onCancel);
-		cleanups.push(() => window.removeEventListener("usketch:domain-design:commit", onCommit));
-		cleanups.push(() => window.removeEventListener("usketch:domain-design:cancel", onCancel));
-
-		// canvas:pointerdown でクリック・ダブルクリック判定
-		const offCanvasPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
-			let hitShapeId: string | null = null;
-			const point = event.worldPoint;
-			const sorted = ctx.store.getShapesSorted();
-			for (let i = sorted.length - 1; i >= 0; i--) {
-				const shape = sorted[i];
-				if (!shape) continue;
-				if (!EDITABLE_DOMAIN_TYPES.has(shape.type)) continue;
-				const def: ShapeDefinition | undefined = ctx.shapes.get(shape.type);
-				if (!def) continue;
-				if (def.hitTest(shape, point)) {
-					hitShapeId = shape.id;
-					break;
-				}
+				drawState = null;
+				toolCtx.store.setActiveToolId("select");
 			}
-			send({ type: "POINTER_DOWN", shapeId: hitShapeId });
-		});
-		cleanups.push(offCanvasPointer);
 
-		// 選択が外れたら editing 終了。queueMicrotask で 1 ターン遅延させ、
-		// editor の onBlur 経由の COMMIT が先に処理されるのを待つ。
-		let pendingDeselectedShapeId: string | null = null;
-		const unsubscribe = ctx.store.subscribe(() => {
-			const editingId = editingService.editingShapeId;
-			if (!editingId) return;
-			const selection = ctx.store.getSelection();
-			if (selection.has(editingId)) return;
-			if (pendingDeselectedShapeId === editingId) return;
-			pendingDeselectedShapeId = editingId;
-			queueMicrotask(() => {
-				const stillEditingId = editingService.editingShapeId;
-				pendingDeselectedShapeId = null;
-				if (!stillEditingId) return;
-				if (stillEditingId !== editingId) return;
-				const stillSelected = ctx.store.getSelection().has(stillEditingId);
-				if (stillSelected) return;
-				send({ type: "DESELECTED" });
+			ctx.tools.register("domain-draw", {
+				icon: DomainDrawIcon,
+				cursor: "crosshair",
+				shortcut: "d",
+				order: 12,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+				onDeactivate(toolCtx: ToolContext) {
+					connectorTool.onDeactivate(toolCtx);
+					if (drawState) {
+						toolCtx.store.deleteShape(drawState.shapeId);
+						drawState = null;
+					}
+				},
 			});
-		});
-		cleanups.push(unsubscribe);
 
-		// ── teardown ──
-		(domainDesignPlugin as { teardown?: () => void }).teardown = () => {
-			for (const fn of cleanups) fn();
-		};
-	},
+			// ── インライン編集（state machine + custom events） ──
+			const editingService = createDomainEditingService(ctx);
+			const { send, stop: stopMachine } = editingService;
+			cleanups.push(stopMachine);
 
-	teardown() {
-		// setup() 内で動的に差し替えられる
-	},
-};
+			const onCommit = (e: Event) => {
+				const detail = (e as CustomEvent).detail as {
+					id: string;
+					nextMeta: Record<string, unknown>;
+				};
+				send({ type: "COMMIT", id: detail.id, nextMeta: detail.nextMeta });
+			};
+			const onCancel = (e: Event) => {
+				const detail = (e as CustomEvent).detail as { id: string };
+				send({ type: "CANCEL", id: detail.id });
+			};
+			window.addEventListener("usketch:domain-design:commit", onCommit);
+			window.addEventListener("usketch:domain-design:cancel", onCancel);
+			cleanups.push(() => window.removeEventListener("usketch:domain-design:commit", onCommit));
+			cleanups.push(() => window.removeEventListener("usketch:domain-design:cancel", onCancel));
+
+			// canvas:pointerdown でクリック・ダブルクリック判定
+			const offCanvasPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+				let hitShapeId: string | null = null;
+				const point = event.worldPoint;
+				const sorted = ctx.store.getShapesSorted();
+				for (let i = sorted.length - 1; i >= 0; i--) {
+					const shape = sorted[i];
+					if (!shape) continue;
+					if (!EDITABLE_DOMAIN_TYPES.has(shape.type)) continue;
+					const def: ShapeDefinition | undefined = ctx.shapes.get(shape.type);
+					if (!def) continue;
+					if (def.hitTest(shape, point)) {
+						hitShapeId = shape.id;
+						break;
+					}
+				}
+				send({ type: "POINTER_DOWN", shapeId: hitShapeId });
+			});
+			cleanups.push(offCanvasPointer);
+
+			// 選択が外れたら editing 終了。queueMicrotask で 1 ターン遅延させ、
+			// editor の onBlur 経由の COMMIT が先に処理されるのを待つ。
+			let pendingDeselectedShapeId: string | null = null;
+			const unsubscribe = ctx.store.subscribe(() => {
+				const editingId = editingService.editingShapeId;
+				if (!editingId) return;
+				const selection = ctx.store.getSelection();
+				if (selection.has(editingId)) return;
+				if (pendingDeselectedShapeId === editingId) return;
+				pendingDeselectedShapeId = editingId;
+				queueMicrotask(() => {
+					const stillEditingId = editingService.editingShapeId;
+					pendingDeselectedShapeId = null;
+					if (!stillEditingId) return;
+					if (stillEditingId !== editingId) return;
+					const stillSelected = ctx.store.getSelection().has(stillEditingId);
+					if (stillSelected) return;
+					send({ type: "DESELECTED" });
+				});
+			});
+			cleanups.push(unsubscribe);
+
+			// ── teardown ──
+			return () => {
+				for (const fn of cleanups) fn();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-effect-ripple/src/index.ts
+++ b/plugins/usketch-plugin-effect-ripple/src/index.ts
@@ -1,1 +1,1 @@
-export { createRippleEffectPlugin, rippleEffectPlugin } from "./plugin.js";
+export { createRippleEffectPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-effect-ripple/src/plugin.tsx
+++ b/plugins/usketch-plugin-effect-ripple/src/plugin.tsx
@@ -72,8 +72,6 @@ function injectStyle() {
 }
 
 function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-effect-ripple",
 		name: "リップルエフェクト",
@@ -146,21 +144,14 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				onPointerDown,
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubBroadcast?.();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }
 
 /** WsProvider付きファクトリ（リアルタイム同期対応） */
-export function createRippleEffectPlugin(wsProvider: WsProviderHandle): UsketchPlugin {
+export function createRippleEffectPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 	return createPlugin(wsProvider);
 }
-
-/** ローカル専用（後方互換） */
-export const rippleEffectPlugin: UsketchPlugin = createPlugin();

--- a/plugins/usketch-plugin-export/src/index.ts
+++ b/plugins/usketch-plugin-export/src/index.ts
@@ -1,2 +1,2 @@
 export { downloadBlob, type ExportOptions, exportCanvas, exportJson } from "./exporter.js";
-export { exportPlugin } from "./plugin.js";
+export { createExportPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-export/src/plugin.tsx
+++ b/plugins/usketch-plugin-export/src/plugin.tsx
@@ -1,42 +1,37 @@
 import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
 import { downloadBlob, exportCanvas, exportJson } from "./exporter.js";
 
-export const exportPlugin: UsketchPlugin = {
-	id: "usketch-plugin-export",
-	name: "エクスポート",
+export function createExportPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-export",
+		name: "エクスポート",
 
-	setup(ctx: PluginContext) {
-		const unsub1 = ctx.shortcuts.register("ctrl+shift+e", () => {
-			const shapes = new Map(ctx.store.getShapes());
-			exportCanvas(shapes, ctx.shapes, { format: "png" })
-				.then((blob) => downloadBlob(blob, "usketch-export.png"))
-				.catch((e) => console.error("PNG export failed:", e));
-		});
+		setup(ctx: PluginContext) {
+			const unsub1 = ctx.shortcuts.register("ctrl+shift+e", () => {
+				const shapes = new Map(ctx.store.getShapes());
+				exportCanvas(shapes, ctx.shapes, { format: "png" })
+					.then((blob) => downloadBlob(blob, "usketch-export.png"))
+					.catch((e) => console.error("PNG export failed:", e));
+			});
 
-		const unsub2 = ctx.shortcuts.register("ctrl+shift+alt+e", () => {
-			const shapes = new Map(ctx.store.getShapes());
-			exportCanvas(shapes, ctx.shapes, { format: "svg" })
-				.then((blob) => downloadBlob(blob, "usketch-export.svg"))
-				.catch((e) => console.error("SVG export failed:", e));
-		});
+			const unsub2 = ctx.shortcuts.register("ctrl+shift+alt+e", () => {
+				const shapes = new Map(ctx.store.getShapes());
+				exportCanvas(shapes, ctx.shapes, { format: "svg" })
+					.then((blob) => downloadBlob(blob, "usketch-export.svg"))
+					.catch((e) => console.error("SVG export failed:", e));
+			});
 
-		const unsub3 = ctx.shortcuts.register("ctrl+shift+j", () => {
-			const shapes = new Map(ctx.store.getShapes());
-			const blob = exportJson(shapes);
-			downloadBlob(blob, "usketch-export.json");
-		});
+			const unsub3 = ctx.shortcuts.register("ctrl+shift+j", () => {
+				const shapes = new Map(ctx.store.getShapes());
+				const blob = exportJson(shapes);
+				downloadBlob(blob, "usketch-export.json");
+			});
 
-		(this as unknown as Record<string, unknown>)._cleanup = () => {
-			unsub1();
-			unsub2();
-			unsub3();
-		};
-	},
-
-	teardown() {
-		const cleanup = (this as unknown as Record<string, unknown>)._cleanup as
-			| (() => void)
-			| undefined;
-		cleanup?.();
-	},
-};
+			return () => {
+				unsub1();
+				unsub2();
+				unsub3();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-follow-me/src/plugin.tsx
+++ b/plugins/usketch-plugin-follow-me/src/plugin.tsx
@@ -34,8 +34,6 @@ export function createFollowMePlugin(options: FollowMePluginOptions): UsketchPlu
 	const { wsProvider } = options;
 	const { awareness } = wsProvider;
 
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-follow-me",
 		name: "Follow Me",
@@ -132,7 +130,7 @@ export function createFollowMePlugin(options: FollowMePluginOptions): UsketchPlu
 				}
 			});
 
-			cleanup = () => {
+			return () => {
 				awareness.off("change", onAwarenessChange);
 				unsubFollow();
 				unsubFollowEvent();
@@ -140,10 +138,6 @@ export function createFollowMePlugin(options: FollowMePluginOptions): UsketchPlu
 				ctx.layers.unregister("follow-banner");
 				followingClientId = null;
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/plugin.tsx
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/plugin.tsx
@@ -17,14 +17,14 @@ export interface KeyboardShortcutsPluginOptions {
 export function createKeyboardShortcutsPlugin(
 	options?: KeyboardShortcutsPluginOptions,
 ): UsketchPlugin {
-	let cleanups: (() => void)[] = [];
-	let palette: CommandPaletteController | null = null;
-
 	return {
 		id: "usketch-plugin-keyboard-shortcuts",
 		name: "Keyboard Shortcuts",
 
 		setup(ctx: PluginContext) {
+			const cleanups: (() => void)[] = [];
+			let palette: CommandPaletteController | null = null;
+
 			const { store, shortcuts, events, commands } = ctx;
 
 			// ── Side panel state tracking ──
@@ -203,12 +203,13 @@ export function createKeyboardShortcutsPlugin(
 				window.addEventListener("keydown", handleSlashKey);
 				cleanups.push(() => window.removeEventListener("keydown", handleSlashKey));
 			}
-		},
 
-		teardown() {
-			for (const fn of cleanups) fn();
-			cleanups = [];
-			palette?.dispose();
+			return () => {
+				for (const fn of cleanups) fn();
+				cleanups.length = 0;
+				palette?.dispose();
+				palette = null;
+			};
 		},
 	};
 }

--- a/plugins/usketch-plugin-laser/src/index.ts
+++ b/plugins/usketch-plugin-laser/src/index.ts
@@ -1,1 +1,1 @@
-export { createLaserPlugin, laserPlugin } from "./plugin.js";
+export { createLaserPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-laser/src/plugin.tsx
+++ b/plugins/usketch-plugin-laser/src/plugin.tsx
@@ -246,8 +246,6 @@ function LaserIcon() {
 }
 
 function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-laser",
 		name: "レーザーポインタ",
@@ -352,23 +350,16 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				},
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubBroadcast?.();
 				ctx.layers.unregister("laser");
 				strokeStore.strokes.clear();
 			};
 		},
-
-		teardown() {
-			cleanup?.();
-		},
 	};
 }
 
 /** WsProvider付きファクトリ（リアルタイム同期対応） */
-export function createLaserPlugin(wsProvider: WsProviderHandle): UsketchPlugin {
+export function createLaserPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 	return createPlugin(wsProvider);
 }
-
-/** ローカル専用 */
-export const laserPlugin: UsketchPlugin = createPlugin();

--- a/plugins/usketch-plugin-presence-cursor/src/plugin.tsx
+++ b/plugins/usketch-plugin-presence-cursor/src/plugin.tsx
@@ -82,8 +82,6 @@ export function createPresenceCursorPlugin(options: PresenceCursorOptions): Uske
 	const color = getUserColor(userId);
 	const { awareness } = wsProvider;
 
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-presence-cursor",
 		name: "プレゼンスカーソル",
@@ -154,15 +152,11 @@ export function createPresenceCursorPlugin(options: PresenceCursorOptions): Uske
 
 			window.addEventListener("mouseleave", handleMouseLeave);
 
-			cleanup = () => {
+			return () => {
 				awareness.off("change", onAwarenessChange);
 				unsubPointerMove();
 				window.removeEventListener("mouseleave", handleMouseLeave);
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-presence-enhanced/src/plugin.tsx
+++ b/plugins/usketch-plugin-presence-enhanced/src/plugin.tsx
@@ -111,8 +111,6 @@ export function createPresenceEnhancedPlugin(options: PresenceEnhancedOptions): 
 	const { wsProvider, boardId, apiUrl } = options;
 	const { awareness } = wsProvider;
 
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-presence-enhanced",
 		name: "拡張プレゼンス",
@@ -195,7 +193,7 @@ export function createPresenceEnhancedPlugin(options: PresenceEnhancedOptions): 
 			}
 			awareness.on("change", onAwarenessChange);
 
-			cleanup = () => {
+			return () => {
 				if (pollTimer) clearInterval(pollTimer);
 				awareness.off("change", onAwarenessChange);
 				for (const id of activeGhosts) {
@@ -204,10 +202,6 @@ export function createPresenceEnhancedPlugin(options: PresenceEnhancedOptions): 
 				activeGhosts.clear();
 				ctx.layers.unregister("presence-enhanced");
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -59,14 +59,13 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 	const subscribeMode = opts.subscribeMode ?? defaultSubscribeMode;
 	const navigateToBoard = opts.navigateToBoard ?? defaultNavigateToBoard;
 	const getViewportSize = opts.getViewportSize ?? defaultGetViewportSize;
-	let nav: SlideNavigator | null = null;
-	const unregisters: Array<() => void> = [];
 
 	return {
 		id: "presentation",
 		name: "Presentation",
 		setup(ctx: PluginContext) {
-			nav = new SlideNavigator(ctx.store, getViewportSize);
+			let nav: SlideNavigator | null = new SlideNavigator(ctx.store, getViewportSize);
+			const unregisters: Array<() => void> = [];
 			const navRef = nav;
 
 			// 発表モード中のみ動くショートカット群（mode を実行時に毎回評価する）
@@ -167,12 +166,13 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 				},
 			});
 			unregisters.push(() => ctx.layers.unregister(layerId));
-		},
-		teardown() {
-			for (const u of unregisters) u();
-			unregisters.length = 0;
-			nav?.destroy();
-			nav = null;
+
+			return () => {
+				for (const u of unregisters) u();
+				unregisters.length = 0;
+				nav?.destroy();
+				nav = null;
+			};
 		},
 	};
 }

--- a/plugins/usketch-plugin-reactions/src/index.ts
+++ b/plugins/usketch-plugin-reactions/src/index.ts
@@ -1,1 +1,1 @@
-export { createReactionsPlugin, reactionsPlugin } from "./plugin.js";
+export { createReactionsPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-reactions/src/plugin.tsx
+++ b/plugins/usketch-plugin-reactions/src/plugin.tsx
@@ -63,14 +63,13 @@ function injectStyle() {
 }
 
 function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-	let selectedEmoji = "👍";
-
 	return {
 		id: "usketch-plugin-reactions",
 		name: "リアクション",
 
 		setup(ctx: PluginContext) {
+			let selectedEmoji = "👍";
+
 			injectStyle();
 
 			ctx.transient.registerType("reaction", {
@@ -154,22 +153,15 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				unsubShortcuts.push(unsub);
 			}
 
-			cleanup = () => {
+			return () => {
 				unsubBroadcast?.();
 				for (const unsub of unsubShortcuts) unsub();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }
 
 /** WsProvider付きファクトリ（リアルタイム同期対応） */
-export function createReactionsPlugin(wsProvider: WsProviderHandle): UsketchPlugin {
+export function createReactionsPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 	return createPlugin(wsProvider);
 }
-
-/** ローカル専用 */
-export const reactionsPlugin: UsketchPlugin = createPlugin();

--- a/plugins/usketch-plugin-shape-basic/src/index.ts
+++ b/plugins/usketch-plugin-shape-basic/src/index.ts
@@ -4,7 +4,7 @@ export {
 	rectGpuPrimitive,
 	roundedRectGpuPrimitive,
 } from "./gpu.js";
-export { basicShapePlugin } from "./plugin.js";
+export { createBasicShapePlugin } from "./plugin.js";
 export type { BasicShapeSubtype } from "./registry.js";
 export { BASIC_SHAPE_SUBTYPES } from "./registry.js";
 export type { RectangleShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-basic/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-basic/src/plugin.tsx
@@ -105,91 +105,89 @@ function BasicShapeIcon() {
 	);
 }
 
-let cleanupFn: (() => void) | null = null;
+export function createBasicShapePlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-basic",
+		name: "基本シェイプ",
 
-export const basicShapePlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-basic",
-	name: "基本シェイプ",
+		setup(ctx: PluginContext) {
+			// Register all 8 shape types
+			for (const subtype of BASIC_SHAPE_SUBTYPES) {
+				const renderer = SHAPE_RENDERERS[subtype.type];
+				const hitTestFn = SHAPE_HIT_TESTS[subtype.type];
+				if (!renderer || !hitTestFn) continue;
 
-	setup(ctx: PluginContext) {
-		// Register all 8 shape types
-		for (const subtype of BASIC_SHAPE_SUBTYPES) {
-			const renderer = SHAPE_RENDERERS[subtype.type];
-			const hitTestFn = SHAPE_HIT_TESTS[subtype.type];
-			if (!renderer || !hitTestFn) continue;
-
-			const gpuFn = SHAPE_GPU_PRIMITIVES[subtype.type];
-			const isRectangle = subtype.type === "rectangle";
-			ctx.shapes.register(subtype.type, {
-				render: renderer,
-				getBounds,
-				hitTest: hitTestFn,
-				resize: createResize(1, 1),
-				createDefault: subtype.createDefault,
-				gpuPrimitive: gpuFn,
-				serializeForAi: isRectangle ? rectangleSerializeForAi : undefined,
-				debugFields: isRectangle ? rectangleDebugFields : undefined,
-			});
-		}
-
-		// Tool state
-		let currentSubtype = BASIC_SHAPE_SUBTYPES[0].type;
-		let drawState: { startX: number; startY: number; shapeId: string } | null = null;
-
-		// Listen for subtype changes from the toolbar picker
-		const offSubtype = ctx.events.on<{ type: string }>("basic-shape:select-subtype", (data) => {
-			currentSubtype = data.type;
-		});
-		cleanupFn = offSubtype;
-
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			const subtype = BASIC_SHAPE_SUBTYPES.find((s) => s.type === currentSubtype);
-			if (!subtype) return;
-
-			const id = generateId();
-			drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-			const shape = subtype.createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
-			shape.width = 0;
-			shape.height = 0;
-			shape.style = { ...toolCtx.store.getStyleSettings() };
-			toolCtx.store.addShape(shape);
-		}
-
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!drawState) return;
-			const x = Math.min(drawState.startX, event.worldPoint.x);
-			const y = Math.min(drawState.startY, event.worldPoint.y);
-			const width = Math.abs(event.worldPoint.x - drawState.startX);
-			const height = Math.abs(event.worldPoint.y - drawState.startY);
-			toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
-		}
-
-		function onPointerUp(toolCtx: ToolContext) {
-			if (!drawState) return;
-			const shape = toolCtx.store.getShape(drawState.shapeId);
-			if (shape && shape.width > 2 && shape.height > 2) {
-				toolCtx.store.deleteShape(drawState.shapeId);
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-			} else {
-				toolCtx.store.deleteShape(drawState.shapeId);
+				const gpuFn = SHAPE_GPU_PRIMITIVES[subtype.type];
+				const isRectangle = subtype.type === "rectangle";
+				ctx.shapes.register(subtype.type, {
+					render: renderer,
+					getBounds,
+					hitTest: hitTestFn,
+					resize: createResize(1, 1),
+					createDefault: subtype.createDefault,
+					gpuPrimitive: gpuFn,
+					serializeForAi: isRectangle ? rectangleSerializeForAi : undefined,
+					debugFields: isRectangle ? rectangleDebugFields : undefined,
+				});
 			}
-			drawState = null;
-			toolCtx.store.setActiveToolId("select");
-		}
 
-		ctx.tools.register("basic-shape-draw", {
-			icon: BasicShapeIcon,
-			cursor: "crosshair",
-			shortcut: "r",
-			order: 10,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-		});
-	},
+			// Tool state
+			let currentSubtype = BASIC_SHAPE_SUBTYPES[0].type;
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
 
-	teardown() {
-		cleanupFn?.();
-		cleanupFn = null;
-	},
-};
+			// Listen for subtype changes from the toolbar picker
+			const offSubtype = ctx.events.on<{ type: string }>("basic-shape:select-subtype", (data) => {
+				currentSubtype = data.type;
+			});
+
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				const subtype = BASIC_SHAPE_SUBTYPES.find((s) => s.type === currentSubtype);
+				if (!subtype) return;
+
+				const id = generateId();
+				drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+				const shape = subtype.createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+				shape.width = 0;
+				shape.height = 0;
+				shape.style = { ...toolCtx.store.getStyleSettings() };
+				toolCtx.store.addShape(shape);
+			}
+
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!drawState) return;
+				const x = Math.min(drawState.startX, event.worldPoint.x);
+				const y = Math.min(drawState.startY, event.worldPoint.y);
+				const width = Math.abs(event.worldPoint.x - drawState.startX);
+				const height = Math.abs(event.worldPoint.y - drawState.startY);
+				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+			}
+
+			function onPointerUp(toolCtx: ToolContext) {
+				if (!drawState) return;
+				const shape = toolCtx.store.getShape(drawState.shapeId);
+				if (shape && shape.width > 2 && shape.height > 2) {
+					toolCtx.store.deleteShape(drawState.shapeId);
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+				} else {
+					toolCtx.store.deleteShape(drawState.shapeId);
+				}
+				drawState = null;
+				toolCtx.store.setActiveToolId("select");
+			}
+
+			ctx.tools.register("basic-shape-draw", {
+				icon: BasicShapeIcon,
+				cursor: "crosshair",
+				shortcut: "r",
+				order: 10,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+			});
+
+			return () => {
+				offSubtype();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-community-region/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-community-region/src/plugin.tsx
@@ -172,13 +172,13 @@ function RegionCard({ data: shape }: { data: ShapeData }) {
 }
 
 export function createCommunityRegionPlugin(options?: CommunityRegionPluginOptions): UsketchPlugin {
-	const cleanups: (() => void)[] = [];
-
 	return {
 		id: "usketch-plugin-shape-community-region",
 		name: "Community Region",
 
 		setup(ctx: PluginContext) {
+			const cleanups: (() => void)[] = [];
+
 			ctx.shapes.register("community-region", {
 				renderTarget: "html",
 
@@ -248,11 +248,11 @@ export function createCommunityRegionPlugin(options?: CommunityRegionPluginOptio
 				});
 				cleanups.push(unsub);
 			}
-		},
 
-		teardown() {
-			for (const fn of cleanups) fn();
-			cleanups.length = 0;
+			return () => {
+				for (const fn of cleanups) fn();
+				cleanups.length = 0;
+			};
 		},
 	};
 }

--- a/plugins/usketch-plugin-shape-connector/src/index.ts
+++ b/plugins/usketch-plugin-shape-connector/src/index.ts
@@ -1,1 +1,1 @@
-export { connectorPlugin } from "./plugin.js";
+export { createConnectorPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -62,207 +62,209 @@ function debugFields(shape: ShapeData): Record<string, unknown> {
 	};
 }
 
-export const connectorPlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-connector",
-	name: "コネクタ",
+export function createConnectorPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-connector",
+		name: "コネクタ",
 
-	setup(ctx: PluginContext) {
-		// Register connector shape
-		ctx.shapes.register("connector", {
-			render: renderConnector,
-			getBounds: getBoundsConnector,
-			hitTest: hitTestConnector,
-			resize: (data) => ({ ...data }),
-			createDefault: createDefaultConnector,
-			renderTarget: "svg",
-			resizable: false,
-			simplifiedComponent: SimplifiedConnector,
-			debugFields,
-		});
+		setup(ctx: PluginContext) {
+			// Register connector shape
+			ctx.shapes.register("connector", {
+				render: renderConnector,
+				getBounds: getBoundsConnector,
+				hitTest: hitTestConnector,
+				resize: (data) => ({ ...data }),
+				createDefault: createDefaultConnector,
+				renderTarget: "svg",
+				resizable: false,
+				simplifiedComponent: SimplifiedConnector,
+				debugFields,
+			});
 
-		// ── Drawing tool ──
+			// ── Drawing tool ──
 
-		let drawState: {
-			connectorId: string;
-			sourceShape: ShapeData;
-			sourceAnchor: AnchorType;
-		} | null = null;
+			let drawState: {
+				connectorId: string;
+				sourceShape: ShapeData;
+				sourceAnchor: AnchorType;
+			} | null = null;
 
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			const sourceShape = findShapeAtPoint(toolCtx, event.worldPoint);
-			if (!sourceShape) return;
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				const sourceShape = findShapeAtPoint(toolCtx, event.worldPoint);
+				if (!sourceShape) return;
 
-			const id = generateId();
-			const sourceAnchor: AnchorType = "auto";
-			const sourcePoint = getAnchorPoint(sourceShape, sourceAnchor, event.worldPoint);
+				const id = generateId();
+				const sourceAnchor: AnchorType = "auto";
+				const sourcePoint = getAnchorPoint(sourceShape, sourceAnchor, event.worldPoint);
 
-			const connector: ConnectorShapeData = {
-				...createDefaultConnector({ id, x: sourcePoint.x, y: sourcePoint.y }),
-				sourceId: sourceShape.id,
-				targetId: undefined,
-				sourceAnchor,
-				targetAnchor: "auto",
-				sourcePoint,
-				targetPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
-				style: { ...toolCtx.store.getStyleSettings(), fill: "transparent" },
-			};
+				const connector: ConnectorShapeData = {
+					...createDefaultConnector({ id, x: sourcePoint.x, y: sourcePoint.y }),
+					sourceId: sourceShape.id,
+					targetId: undefined,
+					sourceAnchor,
+					targetAnchor: "auto",
+					sourcePoint,
+					targetPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
+					style: { ...toolCtx.store.getStyleSettings(), fill: "transparent" },
+				};
 
-			toolCtx.store.addShape(connector);
-			drawState = { connectorId: id, sourceShape, sourceAnchor };
-		}
-
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!drawState) return;
-
-			const targetShape = findShapeAtPoint(toolCtx, event.worldPoint);
-			const targetPoint = event.worldPoint;
-
-			const sourcePoint = getAnchorPoint(
-				drawState.sourceShape,
-				drawState.sourceAnchor,
-				targetPoint,
-			);
-
-			const updates: Partial<ConnectorShapeData> = {
-				sourcePoint,
-				targetPoint: targetShape ? getAnchorPoint(targetShape, "auto", sourcePoint) : targetPoint,
-			};
-
-			const sp = updates.sourcePoint as Point;
-			const tp = updates.targetPoint as Point;
-			updates.x = Math.min(sp.x, tp.x);
-			updates.y = Math.min(sp.y, tp.y);
-			updates.width = Math.abs(tp.x - sp.x);
-			updates.height = Math.abs(tp.y - sp.y);
-
-			toolCtx.store.updateShape(drawState.connectorId, updates);
-		}
-
-		function onPointerUp(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!drawState) return;
-
-			const targetShape = findShapeAtPoint(toolCtx, event.worldPoint);
-			const connector = toolCtx.store.getShape(drawState.connectorId);
-
-			if (!connector || !targetShape || targetShape.id === drawState.sourceShape.id) {
-				toolCtx.store.deleteShape(drawState.connectorId);
-				drawState = null;
-				return;
+				toolCtx.store.addShape(connector);
+				drawState = { connectorId: id, sourceShape, sourceAnchor };
 			}
 
-			const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, {
-				x: targetShape.x + targetShape.width / 2,
-				y: targetShape.y + targetShape.height / 2,
-			});
-			const targetPoint = getAnchorPoint(targetShape, "auto", sourcePoint);
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!drawState) return;
 
-			const finalUpdates: Partial<ConnectorShapeData> = {
-				targetId: targetShape.id,
-				targetAnchor: "auto",
-				sourcePoint,
-				targetPoint,
-				x: Math.min(sourcePoint.x, targetPoint.x),
-				y: Math.min(sourcePoint.y, targetPoint.y),
-				width: Math.abs(targetPoint.x - sourcePoint.x),
-				height: Math.abs(targetPoint.y - sourcePoint.y),
-			};
+				const targetShape = findShapeAtPoint(toolCtx, event.worldPoint);
+				const targetPoint = event.worldPoint;
 
-			toolCtx.store.deleteShape(drawState.connectorId);
-			const finalShape: ConnectorShapeData = { ...connector, ...finalUpdates };
-			toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, finalShape));
+				const sourcePoint = getAnchorPoint(
+					drawState.sourceShape,
+					drawState.sourceAnchor,
+					targetPoint,
+				);
 
-			drawState = null;
-			toolCtx.store.setActiveToolId("select");
-		}
+				const updates: Partial<ConnectorShapeData> = {
+					sourcePoint,
+					targetPoint: targetShape ? getAnchorPoint(targetShape, "auto", sourcePoint) : targetPoint,
+				};
 
-		ctx.tools.register("connector-draw", {
-			icon: ConnectorIcon,
-			cursor: "crosshair",
-			shortcut: "l",
-			order: 12,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-			onDeactivate() {
-				if (drawState) {
-					ctx.store.deleteShape(drawState.connectorId);
+				const sp = updates.sourcePoint as Point;
+				const tp = updates.targetPoint as Point;
+				updates.x = Math.min(sp.x, tp.x);
+				updates.y = Math.min(sp.y, tp.y);
+				updates.width = Math.abs(tp.x - sp.x);
+				updates.height = Math.abs(tp.y - sp.y);
+
+				toolCtx.store.updateShape(drawState.connectorId, updates);
+			}
+
+			function onPointerUp(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!drawState) return;
+
+				const targetShape = findShapeAtPoint(toolCtx, event.worldPoint);
+				const connector = toolCtx.store.getShape(drawState.connectorId);
+
+				if (!connector || !targetShape || targetShape.id === drawState.sourceShape.id) {
+					toolCtx.store.deleteShape(drawState.connectorId);
 					drawState = null;
+					return;
 				}
-			},
-		});
 
-		// ── Connector property bar (Phase 4) ──
+				const sourcePoint = getAnchorPoint(drawState.sourceShape, drawState.sourceAnchor, {
+					x: targetShape.x + targetShape.width / 2,
+					y: targetShape.y + targetShape.height / 2,
+				});
+				const targetPoint = getAnchorPoint(targetShape, "auto", sourcePoint);
 
-		ctx.layers.register({
-			id: "connector-properties",
-			order: 82,
-			fixed: true,
-			render: () => <ConnectorPropertyBar />,
-		});
+				const finalUpdates: Partial<ConnectorShapeData> = {
+					targetId: targetShape.id,
+					targetAnchor: "auto",
+					sourcePoint,
+					targetPoint,
+					x: Math.min(sourcePoint.x, targetPoint.x),
+					y: Math.min(sourcePoint.y, targetPoint.y),
+					width: Math.abs(targetPoint.x - sourcePoint.x),
+					height: Math.abs(targetPoint.y - sourcePoint.y),
+				};
 
-		// ── Endpoint overlay (Phase 5) ──
+				toolCtx.store.deleteShape(drawState.connectorId);
+				const finalShape: ConnectorShapeData = { ...connector, ...finalUpdates };
+				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, finalShape));
 
-		ctx.layers.register({
-			id: "connector-endpoints",
-			order: 81,
-			fixed: true,
-			render: (renderCtx) => <EndpointOverlay ctx={ctx} viewport={renderCtx.viewport} />,
-		});
+				drawState = null;
+				toolCtx.store.setActiveToolId("select");
+			}
 
-		// ── Label editor overlay (Phase 6) ──
+			ctx.tools.register("connector-draw", {
+				icon: ConnectorIcon,
+				cursor: "crosshair",
+				shortcut: "l",
+				order: 12,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+				onDeactivate() {
+					if (drawState) {
+						ctx.store.deleteShape(drawState.connectorId);
+						drawState = null;
+					}
+				},
+			});
 
-		ctx.layers.register({
-			id: "connector-label-editor",
-			order: 83,
-			fixed: true,
-			render: (renderCtx) => <ConnectorLabelEditor ctx={ctx} viewport={renderCtx.viewport} />,
-		});
+			// ── Connector property bar (Phase 4) ──
 
-		// ── Anchor handle overlay (hover to show anchor points) ──
+			ctx.layers.register({
+				id: "connector-properties",
+				order: 82,
+				fixed: true,
+				render: () => <ConnectorPropertyBar />,
+			});
 
-		ctx.layers.register({
-			id: "connector-anchor-handles",
-			order: 79,
-			fixed: true,
-			render: (renderCtx) => <AnchorHandleOverlay ctx={ctx} viewport={renderCtx.viewport} />,
-		});
+			// ── Endpoint overlay (Phase 5) ──
 
-		const cleanupAnchorHandles = setupAnchorHandles(ctx);
+			ctx.layers.register({
+				id: "connector-endpoints",
+				order: 81,
+				fixed: true,
+				render: (renderCtx) => <EndpointOverlay ctx={ctx} viewport={renderCtx.viewport} />,
+			});
 
-		// Double-click detection for label editing
-		const unsubLabelClick = ctx.store.onMutation((event) => {
-			if (event.type !== "selection:changed") return;
-			// Clear label editing when selection changes
-			setEditingLabel(null);
-		});
+			// ── Label editor overlay (Phase 6) ──
 
-		// Listen for pointer events on connectors for double-click
-		const unsubPointerForLabel = ctx.events.on<{ shapeId: string }>(
-			"shape:clicked",
-			({ shapeId }) => {
-				const shape = ctx.store.getShape(shapeId);
-				if (shape?.type === "connector") {
-					handleConnectorClick(shapeId);
-				}
-			},
-		);
+			ctx.layers.register({
+				id: "connector-label-editor",
+				order: 83,
+				fixed: true,
+				render: (renderCtx) => <ConnectorLabelEditor ctx={ctx} viewport={renderCtx.viewport} />,
+			});
 
-		// ── Position tracking & cascade delete (extracted into shared package) ──
+			// ── Anchor handle overlay (hover to show anchor points) ──
 
-		const isConnectorType = (t: string) => t === "connector";
-		const stopTracker = createConnectorTracker({ store: ctx.store, isConnectorType });
-		const stopCascade = createCascadeDelete({ store: ctx.store, isConnectorType });
+			ctx.layers.register({
+				id: "connector-anchor-handles",
+				order: 79,
+				fixed: true,
+				render: (renderCtx) => <AnchorHandleOverlay ctx={ctx} viewport={renderCtx.viewport} />,
+			});
 
-		(this as UsketchPlugin).teardown = () => {
-			stopTracker();
-			stopCascade();
-			unsubLabelClick();
-			unsubPointerForLabel();
-			cleanupAnchorHandles();
-			ctx.layers.unregister("connector-properties");
-			ctx.layers.unregister("connector-endpoints");
-			ctx.layers.unregister("connector-label-editor");
-			ctx.layers.unregister("connector-anchor-handles");
-		};
-	},
-};
+			const cleanupAnchorHandles = setupAnchorHandles(ctx);
+
+			// Double-click detection for label editing
+			const unsubLabelClick = ctx.store.onMutation((event) => {
+				if (event.type !== "selection:changed") return;
+				// Clear label editing when selection changes
+				setEditingLabel(null);
+			});
+
+			// Listen for pointer events on connectors for double-click
+			const unsubPointerForLabel = ctx.events.on<{ shapeId: string }>(
+				"shape:clicked",
+				({ shapeId }) => {
+					const shape = ctx.store.getShape(shapeId);
+					if (shape?.type === "connector") {
+						handleConnectorClick(shapeId);
+					}
+				},
+			);
+
+			// ── Position tracking & cascade delete (extracted into shared package) ──
+
+			const isConnectorType = (t: string) => t === "connector";
+			const stopTracker = createConnectorTracker({ store: ctx.store, isConnectorType });
+			const stopCascade = createCascadeDelete({ store: ctx.store, isConnectorType });
+
+			return () => {
+				stopTracker();
+				stopCascade();
+				unsubLabelClick();
+				unsubPointerForLabel();
+				cleanupAnchorHandles();
+				ctx.layers.unregister("connector-properties");
+				ctx.layers.unregister("connector-endpoints");
+				ctx.layers.unregister("connector-label-editor");
+				ctx.layers.unregister("connector-anchor-handles");
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-counter/src/index.ts
+++ b/plugins/usketch-plugin-shape-counter/src/index.ts
@@ -1,2 +1,2 @@
-export { counterPlugin } from "./plugin.js";
+export { createCounterPlugin } from "./plugin.js";
 export type { CounterShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-counter/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-counter/src/plugin.tsx
@@ -215,84 +215,90 @@ function CounterIcon() {
 
 // ── Plugin ──
 
-export const counterPlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-counter",
-	name: "カウンター",
+export function createCounterPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-counter",
+		name: "カウンター",
 
-	setup(ctx: PluginContext) {
-		// Register shape with HTML render target
-		ctx.shapes.register("counter", {
-			render,
-			getBounds,
-			hitTest,
-			resize,
-			createDefault,
-			renderTarget: "html",
-			minSize: { width: 100, height: 100 },
-			simplifiedComponent: SimplifiedCounter,
-		});
+		setup(ctx: PluginContext) {
+			// Register shape with HTML render target
+			ctx.shapes.register("counter", {
+				render,
+				getBounds,
+				hitTest,
+				resize,
+				createDefault,
+				renderTarget: "html",
+				minSize: { width: 100, height: 100 },
+				simplifiedComponent: SimplifiedCounter,
+			});
 
-		// Listen for counter updates from the rendered buttons
-		const onCounterUpdate = (e: Event) => {
-			const { id, delta } = (e as CustomEvent).detail;
-			const shape = ctx.store.getShape(id) as CounterShapeData | undefined;
-			if (shape) {
-				const count = (shape.count ?? 0) + delta;
-				ctx.store.updateShape(id, { count } as Partial<ShapeData>);
+			// Listen for counter updates from the rendered buttons
+			const onCounterUpdate = (e: Event) => {
+				const { id, delta } = (e as CustomEvent).detail;
+				const shape = ctx.store.getShape(id) as CounterShapeData | undefined;
+				if (shape) {
+					const count = (shape.count ?? 0) + delta;
+					ctx.store.updateShape(id, { count } as Partial<ShapeData>);
+				}
+			};
+			window.addEventListener("usketch:counter-update", onCounterUpdate);
+
+			// Draw tool
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				const id = generateId();
+				drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+				const shape = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+				shape.width = 0;
+				shape.height = 0;
+				toolCtx.store.addShape(shape);
 			}
-		};
-		window.addEventListener("usketch:counter-update", onCounterUpdate);
 
-		// Draw tool
-		let drawState: { startX: number; startY: number; shapeId: string } | null = null;
-
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			const id = generateId();
-			drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-			const shape = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
-			shape.width = 0;
-			shape.height = 0;
-			toolCtx.store.addShape(shape);
-		}
-
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!drawState) return;
-			const x = Math.min(drawState.startX, event.worldPoint.x);
-			const y = Math.min(drawState.startY, event.worldPoint.y);
-			const width = Math.abs(event.worldPoint.x - drawState.startX);
-			const height = Math.abs(event.worldPoint.y - drawState.startY);
-			toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
-		}
-
-		function onPointerUp(toolCtx: ToolContext) {
-			if (!drawState) return;
-			const shape = toolCtx.store.getShape(drawState.shapeId);
-			if (shape && shape.width < 10 && shape.height < 10) {
-				// Too small — replace with default size
-				toolCtx.store.deleteShape(drawState.shapeId);
-				const defaultShape = createDefault({
-					id: drawState.shapeId,
-					x: drawState.startX - 70,
-					y: drawState.startY - 60,
-				});
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, defaultShape));
-			} else if (shape) {
-				// Finalize via command for undo support
-				toolCtx.store.deleteShape(drawState.shapeId);
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!drawState) return;
+				const x = Math.min(drawState.startX, event.worldPoint.x);
+				const y = Math.min(drawState.startY, event.worldPoint.y);
+				const width = Math.abs(event.worldPoint.x - drawState.startX);
+				const height = Math.abs(event.worldPoint.y - drawState.startY);
+				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
 			}
-			drawState = null;
-			toolCtx.store.setActiveToolId("select");
-		}
 
-		ctx.tools.register("counter-draw", {
-			icon: CounterIcon,
-			cursor: "crosshair",
-			shortcut: "c",
-			order: 40,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-		});
-	},
-};
+			function onPointerUp(toolCtx: ToolContext) {
+				if (!drawState) return;
+				const shape = toolCtx.store.getShape(drawState.shapeId);
+				if (shape && shape.width < 10 && shape.height < 10) {
+					// Too small — replace with default size
+					toolCtx.store.deleteShape(drawState.shapeId);
+					const defaultShape = createDefault({
+						id: drawState.shapeId,
+						x: drawState.startX - 70,
+						y: drawState.startY - 60,
+					});
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, defaultShape));
+				} else if (shape) {
+					// Finalize via command for undo support
+					toolCtx.store.deleteShape(drawState.shapeId);
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+				}
+				drawState = null;
+				toolCtx.store.setActiveToolId("select");
+			}
+
+			ctx.tools.register("counter-draw", {
+				icon: CounterIcon,
+				cursor: "crosshair",
+				shortcut: "c",
+				order: 40,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+			});
+
+			return () => {
+				window.removeEventListener("usketch:counter-update", onCounterUpdate);
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-frame/src/index.ts
+++ b/plugins/usketch-plugin-shape-frame/src/index.ts
@@ -1,2 +1,2 @@
-export { framePlugin } from "./plugin.js";
+export { createFramePlugin } from "./plugin.js";
 export type { FrameShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-frame/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-frame/src/plugin.tsx
@@ -69,152 +69,156 @@ function FrameIcon() {
 	);
 }
 
-export const framePlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-frame",
-	name: "フレーム",
+export function createFramePlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-frame",
+		name: "フレーム",
 
-	setup(ctx: PluginContext) {
-		// Register the "frame" shape type
-		ctx.shapes.register("frame", {
-			render: renderFrame,
-			getBounds: getBoundsFrame,
-			hitTest: hitTestFrame,
-			resize: resizeFrame,
-			createDefault: createDefaultFrame,
-			renderTarget: "html",
-			minSize: { width: 50, height: 50 },
-			simplifiedComponent: SimplifiedFrame,
-		});
+		setup(ctx: PluginContext) {
+			// Register the "frame" shape type
+			ctx.shapes.register("frame", {
+				render: renderFrame,
+				getBounds: getBoundsFrame,
+				hitTest: hitTestFrame,
+				resize: resizeFrame,
+				createDefault: createDefaultFrame,
+				renderTarget: "html",
+				minSize: { width: 50, height: 50 },
+				simplifiedComponent: SimplifiedFrame,
+			});
 
-		// Drawing tool state
-		let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+			// Drawing tool state
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
 
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			const id = generateId();
-			drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-			const shape = createDefaultFrame({ id, x: event.worldPoint.x, y: event.worldPoint.y });
-			shape.width = 0;
-			shape.height = 0;
-			shape.style = {
-				...shape.style,
-				stroke: toolCtx.store.getStyleSettings().stroke,
-			};
-			toolCtx.store.addShape(shape);
-		}
-
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!drawState) return;
-			const x = Math.min(drawState.startX, event.worldPoint.x);
-			const y = Math.min(drawState.startY, event.worldPoint.y);
-			const width = Math.abs(event.worldPoint.x - drawState.startX);
-			const height = Math.abs(event.worldPoint.y - drawState.startY);
-			toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
-		}
-
-		function onPointerUp(toolCtx: ToolContext) {
-			if (!drawState) return;
-			const shape = toolCtx.store.getShape(drawState.shapeId);
-			if (shape && shape.width > 10 && shape.height > 10) {
-				toolCtx.store.deleteShape(drawState.shapeId);
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-			} else {
-				toolCtx.store.deleteShape(drawState.shapeId);
-			}
-			drawState = null;
-			toolCtx.store.setActiveToolId("select");
-		}
-
-		ctx.tools.register("frame-draw", {
-			icon: FrameIcon,
-			cursor: "crosshair",
-			shortcut: "f",
-			order: 11,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-			onDeactivate() {
-				if (drawState) {
-					ctx.store.deleteShape(drawState.shapeId);
-					drawState = null;
-				}
-			},
-		});
-
-		// ── Auto-parenting ──
-
-		// On move-end: reparent moved shapes (emitted by select tool after move command commits).
-		// Use setTimeout to defer reparent until after React finishes the current render cycle,
-		// since the emit happens inside a queueMicrotask from the select tool.
-		const unsubMoveEnd = ctx.events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
-			if (!data?.shapeIds) return;
-			setTimeout(() => {
-				for (const shapeId of data.shapeIds) {
-					autoReparent(shapeId);
-				}
-			}, 0);
-		});
-
-		// On shape:added (e.g. drawing inside a frame)
-		const unsubAdded = ctx.store.onMutation((event) => {
-			if (event.type !== "shape:added") return;
-			const payload = event.payload as { id: string } | undefined;
-			if (!payload?.id) return;
-			const shape = ctx.store.getShape(payload.id);
-			if (!shape || shape.type === "frame" || shape.type === "connector") return;
-			autoReparent(payload.id);
-		});
-
-		function autoReparent(shapeId: string) {
-			const shape = ctx.store.getShape(shapeId);
-			if (!shape || shape.type === "frame" || shape.type === "connector") return;
-
-			const shapeBounds = { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
-
-			// Find the smallest frame that fully contains this shape
-			let bestFrame: ShapeData | null = null;
-			for (const [id, candidate] of ctx.store.getShapes()) {
-				if (id === shapeId || candidate.type !== "frame") continue;
-				const frameBounds = {
-					x: candidate.x,
-					y: candidate.y,
-					width: candidate.width,
-					height: candidate.height,
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				const id = generateId();
+				drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+				const shape = createDefaultFrame({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+				shape.width = 0;
+				shape.height = 0;
+				shape.style = {
+					...shape.style,
+					stroke: toolCtx.store.getStyleSettings().stroke,
 				};
-				if (containsAABB(frameBounds, shapeBounds)) {
-					if (
-						!bestFrame ||
-						candidate.width * candidate.height < bestFrame.width * bestFrame.height
-					) {
-						bestFrame = candidate;
+				toolCtx.store.addShape(shape);
+			}
+
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!drawState) return;
+				const x = Math.min(drawState.startX, event.worldPoint.x);
+				const y = Math.min(drawState.startY, event.worldPoint.y);
+				const width = Math.abs(event.worldPoint.x - drawState.startX);
+				const height = Math.abs(event.worldPoint.y - drawState.startY);
+				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+			}
+
+			function onPointerUp(toolCtx: ToolContext) {
+				if (!drawState) return;
+				const shape = toolCtx.store.getShape(drawState.shapeId);
+				if (shape && shape.width > 10 && shape.height > 10) {
+					toolCtx.store.deleteShape(drawState.shapeId);
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+				} else {
+					toolCtx.store.deleteShape(drawState.shapeId);
+				}
+				drawState = null;
+				toolCtx.store.setActiveToolId("select");
+			}
+
+			ctx.tools.register("frame-draw", {
+				icon: FrameIcon,
+				cursor: "crosshair",
+				shortcut: "f",
+				order: 11,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+				onDeactivate() {
+					if (drawState) {
+						ctx.store.deleteShape(drawState.shapeId);
+						drawState = null;
+					}
+				},
+			});
+
+			// ── Auto-parenting ──
+
+			// On move-end: reparent moved shapes (emitted by select tool after move command commits).
+			// Use setTimeout to defer reparent until after React finishes the current render cycle,
+			// since the emit happens inside a queueMicrotask from the select tool.
+			const unsubMoveEnd = ctx.events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
+				if (!data?.shapeIds) return;
+				setTimeout(() => {
+					for (const shapeId of data.shapeIds) {
+						autoReparent(shapeId);
+					}
+				}, 0);
+			});
+
+			// On shape:added (e.g. drawing inside a frame)
+			const unsubAdded = ctx.store.onMutation((event) => {
+				if (event.type !== "shape:added") return;
+				const payload = event.payload as { id: string } | undefined;
+				if (!payload?.id) return;
+				const shape = ctx.store.getShape(payload.id);
+				if (!shape || shape.type === "frame" || shape.type === "connector") return;
+				autoReparent(payload.id);
+			});
+
+			function autoReparent(shapeId: string) {
+				const shape = ctx.store.getShape(shapeId);
+				if (!shape || shape.type === "frame" || shape.type === "connector") return;
+
+				const shapeBounds = { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+
+				// Find the smallest frame that fully contains this shape
+				let bestFrame: ShapeData | null = null;
+				for (const [id, candidate] of ctx.store.getShapes()) {
+					if (id === shapeId || candidate.type !== "frame") continue;
+					const frameBounds = {
+						x: candidate.x,
+						y: candidate.y,
+						width: candidate.width,
+						height: candidate.height,
+					};
+					if (containsAABB(frameBounds, shapeBounds)) {
+						if (
+							!bestFrame ||
+							candidate.width * candidate.height < bestFrame.width * bestFrame.height
+						) {
+							bestFrame = candidate;
+						}
 					}
 				}
+
+				const currentParentId = shape.parentId as string | undefined;
+				const newParentId = bestFrame?.id;
+
+				if (currentParentId !== newParentId) {
+					ctx.commands.execute(
+						createReparentCommand(ctx.store, [shapeId], newParentId ?? undefined),
+					);
+				}
 			}
 
-			const currentParentId = shape.parentId as string | undefined;
-			const newParentId = bestFrame?.id;
+			// ── Frame move: move all children along with the frame ──
+			const unsubMove = ctx.store.onMutation((event) => {
+				if (event.type !== "shape:updated") return;
+				const payload = event.payload as { id: string } | undefined;
+				if (!payload?.id) return;
 
-			if (currentParentId !== newParentId) {
-				ctx.commands.execute(createReparentCommand(ctx.store, [shapeId], newParentId ?? undefined));
-			}
-		}
+				const shape = ctx.store.getShape(payload.id);
+				if (!shape || shape.type !== "frame") return;
 
-		// ── Frame move: move all children along with the frame ──
-		const unsubMove = ctx.store.onMutation((event) => {
-			if (event.type !== "shape:updated") return;
-			const payload = event.payload as { id: string } | undefined;
-			if (!payload?.id) return;
+				// This is handled by the select tool which includes children in snapshots
+				// when moving a frame. No additional logic needed here.
+			});
 
-			const shape = ctx.store.getShape(payload.id);
-			if (!shape || shape.type !== "frame") return;
-
-			// This is handled by the select tool which includes children in snapshots
-			// when moving a frame. No additional logic needed here.
-		});
-
-		(this as UsketchPlugin).teardown = () => {
-			unsubMoveEnd();
-			unsubAdded();
-			unsubMove();
-		};
-	},
-};
+			return () => {
+				unsubMoveEnd();
+				unsubAdded();
+				unsubMove();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-freedraw/src/index.ts
+++ b/plugins/usketch-plugin-shape-freedraw/src/index.ts
@@ -1,2 +1,2 @@
-export { freedrawPlugin } from "./plugin.js";
+export { createFreedrawPlugin } from "./plugin.js";
 export type { FreedrawShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-freedraw/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-freedraw/src/plugin.tsx
@@ -222,100 +222,102 @@ function FreedrawIcon() {
 	);
 }
 
-export const freedrawPlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-freedraw",
-	name: "フリーハンド",
+export function createFreedrawPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-freedraw",
+		name: "フリーハンド",
 
-	setup(ctx: PluginContext) {
-		// ── Local draw state (scoped to this setup closure) ──
-		let drawState: { shapeId: string; points: Point[] } | null = null;
+		setup(ctx: PluginContext) {
+			// ── Local draw state (scoped to this setup closure) ──
+			let drawState: { shapeId: string; points: Point[] } | null = null;
 
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			const id = generateId();
-			const startPoint: Point = { x: event.worldPoint.x, y: event.worldPoint.y };
-			drawState = { shapeId: id, points: [startPoint] };
-			const shape = createDefault({ id, x: startPoint.x, y: startPoint.y });
-			shape.points = [startPoint];
-			shape.style = { ...toolCtx.store.getStyleSettings() };
-			toolCtx.store.addShape(shape);
-		}
-
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!drawState) return;
-			const newPoint: Point = { x: event.worldPoint.x, y: event.worldPoint.y };
-			drawState.points.push(newPoint);
-
-			const bounds = computeBounds(drawState.points);
-			toolCtx.store.updateShape(drawState.shapeId, {
-				x: bounds.x,
-				y: bounds.y,
-				width: bounds.width,
-				height: bounds.height,
-				points: [...drawState.points],
-			} as Partial<FreedrawShapeData>);
-		}
-
-		function onPointerUp(toolCtx: ToolContext) {
-			if (!drawState) return;
-			const shape = toolCtx.store.getShape(drawState.shapeId);
-			if (shape && drawState.points.length > 1) {
-				// Replace with undoable command
-				toolCtx.store.deleteShape(drawState.shapeId);
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-			} else {
-				toolCtx.store.deleteShape(drawState.shapeId);
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				const id = generateId();
+				const startPoint: Point = { x: event.worldPoint.x, y: event.worldPoint.y };
+				drawState = { shapeId: id, points: [startPoint] };
+				const shape = createDefault({ id, x: startPoint.x, y: startPoint.y });
+				shape.points = [startPoint];
+				shape.style = { ...toolCtx.store.getStyleSettings() };
+				toolCtx.store.addShape(shape);
 			}
-			drawState = null;
-		}
 
-		function gpuPrimitive(shape: ShapeData): GpuPrimitive | null {
-			const data = shape as FreedrawShapeData;
-			const pts = data.points ?? [];
-			if (pts.length < 2) return null;
-			const verts = new Float32Array(pts.length * 2);
-			for (let i = 0; i < pts.length; i++) {
-				verts[i * 2] = pts[i].x;
-				verts[i * 2 + 1] = pts[i].y;
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!drawState) return;
+				const newPoint: Point = { x: event.worldPoint.x, y: event.worldPoint.y };
+				drawState.points.push(newPoint);
+
+				const bounds = computeBounds(drawState.points);
+				toolCtx.store.updateShape(drawState.shapeId, {
+					x: bounds.x,
+					y: bounds.y,
+					width: bounds.width,
+					height: bounds.height,
+					points: [...drawState.points],
+				} as Partial<FreedrawShapeData>);
 			}
-			return {
-				kind: "polyline",
-				bounds: getBounds(data),
-				vertices: verts,
-				fill: [0, 0, 0, 0],
-				stroke: cssColorToRgbaOrDefault(data.style.stroke),
-				strokeWidth: data.style.strokeWidth,
-				opacity: data.style.opacity,
-			};
-		}
 
-		ctx.shapes.register("freedraw", {
-			render,
-			getBounds,
-			hitTest,
-			resize,
-			createDefault,
-			move,
-			applyBounds,
-			gpuPrimitive,
-			serializeForAi,
-			serializeForRecognition,
-			debugFields,
-		});
+			function onPointerUp(toolCtx: ToolContext) {
+				if (!drawState) return;
+				const shape = toolCtx.store.getShape(drawState.shapeId);
+				if (shape && drawState.points.length > 1) {
+					// Replace with undoable command
+					toolCtx.store.deleteShape(drawState.shapeId);
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+				} else {
+					toolCtx.store.deleteShape(drawState.shapeId);
+				}
+				drawState = null;
+			}
 
-		ctx.tools.register("freedraw-draw", {
-			icon: FreedrawIcon,
-			cursor: "crosshair",
-			shortcut: "p",
-			order: 30,
-			onActivate(toolCtx) {
-				toolCtx.events.emit("snap:configure", { enabled: false });
-			},
-			onDeactivate(toolCtx) {
-				toolCtx.events.emit("snap:configure", { enabled: true });
-			},
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-		});
-	},
-};
+			function gpuPrimitive(shape: ShapeData): GpuPrimitive | null {
+				const data = shape as FreedrawShapeData;
+				const pts = data.points ?? [];
+				if (pts.length < 2) return null;
+				const verts = new Float32Array(pts.length * 2);
+				for (let i = 0; i < pts.length; i++) {
+					verts[i * 2] = pts[i].x;
+					verts[i * 2 + 1] = pts[i].y;
+				}
+				return {
+					kind: "polyline",
+					bounds: getBounds(data),
+					vertices: verts,
+					fill: [0, 0, 0, 0],
+					stroke: cssColorToRgbaOrDefault(data.style.stroke),
+					strokeWidth: data.style.strokeWidth,
+					opacity: data.style.opacity,
+				};
+			}
+
+			ctx.shapes.register("freedraw", {
+				render,
+				getBounds,
+				hitTest,
+				resize,
+				createDefault,
+				move,
+				applyBounds,
+				gpuPrimitive,
+				serializeForAi,
+				serializeForRecognition,
+				debugFields,
+			});
+
+			ctx.tools.register("freedraw-draw", {
+				icon: FreedrawIcon,
+				cursor: "crosshair",
+				shortcut: "p",
+				order: 30,
+				onActivate(toolCtx) {
+					toolCtx.events.emit("snap:configure", { enabled: false });
+				},
+				onDeactivate(toolCtx) {
+					toolCtx.events.emit("snap:configure", { enabled: true });
+				},
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+			});
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-group/src/index.ts
+++ b/plugins/usketch-plugin-shape-group/src/index.ts
@@ -1,1 +1,1 @@
-export { groupPlugin } from "./plugin.js";
+export { createGroupPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-shape-group/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-group/src/plugin.tsx
@@ -15,122 +15,124 @@ import {
 	resizeGroup,
 } from "./shapes/group.js";
 
-export const groupPlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-group",
-	name: "グループ",
+export function createGroupPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-group",
+		name: "グループ",
 
-	setup(ctx: PluginContext) {
-		// Register the "group" shape type
-		ctx.shapes.register("group", {
-			render: renderGroup,
-			getBounds: getBoundsGroup,
-			hitTest: hitTestGroup,
-			resize: resizeGroup,
-			createDefault: createDefaultGroup,
-			minSize: { width: 1, height: 1 },
-			resizable: false,
-		});
+		setup(ctx: PluginContext) {
+			// Register the "group" shape type
+			ctx.shapes.register("group", {
+				render: renderGroup,
+				getBounds: getBoundsGroup,
+				hitTest: hitTestGroup,
+				resize: resizeGroup,
+				createDefault: createDefaultGroup,
+				minSize: { width: 1, height: 1 },
+				resizable: false,
+			});
 
-		function groupSelected() {
-			const selection = ctx.store.getSelection();
-			if (selection.size < 2) return;
+			function groupSelected() {
+				const selection = ctx.store.getSelection();
+				if (selection.size < 2) return;
 
-			const childIds = [...selection];
-			const children: ShapeData[] = [];
-			for (const id of childIds) {
-				const shape = ctx.store.getShape(id);
-				if (shape) children.push(shape);
+				const childIds = [...selection];
+				const children: ShapeData[] = [];
+				for (const id of childIds) {
+					const shape = ctx.store.getShape(id);
+					if (shape) children.push(shape);
+				}
+				if (children.length < 2) return;
+
+				const bounds = computeGroupBounds(children);
+				const groupId = generateId();
+				const groupShape: ShapeData = {
+					...createDefaultGroup({ id: groupId, x: bounds.x, y: bounds.y }),
+					width: bounds.width,
+					height: bounds.height,
+				};
+
+				ctx.commands.execute(createGroupCommand(ctx.store, groupShape, childIds));
+				ctx.store.setSelection([groupId]);
 			}
-			if (children.length < 2) return;
 
-			const bounds = computeGroupBounds(children);
-			const groupId = generateId();
-			const groupShape: ShapeData = {
-				...createDefaultGroup({ id: groupId, x: bounds.x, y: bounds.y }),
-				width: bounds.width,
-				height: bounds.height,
-			};
+			function ungroupSelected() {
+				const selection = ctx.store.getSelection();
+				const groupIds: string[] = [];
+				const restoredChildIds: string[] = [];
 
-			ctx.commands.execute(createGroupCommand(ctx.store, groupShape, childIds));
-			ctx.store.setSelection([groupId]);
-		}
-
-		function ungroupSelected() {
-			const selection = ctx.store.getSelection();
-			const groupIds: string[] = [];
-			const restoredChildIds: string[] = [];
-
-			for (const id of selection) {
-				const shape = ctx.store.getShape(id);
-				if (shape?.type === "group") {
-					groupIds.push(id);
-					const children = getChildShapes(ctx.store, id);
-					for (const child of children) {
-						restoredChildIds.push(child.id);
+				for (const id of selection) {
+					const shape = ctx.store.getShape(id);
+					if (shape?.type === "group") {
+						groupIds.push(id);
+						const children = getChildShapes(ctx.store, id);
+						for (const child of children) {
+							restoredChildIds.push(child.id);
+						}
 					}
 				}
+
+				if (groupIds.length === 0) return;
+
+				for (const groupId of groupIds) {
+					ctx.commands.execute(createUngroupCommand(ctx.store, groupId));
+				}
+
+				ctx.store.setSelection(restoredChildIds);
 			}
 
-			if (groupIds.length === 0) return;
+			// Ctrl+G (Cmd+G on Mac) to group
+			ctx.shortcuts.register("Ctrl+g", groupSelected);
+			// Ctrl+Shift+G (Cmd+Shift+G on Mac) to ungroup
+			ctx.shortcuts.register("Ctrl+Shift+g", ungroupSelected);
 
-			for (const groupId of groupIds) {
-				ctx.commands.execute(createUngroupCommand(ctx.store, groupId));
-			}
-
-			ctx.store.setSelection(restoredChildIds);
-		}
-
-		// Ctrl+G (Cmd+G on Mac) to group
-		ctx.shortcuts.register("Ctrl+g", groupSelected);
-		// Ctrl+Shift+G (Cmd+Shift+G on Mac) to ungroup
-		ctx.shortcuts.register("Ctrl+Shift+g", ungroupSelected);
-
-		// Override delete for groups to cascade
-		ctx.events.on<{ shapeId: string }>("group:delete-request", (data) => {
-			const shape = ctx.store.getShape(data.shapeId);
-			if (shape?.type === "group") {
-				ctx.commands.execute(createDeleteWithChildrenCommand(ctx.store, data.shapeId));
-			}
-		});
-
-		// Update group bounds when children move.
-		// Skip if bounds haven't actually changed to avoid extra re-renders.
-		const unsubscribe = ctx.store.onMutation((event) => {
-			if (event.type !== "shape:updated") return;
-			const payload = event.payload as { id: string } | undefined;
-			if (!payload?.id) return;
-
-			const shape = ctx.store.getShape(payload.id);
-			if (!shape || typeof shape.parentId !== "string") return;
-
-			const parent = ctx.store.getShape(shape.parentId);
-			if (!parent || parent.type !== "group") return;
-
-			// Recalculate group bounds
-			const children = getChildShapes(ctx.store, parent.id);
-			if (children.length === 0) return;
-			const bounds = computeGroupBounds(children);
-
-			// Skip update if bounds are unchanged
-			if (
-				Math.abs(parent.x - bounds.x) < 0.1 &&
-				Math.abs(parent.y - bounds.y) < 0.1 &&
-				Math.abs(parent.width - bounds.width) < 0.1 &&
-				Math.abs(parent.height - bounds.height) < 0.1
-			) {
-				return;
-			}
-
-			ctx.store.updateShape(parent.id, {
-				x: bounds.x,
-				y: bounds.y,
-				width: bounds.width,
-				height: bounds.height,
+			// Override delete for groups to cascade
+			ctx.events.on<{ shapeId: string }>("group:delete-request", (data) => {
+				const shape = ctx.store.getShape(data.shapeId);
+				if (shape?.type === "group") {
+					ctx.commands.execute(createDeleteWithChildrenCommand(ctx.store, data.shapeId));
+				}
 			});
-		});
 
-		(this as UsketchPlugin).teardown = () => {
-			unsubscribe();
-		};
-	},
-};
+			// Update group bounds when children move.
+			// Skip if bounds haven't actually changed to avoid extra re-renders.
+			const unsubscribe = ctx.store.onMutation((event) => {
+				if (event.type !== "shape:updated") return;
+				const payload = event.payload as { id: string } | undefined;
+				if (!payload?.id) return;
+
+				const shape = ctx.store.getShape(payload.id);
+				if (!shape || typeof shape.parentId !== "string") return;
+
+				const parent = ctx.store.getShape(shape.parentId);
+				if (!parent || parent.type !== "group") return;
+
+				// Recalculate group bounds
+				const children = getChildShapes(ctx.store, parent.id);
+				if (children.length === 0) return;
+				const bounds = computeGroupBounds(children);
+
+				// Skip update if bounds are unchanged
+				if (
+					Math.abs(parent.x - bounds.x) < 0.1 &&
+					Math.abs(parent.y - bounds.y) < 0.1 &&
+					Math.abs(parent.width - bounds.width) < 0.1 &&
+					Math.abs(parent.height - bounds.height) < 0.1
+				) {
+					return;
+				}
+
+				ctx.store.updateShape(parent.id, {
+					x: bounds.x,
+					y: bounds.y,
+					width: bounds.width,
+					height: bounds.height,
+				});
+			});
+
+			return () => {
+				unsubscribe();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-image/src/index.ts
+++ b/plugins/usketch-plugin-shape-image/src/index.ts
@@ -1,2 +1,2 @@
-export { imageShapePlugin } from "./plugin.js";
+export { createImageShapePlugin } from "./plugin.js";
 export type { ImageShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-image/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-image/src/plugin.tsx
@@ -149,31 +149,33 @@ function debugFields(shape: ShapeData): Record<string, unknown> {
 	return { src: data.src ?? "" };
 }
 
-export const imageShapePlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-image",
-	name: "画像",
+export function createImageShapePlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-image",
+		name: "画像",
 
-	setup(ctx: PluginContext) {
-		ctx.shapes.register("image", {
-			render,
-			getBounds,
-			hitTest: withRotation(hitTest),
-			resize,
-			createDefault,
-			renderTarget: "html",
-			minSize: { width: 40, height: 40 },
-			serializeForAi,
-			serializeForRecognition,
-			debugFields,
-		});
+		setup(ctx: PluginContext) {
+			ctx.shapes.register("image", {
+				render,
+				getBounds,
+				hitTest: withRotation(hitTest),
+				resize,
+				createDefault,
+				renderTarget: "html",
+				minSize: { width: 40, height: 40 },
+				serializeForAi,
+				serializeForRecognition,
+				debugFields,
+			});
 
-		// Self-register the default "image file → image shape" external-content
-		// handler at order 0. Apps and third-party plugins can override by
-		// registering a higher-`order` `kind: "file"` handler.
-		const unregisterHandler = ctx.externalContent.register(createImageFileHandler());
+			// Self-register the default "image file → image shape" external-content
+			// handler at order 0. Apps and third-party plugins can override by
+			// registering a higher-`order` `kind: "file"` handler.
+			const unregisterHandler = ctx.externalContent.register(createImageFileHandler());
 
-		(this as UsketchPlugin).teardown = () => {
-			unregisterHandler();
-		};
-	},
-};
+			return () => {
+				unregisterHandler();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-island/src/index.ts
+++ b/plugins/usketch-plugin-shape-island/src/index.ts
@@ -1,2 +1,2 @@
-export { islandPlugin } from "./plugin.js";
+export { createIslandPlugin } from "./plugin.js";
 export type { IslandShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-island/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-island/src/plugin.tsx
@@ -28,195 +28,199 @@ function IslandIcon() {
 	);
 }
 
-export const islandPlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-island",
-	name: "Island",
+export function createIslandPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-island",
+		name: "Island",
 
-	setup(ctx: PluginContext) {
-		// ── Shape registration ──
-		ctx.shapes.register("island", {
-			render: renderIsland,
-			getBounds: getBoundsIsland,
-			hitTest: hitTestIsland,
-			resize: resizeIsland,
-			createDefault: createDefaultIsland,
-			renderTarget: "html",
-			minSize: { width: 100, height: 100 },
-		});
+		setup(ctx: PluginContext) {
+			// ── Shape registration ──
+			ctx.shapes.register("island", {
+				render: renderIsland,
+				getBounds: getBoundsIsland,
+				hitTest: hitTestIsland,
+				resize: resizeIsland,
+				createDefault: createDefaultIsland,
+				renderTarget: "html",
+				minSize: { width: 100, height: 100 },
+			});
 
-		// ── Metaball background layer (renders below shapes) ──
-		ctx.layers.register({
-			id: "island-metaball",
-			order: -1,
-			fixed: true,
-			render: () => <IslandMetaballLayer store={ctx.store} />,
-		});
+			// ── Metaball background layer (renders below shapes) ──
+			ctx.layers.register({
+				id: "island-metaball",
+				order: -1,
+				fixed: true,
+				render: () => <IslandMetaballLayer store={ctx.store} />,
+			});
 
-		// ── Drawing tool ──
-		let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+			// ── Drawing tool ──
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
 
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			const id = generateId();
-			drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-			const shape = createDefaultIsland({ id, x: event.worldPoint.x, y: event.worldPoint.y });
-			shape.width = 0;
-			shape.height = 0;
-			toolCtx.store.addShape(shape);
-		}
-
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!drawState) return;
-			const x = Math.min(drawState.startX, event.worldPoint.x);
-			const y = Math.min(drawState.startY, event.worldPoint.y);
-			const width = Math.abs(event.worldPoint.x - drawState.startX);
-			const height = Math.abs(event.worldPoint.y - drawState.startY);
-			toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
-		}
-
-		function onPointerUp(toolCtx: ToolContext) {
-			if (!drawState) return;
-			const shape = toolCtx.store.getShape(drawState.shapeId);
-			if (shape && shape.width > 10 && shape.height > 10) {
-				toolCtx.store.deleteShape(drawState.shapeId);
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-			} else {
-				toolCtx.store.deleteShape(drawState.shapeId);
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				const id = generateId();
+				drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+				const shape = createDefaultIsland({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+				shape.width = 0;
+				shape.height = 0;
+				toolCtx.store.addShape(shape);
 			}
-			drawState = null;
-			toolCtx.store.setActiveToolId("select");
-		}
 
-		ctx.tools.register("island-draw", {
-			icon: IslandIcon,
-			cursor: "crosshair",
-			shortcut: "i",
-			order: 6,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-			onDeactivate() {
-				if (drawState) {
-					ctx.store.deleteShape(drawState.shapeId);
-					drawState = null;
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!drawState) return;
+				const x = Math.min(drawState.startX, event.worldPoint.x);
+				const y = Math.min(drawState.startY, event.worldPoint.y);
+				const width = Math.abs(event.worldPoint.x - drawState.startX);
+				const height = Math.abs(event.worldPoint.y - drawState.startY);
+				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+			}
+
+			function onPointerUp(toolCtx: ToolContext) {
+				if (!drawState) return;
+				const shape = toolCtx.store.getShape(drawState.shapeId);
+				if (shape && shape.width > 10 && shape.height > 10) {
+					toolCtx.store.deleteShape(drawState.shapeId);
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+				} else {
+					toolCtx.store.deleteShape(drawState.shapeId);
 				}
-			},
-		});
+				drawState = null;
+				toolCtx.store.setActiveToolId("select");
+			}
 
-		// ── Auto-parenting (same pattern as frame plugin) ──
+			ctx.tools.register("island-draw", {
+				icon: IslandIcon,
+				cursor: "crosshair",
+				shortcut: "i",
+				order: 6,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+				onDeactivate() {
+					if (drawState) {
+						ctx.store.deleteShape(drawState.shapeId);
+						drawState = null;
+					}
+				},
+			});
 
-		const CONTAINER_TYPES = new Set(["frame", "island"]);
+			// ── Auto-parenting (same pattern as frame plugin) ──
 
-		function autoReparent(shapeId: string) {
-			const shape = ctx.store.getShape(shapeId);
-			if (!shape || CONTAINER_TYPES.has(shape.type) || shape.type === "connector") return;
+			const CONTAINER_TYPES = new Set(["frame", "island"]);
 
-			const shapeBounds = { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+			function autoReparent(shapeId: string) {
+				const shape = ctx.store.getShape(shapeId);
+				if (!shape || CONTAINER_TYPES.has(shape.type) || shape.type === "connector") return;
 
-			let bestContainer: ShapeData | null = null;
-			for (const [id, candidate] of ctx.store.getShapes()) {
-				if (id === shapeId || !CONTAINER_TYPES.has(candidate.type)) continue;
-				const containerBounds = {
-					x: candidate.x,
-					y: candidate.y,
-					width: candidate.width,
-					height: candidate.height,
+				const shapeBounds = { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+
+				let bestContainer: ShapeData | null = null;
+				for (const [id, candidate] of ctx.store.getShapes()) {
+					if (id === shapeId || !CONTAINER_TYPES.has(candidate.type)) continue;
+					const containerBounds = {
+						x: candidate.x,
+						y: candidate.y,
+						width: candidate.width,
+						height: candidate.height,
+					};
+					if (containsAABB(containerBounds, shapeBounds)) {
+						if (
+							!bestContainer ||
+							candidate.width * candidate.height < bestContainer.width * bestContainer.height
+						) {
+							bestContainer = candidate;
+						}
+					}
+				}
+
+				const currentParentId = shape.parentId as string | undefined;
+				const newParentId = bestContainer?.id;
+
+				if (currentParentId !== newParentId) {
+					ctx.commands.execute(
+						createReparentCommand(ctx.store, [shapeId], newParentId ?? undefined),
+					);
+				}
+			}
+
+			// ── Auto-grouping: islands that touch form a group ──
+
+			const unsubMoveEnd = ctx.events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
+				if (!data?.shapeIds) return;
+				setTimeout(() => {
+					for (const shapeId of data.shapeIds) {
+						const shape = ctx.store.getShape(shapeId);
+						if (shape?.type === "island") {
+							// Island moved — adopt shapes now inside it
+							adoptContainedShapes(shapeId);
+						} else {
+							// Non-island moved — reparent into nearest container
+							autoReparent(shapeId);
+						}
+					}
+					const prevSelection = [...ctx.store.getSelection()];
+					reconcileIslandGroups(ctx.store, ctx.commands);
+					if (prevSelection.length > 0) {
+						ctx.store.setSelection(prevSelection.filter((id) => ctx.store.getShape(id)));
+					}
+				}, 0);
+			});
+
+			// Adopt all non-container shapes fully inside an island
+			function adoptContainedShapes(islandId: string) {
+				const island = ctx.store.getShape(islandId);
+				if (!island || island.type !== "island") return;
+				const islandBounds = {
+					x: island.x,
+					y: island.y,
+					width: island.width,
+					height: island.height,
 				};
-				if (containsAABB(containerBounds, shapeBounds)) {
-					if (
-						!bestContainer ||
-						candidate.width * candidate.height < bestContainer.width * bestContainer.height
-					) {
-						bestContainer = candidate;
+				for (const [childId, child] of ctx.store.getShapes()) {
+					if (childId === islandId || CONTAINER_TYPES.has(child.type) || child.type === "connector")
+						continue;
+					if (child.parentId === islandId) continue;
+					const childBounds = { x: child.x, y: child.y, width: child.width, height: child.height };
+					if (containsAABB(islandBounds, childBounds)) {
+						ctx.commands.execute(createReparentCommand(ctx.store, [childId], islandId));
 					}
 				}
 			}
 
-			const currentParentId = shape.parentId as string | undefined;
-			const newParentId = bestContainer?.id;
+			const unsubAdded = ctx.store.onMutation((event) => {
+				if (event.type !== "shape:added") return;
+				const payload = event.payload as { id: string } | undefined;
+				if (!payload?.id) return;
+				const shape = ctx.store.getShape(payload.id);
+				if (!shape) return;
 
-			if (currentParentId !== newParentId) {
-				ctx.commands.execute(createReparentCommand(ctx.store, [shapeId], newParentId ?? undefined));
-			}
-		}
+				if (shape.type === "island") {
+					// Island was just created — adopt shapes already inside it
+					adoptContainedShapes(payload.id);
+					return;
+				}
+				if (CONTAINER_TYPES.has(shape.type) || shape.type === "connector") return;
+				autoReparent(payload.id);
+			});
 
-		// ── Auto-grouping: islands that touch form a group ──
+			// ── Detach: Shift+D to detach selected island from its group ──
 
-		const unsubMoveEnd = ctx.events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
-			if (!data?.shapeIds) return;
-			setTimeout(() => {
-				for (const shapeId of data.shapeIds) {
-					const shape = ctx.store.getShape(shapeId);
+			const unsubDetach = ctx.shortcuts.register("Shift+D", () => {
+				const selection = ctx.store.getSelection();
+				for (const id of selection) {
+					const shape = ctx.store.getShape(id);
 					if (shape?.type === "island") {
-						// Island moved — adopt shapes now inside it
-						adoptContainedShapes(shapeId);
-					} else {
-						// Non-island moved — reparent into nearest container
-						autoReparent(shapeId);
+						detachIsland(ctx.store, ctx.commands, id);
 					}
 				}
-				const prevSelection = [...ctx.store.getSelection()];
-				reconcileIslandGroups(ctx.store, ctx.commands);
-				if (prevSelection.length > 0) {
-					ctx.store.setSelection(prevSelection.filter((id) => ctx.store.getShape(id)));
-				}
-			}, 0);
-		});
+			});
 
-		// Adopt all non-container shapes fully inside an island
-		function adoptContainedShapes(islandId: string) {
-			const island = ctx.store.getShape(islandId);
-			if (!island || island.type !== "island") return;
-			const islandBounds = {
-				x: island.x,
-				y: island.y,
-				width: island.width,
-				height: island.height,
+			return () => {
+				unsubMoveEnd();
+				unsubAdded();
+				unsubDetach();
+				cleanupIslandGroupTimers();
+				ctx.layers.unregister("island-metaball");
 			};
-			for (const [childId, child] of ctx.store.getShapes()) {
-				if (childId === islandId || CONTAINER_TYPES.has(child.type) || child.type === "connector")
-					continue;
-				if (child.parentId === islandId) continue;
-				const childBounds = { x: child.x, y: child.y, width: child.width, height: child.height };
-				if (containsAABB(islandBounds, childBounds)) {
-					ctx.commands.execute(createReparentCommand(ctx.store, [childId], islandId));
-				}
-			}
-		}
-
-		const unsubAdded = ctx.store.onMutation((event) => {
-			if (event.type !== "shape:added") return;
-			const payload = event.payload as { id: string } | undefined;
-			if (!payload?.id) return;
-			const shape = ctx.store.getShape(payload.id);
-			if (!shape) return;
-
-			if (shape.type === "island") {
-				// Island was just created — adopt shapes already inside it
-				adoptContainedShapes(payload.id);
-				return;
-			}
-			if (CONTAINER_TYPES.has(shape.type) || shape.type === "connector") return;
-			autoReparent(payload.id);
-		});
-
-		// ── Detach: Shift+D to detach selected island from its group ──
-
-		const unsubDetach = ctx.shortcuts.register("Shift+D", () => {
-			const selection = ctx.store.getSelection();
-			for (const id of selection) {
-				const shape = ctx.store.getShape(id);
-				if (shape?.type === "island") {
-					detachIsland(ctx.store, ctx.commands, id);
-				}
-			}
-		});
-
-		(this as UsketchPlugin).teardown = () => {
-			unsubMoveEnd();
-			unsubAdded();
-			unsubDetach();
-			cleanupIslandGroupTimers();
-			ctx.layers.unregister("island-metaball");
-		};
-	},
-};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-openui/src/__tests__/plugin.test.tsx
+++ b/plugins/usketch-plugin-shape-openui/src/__tests__/plugin.test.tsx
@@ -1,6 +1,6 @@
 import type { ShapeData, ShapeRegistry } from "@edv4h/usketch-shared";
 import { describe, expect, it, vi } from "vitest";
-import { openUIShapePlugin } from "../plugin.js";
+import { createOpenUIShapePlugin } from "../plugin.js";
 import type { OpenUIShapeData } from "../types.js";
 
 interface CapturedDefinition {
@@ -24,15 +24,15 @@ function setupPlugin(): CapturedDefinition {
 			captured = def;
 		}),
 	} as unknown as ShapeRegistry;
-	openUIShapePlugin.setup({ shapes } as never);
+	createOpenUIShapePlugin().setup({ shapes } as never);
 	if (!captured) throw new Error("ShapeDefinition was not registered");
 	return captured;
 }
 
-describe("openUIShapePlugin", () => {
+describe("createOpenUIShapePlugin", () => {
 	it("registers the `openui` shape", () => {
 		const shapes = { register: vi.fn() } as unknown as ShapeRegistry;
-		openUIShapePlugin.setup({ shapes } as never);
+		createOpenUIShapePlugin().setup({ shapes } as never);
 		expect(shapes.register).toHaveBeenCalledWith("openui", expect.any(Object));
 	});
 

--- a/plugins/usketch-plugin-shape-openui/src/index.ts
+++ b/plugins/usketch-plugin-shape-openui/src/index.ts
@@ -1,4 +1,4 @@
 export { getOpenUILibrary, setOpenUILibrary } from "./library-registry.js";
-export { openUIShapePlugin } from "./plugin.js";
+export { createOpenUIShapePlugin } from "./plugin.js";
 export { sanitizeLangSource } from "./sanitize.js";
 export type { OpenUIShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-openui/src/plugin.tsx
@@ -170,21 +170,23 @@ function debugFields(shape: ShapeData): Record<string, unknown> {
 	};
 }
 
-export const openUIShapePlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-openui",
-	name: "OpenUI",
+export function createOpenUIShapePlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-openui",
+		name: "OpenUI",
 
-	setup(ctx: PluginContext) {
-		ctx.shapes.register("openui", {
-			render,
-			getBounds,
-			hitTest: withRotation(hitTest),
-			resize,
-			createDefault,
-			renderTarget: "html",
-			minSize: { width: 160, height: 100 },
-			serializeForAi,
-			debugFields,
-		});
-	},
-};
+		setup(ctx: PluginContext) {
+			ctx.shapes.register("openui", {
+				render,
+				getBounds,
+				hitTest: withRotation(hitTest),
+				resize,
+				createDefault,
+				renderTarget: "html",
+				minSize: { width: 160, height: 100 },
+				serializeForAi,
+				debugFields,
+			});
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-sticky/src/index.ts
+++ b/plugins/usketch-plugin-shape-sticky/src/index.ts
@@ -1,2 +1,2 @@
 export { DEFAULT_STICKY_COLOR, STICKY_COLOR_KEYS, STICKY_COLORS } from "./constants.js";
-export { stickyPlugin } from "./plugin.js";
+export { createStickyPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-shape-sticky/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-sticky/src/plugin.tsx
@@ -451,170 +451,172 @@ function StickyIcon() {
 
 // ── Plugin ──
 
-export const stickyPlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-sticky",
-	name: "付箋",
+export function createStickyPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-sticky",
+		name: "付箋",
 
-	setup(ctx: PluginContext) {
-		// ── State Machine ──
-		const service = createStickyTextService(ctx);
-		const { send, matches, stop: stopMachine } = service;
+		setup(ctx: PluginContext) {
+			// ── State Machine ──
+			const service = createStickyTextService(ctx);
+			const { send, matches, stop: stopMachine } = service;
 
-		// ── CustomEvent listeners (shared with text plugin via same event names) ──
-		const onTextInput = (e: Event) => {
-			const { id, text, scrollHeight } = (e as CustomEvent).detail;
-			// Only handle events for sticky shapes
-			const shape = ctx.store.getShape(id);
-			if (!shape || shape.type !== "sticky") return;
-			send({ type: "TEXT_INPUT", id, text, scrollHeight });
-		};
+			// ── CustomEvent listeners (shared with text plugin via same event names) ──
+			const onTextInput = (e: Event) => {
+				const { id, text, scrollHeight } = (e as CustomEvent).detail;
+				// Only handle events for sticky shapes
+				const shape = ctx.store.getShape(id);
+				if (!shape || shape.type !== "sticky") return;
+				send({ type: "TEXT_INPUT", id, text, scrollHeight });
+			};
 
-		const onTextBlur = (e: Event) => {
-			const { id } = (e as CustomEvent).detail;
-			const shape = ctx.store.getShape(id);
-			if (!shape || shape.type !== "sticky") return;
-			requestAnimationFrame(() => {
-				send({ type: "TEXT_BLUR", id });
-			});
-		};
+			const onTextBlur = (e: Event) => {
+				const { id } = (e as CustomEvent).detail;
+				const shape = ctx.store.getShape(id);
+				if (!shape || shape.type !== "sticky") return;
+				requestAnimationFrame(() => {
+					send({ type: "TEXT_BLUR", id });
+				});
+			};
 
-		const onTextEscape = (e: Event) => {
-			const { id } = (e as CustomEvent).detail;
-			const shape = ctx.store.getShape(id);
-			if (!shape || shape.type !== "sticky") return;
-			send({ type: "TEXT_ESCAPE", id });
-		};
+			const onTextEscape = (e: Event) => {
+				const { id } = (e as CustomEvent).detail;
+				const shape = ctx.store.getShape(id);
+				if (!shape || shape.type !== "sticky") return;
+				send({ type: "TEXT_ESCAPE", id });
+			};
 
-		window.addEventListener("usketch:text-input", onTextInput);
-		window.addEventListener("usketch:text-blur", onTextBlur);
-		window.addEventListener("usketch:text-escape", onTextEscape);
+			window.addEventListener("usketch:text-input", onTextInput);
+			window.addEventListener("usketch:text-blur", onTextBlur);
+			window.addEventListener("usketch:text-escape", onTextEscape);
 
-		// ── Global pointerdown to exit edit mode on outside click ──
-		const onWindowPointerDown = (e: PointerEvent) => {
-			if (!matches("editing")) return;
-			const target = e.target instanceof Element ? e.target : (e.target as Node).parentElement;
-			if (target?.closest("[contenteditable]")) return;
-			send({ type: "OUTSIDE_CLICK" });
-		};
-		window.addEventListener("pointerdown", onWindowPointerDown, true);
+			// ── Global pointerdown to exit edit mode on outside click ──
+			const onWindowPointerDown = (e: PointerEvent) => {
+				if (!matches("editing")) return;
+				const target = e.target instanceof Element ? e.target : (e.target as Node).parentElement;
+				if (target?.closest("[contenteditable]")) return;
+				send({ type: "OUTSIDE_CLICK" });
+			};
+			window.addEventListener("pointerdown", onWindowPointerDown, true);
 
-		// ── Double-click detection via EventBus ──
-		const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
-			const shapes = ctx.store.getShapes();
-			let hitShapeId: string | null = null;
-			for (const [id, shape] of shapes) {
-				if (shape.type === "sticky" && hitTest(shape, event.worldPoint)) {
-					hitShapeId = id;
+			// ── Double-click detection via EventBus ──
+			const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+				const shapes = ctx.store.getShapes();
+				let hitShapeId: string | null = null;
+				for (const [id, shape] of shapes) {
+					if (shape.type === "sticky" && hitTest(shape, event.worldPoint)) {
+						hitShapeId = id;
+					}
 				}
-			}
-			if (hitShapeId) {
-				send({ type: "POINTER_DOWN", shapeId: hitShapeId });
-			}
-		});
+				if (hitShapeId) {
+					send({ type: "POINTER_DOWN", shapeId: hitShapeId });
+				}
+			});
 
-		// ── Selection change monitoring ──
-		const unsubscribe = ctx.store.subscribe(() => {
-			const editingShapeId = service.context.editingShapeId;
-			if (!editingShapeId) return;
-			const selection = ctx.store.getSelection();
-			if (!selection.has(editingShapeId)) {
-				send({ type: "DESELECTED" });
-			}
-		});
+			// ── Selection change monitoring ──
+			const unsubscribe = ctx.store.subscribe(() => {
+				const editingShapeId = service.context.editingShapeId;
+				if (!editingShapeId) return;
+				const selection = ctx.store.getSelection();
+				if (!selection.has(editingShapeId)) {
+					send({ type: "DESELECTED" });
+				}
+			});
 
-		// ── Sticky color state ──
-		let currentColor = DEFAULT_STICKY_COLOR;
+			// ── Sticky color state ──
+			let currentColor = DEFAULT_STICKY_COLOR;
 
-		ctx.events.on<{ color: string }>("sticky:select-color", (data) => {
-			currentColor = data.color;
-		});
+			ctx.events.on<{ color: string }>("sticky:select-color", (data) => {
+				currentColor = data.color;
+			});
 
-		// ── Shape registration ──
-		ctx.shapes.register("sticky", {
-			render,
-			getBounds,
-			hitTest: withRotation(hitTest),
-			resize,
-			createDefault,
-			renderTarget: "html",
-			minSize: { width: 100, height: 100 },
-			simplifiedComponent: SimplifiedSticky,
-			serializeForAi,
-			debugFields,
-		});
+			// ── Shape registration ──
+			ctx.shapes.register("sticky", {
+				render,
+				getBounds,
+				hitTest: withRotation(hitTest),
+				resize,
+				createDefault,
+				renderTarget: "html",
+				minSize: { width: 100, height: 100 },
+				simplifiedComponent: SimplifiedSticky,
+				serializeForAi,
+				debugFields,
+			});
 
-		// ── Draw tool registration ──
-		let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+			// ── Draw tool registration ──
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
 
-		ctx.tools.register("sticky-draw", {
-			icon: StickyIcon,
-			cursor: "crosshair",
-			shortcut: "s",
-			order: 26,
+			ctx.tools.register("sticky-draw", {
+				icon: StickyIcon,
+				cursor: "crosshair",
+				shortcut: "s",
+				order: 26,
 
-			onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-				const id = generateId();
-				const shape = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
-				shape.stickyColor = currentColor;
-				shape.style = {
-					...shape.style,
-					fill: STICKY_COLORS[currentColor] ?? STICKY_COLORS[DEFAULT_STICKY_COLOR],
-				};
-				drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-				shape.width = 0;
-				shape.height = 0;
-				toolCtx.store.addShape(shape);
-			},
-
-			onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-				if (!drawState) return;
-				const x = Math.min(drawState.startX, event.worldPoint.x);
-				const y = Math.min(drawState.startY, event.worldPoint.y);
-				const width = Math.abs(event.worldPoint.x - drawState.startX);
-				const height = Math.abs(event.worldPoint.y - drawState.startY);
-				toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
-			},
-
-			onPointerUp(toolCtx: ToolContext) {
-				if (!drawState) return;
-				const shape = toolCtx.store.getShape(drawState.shapeId);
-				toolCtx.store.deleteShape(drawState.shapeId);
-
-				if (shape && shape.width > 2 && shape.height > 2) {
-					// Dragged: use custom size
-					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-					toolCtx.store.setSelection([shape.id]);
-				} else {
-					// Clicked: use default size, center on click point
-					const defaultShape = createDefault({
-						id: drawState.shapeId,
-						x: drawState.startX - DEFAULT_STICKY_SIZE.width / 2,
-						y: drawState.startY - DEFAULT_STICKY_SIZE.height / 2,
-					});
-					defaultShape.stickyColor = currentColor;
-					defaultShape.style = {
-						...defaultShape.style,
+				onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					const id = generateId();
+					const shape = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+					shape.stickyColor = currentColor;
+					shape.style = {
+						...shape.style,
 						fill: STICKY_COLORS[currentColor] ?? STICKY_COLORS[DEFAULT_STICKY_COLOR],
 					};
-					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, defaultShape));
-					toolCtx.store.setSelection([defaultShape.id]);
-					send({ type: "CREATE_SHAPE", shapeId: defaultShape.id });
-				}
+					drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+					shape.width = 0;
+					shape.height = 0;
+					toolCtx.store.addShape(shape);
+				},
 
-				drawState = null;
-				toolCtx.store.setActiveToolId("select");
-			},
-		});
+				onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					if (!drawState) return;
+					const x = Math.min(drawState.startX, event.worldPoint.x);
+					const y = Math.min(drawState.startY, event.worldPoint.y);
+					const width = Math.abs(event.worldPoint.x - drawState.startX);
+					const height = Math.abs(event.worldPoint.y - drawState.startY);
+					toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+				},
 
-		// ── Teardown ──
-		(this as UsketchPlugin).teardown = () => {
-			stopMachine();
-			window.removeEventListener("usketch:text-input", onTextInput);
-			window.removeEventListener("usketch:text-blur", onTextBlur);
-			window.removeEventListener("usketch:text-escape", onTextEscape);
-			window.removeEventListener("pointerdown", onWindowPointerDown, true);
-			offPointerDown();
-			unsubscribe();
-		};
-	},
-};
+				onPointerUp(toolCtx: ToolContext) {
+					if (!drawState) return;
+					const shape = toolCtx.store.getShape(drawState.shapeId);
+					toolCtx.store.deleteShape(drawState.shapeId);
+
+					if (shape && shape.width > 2 && shape.height > 2) {
+						// Dragged: use custom size
+						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+						toolCtx.store.setSelection([shape.id]);
+					} else {
+						// Clicked: use default size, center on click point
+						const defaultShape = createDefault({
+							id: drawState.shapeId,
+							x: drawState.startX - DEFAULT_STICKY_SIZE.width / 2,
+							y: drawState.startY - DEFAULT_STICKY_SIZE.height / 2,
+						});
+						defaultShape.stickyColor = currentColor;
+						defaultShape.style = {
+							...defaultShape.style,
+							fill: STICKY_COLORS[currentColor] ?? STICKY_COLORS[DEFAULT_STICKY_COLOR],
+						};
+						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, defaultShape));
+						toolCtx.store.setSelection([defaultShape.id]);
+						send({ type: "CREATE_SHAPE", shapeId: defaultShape.id });
+					}
+
+					drawState = null;
+					toolCtx.store.setActiveToolId("select");
+				},
+			});
+
+			// ── Teardown ──
+			return () => {
+				stopMachine();
+				window.removeEventListener("usketch:text-input", onTextInput);
+				window.removeEventListener("usketch:text-blur", onTextBlur);
+				window.removeEventListener("usketch:text-escape", onTextEscape);
+				window.removeEventListener("pointerdown", onWindowPointerDown, true);
+				offPointerDown();
+				unsubscribe();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-text/src/index.ts
+++ b/plugins/usketch-plugin-shape-text/src/index.ts
@@ -1,1 +1,1 @@
-export { textPlugin } from "./plugin.js";
+export { createTextPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-shape-text/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-text/src/plugin.tsx
@@ -256,114 +256,116 @@ function TextIcon() {
 
 // ── Plugin ──
 
-export const textPlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-text",
-	name: "テキスト",
+export function createTextPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-text",
+		name: "テキスト",
 
-	setup(ctx: PluginContext) {
-		// ── State Machine ──
-		const service = createTextEditingService(ctx);
-		const { send, matches, stop: stopMachine } = service;
+		setup(ctx: PluginContext) {
+			// ── State Machine ──
+			const service = createTextEditingService(ctx);
+			const { send, matches, stop: stopMachine } = service;
 
-		// ── CustomEvent listeners ──
-		const onTextInput = (e: Event) => {
-			const { id, text, scrollHeight } = (e as CustomEvent).detail;
-			send({ type: "TEXT_INPUT", id, text, scrollHeight });
-		};
+			// ── CustomEvent listeners ──
+			const onTextInput = (e: Event) => {
+				const { id, text, scrollHeight } = (e as CustomEvent).detail;
+				send({ type: "TEXT_INPUT", id, text, scrollHeight });
+			};
 
-		const onTextBlur = (e: Event) => {
-			const { id } = (e as CustomEvent).detail;
-			requestAnimationFrame(() => {
-				send({ type: "TEXT_BLUR", id });
-			});
-		};
+			const onTextBlur = (e: Event) => {
+				const { id } = (e as CustomEvent).detail;
+				requestAnimationFrame(() => {
+					send({ type: "TEXT_BLUR", id });
+				});
+			};
 
-		const onTextEscape = (e: Event) => {
-			const { id } = (e as CustomEvent).detail;
-			send({ type: "TEXT_ESCAPE", id });
-		};
+			const onTextEscape = (e: Event) => {
+				const { id } = (e as CustomEvent).detail;
+				send({ type: "TEXT_ESCAPE", id });
+			};
 
-		window.addEventListener("usketch:text-input", onTextInput);
-		window.addEventListener("usketch:text-blur", onTextBlur);
-		window.addEventListener("usketch:text-escape", onTextEscape);
+			window.addEventListener("usketch:text-input", onTextInput);
+			window.addEventListener("usketch:text-blur", onTextBlur);
+			window.addEventListener("usketch:text-escape", onTextEscape);
 
-		// ── Global pointerdown to exit edit mode on outside click ──
-		const onWindowPointerDown = (e: PointerEvent) => {
-			if (!matches("editing")) return;
-			// If the click target is inside the editing contentEditable, ignore
-			// e.target can be a Text node, so walk up to nearest Element
-			const target = e.target instanceof Element ? e.target : (e.target as Node).parentElement;
-			if (target?.closest("[contenteditable=true]")) return;
-			send({ type: "OUTSIDE_CLICK" });
-		};
-		window.addEventListener("pointerdown", onWindowPointerDown, true);
+			// ── Global pointerdown to exit edit mode on outside click ──
+			const onWindowPointerDown = (e: PointerEvent) => {
+				if (!matches("editing")) return;
+				// If the click target is inside the editing contentEditable, ignore
+				// e.target can be a Text node, so walk up to nearest Element
+				const target = e.target instanceof Element ? e.target : (e.target as Node).parentElement;
+				if (target?.closest("[contenteditable=true]")) return;
+				send({ type: "OUTSIDE_CLICK" });
+			};
+			window.addEventListener("pointerdown", onWindowPointerDown, true);
 
-		// ── Double-click detection via EventBus ──
-		const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
-			// Find text shape under pointer
-			const shapes = ctx.store.getShapes();
-			let hitShapeId: string | null = null;
-			for (const [id, shape] of shapes) {
-				if (shape.type === "text" && hitTest(shape, event.worldPoint)) {
-					hitShapeId = id;
+			// ── Double-click detection via EventBus ──
+			const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+				// Find text shape under pointer
+				const shapes = ctx.store.getShapes();
+				let hitShapeId: string | null = null;
+				for (const [id, shape] of shapes) {
+					if (shape.type === "text" && hitTest(shape, event.worldPoint)) {
+						hitShapeId = id;
+					}
 				}
-			}
-			send({ type: "POINTER_DOWN", shapeId: hitShapeId });
-		});
+				send({ type: "POINTER_DOWN", shapeId: hitShapeId });
+			});
 
-		// ── Selection change monitoring ──
-		const unsubscribe = ctx.store.subscribe(() => {
-			const editingShapeId = service.context.editingShapeId;
-			if (!editingShapeId) return;
-			const selection = ctx.store.getSelection();
-			if (!selection.has(editingShapeId)) {
-				send({ type: "DESELECTED" });
-			}
-		});
+			// ── Selection change monitoring ──
+			const unsubscribe = ctx.store.subscribe(() => {
+				const editingShapeId = service.context.editingShapeId;
+				if (!editingShapeId) return;
+				const selection = ctx.store.getSelection();
+				if (!selection.has(editingShapeId)) {
+					send({ type: "DESELECTED" });
+				}
+			});
 
-		// ── Shape registration ──
-		ctx.shapes.register("text", {
-			render,
-			getBounds,
-			hitTest: withRotation(hitTest),
-			resize,
-			createDefault,
-			renderTarget: "html",
-			minSize: { width: 40, height: 24 },
-			simplifiedComponent: SimplifiedText,
-			serializeForAi,
-			debugFields,
-		});
+			// ── Shape registration ──
+			ctx.shapes.register("text", {
+				render,
+				getBounds,
+				hitTest: withRotation(hitTest),
+				resize,
+				createDefault,
+				renderTarget: "html",
+				minSize: { width: 40, height: 24 },
+				simplifiedComponent: SimplifiedText,
+				serializeForAi,
+				debugFields,
+			});
 
-		// ── Draw tool registration ──
-		ctx.tools.register("text-draw", {
-			icon: TextIcon,
-			cursor: "text",
-			shortcut: "t",
-			order: 25,
-			onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-				const id = generateId();
-				const defaults = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
-				// Anchor: left-center (shift Y up by half height)
-				const shape = { ...defaults, y: defaults.y - defaults.height / 2 };
-				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-				toolCtx.store.setSelection([id]);
-				toolCtx.store.setActiveToolId("select");
-				send({ type: "CREATE_SHAPE", shapeId: id });
-			},
-			onPointerMove() {},
-			onPointerUp() {},
-		});
+			// ── Draw tool registration ──
+			ctx.tools.register("text-draw", {
+				icon: TextIcon,
+				cursor: "text",
+				shortcut: "t",
+				order: 25,
+				onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					const id = generateId();
+					const defaults = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+					// Anchor: left-center (shift Y up by half height)
+					const shape = { ...defaults, y: defaults.y - defaults.height / 2 };
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+					toolCtx.store.setSelection([id]);
+					toolCtx.store.setActiveToolId("select");
+					send({ type: "CREATE_SHAPE", shapeId: id });
+				},
+				onPointerMove() {},
+				onPointerUp() {},
+			});
 
-		// ── Teardown ──
-		(this as UsketchPlugin).teardown = () => {
-			stopMachine();
-			window.removeEventListener("usketch:text-input", onTextInput);
-			window.removeEventListener("usketch:text-blur", onTextBlur);
-			window.removeEventListener("usketch:text-escape", onTextEscape);
-			window.removeEventListener("pointerdown", onWindowPointerDown, true);
-			offPointerDown();
-			unsubscribe();
-		};
-	},
-};
+			// ── Teardown ──
+			return () => {
+				stopMachine();
+				window.removeEventListener("usketch:text-input", onTextInput);
+				window.removeEventListener("usketch:text-blur", onTextBlur);
+				window.removeEventListener("usketch:text-escape", onTextEscape);
+				window.removeEventListener("pointerdown", onWindowPointerDown, true);
+				offPointerDown();
+				unsubscribe();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-wireframe/src/index.ts
+++ b/plugins/usketch-plugin-shape-wireframe/src/index.ts
@@ -1,4 +1,4 @@
-export { wireframePlugin } from "./plugin.js";
+export { createWireframePlugin } from "./plugin.js";
 export type { WireframeSubtype } from "./shared/wireframe-registry.js";
 export { WIREFRAME_SUBTYPES } from "./shared/wireframe-registry.js";
 export type {

--- a/plugins/usketch-plugin-shape-wireframe/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-wireframe/src/plugin.tsx
@@ -101,57 +101,63 @@ function WireframeIcon() {
 	);
 }
 
-export const wireframePlugin: UsketchPlugin = {
-	id: "usketch-plugin-shape-wireframe",
-	name: "ワイヤーフレーム",
+export function createWireframePlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-wireframe",
+		name: "ワイヤーフレーム",
 
-	setup(ctx: PluginContext) {
-		// ── Register all wireframe shapes ──
-		for (const subtype of WIREFRAME_SUBTYPES) {
-			const renderer = SHAPE_RENDERERS[subtype.type];
-			const minSize = MIN_SIZES[subtype.type];
-			if (!renderer || !minSize) continue;
+		setup(ctx: PluginContext) {
+			// ── Register all wireframe shapes ──
+			for (const subtype of WIREFRAME_SUBTYPES) {
+				const renderer = SHAPE_RENDERERS[subtype.type];
+				const minSize = MIN_SIZES[subtype.type];
+				if (!renderer || !minSize) continue;
 
-			ctx.shapes.register(subtype.type, {
-				render: renderer,
-				getBounds,
-				hitTest: withRotation(hitTest),
-				resize: createResize(minSize.width, minSize.height),
-				createDefault: subtype.createDefault,
-				renderTarget: "html",
-				minSize,
-			});
-		}
+				ctx.shapes.register(subtype.type, {
+					render: renderer,
+					getBounds,
+					hitTest: withRotation(hitTest),
+					resize: createResize(minSize.width, minSize.height),
+					createDefault: subtype.createDefault,
+					renderTarget: "html",
+					minSize,
+				});
+			}
 
-		// ── Tool state ──
-		let currentSubtype = WIREFRAME_SUBTYPES[0].type;
+			// ── Tool state ──
+			let currentSubtype = WIREFRAME_SUBTYPES[0].type;
 
-		ctx.events.on<{ type: string }>("wireframe:select-subtype", (data) => {
-			currentSubtype = data.type;
-		});
-
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			const subtype = WIREFRAME_SUBTYPES.find((s) => s.type === currentSubtype);
-			if (!subtype) return;
-
-			const id = generateId();
-			const shape = subtype.createDefault({
-				id,
-				x: event.worldPoint.x - subtype.defaultSize.width / 2,
-				y: event.worldPoint.y - subtype.defaultSize.height / 2,
+			const offSubtype = ctx.events.on<{ type: string }>("wireframe:select-subtype", (data) => {
+				currentSubtype = data.type;
 			});
 
-			toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
-			toolCtx.store.setSelection([id]);
-			toolCtx.store.setActiveToolId("select");
-		}
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				const subtype = WIREFRAME_SUBTYPES.find((s) => s.type === currentSubtype);
+				if (!subtype) return;
 
-		ctx.tools.register("wireframe-draw", {
-			icon: WireframeIcon,
-			cursor: "crosshair",
-			shortcut: "w",
-			order: 100,
-			onPointerDown,
-		});
-	},
-};
+				const id = generateId();
+				const shape = subtype.createDefault({
+					id,
+					x: event.worldPoint.x - subtype.defaultSize.width / 2,
+					y: event.worldPoint.y - subtype.defaultSize.height / 2,
+				});
+
+				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+				toolCtx.store.setSelection([id]);
+				toolCtx.store.setActiveToolId("select");
+			}
+
+			ctx.tools.register("wireframe-draw", {
+				icon: WireframeIcon,
+				cursor: "crosshair",
+				shortcut: "w",
+				order: 100,
+				onPointerDown,
+			});
+
+			return () => {
+				offSubtype();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-side-panel/src/plugin.tsx
+++ b/plugins/usketch-plugin-side-panel/src/plugin.tsx
@@ -13,8 +13,6 @@ import type { SidePanelRegisterEvent, SidePanelUnregisterEvent } from "./types.j
  * 明示することを推奨。
  */
 export function createSidePanelPlugin(): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-side-panel",
 		name: "Side Panel",
@@ -44,15 +42,11 @@ export function createSidePanelPlugin(): UsketchPlugin {
 				render: () => <SidePanelUI events={ctx.events} tabStore={tabStore} />,
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubRegister();
 				unsubUnregister();
 				ctx.layers.unregister("side-panel");
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-snap/src/index.ts
+++ b/plugins/usketch-plugin-snap/src/index.ts
@@ -1,2 +1,2 @@
 export type { GuideStyle, SnapLine, SnapResult, SnapSettings } from "./engine/types.js";
-export { snapPlugin } from "./plugin.js";
+export { createSnapPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -91,213 +91,215 @@ function SnapGuideOverlay({ viewport }: SnapGuideOverlayProps) {
 
 // ── Plugin ──
 
-export const snapPlugin: UsketchPlugin = {
-	id: "usketch-plugin-snap",
-	name: "スナップ",
+export function createSnapPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-snap",
+		name: "スナップ",
 
-	setup(ctx: PluginContext) {
-		const settings: SnapSettings = {
-			enabled: true,
-			threshold: DEFAULT_SNAP_THRESHOLD,
-			edgeSnap: true,
-			centerSnap: true,
-			viewportOnly: true,
-			guideStyle: { ...DEFAULT_GUIDE_STYLE },
-		};
+		setup(ctx: PluginContext) {
+			const settings: SnapSettings = {
+				enabled: true,
+				threshold: DEFAULT_SNAP_THRESHOLD,
+				edgeSnap: true,
+				centerSnap: true,
+				viewportOnly: true,
+				guideStyle: { ...DEFAULT_GUIDE_STYLE },
+			};
 
-		// Sync initial guide style to shared state
-		setState({ guideStyle: settings.guideStyle });
+			// Sync initial guide style to shared state
+			setState({ guideStyle: settings.guideStyle });
 
-		let pointerDown = false;
-		let altKeyHeld = false;
+			let pointerDown = false;
+			let altKeyHeld = false;
 
-		// Frame-level caches for multi-shape snap consistency
-		let frameSnapResult: SnapResult | null = null;
-		let frameCandidateBoxes: Map<string, BoundingBox> | null = null;
-		let frameId = 0;
+			// Frame-level caches for multi-shape snap consistency
+			let frameSnapResult: SnapResult | null = null;
+			let frameCandidateBoxes: Map<string, BoundingBox> | null = null;
+			let frameId = 0;
 
-		// ── Pointer tracking ──
+			// ── Pointer tracking ──
 
-		const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", () => {
-			pointerDown = true;
-			frameSnapResult = null;
-			frameCandidateBoxes = null;
-			setState({ lines: [] });
-		});
-
-		const offPointerUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", () => {
-			pointerDown = false;
-			frameSnapResult = null;
-			frameCandidateBoxes = null;
-			setState({ lines: [] });
-		});
-
-		// ── Alt key tracking ──
-
-		function onKeyDown(e: KeyboardEvent) {
-			if (e.key === "Alt") altKeyHeld = true;
-		}
-		function onKeyUp(e: KeyboardEvent) {
-			if (e.key === "Alt") altKeyHeld = false;
-		}
-		function onBlur() {
-			altKeyHeld = false;
-		}
-		window.addEventListener("keydown", onKeyDown);
-		window.addEventListener("keyup", onKeyUp);
-		window.addEventListener("blur", onBlur);
-
-		// ── Settings API via EventBus ──
-
-		const offConfigure = ctx.events.on<Partial<SnapSettings>>("snap:configure", (patch) => {
-			if (patch.guideStyle) {
-				settings.guideStyle = { ...settings.guideStyle, ...patch.guideStyle };
-				setState({ guideStyle: settings.guideStyle });
-			}
-			const { guideStyle: _gs, ...rest } = patch;
-			Object.assign(settings, rest);
-		});
-
-		const offGetSettings = ctx.events.on<(s: SnapSettings) => void>("snap:get-settings", (cb) => {
-			cb({ ...settings, guideStyle: { ...settings.guideStyle } });
-		});
-
-		// ── Monkey-patch store.updateShape ──
-
-		const originalUpdateShape = ctx.store.updateShape.bind(ctx.store);
-
-		function patchedUpdateShape(id: string, updates: Partial<ShapeData>) {
-			// Only snap during pointer-down, when enabled, and Alt not held
-			const shouldSnap =
-				pointerDown && settings.enabled && !altKeyHeld && hasPositionUpdate(updates);
-
-			if (!shouldSnap) {
-				originalUpdateShape(id, updates);
-				if (pointerDown && altKeyHeld) {
-					setState({ lines: [] });
-				}
-				return;
-			}
-
-			const shape = ctx.store.getShape(id);
-			if (!shape) {
-				originalUpdateShape(id, updates);
-				return;
-			}
-
-			// Skip snap for connectors — they have their own anchor/snap logic
-			if (shape.type === "connector") {
-				originalUpdateShape(id, updates);
+			const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", () => {
+				pointerDown = true;
+				frameSnapResult = null;
+				frameCandidateBoxes = null;
 				setState({ lines: [] });
-				return;
-			}
+			});
 
-			// Skip snap for child shapes whose parent is being dragged (in selection).
-			// Children follow their parent's snap offset; snapping them individually
-			// causes jitter because each child gets its own snap delta.
-			const parentId = shape.parentId as string | undefined;
-			if (parentId) {
-				const sel = ctx.store.getSelection();
-				if (sel.has(parentId)) {
+			const offPointerUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", () => {
+				pointerDown = false;
+				frameSnapResult = null;
+				frameCandidateBoxes = null;
+				setState({ lines: [] });
+			});
+
+			// ── Alt key tracking ──
+
+			function onKeyDown(e: KeyboardEvent) {
+				if (e.key === "Alt") altKeyHeld = true;
+			}
+			function onKeyUp(e: KeyboardEvent) {
+				if (e.key === "Alt") altKeyHeld = false;
+			}
+			function onBlur() {
+				altKeyHeld = false;
+			}
+			window.addEventListener("keydown", onKeyDown);
+			window.addEventListener("keyup", onKeyUp);
+			window.addEventListener("blur", onBlur);
+
+			// ── Settings API via EventBus ──
+
+			const offConfigure = ctx.events.on<Partial<SnapSettings>>("snap:configure", (patch) => {
+				if (patch.guideStyle) {
+					settings.guideStyle = { ...settings.guideStyle, ...patch.guideStyle };
+					setState({ guideStyle: settings.guideStyle });
+				}
+				const { guideStyle: _gs, ...rest } = patch;
+				Object.assign(settings, rest);
+			});
+
+			const offGetSettings = ctx.events.on<(s: SnapSettings) => void>("snap:get-settings", (cb) => {
+				cb({ ...settings, guideStyle: { ...settings.guideStyle } });
+			});
+
+			// ── Monkey-patch store.updateShape ──
+
+			const originalUpdateShape = ctx.store.updateShape.bind(ctx.store);
+
+			function patchedUpdateShape(id: string, updates: Partial<ShapeData>) {
+				// Only snap during pointer-down, when enabled, and Alt not held
+				const shouldSnap =
+					pointerDown && settings.enabled && !altKeyHeld && hasPositionUpdate(updates);
+
+				if (!shouldSnap) {
+					originalUpdateShape(id, updates);
+					if (pointerDown && altKeyHeld) {
+						setState({ lines: [] });
+					}
+					return;
+				}
+
+				const shape = ctx.store.getShape(id);
+				if (!shape) {
 					originalUpdateShape(id, updates);
 					return;
 				}
-			}
 
-			const isResize = isResizeUpdate(updates);
-
-			// Get current frame ID to cache snap results across multi-shape updates
-			const currentFrame = frameId;
-
-			// Build movingBox early so it can be used in both cached and fresh paths
-			const selection = ctx.store.getSelection();
-			const movingIds = selection.size > 0 && selection.has(id) ? selection : new Set([id]);
-
-			const movingBox = isResize
-				? getResizedBoundingBox(shape, updates)
-				: getMovingBoundingBox(
-						ctx.store,
-						movingIds,
-						"x" in updates && typeof updates.x === "number" ? updates.x - shape.x : 0,
-						"y" in updates && typeof updates.y === "number" ? updates.y - shape.y : 0,
-					);
-
-			if (frameSnapResult && currentFrame === frameId) {
-				const snapped = isResize
-					? applySnapToResize(updates, frameSnapResult, shape, movingBox)
-					: applySnapToUpdates(updates, frameSnapResult);
-				originalUpdateShape(id, snapped);
-				return;
-			}
-
-			const candidateBoxes =
-				frameCandidateBoxes ??
-				getCandidateBoxes(
-					ctx.store,
-					ctx,
-					movingIds,
-					settings.viewportOnly ? ctx.store.getViewport() : null,
-				);
-			frameCandidateBoxes = candidateBoxes;
-
-			const movingOverrides = isResize
-				? { edgeSnap: settings.edgeSnap, centerSnap: false as const }
-				: undefined;
-			const edgeFilter = isResize ? getResizeEdgeFilter(shape, movingBox) : undefined;
-			const result = calculateSnap(
-				movingBox,
-				movingIds,
-				candidateBoxes,
-				settings,
-				movingOverrides,
-				edgeFilter,
-			);
-			frameSnapResult = result;
-
-			queueMicrotask(() => {
-				if (frameId === currentFrame) {
-					frameId++;
-					frameSnapResult = null;
-					frameCandidateBoxes = null;
+				// Skip snap for connectors — they have their own anchor/snap logic
+				if (shape.type === "connector") {
+					originalUpdateShape(id, updates);
+					setState({ lines: [] });
+					return;
 				}
+
+				// Skip snap for child shapes whose parent is being dragged (in selection).
+				// Children follow their parent's snap offset; snapping them individually
+				// causes jitter because each child gets its own snap delta.
+				const parentId = shape.parentId as string | undefined;
+				if (parentId) {
+					const sel = ctx.store.getSelection();
+					if (sel.has(parentId)) {
+						originalUpdateShape(id, updates);
+						return;
+					}
+				}
+
+				const isResize = isResizeUpdate(updates);
+
+				// Get current frame ID to cache snap results across multi-shape updates
+				const currentFrame = frameId;
+
+				// Build movingBox early so it can be used in both cached and fresh paths
+				const selection = ctx.store.getSelection();
+				const movingIds = selection.size > 0 && selection.has(id) ? selection : new Set([id]);
+
+				const movingBox = isResize
+					? getResizedBoundingBox(shape, updates)
+					: getMovingBoundingBox(
+							ctx.store,
+							movingIds,
+							"x" in updates && typeof updates.x === "number" ? updates.x - shape.x : 0,
+							"y" in updates && typeof updates.y === "number" ? updates.y - shape.y : 0,
+						);
+
+				if (frameSnapResult && currentFrame === frameId) {
+					const snapped = isResize
+						? applySnapToResize(updates, frameSnapResult, shape, movingBox)
+						: applySnapToUpdates(updates, frameSnapResult);
+					originalUpdateShape(id, snapped);
+					return;
+				}
+
+				const candidateBoxes =
+					frameCandidateBoxes ??
+					getCandidateBoxes(
+						ctx.store,
+						ctx,
+						movingIds,
+						settings.viewportOnly ? ctx.store.getViewport() : null,
+					);
+				frameCandidateBoxes = candidateBoxes;
+
+				const movingOverrides = isResize
+					? { edgeSnap: settings.edgeSnap, centerSnap: false as const }
+					: undefined;
+				const edgeFilter = isResize ? getResizeEdgeFilter(shape, movingBox) : undefined;
+				const result = calculateSnap(
+					movingBox,
+					movingIds,
+					candidateBoxes,
+					settings,
+					movingOverrides,
+					edgeFilter,
+				);
+				frameSnapResult = result;
+
+				queueMicrotask(() => {
+					if (frameId === currentFrame) {
+						frameId++;
+						frameSnapResult = null;
+						frameCandidateBoxes = null;
+					}
+				});
+
+				const snapped = isResize
+					? applySnapToResize(updates, result, shape, movingBox)
+					: applySnapToUpdates(updates, result);
+				originalUpdateShape(id, snapped);
+
+				setState({ lines: result.lines });
+			}
+
+			ctx.store.updateShape = patchedUpdateShape;
+
+			// ── Register overlay guide layer (above shapes) ──
+
+			ctx.layers.register({
+				id: "snap-guides",
+				order: 90,
+				fixed: true,
+				render: (renderCtx) => <SnapGuideOverlay viewport={renderCtx.viewport} />,
 			});
 
-			const snapped = isResize
-				? applySnapToResize(updates, result, shape, movingBox)
-				: applySnapToUpdates(updates, result);
-			originalUpdateShape(id, snapped);
+			// ── Teardown ──
 
-			setState({ lines: result.lines });
-		}
-
-		ctx.store.updateShape = patchedUpdateShape;
-
-		// ── Register overlay guide layer (above shapes) ──
-
-		ctx.layers.register({
-			id: "snap-guides",
-			order: 90,
-			fixed: true,
-			render: (renderCtx) => <SnapGuideOverlay viewport={renderCtx.viewport} />,
-		});
-
-		// ── Teardown ──
-
-		(this as UsketchPlugin).teardown = () => {
-			offPointerDown();
-			offPointerUp();
-			offConfigure();
-			offGetSettings();
-			window.removeEventListener("keydown", onKeyDown);
-			window.removeEventListener("keyup", onKeyUp);
-			window.removeEventListener("blur", onBlur);
-			ctx.store.updateShape = originalUpdateShape;
-			ctx.layers.unregister("snap-guides");
-			setState({ lines: [], guideStyle: { ...DEFAULT_GUIDE_STYLE } });
-			stateListeners.clear();
-		};
-	},
-};
+			return () => {
+				offPointerDown();
+				offPointerUp();
+				offConfigure();
+				offGetSettings();
+				window.removeEventListener("keydown", onKeyDown);
+				window.removeEventListener("keyup", onKeyUp);
+				window.removeEventListener("blur", onBlur);
+				ctx.store.updateShape = originalUpdateShape;
+				ctx.layers.unregister("snap-guides");
+				setState({ lines: [], guideStyle: { ...DEFAULT_GUIDE_STYLE } });
+				stateListeners.clear();
+			};
+		},
+	};
+}
 
 // ── Helpers ──
 

--- a/plugins/usketch-plugin-spatial-chat/src/index.ts
+++ b/plugins/usketch-plugin-spatial-chat/src/index.ts
@@ -1,1 +1,1 @@
-export { createSpatialChatPlugin, spatialChatPlugin } from "./plugin.js";
+export { createSpatialChatPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-spatial-chat/src/plugin.tsx
+++ b/plugins/usketch-plugin-spatial-chat/src/plugin.tsx
@@ -219,8 +219,6 @@ function ChatIcon() {
 }
 
 function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-spatial-chat",
 		name: "空間チャット",
@@ -355,22 +353,16 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				wasActive = isActive;
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubBroadcast?.();
 				unsubToolChange();
 				unsubEmptyClick();
 				hideInput();
 			};
 		},
-
-		teardown() {
-			cleanup?.();
-		},
 	};
 }
 
-export function createSpatialChatPlugin(wsProvider: WsProviderHandle): UsketchPlugin {
+export function createSpatialChatPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 	return createPlugin(wsProvider);
 }
-
-export const spatialChatPlugin: UsketchPlugin = createPlugin();

--- a/plugins/usketch-plugin-spotlight/src/index.ts
+++ b/plugins/usketch-plugin-spotlight/src/index.ts
@@ -1,1 +1,1 @@
-export { createSpotlightPlugin, spotlightPlugin } from "./plugin.js";
+export { createSpotlightPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-spotlight/src/plugin.tsx
+++ b/plugins/usketch-plugin-spotlight/src/plugin.tsx
@@ -148,8 +148,6 @@ function SpotlightIcon() {
 }
 
 function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-spotlight",
 		name: "スポットライト",
@@ -236,22 +234,16 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				wasToolActive = isToolActive;
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubBroadcast?.();
 				unsubToolChange();
 				ctx.layers.unregister("spotlight");
 				spotlightState.active = false;
 			};
 		},
-
-		teardown() {
-			cleanup?.();
-		},
 	};
 }
 
-export function createSpotlightPlugin(wsProvider: WsProviderHandle): UsketchPlugin {
+export function createSpotlightPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 	return createPlugin(wsProvider);
 }
-
-export const spotlightPlugin: UsketchPlugin = createPlugin();

--- a/plugins/usketch-plugin-sync-localstorage-yjs/src/index.ts
+++ b/plugins/usketch-plugin-sync-localstorage-yjs/src/index.ts
@@ -1,2 +1,2 @@
-export { syncLocalstorageYjsPlugin } from "./plugin.js";
+export { createSyncLocalstorageYjsPlugin } from "./plugin.js";
 export { createYjsSync, type YjsSyncHandle } from "./yjs-sync.js";

--- a/plugins/usketch-plugin-sync-localstorage-yjs/src/plugin.ts
+++ b/plugins/usketch-plugin-sync-localstorage-yjs/src/plugin.ts
@@ -1,30 +1,26 @@
 import type { UsketchPlugin } from "@edv4h/usketch-shared";
-import type { YjsSyncHandle } from "./yjs-sync.js";
 import { createYjsSync } from "./yjs-sync.js";
 
 const DOC_NAME = "usketch-default";
 
-export const syncLocalstorageYjsPlugin: UsketchPlugin = {
-	id: "usketch-plugin-sync-localstorage-yjs",
-	name: "ローカル永続化 (Yjs + IndexedDB)",
+export function createSyncLocalstorageYjsPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-sync-localstorage-yjs",
+		name: "ローカル永続化 (Yjs + IndexedDB)",
 
-	async setup(ctx) {
-		const handle = createYjsSync(ctx.store, DOC_NAME);
+		async setup(ctx) {
+			const handle = createYjsSync(ctx.store, DOC_NAME);
 
-		// Expose sync status on window for DebugHUD to pick up
-		(globalThis as Record<string, unknown>).__usketchSyncStatus = handle.status;
+			// Expose sync status on window for DebugHUD to pick up
+			(globalThis as Record<string, unknown>).__usketchSyncStatus = handle.status;
 
-		// Wait for IndexedDB restoration before continuing plugin setup chain
-		await handle.whenSynced;
+			// Wait for IndexedDB restoration before continuing plugin setup chain
+			await handle.whenSynced;
 
-		// Store handle for teardown
-		(this as { _handle?: YjsSyncHandle })._handle = handle;
-	},
-
-	teardown() {
-		const handle = (this as { _handle?: YjsSyncHandle })._handle;
-		handle?.destroy();
-		delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
-		delete (this as { _handle?: YjsSyncHandle })._handle;
-	},
-};
+			return () => {
+				handle.destroy();
+				delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-sync-ywebsocket/src/plugin.tsx
+++ b/plugins/usketch-plugin-sync-ywebsocket/src/plugin.tsx
@@ -22,7 +22,6 @@ const UNCONFIRMED_OVERLAY_LAYER_ID = "unconfirmed-shapes-overlay";
 
 export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): YwebsocketSyncPlugin {
 	let handle: YwebsocketSyncHandle | null = null;
-	let unregisterOverlay: (() => void) | null = null;
 
 	const plugin: YwebsocketSyncPlugin = {
 		id: "usketch-plugin-sync-ywebsocket",
@@ -49,7 +48,6 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 					/>
 				),
 			});
-			unregisterOverlay = () => ctx.layers.unregister(UNCONFIRMED_OVERLAY_LAYER_ID);
 
 			// When `autoConnect: false`, `connect()` is never called, so awaiting
 			// `whenSynced` here would hang the entire plugin setup chain. Skip it
@@ -57,14 +55,13 @@ export function createYwebsocketSyncPlugin(options: YwebsocketSyncOptions): Yweb
 			if (options.autoConnect !== false) {
 				await handle.whenSynced;
 			}
-		},
 
-		teardown() {
-			unregisterOverlay?.();
-			unregisterOverlay = null;
-			handle?.destroy();
-			delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
-			handle = null;
+			return () => {
+				ctx.layers.unregister(UNCONFIRMED_OVERLAY_LAYER_ID);
+				handle?.destroy();
+				delete (globalThis as Record<string, unknown>).__usketchSyncStatus;
+				handle = null;
+			};
 		},
 
 		getWsProvider(): WsProviderHandle {

--- a/plugins/usketch-plugin-tool-openui/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-openui/src/plugin.tsx
@@ -66,8 +66,6 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 		stream: defaultStream = true,
 	} = opts;
 
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-tool-openui",
 		name: "OpenUI Tool",
@@ -229,7 +227,7 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 				void runGenerate(data as OpenUIGenerateRequest);
 			});
 
-			cleanup = () => {
+			return () => {
 				offGenerate();
 				ctx.events.emit("side-panel:unregister-tab", { tabId: SIDE_PANEL_TAB_ID });
 				if (enableMakeReal && provider.supportsVision) {
@@ -238,10 +236,6 @@ export function createOpenUIToolPlugin(opts: OpenUIToolOptions): UsketchPlugin {
 				setOpenUILibrary(null);
 				activeController?.abort();
 			};
-		},
-
-		teardown() {
-			cleanup?.();
 		},
 	};
 }

--- a/plugins/usketch-plugin-tool-pan/src/index.ts
+++ b/plugins/usketch-plugin-tool-pan/src/index.ts
@@ -1,1 +1,1 @@
-export { panToolPlugin } from "./plugin.js";
+export { createPanToolPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-tool-pan/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-pan/src/plugin.tsx
@@ -25,48 +25,50 @@ function PanIcon() {
 
 // ── Plugin ──
 
-export const panToolPlugin: UsketchPlugin = {
-	id: "usketch-plugin-tool-pan",
-	name: "パン",
+export function createPanToolPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-tool-pan",
+		name: "パン",
 
-	setup(ctx: PluginContext) {
-		// ── Local pan state (scoped to this setup closure) ──
-		let panState: { lastPoint: Point } | null = null;
+		setup(ctx: PluginContext) {
+			// ── Local pan state (scoped to this setup closure) ──
+			let panState: { lastPoint: Point } | null = null;
 
-		function onPointerDown(_toolCtx: ToolContext, event: CanvasPointerEvent) {
-			panState = {
-				lastPoint: { x: event.screenPoint.x, y: event.screenPoint.y },
-			};
-		}
+			function onPointerDown(_toolCtx: ToolContext, event: CanvasPointerEvent) {
+				panState = {
+					lastPoint: { x: event.screenPoint.x, y: event.screenPoint.y },
+				};
+			}
 
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!panState) return;
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!panState) return;
 
-			const dx = event.screenPoint.x - panState.lastPoint.x;
-			const dy = event.screenPoint.y - panState.lastPoint.y;
+				const dx = event.screenPoint.x - panState.lastPoint.x;
+				const dy = event.screenPoint.y - panState.lastPoint.y;
 
-			toolCtx.store.panBy(dx, dy);
+				toolCtx.store.panBy(dx, dy);
 
-			panState.lastPoint = { x: event.screenPoint.x, y: event.screenPoint.y };
-		}
+				panState.lastPoint = { x: event.screenPoint.x, y: event.screenPoint.y };
+			}
 
-		function onPointerUp(_toolCtx: ToolContext, _event: CanvasPointerEvent) {
-			panState = null;
-		}
+			function onPointerUp(_toolCtx: ToolContext, _event: CanvasPointerEvent) {
+				panState = null;
+			}
 
-		function onDeactivate(_toolCtx: ToolContext) {
-			panState = null;
-		}
+			function onDeactivate(_toolCtx: ToolContext) {
+				panState = null;
+			}
 
-		ctx.tools.register("pan", {
-			icon: PanIcon,
-			cursor: "grab",
-			shortcut: "h",
-			order: 1,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-			onDeactivate,
-		});
-	},
-};
+			ctx.tools.register("pan", {
+				icon: PanIcon,
+				cursor: "grab",
+				shortcut: "h",
+				order: 1,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+				onDeactivate,
+			});
+		},
+	};
+}

--- a/plugins/usketch-plugin-tool-select/src/index.ts
+++ b/plugins/usketch-plugin-tool-select/src/index.ts
@@ -1,1 +1,1 @@
-export { selectToolPlugin } from "./plugin.js";
+export { createSelectToolPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -101,382 +101,384 @@ type DragState =
 
 // ── Plugin ──
 
-export const selectToolPlugin: UsketchPlugin = {
-	id: "usketch-plugin-tool-select",
-	name: "選択",
+export function createSelectToolPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-tool-select",
+		name: "選択",
 
-	setup(ctx: PluginContext) {
-		// Wrap setDropTargetId to also emit on EventBus for DomShapeLayer
-		function updateDropTarget(id: string | null) {
-			setDropTargetId(id);
-			ctx.events.emit("drop-target:changed", { id });
-		}
-
-		// ── Local drag state (scoped to this setup closure) ──
-		let dragState: DragState = null;
-		let overrideCursor = "";
-		let lastClickTime = 0;
-		let lastClickId: string | null = null;
-
-		// Inject a <style> tag to override canvas cursor via !important
-		const styleEl = document.createElement("style");
-		styleEl.dataset.selectTool = "";
-		document.head.appendChild(styleEl);
-
-		function setOverrideCursor(cursor: string) {
-			if (cursor === overrideCursor) return;
-			overrideCursor = cursor;
-			styleEl.textContent = cursor ? `* { cursor: ${cursor} !important; }` : "";
-		}
-
-		// Prevent text selection during drag operations
-		const preventSelect = (e: Event) => e.preventDefault();
-		function disableTextSelection() {
-			document.addEventListener("selectstart", preventSelect);
-		}
-		function enableTextSelection() {
-			document.removeEventListener("selectstart", preventSelect);
-		}
-
-		// ── Tool handlers ──
-
-		function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			disableTextSelection();
-			const viewport = toolCtx.store.getViewport();
-
-			// 0. Rotation handle (outside bbox, no conflict with resize)
-			const rotationHit = findRotationHandleAtScreenPoint(
-				event.screenPoint,
-				toolCtx.shapes,
-				toolCtx.store,
-				viewport,
-			);
-			if (rotationHit) {
-				const shape = toolCtx.store.getShape(rotationHit);
-				if (shape) {
-					const cx = shape.x + shape.width / 2;
-					const cy = shape.y + shape.height / 2;
-					const startAngle =
-						Math.atan2(event.worldPoint.y - cy, event.worldPoint.x - cx) * (180 / Math.PI);
-					setOverrideCursor("grabbing");
-					dragState = {
-						kind: "rotate",
-						session: startRotateSession({
-							ctx: toolCtx,
-							shapeId: rotationHit,
-							center: { x: cx, y: cy },
-							startAngle,
-							startRotation: safeRotation(shape.rotation),
-						}),
-					};
-					return;
-				}
+		setup(ctx: PluginContext) {
+			// Wrap setDropTargetId to also emit on EventBus for DomShapeLayer
+			function updateDropTarget(id: string | null) {
+				setDropTargetId(id);
+				ctx.events.emit("drop-target:changed", { id });
 			}
 
-			// 1. Single-shape resize handle
-			const handleHit = findHandleAtScreenPoint(
-				event.screenPoint,
-				toolCtx.shapes,
-				toolCtx.store,
-				viewport,
-			);
-			if (handleHit) {
-				const shape = toolCtx.store.getShape(handleHit.shapeId);
-				if (shape) {
-					const shapeRotation = safeRotation(shape.rotation);
-					setOverrideCursor(
-						shapeRotation
-							? getRotatedCursorForHandle(handleHit.handle, shapeRotation)
-							: getCursorForHandle(handleHit.handle),
-					);
-					dragState = {
-						kind: "resize",
-						rotation: shapeRotation,
-						session: startResizeSession({
-							kind: "single",
-							ctx: toolCtx,
-							shapeId: handleHit.shapeId,
-							handle: handleHit.handle,
-							startPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
-						}),
-					};
-					return;
-				}
+			// ── Local drag state (scoped to this setup closure) ──
+			let dragState: DragState = null;
+			let overrideCursor = "";
+			let lastClickTime = 0;
+			let lastClickId: string | null = null;
+
+			// Inject a <style> tag to override canvas cursor via !important
+			const styleEl = document.createElement("style");
+			styleEl.dataset.selectTool = "";
+			document.head.appendChild(styleEl);
+
+			function setOverrideCursor(cursor: string) {
+				if (cursor === overrideCursor) return;
+				overrideCursor = cursor;
+				styleEl.textContent = cursor ? `* { cursor: ${cursor} !important; }` : "";
 			}
 
-			// 1b. Multi-selection resize handle
-			const selection = toolCtx.store.getSelection();
-			if (selection.size > 1) {
-				const groupBounds = getMultiSelectionBounds(toolCtx.store, toolCtx.shapes, selection);
-				if (groupBounds) {
-					const multiHandle = findMultiHandleAtScreenPoint(
-						event.screenPoint,
-						groupBounds,
-						viewport,
-					);
-					if (multiHandle) {
-						setOverrideCursor(getCursorForHandle(multiHandle));
+			// Prevent text selection during drag operations
+			const preventSelect = (e: Event) => e.preventDefault();
+			function disableTextSelection() {
+				document.addEventListener("selectstart", preventSelect);
+			}
+			function enableTextSelection() {
+				document.removeEventListener("selectstart", preventSelect);
+			}
+
+			// ── Tool handlers ──
+
+			function onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				disableTextSelection();
+				const viewport = toolCtx.store.getViewport();
+
+				// 0. Rotation handle (outside bbox, no conflict with resize)
+				const rotationHit = findRotationHandleAtScreenPoint(
+					event.screenPoint,
+					toolCtx.shapes,
+					toolCtx.store,
+					viewport,
+				);
+				if (rotationHit) {
+					const shape = toolCtx.store.getShape(rotationHit);
+					if (shape) {
+						const cx = shape.x + shape.width / 2;
+						const cy = shape.y + shape.height / 2;
+						const startAngle =
+							Math.atan2(event.worldPoint.y - cy, event.worldPoint.x - cx) * (180 / Math.PI);
+						setOverrideCursor("grabbing");
 						dragState = {
-							kind: "multi-resize",
-							session: startResizeSession({
-								kind: "multi",
+							kind: "rotate",
+							session: startRotateSession({
 								ctx: toolCtx,
-								selection,
-								handle: multiHandle,
-								startPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
-								groupBounds,
+								shapeId: rotationHit,
+								center: { x: cx, y: cy },
+								startAngle,
+								startRotation: safeRotation(shape.rotation),
 							}),
 						};
 						return;
 					}
 				}
-			}
 
-			// 2. Double-click detection for group enter/exit
-			const now = Date.now();
-			const rawHitId = findShapeAtPoint(toolCtx, event.worldPoint, {
-				editingGroupId: getEditingGroupId(),
-			});
-
-			if (rawHitId && now - lastClickTime < 400 && lastClickId === rawHitId) {
-				const shape = toolCtx.store.getShape(rawHitId);
-				if (shape?.type === "group" || shape?.type === "frame") {
-					setEditingGroupId(rawHitId);
-					toolCtx.store.clearSelection();
-					lastClickTime = 0;
-					lastClickId = null;
-					return;
-				}
-			}
-			lastClickTime = now;
-			lastClickId = rawHitId;
-
-			// If clicking outside the editing group, exit group edit mode
-			const editingGroupId = getEditingGroupId();
-			if (editingGroupId && rawHitId !== editingGroupId) {
-				const hitShape = rawHitId ? toolCtx.store.getShape(rawHitId) : null;
-				if (!hitShape || hitShape.parentId !== editingGroupId) {
-					setEditingGroupId(null);
-				}
-			}
-
-			const hitId = rawHitId;
-
-			if (hitId) {
-				if (event.shiftKey) {
-					if (selection.has(hitId)) {
-						toolCtx.store.removeFromSelection(hitId);
-					} else {
-						toolCtx.store.addToSelection(hitId);
+				// 1. Single-shape resize handle
+				const handleHit = findHandleAtScreenPoint(
+					event.screenPoint,
+					toolCtx.shapes,
+					toolCtx.store,
+					viewport,
+				);
+				if (handleHit) {
+					const shape = toolCtx.store.getShape(handleHit.shapeId);
+					if (shape) {
+						const shapeRotation = safeRotation(shape.rotation);
+						setOverrideCursor(
+							shapeRotation
+								? getRotatedCursorForHandle(handleHit.handle, shapeRotation)
+								: getCursorForHandle(handleHit.handle),
+						);
+						dragState = {
+							kind: "resize",
+							rotation: shapeRotation,
+							session: startResizeSession({
+								kind: "single",
+								ctx: toolCtx,
+								shapeId: handleHit.shapeId,
+								handle: handleHit.handle,
+								startPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
+							}),
+						};
+						return;
 					}
-				} else if (!selection.has(hitId)) {
-					toolCtx.store.setSelection([hitId]);
 				}
 
-				const currentSelection = toolCtx.store.getSelection();
-				setMovingSelection(true);
-				const session = startDragSession({
-					ctx: toolCtx,
-					startPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
-					shapeIds: currentSelection,
-				});
-				// Drop-target hit test must exclude every shape the session
-				// touches — including descendants of dragged containers — or
-				// the container's own children would falsely register as drop
-				// targets.
-				dragState = {
-					kind: "move",
-					session,
-					movingIds: session.movingShapeIds,
-				};
-			} else {
-				// Click on empty — start marquee selection
-				if (!event.shiftKey) {
-					toolCtx.store.clearSelection();
+				// 1b. Multi-selection resize handle
+				const selection = toolCtx.store.getSelection();
+				if (selection.size > 1) {
+					const groupBounds = getMultiSelectionBounds(toolCtx.store, toolCtx.shapes, selection);
+					if (groupBounds) {
+						const multiHandle = findMultiHandleAtScreenPoint(
+							event.screenPoint,
+							groupBounds,
+							viewport,
+						);
+						if (multiHandle) {
+							setOverrideCursor(getCursorForHandle(multiHandle));
+							dragState = {
+								kind: "multi-resize",
+								session: startResizeSession({
+									kind: "multi",
+									ctx: toolCtx,
+									selection,
+									handle: multiHandle,
+									startPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
+									groupBounds,
+								}),
+							};
+							return;
+						}
+					}
 				}
-				dragState = {
-					kind: "marquee",
-					shiftKey: event.shiftKey,
-					session: startMarqueeSession({
-						ctx: toolCtx,
-						startWorldPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
-						editingGroupId: getEditingGroupId(),
-					}),
-				};
-			}
-		}
 
-		function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-			if (!dragState) {
-				// Hover precedence (rotation handle → resize handle → multi-handle
-				// → shape body) is handled by the helper. The cursor is mirrored
-				// onto our `<style>` injection so it overrides any per-shape cursor.
-				const result = trackHover(toolCtx, event, {
+				// 2. Double-click detection for group enter/exit
+				const now = Date.now();
+				const rawHitId = findShapeAtPoint(toolCtx, event.worldPoint, {
 					editingGroupId: getEditingGroupId(),
 				});
-				setOverrideCursor(result.cursor);
-				setHoveredShapeId(result.handleHit || result.rotationHit ? null : result.hoveredShapeId);
-				return;
-			}
 
-			if (dragState.kind === "rotate") {
-				dragState.session.update(event);
-				return;
-			}
-
-			if (dragState.kind === "marquee") {
-				const u = dragState.session.update(event);
-				setMarqueeMode(u.mode);
-				setMarquee(u.rect as MarqueeRect, [...u.hitIds]);
-				return;
-			}
-
-			if (dragState.kind === "resize" || dragState.kind === "multi-resize") {
-				const u = dragState.session.update(event);
-				if (u.flippedHandle) {
-					setOverrideCursor(
-						dragState.kind === "resize" && dragState.rotation
-							? getRotatedCursorForHandle(u.flippedHandle, dragState.rotation)
-							: getCursorForHandle(u.flippedHandle),
-					);
-				}
-				return;
-			}
-
-			// kind === "move"
-			dragState.session.update(event);
-
-			// Drop target: find frame/group under the cursor (excluding dragged shapes).
-			const allShapes = toolCtx.store.getShapes();
-			let dropTarget: string | null = null;
-			const entries = [...allShapes.entries()].reverse();
-			for (const [id, shape] of entries) {
-				if (dragState.movingIds.has(id)) continue;
-				if (shape.type !== "frame" && shape.type !== "group") continue;
-				const def = toolCtx.shapes.get(shape.type);
-				const bounds = def
-					? def.getBounds(shape)
-					: { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
-				if (
-					event.worldPoint.x >= bounds.x &&
-					event.worldPoint.x <= bounds.x + bounds.width &&
-					event.worldPoint.y >= bounds.y &&
-					event.worldPoint.y <= bounds.y + bounds.height
-				) {
-					dropTarget = id;
-					break;
-				}
-			}
-			updateDropTarget(dropTarget);
-		}
-
-		function onPointerUp(toolCtx: ToolContext, _event: CanvasPointerEvent) {
-			enableTextSelection();
-			updateDropTarget(null);
-			if (!dragState) return;
-
-			if (dragState.kind === "rotate") {
-				setOverrideCursor("");
-				const result = dragState.session.commit();
-				if (result) {
-					queueMicrotask(() => toolCtx.commands.execute(result.command));
-				}
-				dragState = null;
-				return;
-			}
-
-			if (dragState.kind === "marquee") {
-				setMarquee(null);
-				const result = dragState.session.commit();
-				if (result) {
-					if (dragState.shiftKey) {
-						for (const id of result.selection) toolCtx.store.addToSelection(id);
-					} else {
-						toolCtx.store.setSelection([...result.selection]);
+				if (rawHitId && now - lastClickTime < 400 && lastClickId === rawHitId) {
+					const shape = toolCtx.store.getShape(rawHitId);
+					if (shape?.type === "group" || shape?.type === "frame") {
+						setEditingGroupId(rawHitId);
+						toolCtx.store.clearSelection();
+						lastClickTime = 0;
+						lastClickId = null;
+						return;
 					}
 				}
-				dragState = null;
-				return;
+				lastClickTime = now;
+				lastClickId = rawHitId;
+
+				// If clicking outside the editing group, exit group edit mode
+				const editingGroupId = getEditingGroupId();
+				if (editingGroupId && rawHitId !== editingGroupId) {
+					const hitShape = rawHitId ? toolCtx.store.getShape(rawHitId) : null;
+					if (!hitShape || hitShape.parentId !== editingGroupId) {
+						setEditingGroupId(null);
+					}
+				}
+
+				const hitId = rawHitId;
+
+				if (hitId) {
+					if (event.shiftKey) {
+						if (selection.has(hitId)) {
+							toolCtx.store.removeFromSelection(hitId);
+						} else {
+							toolCtx.store.addToSelection(hitId);
+						}
+					} else if (!selection.has(hitId)) {
+						toolCtx.store.setSelection([hitId]);
+					}
+
+					const currentSelection = toolCtx.store.getSelection();
+					setMovingSelection(true);
+					const session = startDragSession({
+						ctx: toolCtx,
+						startPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
+						shapeIds: currentSelection,
+					});
+					// Drop-target hit test must exclude every shape the session
+					// touches — including descendants of dragged containers — or
+					// the container's own children would falsely register as drop
+					// targets.
+					dragState = {
+						kind: "move",
+						session,
+						movingIds: session.movingShapeIds,
+					};
+				} else {
+					// Click on empty — start marquee selection
+					if (!event.shiftKey) {
+						toolCtx.store.clearSelection();
+					}
+					dragState = {
+						kind: "marquee",
+						shiftKey: event.shiftKey,
+						session: startMarqueeSession({
+							ctx: toolCtx,
+							startWorldPoint: { x: event.worldPoint.x, y: event.worldPoint.y },
+							editingGroupId: getEditingGroupId(),
+						}),
+					};
+				}
 			}
 
-			if (dragState.kind === "resize" || dragState.kind === "multi-resize") {
-				setOverrideCursor("");
+			function onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+				if (!dragState) {
+					// Hover precedence (rotation handle → resize handle → multi-handle
+					// → shape body) is handled by the helper. The cursor is mirrored
+					// onto our `<style>` injection so it overrides any per-shape cursor.
+					const result = trackHover(toolCtx, event, {
+						editingGroupId: getEditingGroupId(),
+					});
+					setOverrideCursor(result.cursor);
+					setHoveredShapeId(result.handleHit || result.rotationHit ? null : result.hoveredShapeId);
+					return;
+				}
+
+				if (dragState.kind === "rotate") {
+					dragState.session.update(event);
+					return;
+				}
+
+				if (dragState.kind === "marquee") {
+					const u = dragState.session.update(event);
+					setMarqueeMode(u.mode);
+					setMarquee(u.rect as MarqueeRect, [...u.hitIds]);
+					return;
+				}
+
+				if (dragState.kind === "resize" || dragState.kind === "multi-resize") {
+					const u = dragState.session.update(event);
+					if (u.flippedHandle) {
+						setOverrideCursor(
+							dragState.kind === "resize" && dragState.rotation
+								? getRotatedCursorForHandle(u.flippedHandle, dragState.rotation)
+								: getCursorForHandle(u.flippedHandle),
+						);
+					}
+					return;
+				}
+
+				// kind === "move"
+				dragState.session.update(event);
+
+				// Drop target: find frame/group under the cursor (excluding dragged shapes).
+				const allShapes = toolCtx.store.getShapes();
+				let dropTarget: string | null = null;
+				const entries = [...allShapes.entries()].reverse();
+				for (const [id, shape] of entries) {
+					if (dragState.movingIds.has(id)) continue;
+					if (shape.type !== "frame" && shape.type !== "group") continue;
+					const def = toolCtx.shapes.get(shape.type);
+					const bounds = def
+						? def.getBounds(shape)
+						: { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+					if (
+						event.worldPoint.x >= bounds.x &&
+						event.worldPoint.x <= bounds.x + bounds.width &&
+						event.worldPoint.y >= bounds.y &&
+						event.worldPoint.y <= bounds.y + bounds.height
+					) {
+						dropTarget = id;
+						break;
+					}
+				}
+				updateDropTarget(dropTarget);
+			}
+
+			function onPointerUp(toolCtx: ToolContext, _event: CanvasPointerEvent) {
+				enableTextSelection();
+				updateDropTarget(null);
+				if (!dragState) return;
+
+				if (dragState.kind === "rotate") {
+					setOverrideCursor("");
+					const result = dragState.session.commit();
+					if (result) {
+						queueMicrotask(() => toolCtx.commands.execute(result.command));
+					}
+					dragState = null;
+					return;
+				}
+
+				if (dragState.kind === "marquee") {
+					setMarquee(null);
+					const result = dragState.session.commit();
+					if (result) {
+						if (dragState.shiftKey) {
+							for (const id of result.selection) toolCtx.store.addToSelection(id);
+						} else {
+							toolCtx.store.setSelection([...result.selection]);
+						}
+					}
+					dragState = null;
+					return;
+				}
+
+				if (dragState.kind === "resize" || dragState.kind === "multi-resize") {
+					setOverrideCursor("");
+					const result = dragState.session.commit();
+					if (result) {
+						queueMicrotask(() => toolCtx.commands.execute(result.command));
+					}
+					dragState = null;
+					return;
+				}
+
+				// kind === "move"
+				setMovingSelection(false);
+				const userSelectedIds = [...toolCtx.store.getSelection()];
 				const result = dragState.session.commit();
 				if (result) {
-					queueMicrotask(() => toolCtx.commands.execute(result.command));
+					queueMicrotask(() => {
+						toolCtx.commands.execute(result.command);
+						// Notify after the move command is committed so reparent won't be undone.
+						toolCtx.events.emit("shapes:move-end", { shapeIds: userSelectedIds });
+					});
 				}
 				dragState = null;
-				return;
 			}
 
-			// kind === "move"
-			setMovingSelection(false);
-			const userSelectedIds = [...toolCtx.store.getSelection()];
-			const result = dragState.session.commit();
-			if (result) {
-				queueMicrotask(() => {
-					toolCtx.commands.execute(result.command);
-					// Notify after the move command is committed so reparent won't be undone.
-					toolCtx.events.emit("shapes:move-end", { shapeIds: userSelectedIds });
-				});
+			function onDeactivate(_toolCtx: ToolContext) {
+				dragState = null;
+				enableTextSelection();
+				setMovingSelection(false);
+				setMarquee(null);
+				setOverrideCursor("");
+				setEditingGroupId(null);
+				setHoveredShapeId(null);
+				updateDropTarget(null);
 			}
-			dragState = null;
-		}
 
-		function onDeactivate(_toolCtx: ToolContext) {
-			dragState = null;
-			enableTextSelection();
-			setMovingSelection(false);
-			setMarquee(null);
-			setOverrideCursor("");
-			setEditingGroupId(null);
-			setHoveredShapeId(null);
-			updateDropTarget(null);
-		}
+			ctx.tools.register("select", {
+				icon: SelectIcon,
+				cursor: "default",
+				shortcut: "v",
+				order: 0,
+				onPointerDown,
+				onPointerMove,
+				onPointerUp,
+				onDeactivate,
+			});
 
-		ctx.tools.register("select", {
-			icon: SelectIcon,
-			cursor: "default",
-			shortcut: "v",
-			order: 0,
-			onPointerDown,
-			onPointerMove,
-			onPointerUp,
-			onDeactivate,
-		});
+			// ── Selection foreground (default) ──
+			// Registered at priority 0 so any app option or third-party plugin
+			// (recommended: 50) replaces it. See guides/selection-foreground.
+			const unregisterSelectionForeground = ctx.ui.registerSelectionForeground({
+				id: "tool-select-default",
+				priority: 0,
+				order: 80,
+				fixed: true,
+				render: (renderCtx) => (
+					<SelectionOverlay store={ctx.store} shapes={ctx.shapes} viewport={renderCtx.viewport} />
+				),
+			});
 
-		// ── Selection foreground (default) ──
-		// Registered at priority 0 so any app option or third-party plugin
-		// (recommended: 50) replaces it. See guides/selection-foreground.
-		const unregisterSelectionForeground = ctx.ui.registerSelectionForeground({
-			id: "tool-select-default",
-			priority: 0,
-			order: 80,
-			fixed: true,
-			render: (renderCtx) => (
-				<SelectionOverlay store={ctx.store} shapes={ctx.shapes} viewport={renderCtx.viewport} />
-			),
-		});
+			// Delete selected shapes
+			ctx.shortcuts.register("Delete", () => deleteSelectedShapes(ctx));
+			ctx.shortcuts.register("Backspace", () => deleteSelectedShapes(ctx));
 
-		// Delete selected shapes
-		ctx.shortcuts.register("Delete", () => deleteSelectedShapes(ctx));
-		ctx.shortcuts.register("Backspace", () => deleteSelectedShapes(ctx));
-
-		// ── Teardown ──
-		(this as UsketchPlugin).teardown = () => {
-			setOverrideCursor("");
-			setMovingSelection(false);
-			setMarquee(null);
-			setEditingGroupId(null);
-			setHoveredShapeId(null);
-			updateDropTarget(null);
-			clearMarqueeListeners();
-			clearMovingSelectionListeners();
-			clearEditingGroupListeners();
-			clearHoveredShapeListeners();
-			clearDropTargetListeners();
-			styleEl.remove();
-			unregisterSelectionForeground();
-		};
-	},
-};
+			// ── Teardown ──
+			return () => {
+				setOverrideCursor("");
+				setMovingSelection(false);
+				setMarquee(null);
+				setEditingGroupId(null);
+				setHoveredShapeId(null);
+				updateDropTarget(null);
+				clearMarqueeListeners();
+				clearMovingSelectionListeners();
+				clearEditingGroupListeners();
+				clearHoveredShapeListeners();
+				clearDropTargetListeners();
+				styleEl.remove();
+				unregisterSelectionForeground();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-viewport-nav/src/index.ts
+++ b/plugins/usketch-plugin-viewport-nav/src/index.ts
@@ -1,1 +1,1 @@
-export { viewportNavPlugin } from "./plugin.js";
+export { createViewportNavPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-viewport-nav/src/plugin.ts
+++ b/plugins/usketch-plugin-viewport-nav/src/plugin.ts
@@ -6,50 +6,60 @@ import type {
 	UsketchPlugin,
 } from "@edv4h/usketch-shared";
 
-export const viewportNavPlugin: UsketchPlugin = {
-	id: "usketch-plugin-viewport-nav",
-	name: "ビューポートナビゲーション",
+export function createViewportNavPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-viewport-nav",
+		name: "ビューポートナビゲーション",
 
-	setup(ctx: PluginContext) {
-		// ── Local pan state (scoped to this setup closure) ──
-		let middlePanState: { lastPoint: Point } | null = null;
+		setup(ctx: PluginContext) {
+			// ── Local pan state (scoped to this setup closure) ──
+			let middlePanState: { lastPoint: Point } | null = null;
 
-		// ── Wheel: zoom & pan ──
-		ctx.events.on<CanvasWheelEvent>("canvas:wheel", (event) => {
-			if (event.ctrlKey || event.metaKey) {
-				// Zoom toward cursor
-				const viewport = ctx.store.getViewport();
-				const factor = event.deltaY > 0 ? 0.9 : 1.1;
-				ctx.store.zoomTo(viewport.zoom * factor, event.screenPoint);
-			} else {
-				// Pan
-				ctx.store.panBy(-event.deltaX, -event.deltaY);
-			}
-		});
+			// ── Wheel: zoom & pan ──
+			const offWheel = ctx.events.on<CanvasWheelEvent>("canvas:wheel", (event) => {
+				if (event.ctrlKey || event.metaKey) {
+					// Zoom toward cursor
+					const viewport = ctx.store.getViewport();
+					const factor = event.deltaY > 0 ? 0.9 : 1.1;
+					ctx.store.zoomTo(viewport.zoom * factor, event.screenPoint);
+				} else {
+					// Pan
+					ctx.store.panBy(-event.deltaX, -event.deltaY);
+				}
+			});
 
-		// ── Middle-click pan ──
-		ctx.events.on<CanvasPointerEvent>("canvas:middle-down", (event) => {
-			middlePanState = {
-				lastPoint: { x: event.screenPoint.x, y: event.screenPoint.y },
+			// ── Middle-click pan ──
+			const offMiddleDown = ctx.events.on<CanvasPointerEvent>("canvas:middle-down", (event) => {
+				middlePanState = {
+					lastPoint: { x: event.screenPoint.x, y: event.screenPoint.y },
+				};
+			});
+
+			const offPointerMove = ctx.events.on<CanvasPointerEvent>("canvas:pointermove", (event) => {
+				if (!middlePanState) return;
+
+				const dx = event.screenPoint.x - middlePanState.lastPoint.x;
+				const dy = event.screenPoint.y - middlePanState.lastPoint.y;
+
+				ctx.store.panBy(dx, dy);
+
+				middlePanState.lastPoint = {
+					x: event.screenPoint.x,
+					y: event.screenPoint.y,
+				};
+			});
+
+			const offPointerUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", (_event) => {
+				middlePanState = null;
+			});
+
+			return () => {
+				offWheel();
+				offMiddleDown();
+				offPointerMove();
+				offPointerUp();
+				middlePanState = null;
 			};
-		});
-
-		ctx.events.on<CanvasPointerEvent>("canvas:pointermove", (event) => {
-			if (!middlePanState) return;
-
-			const dx = event.screenPoint.x - middlePanState.lastPoint.x;
-			const dy = event.screenPoint.y - middlePanState.lastPoint.y;
-
-			ctx.store.panBy(dx, dy);
-
-			middlePanState.lastPoint = {
-				x: event.screenPoint.x,
-				y: event.screenPoint.y,
-			};
-		});
-
-		ctx.events.on<CanvasPointerEvent>("canvas:pointerup", (_event) => {
-			middlePanState = null;
-		});
-	},
-};
+		},
+	};
+}

--- a/plugins/usketch-plugin-voting/src/index.ts
+++ b/plugins/usketch-plugin-voting/src/index.ts
@@ -1,1 +1,1 @@
-export { createVotingPlugin, votingPlugin } from "./plugin.js";
+export { createVotingPlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-voting/src/plugin.tsx
+++ b/plugins/usketch-plugin-voting/src/plugin.tsx
@@ -114,8 +114,6 @@ function VotingIcon() {
 }
 
 function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
-	let cleanup: (() => void) | undefined;
-
 	return {
 		id: "usketch-plugin-voting",
 		name: "空間投票",
@@ -240,7 +238,7 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				},
 			});
 
-			cleanup = () => {
+			return () => {
 				unsubBroadcast?.();
 				unsubCreate();
 				unsubCast();
@@ -250,15 +248,9 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				polls.clear();
 			};
 		},
-
-		teardown() {
-			cleanup?.();
-		},
 	};
 }
 
-export function createVotingPlugin(wsProvider: WsProviderHandle): UsketchPlugin {
+export function createVotingPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 	return createPlugin(wsProvider);
 }
-
-export const votingPlugin: UsketchPlugin = createPlugin();

--- a/plugins/usketch-plugin-whistle/src/index.ts
+++ b/plugins/usketch-plugin-whistle/src/index.ts
@@ -1,1 +1,1 @@
-export { createWhistlePlugin, whistlePlugin } from "./plugin.js";
+export { createWhistlePlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-whistle/src/plugin.tsx
+++ b/plugins/usketch-plugin-whistle/src/plugin.tsx
@@ -250,49 +250,49 @@ function WhistleIndicatorLayer({
 // ── Plugin factory ──
 
 function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
-	const cleanups: (() => void)[] = [];
-	let indicators: WhistleIndicatorData[] = [];
-	const indicatorListeners = new Set<() => void>();
-	const indicatorTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
-	function indicatorSubscribe(cb: () => void): () => void {
-		indicatorListeners.add(cb);
-		return () => indicatorListeners.delete(cb);
-	}
-
-	function indicatorGetSnapshot(): WhistleIndicatorData[] {
-		return indicators;
-	}
-
-	function addIndicator(data: WhistleIndicatorData) {
-		indicators = [...indicators, data];
-		for (const cb of indicatorListeners) cb();
-
-		const timer = setTimeout(() => {
-			removeIndicator(data.id);
-		}, INDICATOR_TTL);
-
-		indicatorTimers.set(data.id, timer);
-	}
-
-	function removeIndicator(id: string) {
-		const prevLen = indicators.length;
-		indicators = indicators.filter((i) => i.id !== id);
-		const timer = indicatorTimers.get(id);
-		if (timer !== undefined) {
-			clearTimeout(timer);
-			indicatorTimers.delete(id);
-		}
-		if (indicators.length < prevLen) {
-			for (const cb of indicatorListeners) cb();
-		}
-	}
-
 	return {
 		id: "usketch-plugin-whistle",
 		name: "ホイッスル",
 
 		setup(ctx: PluginContext) {
+			const cleanups: (() => void)[] = [];
+			let indicators: WhistleIndicatorData[] = [];
+			const indicatorListeners = new Set<() => void>();
+			const indicatorTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+			function indicatorSubscribe(cb: () => void): () => void {
+				indicatorListeners.add(cb);
+				return () => indicatorListeners.delete(cb);
+			}
+
+			function indicatorGetSnapshot(): WhistleIndicatorData[] {
+				return indicators;
+			}
+
+			function addIndicator(data: WhistleIndicatorData) {
+				indicators = [...indicators, data];
+				for (const cb of indicatorListeners) cb();
+
+				const timer = setTimeout(() => {
+					removeIndicator(data.id);
+				}, INDICATOR_TTL);
+
+				indicatorTimers.set(data.id, timer);
+			}
+
+			function removeIndicator(id: string) {
+				const prevLen = indicators.length;
+				indicators = indicators.filter((i) => i.id !== id);
+				const timer = indicatorTimers.get(id);
+				if (timer !== undefined) {
+					clearTimeout(timer);
+					indicatorTimers.delete(id);
+				}
+				if (indicators.length < prevLen) {
+					for (const cb of indicatorListeners) cb();
+				}
+			}
+
 			injectStyle();
 
 			ctx.transient.registerType("whistle", {
@@ -414,21 +414,19 @@ function createPlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 				),
 			});
 			cleanups.push(() => ctx.layers.unregister("whistle-indicator"));
-		},
 
-		teardown() {
-			for (const fn of cleanups) fn();
-			cleanups.length = 0;
-			for (const timer of indicatorTimers.values()) clearTimeout(timer);
-			indicatorTimers.clear();
-			indicators = [];
-			indicatorListeners.clear();
+			return () => {
+				for (const fn of cleanups) fn();
+				cleanups.length = 0;
+				for (const timer of indicatorTimers.values()) clearTimeout(timer);
+				indicatorTimers.clear();
+				indicators = [];
+				indicatorListeners.clear();
+			};
 		},
 	};
 }
 
-export function createWhistlePlugin(wsProvider: WsProviderHandle): UsketchPlugin {
+export function createWhistlePlugin(wsProvider?: WsProviderHandle): UsketchPlugin {
 	return createPlugin(wsProvider);
 }
-
-export const whistlePlugin: UsketchPlugin = createPlugin();


### PR DESCRIPTION
## Summary

Fixes #609. Plugin lifecycle was unsafe under React StrictMode because every singleton plugin assigned its teardown closure to itself via `(this as UsketchPlugin).teardown = ...`. A second `createApp().setup` would silently overwrite the first instance's closure, and the first `destroy()` would later tear down the *second* registry's entries instead of its own. The Issue #609 minimal reproduction (a `createApp` inside `useEffect` with `<React.StrictMode>` wrapper) leaves `app.selectionForeground.getActive() === null` and no SelectionOverlay / resize handles / marquee on canvas.

Two changes together make the bug impossible by construction:

1. **`UsketchPlugin.setup(ctx)` now returns the teardown directly**; the `teardown?(): void` property is removed. `createApp` collects per-instance teardowns into a private array, runs them in **LIFO order** on `destroy()`, makes `destroy()` **idempotent** (the second call is a no-op), and rolls back already-installed teardowns if a later `setup` throws.

2. **All previously-singleton plugins are now factory functions** (`selectToolPlugin` → `createSelectToolPlugin()`, `panToolPlugin` → `createPanToolPlugin()`, etc.). Each `createApp` call holds its own fresh plugin instance — sharing across mounts is no longer possible.

This is the two-layer fix Issue #609 calls out (A: factory + B: per-instance teardown), applied to all 33 plugins so the unsafe pattern is rooted out everywhere, not just in `tool-select`.

## Scope

- `packages/shared`: `UsketchPlugin` type change, new `PluginTeardown` export
- `packages/core`: `createApp` teardown array + idempotent destroy + rollback
- `packages/{dom,gpu}-renderer`: teardown from `setup` return
- 33 plugins under `plugins/`: factory-function form, teardown returned from `setup`, no more `this.teardown = ...`
- `apps/web`: 4 consumer files updated; plugin arrays now built inside `useEffect` (not module-level) so factory instances are fresh per mount
- `docs/plugin-system-design.md`: lifecycle section updated
- new `packages/core/src/__tests__/create-app-strict-mode.test.ts`: 5 test cases (StrictMode double-mount, idempotent destroy, LIFO rollback on setup throw, LIFO order on destroy, no-teardown plugins)
- updated `create-app-{external-content,selection-foreground}.test.ts` and `domain-design/plugin.test.ts` to the new API
- changeset: major bump for all touched packages (the type change is breaking)

## Test plan

- [x] `pnpm turbo run typecheck --continue` — 0 errors across 143 tasks
- [x] `pnpm turbo run build typecheck test --continue` — 219 tasks pass
- [x] `grep -rn "this as UsketchPlugin\|this\.teardown\s*=\|this\._cleanup\s*=" plugins/ packages/` — 0 hits
- [x] `grep -rn "export const [a-zA-Z]*Plugin\s*:\s*UsketchPlugin" plugins/ packages/` — 0 hits (no singletons left)
- [ ] StrictMode smoke test: open `apps/web` under `<React.StrictMode>`, confirm SelectionOverlay renders and resize handles work
- [ ] Issue #609's minimal reproduction no longer triggers the bug (`createApp` inside `useEffect`, fresh factory instances per mount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)