### PR TITLE
✨ feat(shape-card): カードシェイプ・プラグインを追加

### DIFF
--- a/.changeset/add-shape-card-plugin.md
+++ b/.changeset/add-shape-card-plugin.md
@@ -1,0 +1,6 @@
+---
+"@edv4h/usketch-plugin-shape-card": minor
+"@edv4h/usketch-web": patch
+---
+
+新規プラグイン `@edv4h/usketch-plugin-shape-card` を追加。トランプ・UNO・メディアカード等を表現できる **card-type 拡張ポイント**を持つカードシェイプ。カードは表/裏を持ちダブルクリックで裏返せる（3D フリップ）。配置時アニメーション（カスタマイズ可）とデッキ（山札）機構（ドロー / シャッフル）を備える。リサイズは card-type ごとのアスペクト比固定。データモデルは `ShapeData<TMeta>` の generic（meta）方式。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,6 +54,7 @@
 		"@edv4h/usketch-plugin-domain-design": "workspace:*",
 		"@edv4h/usketch-plugin-shape-counter": "workspace:*",
 		"@edv4h/usketch-plugin-shape-basic": "workspace:*",
+		"@edv4h/usketch-plugin-shape-card": "workspace:*",
 		"@edv4h/usketch-plugin-shape-connector": "workspace:*",
 		"@edv4h/usketch-plugin-shape-frame": "workspace:*",
 		"@edv4h/usketch-plugin-shape-group": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -21,7 +21,7 @@ import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-curso
 import { createPresenceEnhancedPlugin } from "@edv4h/usketch-plugin-presence-enhanced";
 import { createPresentationPlugin } from "@edv4h/usketch-plugin-presentation";
 import { createBasicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
-import { createCardPlugin } from "@edv4h/usketch-plugin-shape-card";
+import { createCardPlugin, EXAMPLE_CARD_TYPES } from "@edv4h/usketch-plugin-shape-card";
 import { createConnectorPlugin } from "@edv4h/usketch-plugin-shape-connector";
 import { createCounterPlugin } from "@edv4h/usketch-plugin-shape-counter";
 import { createFramePlugin } from "@edv4h/usketch-plugin-shape-frame";
@@ -105,7 +105,7 @@ function createBasePlugins(): UsketchPlugin[] {
 		createFreedrawPlugin(),
 		createTextPlugin(),
 		createStickyPlugin(),
-		createCardPlugin(),
+		createCardPlugin({ cardTypes: EXAMPLE_CARD_TYPES }),
 		createImageShapePlugin(),
 		createCounterPlugin(),
 		createWireframePlugin(),

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -21,6 +21,7 @@ import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-curso
 import { createPresenceEnhancedPlugin } from "@edv4h/usketch-plugin-presence-enhanced";
 import { createPresentationPlugin } from "@edv4h/usketch-plugin-presentation";
 import { createBasicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
+import { createCardPlugin } from "@edv4h/usketch-plugin-shape-card";
 import { createConnectorPlugin } from "@edv4h/usketch-plugin-shape-connector";
 import { createCounterPlugin } from "@edv4h/usketch-plugin-shape-counter";
 import { createFramePlugin } from "@edv4h/usketch-plugin-shape-frame";
@@ -104,6 +105,7 @@ function createBasePlugins(): UsketchPlugin[] {
 		createFreedrawPlugin(),
 		createTextPlugin(),
 		createStickyPlugin(),
+		createCardPlugin(),
 		createImageShapePlugin(),
 		createCounterPlugin(),
 		createWireframePlugin(),

--- a/apps/web/src/components/toolbar/tool-button.tsx
+++ b/apps/web/src/components/toolbar/tool-button.tsx
@@ -1,7 +1,7 @@
 import { useApp } from "@edv4h/usketch-canvas-engine";
 import { DOMAIN_SUBTYPES } from "@edv4h/usketch-plugin-domain-design";
 import { BASIC_SHAPE_SUBTYPES } from "@edv4h/usketch-plugin-shape-basic";
-import { BUILTIN_CARD_TYPES } from "@edv4h/usketch-plugin-shape-card";
+import { EXAMPLE_CARD_TYPES } from "@edv4h/usketch-plugin-shape-card";
 import {
 	DEFAULT_STICKY_COLOR,
 	STICKY_COLOR_KEYS,
@@ -26,7 +26,7 @@ export function ToolButton({
 	const [wireframeSubtype, setWireframeSubtype] = useState(WIREFRAME_SUBTYPES[0].type);
 	const [stickyColor, setStickyColor] = useState(DEFAULT_STICKY_COLOR);
 	const [domainSubtype, setDomainSubtype] = useState(DOMAIN_SUBTYPES[0]?.type ?? "");
-	const [cardType, setCardType] = useState(BUILTIN_CARD_TYPES[0]?.id ?? "");
+	const [cardType, setCardType] = useState(EXAMPLE_CARD_TYPES[0]?.id ?? "");
 	const isWireframe = id === "wireframe-draw";
 	const isBasicShape = id === "basic-shape-draw";
 	const isSticky = id === "sticky-draw";
@@ -124,7 +124,7 @@ function CardTypePicker({
 				borderRadius: 10,
 				padding: 8,
 				display: "grid",
-				gridTemplateColumns: `repeat(${BUILTIN_CARD_TYPES.length}, 1fr)`,
+				gridTemplateColumns: `repeat(${EXAMPLE_CARD_TYPES.length}, 1fr)`,
 				gap: 4,
 				boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
 				zIndex: 150,
@@ -132,7 +132,7 @@ function CardTypePicker({
 				whiteSpace: "nowrap",
 			}}
 		>
-			{BUILTIN_CARD_TYPES.map((def) => {
+			{EXAMPLE_CARD_TYPES.map((def) => {
 				const Icon = def.icon;
 				const isActive = def.id === currentType;
 				return (

--- a/apps/web/src/components/toolbar/tool-button.tsx
+++ b/apps/web/src/components/toolbar/tool-button.tsx
@@ -1,6 +1,7 @@
 import { useApp } from "@edv4h/usketch-canvas-engine";
 import { DOMAIN_SUBTYPES } from "@edv4h/usketch-plugin-domain-design";
 import { BASIC_SHAPE_SUBTYPES } from "@edv4h/usketch-plugin-shape-basic";
+import { BUILTIN_CARD_TYPES } from "@edv4h/usketch-plugin-shape-card";
 import {
 	DEFAULT_STICKY_COLOR,
 	STICKY_COLOR_KEYS,
@@ -25,11 +26,13 @@ export function ToolButton({
 	const [wireframeSubtype, setWireframeSubtype] = useState(WIREFRAME_SUBTYPES[0].type);
 	const [stickyColor, setStickyColor] = useState(DEFAULT_STICKY_COLOR);
 	const [domainSubtype, setDomainSubtype] = useState(DOMAIN_SUBTYPES[0]?.type ?? "");
+	const [cardType, setCardType] = useState(BUILTIN_CARD_TYPES[0]?.id ?? "");
 	const isWireframe = id === "wireframe-draw";
 	const isBasicShape = id === "basic-shape-draw";
 	const isSticky = id === "sticky-draw";
 	const isDomainDraw = id === "domain-draw";
-	const hasPicker = isWireframe || isBasicShape || isSticky || isDomainDraw;
+	const isCard = id === "card-draw" || id === "card-deck-draw";
+	const hasPicker = isWireframe || isBasicShape || isSticky || isDomainDraw || isCard;
 
 	return (
 		<div style={{ position: "relative" }}>
@@ -89,6 +92,76 @@ export function ToolButton({
 					}}
 				/>
 			)}
+			{isCard && isActive && showPicker && (
+				<CardTypePicker
+					currentType={cardType}
+					onSelect={(type) => {
+						setCardType(type);
+						app.events.emit("card:select-type", { id: type });
+					}}
+				/>
+			)}
+		</div>
+	);
+}
+
+function CardTypePicker({
+	currentType,
+	onSelect,
+}: {
+	currentType: string;
+	onSelect: (type: string) => void;
+}) {
+	return (
+		<div
+			style={{
+				position: "absolute",
+				bottom: 44,
+				left: "50%",
+				transform: "translateX(-50%)",
+				background: "var(--bg-surface-raised)",
+				border: "1px solid var(--border-default)",
+				borderRadius: 10,
+				padding: 8,
+				display: "grid",
+				gridTemplateColumns: `repeat(${BUILTIN_CARD_TYPES.length}, 1fr)`,
+				gap: 4,
+				boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
+				zIndex: 150,
+				fontFamily: "system-ui, sans-serif",
+				whiteSpace: "nowrap",
+			}}
+		>
+			{BUILTIN_CARD_TYPES.map((def) => {
+				const Icon = def.icon;
+				const isActive = def.id === currentType;
+				return (
+					<button
+						key={def.id}
+						type="button"
+						onClick={() => onSelect(def.id)}
+						title={def.label}
+						style={{
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+							gap: 2,
+							padding: "6px 8px",
+							border: "none",
+							borderRadius: 6,
+							background: isActive ? "#eff6ff" : "transparent",
+							color: isActive ? "#3b82f6" : "#555",
+							cursor: "pointer",
+							fontSize: 10,
+							fontWeight: isActive ? 600 : 400,
+							minWidth: 56,
+						}}
+					>
+						<Icon />
+						{def.label}
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/plugins/usketch-plugin-shape-card/README.md
+++ b/plugins/usketch-plugin-shape-card/README.md
@@ -90,6 +90,29 @@ const front: CardFace = {
 - `align` / `vAlign` で x,y がテキストのどこを指すか（左上・中央・右下など）を決定。
 - `renderFace(face)` をエクスポートしているので、独自 card-type の `renderFront`/`renderBack` でも再利用できます。
 
+## カード / デッキの生成（ファクトリ）
+
+生成は「データ作り」なので、`store.addShape` に渡せる shape データを返す**純ファクトリ**を提供します
+（ツールも内部でこれを使っています）。Undo したい場合は `createAddShapeCommand` に渡します。
+
+```ts
+import { createCardShape, createDeckShape } from "@edv4h/usketch-plugin-shape-card";
+
+// 1枚配置
+store.addShape(createCardShape(myCardType, { x, y }));
+
+// 既定デッキ（card-type の buildDeck() を使用）
+store.addShape(createDeckShape(myCardType, { x, y }));
+
+// 可変デッキ（TCG の構築済みデッキなど）: cards を明示的に渡す
+store.addShape(
+  createDeckShape(myTcgType, { x, y, cards: playerDeckList /* 先頭が山の一番上 */ }),
+);
+```
+
+`cards` は任意の配列なので、固定構成だけでなく**プレイヤーが組んだ山（TCG）**も表現できます。
+ドロー（ダブルクリック）/シャッフル（Shift+S）はこの配列に対して動きます。
+
 ## オプション
 
 ```ts

--- a/plugins/usketch-plugin-shape-card/README.md
+++ b/plugins/usketch-plugin-shape-card/README.md
@@ -52,7 +52,35 @@ const tarotCardType: CardTypeDefinition<TarotFields> = {
 createCardPlugin({ cardTypes: [tarotCardType] });
 ```
 
-組込 card-type: `media` / `playing-card` / `uno`（`BUILTIN_CARD_TYPES`）。
+組込 card-type: `media` / `playing-card` / `uno` / `custom`（`BUILTIN_CARD_TYPES`）。
+
+## テクスチャ + テキスト配置（`custom` card-type / `CardFace`）
+
+コードを書かずに、表/裏それぞれの**テクスチャ（背景画像・色・グラデーション）**と、
+**テキストの配置を細かく**指定できます。組込の `custom` card-type が `meta.fields` に
+`{ front: CardFace; back: CardFace }` を持ち、データ差し替えだけで見た目を完全制御できます。
+
+```ts
+import type { CardFace } from "@edv4h/usketch-plugin-shape-card";
+
+const front: CardFace = {
+  texture: { image: "https://.../bg.png", fit: "cover" }, // cover|contain|fill|tile / color も可
+  texts: [
+    {
+      text: "見出し",
+      x: 0.5, y: 0.2,          // 既定は割合(ratio, 0..1)。unit:"px" で px 指定も可
+      align: "center", vAlign: "middle", // アンカー（x,y が指す基準点）
+      rotation: -6,            // 回転（度）
+      fontSize: 24, fontWeight: 700, color: "#fff",
+      letterSpacing: 2, lineHeight: 1.4, maxWidth: 200, // maxWidth で折り返し
+    },
+  ],
+};
+```
+
+- 位置は `unit: "ratio"`（既定・リサイズ追従）か `"px"`。
+- `align` / `vAlign` で x,y がテキストのどこを指すか（左上・中央・右下など）を決定。
+- `renderFace(face)` をエクスポートしているので、独自 card-type の `renderFront`/`renderBack` でも再利用できます。
 
 ## オプション
 

--- a/plugins/usketch-plugin-shape-card/README.md
+++ b/plugins/usketch-plugin-shape-card/README.md
@@ -126,7 +126,8 @@ createCardPlugin({
 配置アニメは次のいずれか：
 - プリセット `{ preset: "deal" | "drop" | "bounce" | "none" }`
 - **Slam（ドン！）** `{ preset: "slam-light" | "slam-medium" | "slam-heavy" }` — 重みのある着地。
-  衝撃リング + 接地シャドウ + 全周への放射状飛沫が弾け、**重いほど大きく・ゆっくり**（light < medium < heavy）。
+  **一瞬持ち上がってから加速して着地（ズドン）**し、衝撃リング + 接地シャドウ + 全周への放射状飛沫が弾ける。
+  **重いほど大きく・ゆっくり**（light < medium < heavy）。
   組込例では playing-card = `slam-medium`、uno = `slam-heavy`。
 - 独自 `{ keyframes: string; durationMs: number; easing?: string }`
 

--- a/plugins/usketch-plugin-shape-card/README.md
+++ b/plugins/usketch-plugin-shape-card/README.md
@@ -123,8 +123,15 @@ createCardPlugin({
 });
 ```
 
-配置アニメは `{ preset: "deal" | "drop" | "bounce" | "none" }` か、独自の
-`{ keyframes: string; durationMs: number; easing?: string }` を指定できる。
+配置アニメは次のいずれか：
+- プリセット `{ preset: "deal" | "drop" | "bounce" | "none" }`
+- **Slam（ドン！）** `{ preset: "slam-light" | "slam-medium" | "slam-heavy" }` — 重みのある着地。
+  衝撃リング + 接地シャドウ + 全周への放射状飛沫が弾け、**重いほど大きく・ゆっくり**（light < medium < heavy）。
+  組込例では playing-card = `slam-medium`、uno = `slam-heavy`。
+- 独自 `{ keyframes: string; durationMs: number; easing?: string }`
+
+> Slam の見た目・重み3段階は Claude Design の「Card Animations」ショーケース（Slam Place）を移植したもの。
+> ドロップ/移動（`shapes:move-end`）/ドロー時に、配置点を中心とした一発の衝撃エフェクトとして再生される。
 
 ## アーキテクチャ
 

--- a/plugins/usketch-plugin-shape-card/README.md
+++ b/plugins/usketch-plugin-shape-card/README.md
@@ -126,7 +126,7 @@ createCardPlugin({
 配置アニメは次のいずれか：
 - プリセット `{ preset: "deal" | "drop" | "bounce" | "none" }`
 - **Slam（ドン！）** `{ preset: "slam-light" | "slam-medium" | "slam-heavy" }` — 重みのある着地。
-  **一瞬持ち上がってから加速して着地（ズドン）**し、衝撃リング + 接地シャドウ + 全周への放射状飛沫が弾ける。
+  **一瞬持ち上がってから加速して着地（ズドン）**し、衝撃リング + 全周への放射状飛沫がカードの外側に弾ける。
   **重いほど大きく・ゆっくり**（light < medium < heavy）。
   組込例では playing-card = `slam-medium`、uno = `slam-heavy`。
 - 独自 `{ keyframes: string; durationMs: number; easing?: string }`

--- a/plugins/usketch-plugin-shape-card/README.md
+++ b/plugins/usketch-plugin-shape-card/README.md
@@ -6,18 +6,26 @@
 
 ## 使い方
 
+このプラグインは**コア機構のみ**を提供し、card-type は**既定では空**です。
+トランプ等は同梱の**サンプル（`EXAMPLE_CARD_TYPES`）**で、明示的に渡したときだけ有効になります。
+（card-type が1つも無いと描画ツールは表示されません。）
+
 ```ts
-import { createCardPlugin } from "@edv4h/usketch-plugin-shape-card";
+import { createCardPlugin, EXAMPLE_CARD_TYPES } from "@edv4h/usketch-plugin-shape-card";
 
 createApp({
   plugins: [
-    // ...
-    createCardPlugin(),
+    // サンプル（media / playing-card / uno / custom）を使う:
+    createCardPlugin({ cardTypes: EXAMPLE_CARD_TYPES }),
+    // 自前の card-type だけにするなら:
+    // createCardPlugin({ cardTypes: [myCardType] }),
+    // 空でも生成可能（描画ツールは出ない）:
+    // createCardPlugin(),
   ],
 });
 ```
 
-ツール:
+ツール（card-type が1つ以上ある場合のみ表示）:
 - `card-draw`（ショートカット `k`）— カードを描画。ドラッグでサイズ（アスペクト比固定）、クリックで既定サイズ。
 - `card-deck-draw` — 山札を配置。
 
@@ -52,12 +60,12 @@ const tarotCardType: CardTypeDefinition<TarotFields> = {
 createCardPlugin({ cardTypes: [tarotCardType] });
 ```
 
-組込 card-type: `media` / `playing-card` / `uno` / `custom`（`BUILTIN_CARD_TYPES`）。
+サンプル card-type: `media` / `playing-card` / `uno` / `custom`（`EXAMPLE_CARD_TYPES`）。既定では未登録なので、使うときに明示的に渡す。
 
 ## テクスチャ + テキスト配置（`custom` card-type / `CardFace`）
 
 コードを書かずに、表/裏それぞれの**テクスチャ（背景画像・色・グラデーション）**と、
-**テキストの配置を細かく**指定できます。組込の `custom` card-type が `meta.fields` に
+**テキストの配置を細かく**指定できます。サンプルの `custom` card-type が `meta.fields` に
 `{ front: CardFace; back: CardFace }` を持ち、データ差し替えだけで見た目を完全制御できます。
 
 ```ts

--- a/plugins/usketch-plugin-shape-card/README.md
+++ b/plugins/usketch-plugin-shape-card/README.md
@@ -1,0 +1,75 @@
+# @edv4h/usketch-plugin-shape-card
+
+トランプ・UNO・メディアカード等を表現できる **card-type 拡張ポイント**を持つカードシェイプ・プラグイン。
+カードは表/裏を持ち、**ダブルクリックで裏返し（flip）**でき、**配置時アニメーション**と
+**デッキ（山札）機構**を備える。
+
+## 使い方
+
+```ts
+import { createCardPlugin } from "@edv4h/usketch-plugin-shape-card";
+
+createApp({
+  plugins: [
+    // ...
+    createCardPlugin(),
+  ],
+});
+```
+
+ツール:
+- `card-draw`（ショートカット `k`）— カードを描画。ドラッグでサイズ（アスペクト比固定）、クリックで既定サイズ。
+- `card-deck-draw` — 山札を配置。
+
+インタラクション:
+- カードを**ダブルクリック**で裏返し（0.4s の 3D フリップ）。
+- 山札を**ダブルクリック**で1枚ドロー（最前面に配置）。
+- 山札を選択して **Shift+S** でシャッフル。
+- カード/山札はアスペクト比を保ったままのみリサイズ可能。
+
+## card-type の追加
+
+`CardTypeDefinition` を満たすオブジェクトを `createCardPlugin` に渡す:
+
+```tsx
+import { createCardPlugin, type CardTypeDefinition } from "@edv4h/usketch-plugin-shape-card";
+
+interface TarotFields { name: string; }
+
+const tarotCardType: CardTypeDefinition<TarotFields> = {
+  id: "tarot",
+  label: "タロット",
+  icon: () => <svg width="16" height="16" viewBox="0 0 16 16">{/* ... */}</svg>,
+  defaultSize: { width: 120, height: 210 },
+  aspectRatio: 120 / 210,
+  createDefaultFields: () => ({ name: "The Fool" }),
+  renderFront: (f) => <div>{f.name}</div>,
+  renderBack: () => <div>★</div>,
+  placementAnimation: { preset: "deal" },
+  buildDeck: () => [/* 78枚 */],
+};
+
+createCardPlugin({ cardTypes: [tarotCardType] });
+```
+
+組込 card-type: `media` / `playing-card` / `uno`（`BUILTIN_CARD_TYPES`）。
+
+## オプション
+
+```ts
+createCardPlugin({
+  cardTypes,                         // 追加 card-type
+  placementAnimation: { preset: "drop" }, // 既定の配置アニメ（card-type 個別指定が優先）
+  enableDeck: true,                  // デッキ機構の ON/OFF（既定 true）
+});
+```
+
+配置アニメは `{ preset: "deal" | "drop" | "bounce" | "none" }` か、独自の
+`{ keyframes: string; durationMs: number; easing?: string }` を指定できる。
+
+## アーキテクチャ
+
+- データモデルは `ShapeData<CardMeta>` / `ShapeData<DeckMeta>` の **generic（meta）** 方式。
+- 単一 `card` shape type + `meta.cardType` ディスクリミネータ + 内部 card-type レジストリ。
+- 配置アニメは `ctx.transient`（ripple と同じ transient レイヤー）で実装。
+- 山札は card データ配列を保持する**データパイル方式**（枚数分の shape を作らない）。

--- a/plugins/usketch-plugin-shape-card/package.json
+++ b/plugins/usketch-plugin-shape-card/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@edv4h/usketch-plugin-shape-card",
+	"version": "1.0.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-core": "workspace:*",
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*"
+	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.14",
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-card"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-shape-card/src/__tests__/card-face.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/card-face.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { anchorTranslate, faceTextureStyle } from "../card-face.js";
+
+describe("faceTextureStyle", () => {
+	it("returns empty style for no texture", () => {
+		expect(faceTextureStyle(undefined)).toEqual({});
+	});
+
+	it("applies a background color / gradient", () => {
+		expect(faceTextureStyle({ color: "red" }).background).toBe("red");
+	});
+
+	it("uses cover by default and contain/fill/tile when set", () => {
+		expect(faceTextureStyle({ image: "a.png" }).backgroundSize).toBe("cover");
+		expect(faceTextureStyle({ image: "a.png", fit: "contain" }).backgroundSize).toBe("contain");
+		expect(faceTextureStyle({ image: "a.png", fit: "fill" }).backgroundSize).toBe("100% 100%");
+		expect(faceTextureStyle({ image: "a.png", fit: "tile" }).backgroundRepeat).toBe("repeat");
+	});
+
+	it("wraps the image url", () => {
+		expect(faceTextureStyle({ image: "a.png" }).backgroundImage).toBe('url("a.png")');
+	});
+});
+
+describe("anchorTranslate", () => {
+	it("defaults to center/middle", () => {
+		expect(anchorTranslate()).toEqual({ tx: "-50%", ty: "-50%" });
+	});
+
+	it("maps left/top to 0% and right/bottom to -100%", () => {
+		expect(anchorTranslate("left", "top")).toEqual({ tx: "0%", ty: "0%" });
+		expect(anchorTranslate("right", "bottom")).toEqual({ tx: "-100%", ty: "-100%" });
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/__tests__/deck.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/deck.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { drawTop, shuffle } from "../deck.js";
+
+describe("drawTop", () => {
+	it("returns the top card (index 0) and the rest", () => {
+		const { card, rest } = drawTop(["a", "b", "c"]);
+		expect(card).toBe("a");
+		expect(rest).toEqual(["b", "c"]);
+	});
+
+	it("returns null card for an empty deck", () => {
+		const { card, rest } = drawTop<string>([]);
+		expect(card).toBeNull();
+		expect(rest).toEqual([]);
+	});
+
+	it("does not mutate the input", () => {
+		const input = ["a", "b"];
+		drawTop(input);
+		expect(input).toEqual(["a", "b"]);
+	});
+});
+
+describe("shuffle", () => {
+	it("keeps the same multiset of cards", () => {
+		const input = Array.from({ length: 52 }, (_, i) => i);
+		const out = shuffle(input);
+		expect(out).toHaveLength(52);
+		expect([...out].sort((a, b) => a - b)).toEqual(input);
+	});
+
+	it("does not mutate the input", () => {
+		const input = [1, 2, 3, 4, 5];
+		const copy = [...input];
+		shuffle(input);
+		expect(input).toEqual(copy);
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/__tests__/factory.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/factory.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { CARD_TYPE, createCardShape, createDeckShape, DECK_TYPE } from "../factory.js";
+import type { CardTypeDefinition } from "../types.js";
+
+const def: CardTypeDefinition = {
+	id: "tcg",
+	label: "TCG",
+	aspectRatio: 110 / 150,
+	defaultSize: { width: 110, height: 150 },
+	icon: () => null as never,
+	createDefaultFields: () => ({ name: "default" }),
+	renderFront: () => null as never,
+	renderBack: () => null as never,
+	buildDeck: () => [{ name: "starter-a" }, { name: "starter-b" }],
+};
+
+describe("createCardShape", () => {
+	it("builds a card shape from the card-type defaults", () => {
+		const card = createCardShape(def, { x: 10, y: 20 });
+		expect(card.type).toBe(CARD_TYPE);
+		expect(card).toMatchObject({ x: 10, y: 20, width: 110, height: 150 });
+		expect(card.meta).toEqual({ cardType: "tcg", isFlipped: false, fields: { name: "default" } });
+		expect(card.id).toBeTruthy();
+	});
+
+	it("accepts explicit fields / size / zIndex overrides", () => {
+		const card = createCardShape(def, {
+			x: 0,
+			y: 0,
+			width: 0,
+			height: 0,
+			fields: { name: "fireball" },
+			zIndex: "a5",
+		});
+		expect(card).toMatchObject({ width: 0, height: 0, zIndex: "a5" });
+		expect(card.meta?.fields).toEqual({ name: "fireball" });
+	});
+});
+
+describe("createDeckShape", () => {
+	it("uses buildDeck() when no cards are given", () => {
+		const deck = createDeckShape(def, { x: 0, y: 0 });
+		expect(deck.type).toBe(DECK_TYPE);
+		expect(deck.meta?.cards).toEqual([{ name: "starter-a" }, { name: "starter-b" }]);
+		expect(deck.meta?.faceDown).toBe(true);
+	});
+
+	it("accepts an explicit (variable / TCG) card list", () => {
+		const cards = [{ name: "x" }, { name: "y" }, { name: "z" }];
+		const deck = createDeckShape(def, { x: 0, y: 0, cards, faceDown: false });
+		expect(deck.meta?.cards).toBe(cards);
+		expect(deck.meta?.faceDown).toBe(false);
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/__tests__/geometry.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/geometry.test.ts
@@ -1,0 +1,47 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { makeAspectResize, rectHitTest } from "../geometry.js";
+
+const base: ShapeData = {
+	id: "c1",
+	type: "card",
+	x: 100,
+	y: 100,
+	width: 120,
+	height: 160, // aspect 0.75
+	style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+};
+
+const resize = makeAspectResize(() => 120 / 160);
+
+describe("makeAspectResize", () => {
+	it("keeps aspect ratio when dragging a corner", () => {
+		const out = resize(base, "se", { x: 60, y: 0 });
+		// width grows by 60 → height derived from aspect, ratio preserved
+		expect(out.width / out.height).toBeCloseTo(120 / 160, 5);
+		expect(out.width).toBeCloseTo(180, 5);
+		expect(out.height).toBeCloseTo(240, 5);
+	});
+
+	it("anchors the opposite corner (nw keeps bottom-right fixed)", () => {
+		const out = resize(base, "nw", { x: -30, y: 0 });
+		expect(out.x + out.width).toBeCloseTo(base.x + base.width, 5);
+		expect(out.y + out.height).toBeCloseTo(base.y + base.height, 5);
+		expect(out.width / out.height).toBeCloseTo(120 / 160, 5);
+	});
+
+	it("clamps to a minimum size while preserving aspect", () => {
+		const out = resize(base, "se", { x: -1000, y: -1000 });
+		expect(out.width).toBeGreaterThanOrEqual(60);
+		expect(out.width / out.height).toBeCloseTo(120 / 160, 5);
+	});
+});
+
+describe("rectHitTest", () => {
+	it("hits inside the rect", () => {
+		expect(rectHitTest(base, { x: 150, y: 150 })).toBe(true);
+	});
+	it("misses outside the rect", () => {
+		expect(rectHitTest(base, { x: 10, y: 10 })).toBe(false);
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/__tests__/placement.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/placement.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { resolvePlacementAnimation } from "../placement.js";
+
+describe("resolvePlacementAnimation", () => {
+	it("returns null for the 'none' preset", () => {
+		expect(resolvePlacementAnimation({ preset: "none" }, undefined)).toBeNull();
+	});
+
+	it("resolves keyframe presets to css with a duration", () => {
+		const r = resolvePlacementAnimation({ preset: "drop" }, undefined);
+		expect(r).toMatchObject({ kind: "css", name: "usketch-card-drop" });
+		expect((r as { durationMs: number }).durationMs).toBeGreaterThan(0);
+	});
+
+	it("resolves slam presets to a slam kind with the weight", () => {
+		expect(resolvePlacementAnimation({ preset: "slam-light" }, undefined)).toMatchObject({
+			kind: "slam",
+			weight: "light",
+		});
+		expect(resolvePlacementAnimation({ preset: "slam-heavy" }, undefined)).toMatchObject({
+			kind: "slam",
+			weight: "heavy",
+		});
+	});
+
+	it("makes heavier slams slower (longer duration)", () => {
+		const light = resolvePlacementAnimation({ preset: "slam-light" }, undefined) as {
+			durationMs: number;
+		};
+		const medium = resolvePlacementAnimation({ preset: "slam-medium" }, undefined) as {
+			durationMs: number;
+		};
+		const heavy = resolvePlacementAnimation({ preset: "slam-heavy" }, undefined) as {
+			durationMs: number;
+		};
+		expect(light.durationMs).toBeLessThan(medium.durationMs);
+		expect(medium.durationMs).toBeLessThan(heavy.durationMs);
+	});
+
+	it("prefers the card-type animation over the plugin default", () => {
+		const r = resolvePlacementAnimation({ preset: "slam-heavy" }, { preset: "drop" });
+		expect(r).toMatchObject({ kind: "slam", weight: "heavy" });
+	});
+
+	it("falls back to the plugin default, then to drop", () => {
+		expect(resolvePlacementAnimation(undefined, { preset: "bounce" })).toMatchObject({
+			name: "usketch-card-bounce",
+		});
+		expect(resolvePlacementAnimation(undefined, undefined)).toMatchObject({
+			name: "usketch-card-drop",
+		});
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/__tests__/registry.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BUILTIN_CARD_TYPES, createCardTypeRegistry } from "../registry.js";
+import { createCardTypeRegistry, EXAMPLE_CARD_TYPES } from "../registry.js";
 import type { CardTypeDefinition } from "../types.js";
 
 const dummy: CardTypeDefinition = {
@@ -14,23 +14,28 @@ const dummy: CardTypeDefinition = {
 };
 
 describe("createCardTypeRegistry", () => {
-	it("includes all built-in card types by default", () => {
-		const reg = createCardTypeRegistry();
-		for (const def of BUILTIN_CARD_TYPES) {
+	it("is empty by default (built-ins are NOT auto-registered)", () => {
+		expect(createCardTypeRegistry().size).toBe(0);
+	});
+
+	it("registers only the card types passed in", () => {
+		const reg = createCardTypeRegistry([dummy]);
+		expect(reg.get("dummy")).toBe(dummy);
+		expect(reg.size).toBe(1);
+	});
+
+	it("can opt into the example card types explicitly", () => {
+		const reg = createCardTypeRegistry(EXAMPLE_CARD_TYPES);
+		expect(reg.size).toBe(EXAMPLE_CARD_TYPES.length);
+		for (const def of EXAMPLE_CARD_TYPES) {
 			expect(reg.get(def.id)).toBe(def);
 		}
 	});
 
-	it("merges extra card types", () => {
-		const reg = createCardTypeRegistry([dummy]);
-		expect(reg.get("dummy")).toBe(dummy);
-		expect(reg.size).toBe(BUILTIN_CARD_TYPES.length + 1);
-	});
-
-	it("lets extra card types override built-ins with the same id", () => {
+	it("later entries override earlier ones with the same id", () => {
 		const override: CardTypeDefinition = { ...dummy, id: "media", label: "Custom" };
-		const reg = createCardTypeRegistry([override]);
+		const reg = createCardTypeRegistry([...EXAMPLE_CARD_TYPES, override]);
 		expect(reg.get("media")).toBe(override);
-		expect(reg.size).toBe(BUILTIN_CARD_TYPES.length);
+		expect(reg.size).toBe(EXAMPLE_CARD_TYPES.length);
 	});
 });

--- a/plugins/usketch-plugin-shape-card/src/__tests__/registry.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/registry.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { BUILTIN_CARD_TYPES, createCardTypeRegistry } from "../registry.js";
+import type { CardTypeDefinition } from "../types.js";
+
+const dummy: CardTypeDefinition = {
+	id: "dummy",
+	label: "Dummy",
+	aspectRatio: 1,
+	defaultSize: { width: 100, height: 100 },
+	icon: () => null as never,
+	createDefaultFields: () => ({}),
+	renderFront: () => null as never,
+	renderBack: () => null as never,
+};
+
+describe("createCardTypeRegistry", () => {
+	it("includes all built-in card types by default", () => {
+		const reg = createCardTypeRegistry();
+		for (const def of BUILTIN_CARD_TYPES) {
+			expect(reg.get(def.id)).toBe(def);
+		}
+	});
+
+	it("merges extra card types", () => {
+		const reg = createCardTypeRegistry([dummy]);
+		expect(reg.get("dummy")).toBe(dummy);
+		expect(reg.size).toBe(BUILTIN_CARD_TYPES.length + 1);
+	});
+
+	it("lets extra card types override built-ins with the same id", () => {
+		const override: CardTypeDefinition = { ...dummy, id: "media", label: "Custom" };
+		const reg = createCardTypeRegistry([override]);
+		expect(reg.get("media")).toBe(override);
+		expect(reg.size).toBe(BUILTIN_CARD_TYPES.length);
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/card-face.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-face.tsx
@@ -7,7 +7,8 @@ export function faceTextureStyle(texture?: CardTexture): CSSProperties {
 	const style: CSSProperties = {};
 	if (texture.color) style.background = texture.color;
 	if (texture.image) {
-		style.backgroundImage = `url("${texture.image}")`;
+		// URL に " や \ が含まれても壊れない / 注入されないよう JSON.stringify でエスケープ
+		style.backgroundImage = `url(${JSON.stringify(texture.image)})`;
 		if (texture.fit === "tile") {
 			style.backgroundRepeat = "repeat";
 		} else {

--- a/plugins/usketch-plugin-shape-card/src/card-face.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-face.tsx
@@ -1,0 +1,81 @@
+import type { CSSProperties, ReactElement } from "react";
+import type { CardFace, CardText, CardTexture } from "./types.js";
+
+/** テクスチャ定義 → 背景まわりの CSSProperties（純関数・テスト容易）。 */
+export function faceTextureStyle(texture?: CardTexture): CSSProperties {
+	if (!texture) return {};
+	const style: CSSProperties = {};
+	if (texture.color) style.background = texture.color;
+	if (texture.image) {
+		style.backgroundImage = `url("${texture.image}")`;
+		if (texture.fit === "tile") {
+			style.backgroundRepeat = "repeat";
+		} else {
+			style.backgroundRepeat = "no-repeat";
+			style.backgroundPosition = "center";
+			style.backgroundSize =
+				texture.fit === "contain" ? "contain" : texture.fit === "fill" ? "100% 100%" : "cover";
+		}
+	}
+	return style;
+}
+
+/** アンカー（align/vAlign）→ translate 量（純関数・テスト容易）。 */
+export function anchorTranslate(
+	align: CardText["align"] = "center",
+	vAlign: CardText["vAlign"] = "middle",
+): { tx: string; ty: string } {
+	const tx = align === "left" ? "0%" : align === "right" ? "-100%" : "-50%";
+	const ty = vAlign === "top" ? "0%" : vAlign === "bottom" ? "-100%" : "-50%";
+	return { tx, ty };
+}
+
+function textStyle(t: CardText): CSSProperties {
+	const unit = t.unit ?? "ratio";
+	const left = unit === "ratio" ? `${t.x * 100}%` : `${t.x}px`;
+	const top = unit === "ratio" ? `${t.y * 100}%` : `${t.y}px`;
+	const { tx, ty } = anchorTranslate(t.align, t.vAlign);
+	const rot = t.rotation ? ` rotate(${t.rotation}deg)` : "";
+	return {
+		position: "absolute",
+		left,
+		top,
+		transform: `translate(${tx}, ${ty})${rot}`,
+		transformOrigin: "center",
+		textAlign: t.align ?? "center",
+		fontSize: t.fontSize ?? 16,
+		fontFamily: t.fontFamily ?? "system-ui, sans-serif",
+		fontWeight: t.fontWeight ?? 400,
+		fontStyle: t.italic ? "italic" : "normal",
+		color: t.color ?? "#1e1e1e",
+		letterSpacing: t.letterSpacing,
+		lineHeight: t.lineHeight ?? 1.3,
+		maxWidth: t.maxWidth,
+		whiteSpace: t.maxWidth ? "normal" : "pre",
+		wordBreak: t.maxWidth ? "break-word" : "normal",
+		pointerEvents: "none",
+	};
+}
+
+/**
+ * 面（テクスチャ + テキスト配置）を描画する。card-type 作者が renderFront / renderBack で
+ * 再利用できる共通レンダラ。
+ */
+export function renderFace(face: CardFace | undefined): ReactElement {
+	return (
+		<div
+			style={{
+				position: "absolute",
+				inset: 0,
+				overflow: "hidden",
+				...faceTextureStyle(face?.texture),
+			}}
+		>
+			{(face?.texts ?? []).map((t, i) => (
+				<div key={`txt-${i}-${t.text.slice(0, 12)}`} style={textStyle(t)}>
+					{t.text}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-shape-card/src/card-types/custom.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/custom.tsx
@@ -1,0 +1,85 @@
+import { renderFace } from "../card-face.js";
+import type { CardFace, CardTypeDefinition } from "../types.js";
+
+/**
+ * カスタムカード固有データ。表/裏それぞれにテクスチャとテキスト配置を自由に持つ。
+ * コードを書かずに（meta.fields の差し替えだけで）見た目を完全に制御できる card-type。
+ */
+export type CustomCardFields = {
+	front: CardFace;
+	back: CardFace;
+};
+
+function CustomIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<title>Custom card</title>
+			<rect
+				x="3"
+				y="2"
+				width="10"
+				height="12"
+				rx="1.5"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.2"
+			/>
+			<path d="M5 6h6M5 9h4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+		</svg>
+	);
+}
+
+export const customCardType: CardTypeDefinition<CustomCardFields> = {
+	id: "custom",
+	label: "カスタム",
+	icon: CustomIcon,
+	defaultSize: { width: 240, height: 320 },
+	aspectRatio: 240 / 320,
+	createDefaultFields: () => ({
+		front: {
+			texture: { color: "linear-gradient(135deg, #fdfbfb, #ebedee)" },
+			texts: [
+				{
+					text: "タイトル",
+					x: 0.5,
+					y: 0.18,
+					align: "center",
+					vAlign: "middle",
+					fontSize: 22,
+					fontWeight: 700,
+					color: "#1e1e1e",
+				},
+				{
+					text: "本文をここに。\n位置・回転・フォントを\n細かく指定できます。",
+					x: 0.5,
+					y: 0.55,
+					align: "center",
+					vAlign: "middle",
+					fontSize: 13,
+					color: "#444",
+					maxWidth: 200,
+					lineHeight: 1.5,
+				},
+			],
+		},
+		back: {
+			texture: { color: "linear-gradient(135deg, #4f8cff, #1e1e1e)" },
+			texts: [
+				{
+					text: "BACK",
+					x: 0.5,
+					y: 0.5,
+					align: "center",
+					vAlign: "middle",
+					fontSize: 28,
+					fontWeight: 800,
+					color: "#ffffff",
+					letterSpacing: 4,
+				},
+			],
+		},
+	}),
+	renderFront: (fields) => renderFace(fields.front),
+	renderBack: (fields) => renderFace(fields.back),
+	placementAnimation: { preset: "drop" },
+};

--- a/plugins/usketch-plugin-shape-card/src/card-types/media.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/media.tsx
@@ -1,0 +1,142 @@
+import type { CardTypeDefinition } from "../types.js";
+
+/** メディアカード固有データ（Record<string, unknown> に代入可能にするため type で定義）。 */
+export type MediaCardFields = {
+	title: string;
+	body: string;
+	imageUrl?: string;
+	backText?: string;
+	accentColor?: string;
+};
+
+const DEFAULT_ACCENT = "#4f8cff";
+
+function MediaIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<title>Media card</title>
+			<rect
+				x="2"
+				y="2"
+				width="12"
+				height="12"
+				rx="2"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.2"
+			/>
+			<rect x="2" y="2" width="12" height="6" rx="2" fill="currentColor" opacity="0.25" />
+			<line x1="4" y1="10" x2="12" y2="10" stroke="currentColor" strokeWidth="1" />
+			<line x1="4" y1="12" x2="10" y2="12" stroke="currentColor" strokeWidth="1" />
+		</svg>
+	);
+}
+
+function renderFront(fields: MediaCardFields) {
+	const accent = fields.accentColor ?? DEFAULT_ACCENT;
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				fontFamily: "system-ui, sans-serif",
+				color: "#1e1e1e",
+				boxSizing: "border-box",
+			}}
+		>
+			<div style={{ flex: "0 0 50%", overflow: "hidden", background: accent }}>
+				{fields.imageUrl ? (
+					// biome-ignore lint/a11y/useAltText: decorative card image inside canvas shape
+					<img
+						src={fields.imageUrl}
+						style={{ width: "100%", height: "100%", objectFit: "cover" }}
+					/>
+				) : (
+					<div
+						style={{
+							width: "100%",
+							height: "100%",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							color: "rgba(255,255,255,0.85)",
+							fontSize: 28,
+						}}
+					>
+						🖼
+					</div>
+				)}
+			</div>
+			<div style={{ flex: "1 1 auto", padding: 12, overflow: "hidden" }}>
+				<div
+					style={{
+						fontWeight: 700,
+						fontSize: 16,
+						marginBottom: 6,
+						whiteSpace: "nowrap",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+					}}
+				>
+					{fields.title}
+				</div>
+				<div
+					style={{
+						fontSize: 13,
+						lineHeight: 1.4,
+						color: "#444",
+						whiteSpace: "pre-wrap",
+						overflow: "hidden",
+					}}
+				>
+					{fields.body}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function renderBack(fields: MediaCardFields) {
+	const accent = fields.accentColor ?? DEFAULT_ACCENT;
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				padding: 16,
+				boxSizing: "border-box",
+				background: `linear-gradient(135deg, ${accent}, #1e1e1e)`,
+				color: "#fff",
+				fontFamily: "system-ui, sans-serif",
+				fontSize: 13,
+				lineHeight: 1.5,
+				whiteSpace: "pre-wrap",
+				textAlign: "center",
+			}}
+		>
+			{fields.backText ?? "（裏面）"}
+		</div>
+	);
+}
+
+export const mediaCardType: CardTypeDefinition<MediaCardFields> = {
+	id: "media",
+	label: "メディアカード",
+	icon: MediaIcon,
+	defaultSize: { width: 240, height: 320 },
+	aspectRatio: 240 / 320,
+	createDefaultFields: () => ({
+		title: "タイトル",
+		body: "本文をここに表示します。",
+		backText: "メモ・補足を裏面に。",
+		accentColor: DEFAULT_ACCENT,
+	}),
+	renderFront,
+	renderBack,
+	placementAnimation: { preset: "drop" },
+};

--- a/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
@@ -239,7 +239,7 @@ export const playingCardType: CardTypeDefinition<PlayingCardFields> = {
 	createDefaultFields: () => ({ suit: "♠", rank: "A" }),
 	renderFront,
 	renderBack,
-	placementAnimation: { preset: "deal" },
+	placementAnimation: { preset: "slam-medium" },
 	buildDeck: () => {
 		const deck: PlayingCardFields[] = [];
 		for (const suit of SUITS) {

--- a/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
@@ -1,0 +1,134 @@
+import type { CardTypeDefinition } from "../types.js";
+
+export type Suit = "♠" | "♥" | "♦" | "♣";
+
+/** トランプ固有データ。 */
+export type PlayingCardFields = {
+	suit: Suit;
+	rank: string; // "A", "2".."10", "J", "Q", "K"
+};
+
+const SUITS: Suit[] = ["♠", "♥", "♦", "♣"];
+const RANKS = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"];
+
+function isRed(suit: Suit): boolean {
+	return suit === "♥" || suit === "♦";
+}
+
+function PlayingCardIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<title>Playing card</title>
+			<rect
+				x="3"
+				y="2"
+				width="10"
+				height="12"
+				rx="1.5"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.2"
+			/>
+			<text x="8" y="10" fontSize="7" textAnchor="middle" fill="currentColor">
+				A
+			</text>
+		</svg>
+	);
+}
+
+function Corner({ fields, flip }: { fields: PlayingCardFields; flip?: boolean }) {
+	return (
+		<div
+			style={{
+				position: "absolute",
+				...(flip ? { right: 6, bottom: 4, transform: "rotate(180deg)" } : { left: 6, top: 4 }),
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				lineHeight: 1,
+				fontWeight: 700,
+			}}
+		>
+			<span style={{ fontSize: 14 }}>{fields.rank}</span>
+			<span style={{ fontSize: 12 }}>{fields.suit}</span>
+		</div>
+	);
+}
+
+function renderFront(fields: PlayingCardFields) {
+	const color = isRed(fields.suit) ? "#d4233b" : "#1e1e1e";
+	return (
+		<div
+			style={{
+				position: "relative",
+				width: "100%",
+				height: "100%",
+				background: "#fff",
+				color,
+				fontFamily: "Georgia, 'Times New Roman', serif",
+				boxSizing: "border-box",
+			}}
+		>
+			<Corner fields={fields} />
+			<div
+				style={{
+					position: "absolute",
+					inset: 0,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					fontSize: 48,
+				}}
+			>
+				{fields.suit}
+			</div>
+			<Corner fields={fields} flip />
+		</div>
+	);
+}
+
+function renderBack(_fields: PlayingCardFields) {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				background: "#b21f2d",
+				boxSizing: "border-box",
+				padding: 8,
+			}}
+		>
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					borderRadius: 6,
+					border: "2px solid rgba(255,255,255,0.7)",
+					backgroundImage:
+						"repeating-linear-gradient(45deg, rgba(255,255,255,0.18) 0 6px, transparent 6px 12px)",
+				}}
+			/>
+		</div>
+	);
+}
+
+export const playingCardType: CardTypeDefinition<PlayingCardFields> = {
+	id: "playing-card",
+	label: "トランプ",
+	icon: PlayingCardIcon,
+	defaultSize: { width: 120, height: 168 },
+	aspectRatio: 120 / 168,
+	createDefaultFields: () => ({ suit: "♠", rank: "A" }),
+	renderFront,
+	renderBack,
+	placementAnimation: { preset: "deal" },
+	buildDeck: () => {
+		const deck: PlayingCardFields[] = [];
+		for (const suit of SUITS) {
+			for (const rank of RANKS) {
+				deck.push({ suit, rank });
+			}
+		}
+		return deck;
+	},
+};

--- a/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
@@ -36,12 +36,91 @@ function PlayingCardIcon() {
 	);
 }
 
+// ピップ配置（数字カード）。x は列(0=左,0.5=中,1=右)、y は上からの割合。
+// これらは本物のトランプの並びに準拠し、数に応じて記号の数が変わる。
+const PIP_LAYOUTS: Record<string, { x: number; y: number }[]> = {
+	"2": [
+		{ x: 0.5, y: 0.12 },
+		{ x: 0.5, y: 0.88 },
+	],
+	"3": [
+		{ x: 0.5, y: 0.12 },
+		{ x: 0.5, y: 0.5 },
+		{ x: 0.5, y: 0.88 },
+	],
+	"4": [
+		{ x: 0, y: 0.12 },
+		{ x: 1, y: 0.12 },
+		{ x: 0, y: 0.88 },
+		{ x: 1, y: 0.88 },
+	],
+	"5": [
+		{ x: 0, y: 0.12 },
+		{ x: 1, y: 0.12 },
+		{ x: 0.5, y: 0.5 },
+		{ x: 0, y: 0.88 },
+		{ x: 1, y: 0.88 },
+	],
+	"6": [
+		{ x: 0, y: 0.12 },
+		{ x: 1, y: 0.12 },
+		{ x: 0, y: 0.5 },
+		{ x: 1, y: 0.5 },
+		{ x: 0, y: 0.88 },
+		{ x: 1, y: 0.88 },
+	],
+	"7": [
+		{ x: 0, y: 0.12 },
+		{ x: 1, y: 0.12 },
+		{ x: 0.5, y: 0.31 },
+		{ x: 0, y: 0.5 },
+		{ x: 1, y: 0.5 },
+		{ x: 0, y: 0.88 },
+		{ x: 1, y: 0.88 },
+	],
+	"8": [
+		{ x: 0, y: 0.12 },
+		{ x: 1, y: 0.12 },
+		{ x: 0.5, y: 0.31 },
+		{ x: 0, y: 0.5 },
+		{ x: 1, y: 0.5 },
+		{ x: 0.5, y: 0.69 },
+		{ x: 0, y: 0.88 },
+		{ x: 1, y: 0.88 },
+	],
+	"9": [
+		{ x: 0, y: 0.12 },
+		{ x: 1, y: 0.12 },
+		{ x: 0, y: 0.37 },
+		{ x: 1, y: 0.37 },
+		{ x: 0.5, y: 0.5 },
+		{ x: 0, y: 0.63 },
+		{ x: 1, y: 0.63 },
+		{ x: 0, y: 0.88 },
+		{ x: 1, y: 0.88 },
+	],
+	"10": [
+		{ x: 0, y: 0.12 },
+		{ x: 1, y: 0.12 },
+		{ x: 0.5, y: 0.25 },
+		{ x: 0, y: 0.37 },
+		{ x: 1, y: 0.37 },
+		{ x: 0, y: 0.63 },
+		{ x: 1, y: 0.63 },
+		{ x: 0.5, y: 0.75 },
+		{ x: 0, y: 0.88 },
+		{ x: 1, y: 0.88 },
+	],
+};
+
 function Corner({ fields, flip }: { fields: PlayingCardFields; flip?: boolean }) {
 	return (
 		<div
 			style={{
 				position: "absolute",
-				...(flip ? { right: 6, bottom: 4, transform: "rotate(180deg)" } : { left: 6, top: 4 }),
+				...(flip
+					? { right: "6%", bottom: "5%", transform: "rotate(180deg)" }
+					: { left: "6%", top: "5%" }),
 				display: "flex",
 				flexDirection: "column",
 				alignItems: "center",
@@ -49,14 +128,63 @@ function Corner({ fields, flip }: { fields: PlayingCardFields; flip?: boolean })
 				fontWeight: 700,
 			}}
 		>
-			<span style={{ fontSize: 14 }}>{fields.rank}</span>
-			<span style={{ fontSize: 12 }}>{fields.suit}</span>
+			<span style={{ fontSize: "11cqh" }}>{fields.rank}</span>
+			<span style={{ fontSize: "9cqh" }}>{fields.suit}</span>
+		</div>
+	);
+}
+
+/** 数字カードのピップ群を、配置レイアウトに従って描画する。下半分の記号は 180° 回転。 */
+function Pips({ fields }: { fields: PlayingCardFields }) {
+	const layout = PIP_LAYOUTS[fields.rank];
+	if (!layout) return null;
+	return (
+		<div style={{ position: "absolute", inset: "14% 26%" }}>
+			{layout.map((p, i) => (
+				<span
+					key={`pip-${i}-${p.x}-${p.y}`}
+					style={{
+						position: "absolute",
+						left: `${p.x * 100}%`,
+						top: `${p.y * 100}%`,
+						transform: `translate(-50%, -50%)${p.y > 0.5 ? " rotate(180deg)" : ""}`,
+						fontSize: "16cqh",
+						lineHeight: 1,
+					}}
+				>
+					{fields.suit}
+				</span>
+			))}
+		</div>
+	);
+}
+
+/** A は中央に大きな1つ、J/Q/K は文字＋スートで表現する。 */
+function CenterFigure({ fields }: { fields: PlayingCardFields }) {
+	const isAce = fields.rank === "A";
+	return (
+		<div
+			style={{
+				position: "absolute",
+				inset: 0,
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				lineHeight: 1,
+			}}
+		>
+			<span style={{ fontSize: isAce ? "44cqh" : "34cqh", fontWeight: 700 }}>
+				{isAce ? fields.suit : fields.rank}
+			</span>
+			{!isAce && <span style={{ fontSize: "22cqh" }}>{fields.suit}</span>}
 		</div>
 	);
 }
 
 function renderFront(fields: PlayingCardFields) {
 	const color = isRed(fields.suit) ? "#d4233b" : "#1e1e1e";
+	const hasPips = fields.rank in PIP_LAYOUTS;
 	return (
 		<div
 			style={{
@@ -67,21 +195,11 @@ function renderFront(fields: PlayingCardFields) {
 				color,
 				fontFamily: "Georgia, 'Times New Roman', serif",
 				boxSizing: "border-box",
+				containerType: "size",
 			}}
 		>
 			<Corner fields={fields} />
-			<div
-				style={{
-					position: "absolute",
-					inset: 0,
-					display: "flex",
-					alignItems: "center",
-					justifyContent: "center",
-					fontSize: 48,
-				}}
-			>
-				{fields.suit}
-			</div>
+			{hasPips ? <Pips fields={fields} /> : <CenterFigure fields={fields} />}
 			<Corner fields={fields} flip />
 		</div>
 	);

--- a/plugins/usketch-plugin-shape-card/src/card-types/uno.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/uno.tsx
@@ -141,7 +141,7 @@ export const unoCardType: CardTypeDefinition<UnoCardFields> = {
 	createDefaultFields: () => ({ color: "red", value: "0" }),
 	renderFront,
 	renderBack,
-	placementAnimation: { preset: "deal" },
+	placementAnimation: { preset: "slam-heavy" },
 	buildDeck: () => {
 		const deck: UnoCardFields[] = [];
 		for (const color of NUMBER_COLORS) {

--- a/plugins/usketch-plugin-shape-card/src/card-types/uno.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/uno.tsx
@@ -1,0 +1,164 @@
+import type { CardTypeDefinition } from "../types.js";
+
+export type UnoColor = "red" | "yellow" | "green" | "blue" | "wild";
+
+/** UNO 固有データ。 */
+export type UnoCardFields = {
+	color: UnoColor;
+	value: string; // "0".."9", "skip", "reverse", "+2", "wild", "+4"
+};
+
+const COLOR_HEX: Record<UnoColor, string> = {
+	red: "#d4233b",
+	yellow: "#f6c700",
+	green: "#1faa4d",
+	blue: "#1769d6",
+	wild: "#1e1e1e",
+};
+
+const NUMBER_COLORS: UnoColor[] = ["red", "yellow", "green", "blue"];
+const ACTIONS = ["skip", "reverse", "+2"];
+
+function UnoIcon() {
+	return (
+		<svg width="16" height="16" viewBox="0 0 16 16">
+			<title>UNO card</title>
+			<rect x="3" y="2" width="10" height="12" rx="2" fill="#d4233b" />
+			<ellipse cx="8" cy="8" rx="3.5" ry="5" fill="#fff" transform="rotate(20 8 8)" />
+			<text x="8" y="10" fontSize="4" textAnchor="middle" fill="#d4233b" fontWeight="bold">
+				UNO
+			</text>
+		</svg>
+	);
+}
+
+function valueLabel(value: string): string {
+	if (value === "skip") return "⦸";
+	if (value === "reverse") return "⇄";
+	return value.toUpperCase();
+}
+
+function renderFront(fields: UnoCardFields) {
+	const bg = COLOR_HEX[fields.color];
+	const label = valueLabel(fields.value);
+	return (
+		<div
+			style={{
+				position: "relative",
+				width: "100%",
+				height: "100%",
+				background: bg,
+				boxSizing: "border-box",
+				padding: 8,
+				fontFamily: "system-ui, sans-serif",
+				color: "#fff",
+				fontWeight: 800,
+			}}
+		>
+			<span style={{ position: "absolute", left: 8, top: 4, fontSize: 16 }}>{label}</span>
+			<div
+				style={{
+					position: "absolute",
+					inset: 8,
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+				}}
+			>
+				<div
+					style={{
+						width: "70%",
+						height: "60%",
+						background: "#fff",
+						borderRadius: "50%",
+						transform: "rotate(-20deg)",
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						color: bg,
+						fontSize: 30,
+					}}
+				>
+					{label}
+				</div>
+			</div>
+			<span
+				style={{
+					position: "absolute",
+					right: 8,
+					bottom: 4,
+					fontSize: 16,
+					transform: "rotate(180deg)",
+				}}
+			>
+				{label}
+			</span>
+		</div>
+	);
+}
+
+function renderBack(_fields: UnoCardFields) {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				background: "#1e1e1e",
+				boxSizing: "border-box",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+			}}
+		>
+			<div
+				style={{
+					width: "70%",
+					height: "60%",
+					background: "#d4233b",
+					borderRadius: "50%",
+					transform: "rotate(-20deg)",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					color: "#fff",
+					fontWeight: 800,
+					fontSize: 22,
+					fontStyle: "italic",
+				}}
+			>
+				UNO
+			</div>
+		</div>
+	);
+}
+
+export const unoCardType: CardTypeDefinition<UnoCardFields> = {
+	id: "uno",
+	label: "UNO",
+	icon: UnoIcon,
+	defaultSize: { width: 110, height: 165 },
+	aspectRatio: 110 / 165,
+	createDefaultFields: () => ({ color: "red", value: "0" }),
+	renderFront,
+	renderBack,
+	placementAnimation: { preset: "deal" },
+	buildDeck: () => {
+		const deck: UnoCardFields[] = [];
+		for (const color of NUMBER_COLORS) {
+			deck.push({ color, value: "0" }); // 0 は各色1枚
+			for (let n = 1; n <= 9; n++) {
+				deck.push({ color, value: String(n) });
+				deck.push({ color, value: String(n) }); // 1..9 は各色2枚
+			}
+			for (const action of ACTIONS) {
+				deck.push({ color, value: action });
+				deck.push({ color, value: action }); // アクションは各色2枚
+			}
+		}
+		for (let i = 0; i < 4; i++) {
+			deck.push({ color: "wild", value: "wild" });
+			deck.push({ color: "wild", value: "+4" });
+		}
+		return deck;
+	},
+};

--- a/plugins/usketch-plugin-shape-card/src/deck.ts
+++ b/plugins/usketch-plugin-shape-card/src/deck.ts
@@ -1,0 +1,20 @@
+/**
+ * デッキ（山札）操作の純関数群。shape / store に依存しないのでユニットテスト容易。
+ */
+
+/** Fisher–Yates シャッフル。元配列は破壊せず新配列を返す。 */
+export function shuffle<T>(cards: readonly T[]): T[] {
+	const result = cards.slice();
+	for (let i = result.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1));
+		[result[i], result[j]] = [result[j], result[i]];
+	}
+	return result;
+}
+
+/** 一番上（index 0）を1枚引く。残りの配列と引いたカードを返す。空なら card=null。 */
+export function drawTop<T>(cards: readonly T[]): { card: T | null; rest: T[] } {
+	if (cards.length === 0) return { card: null, rest: [] };
+	const [card, ...rest] = cards;
+	return { card, rest };
+}

--- a/plugins/usketch-plugin-shape-card/src/factory.ts
+++ b/plugins/usketch-plugin-shape-card/src/factory.ts
@@ -1,0 +1,90 @@
+import { DEFAULT_STYLE, generateId, type ShapeData } from "@edv4h/usketch-shared";
+import type { CardShape, CardTypeDefinition, DeckShape } from "./types.js";
+
+/** shape type 定数（レンダラ / ツールのディスパッチキー）。 */
+export const CARD_TYPE = "card";
+export const DECK_TYPE = "card-deck";
+
+/**
+ * カード shape データを生成する純ファクトリ。store には触れないので、
+ * `store.addShape(createCardShape(def, {...}))` のように addShape の薄いラッパとして使う
+ * （Undo したいなら createAddShapeCommand に渡す）。
+ */
+export function createCardShape(
+	def: CardTypeDefinition,
+	params: {
+		x: number;
+		y: number;
+		id?: string;
+		width?: number;
+		height?: number;
+		/** 省略時は def.createDefaultFields()。 */
+		fields?: Record<string, unknown>;
+		isFlipped?: boolean;
+		zIndex?: string;
+	},
+): CardShape {
+	return {
+		id: params.id ?? generateId(),
+		type: CARD_TYPE,
+		x: params.x,
+		y: params.y,
+		width: params.width ?? def.defaultSize.width,
+		height: params.height ?? def.defaultSize.height,
+		style: { ...DEFAULT_STYLE },
+		...(params.zIndex ? { zIndex: params.zIndex } : {}),
+		meta: {
+			cardType: def.id,
+			isFlipped: params.isFlipped ?? false,
+			fields: params.fields ?? def.createDefaultFields(),
+		},
+	};
+}
+
+/**
+ * デッキ（山札）shape データを生成する純ファクトリ。
+ * `cards` を渡せば**任意の山**（TCG の構築済みデッキ等）を作れる。省略時は def.buildDeck()。
+ * 生成だけを担い、配置は `store.addShape(createDeckShape(def, {...}))` で行う。
+ */
+export function createDeckShape(
+	def: CardTypeDefinition,
+	params: {
+		x: number;
+		y: number;
+		id?: string;
+		width?: number;
+		height?: number;
+		/** 省略時は def.buildDeck?.() ?? []。index 0 が一番上。 */
+		cards?: Record<string, unknown>[];
+		faceDown?: boolean;
+	},
+): DeckShape {
+	return {
+		id: params.id ?? generateId(),
+		type: DECK_TYPE,
+		x: params.x,
+		y: params.y,
+		width: params.width ?? def.defaultSize.width,
+		height: params.height ?? def.defaultSize.height,
+		style: { ...DEFAULT_STYLE },
+		meta: {
+			cardType: def.id,
+			cards: params.cards ?? def.buildDeck?.() ?? [],
+			faceDown: params.faceDown ?? true,
+		},
+	};
+}
+
+/** 未知 / card-type 不在時の最小カード（描画は unknown フォールバックに任せる）。 */
+export function createBareCardShape(params: { x: number; y: number; id?: string }): ShapeData {
+	return {
+		id: params.id ?? generateId(),
+		type: CARD_TYPE,
+		x: params.x,
+		y: params.y,
+		width: 200,
+		height: 280,
+		style: { ...DEFAULT_STYLE },
+		meta: { cardType: "", isFlipped: false, fields: {} },
+	};
+}

--- a/plugins/usketch-plugin-shape-card/src/geometry.ts
+++ b/plugins/usketch-plugin-shape-card/src/geometry.ts
@@ -1,0 +1,54 @@
+import type { BoundingBox, Point, ResizeHandle, ShapeData } from "@edv4h/usketch-shared";
+
+export function getBounds(data: ShapeData): BoundingBox {
+	return { x: data.x, y: data.y, width: data.width, height: data.height };
+}
+
+export function rectHitTest(data: ShapeData, point: Point): boolean {
+	return (
+		point.x >= data.x &&
+		point.x <= data.x + data.width &&
+		point.y >= data.y &&
+		point.y <= data.y + data.height
+	);
+}
+
+/** リサイズ時の最小幅（高さは aspect から導出）。 */
+export const MIN_CARD_WIDTH = 60;
+
+/**
+ * アスペクト比を固定したリサイズを生成する。比は shape の card-type から取得し、
+ * 取れない場合は現在の縦横比にフォールバックする。ハンドルの反対側を固定する。
+ */
+export function makeAspectResize(getAspect: (data: ShapeData) => number) {
+	return (data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData => {
+		const aspect = getAspect(data) || data.width / data.height || 1;
+		const usesVertical = handle === "n" || handle === "s";
+
+		let width: number;
+		let height: number;
+		if (usesVertical) {
+			const dh = handle === "n" ? -delta.y : delta.y;
+			height = data.height + dh;
+			width = height * aspect;
+		} else {
+			const dw = handle.includes("w") ? -delta.x : delta.x;
+			width = data.width + dw;
+			height = width / aspect;
+		}
+
+		const minW = MIN_CARD_WIDTH;
+		const minH = minW / aspect;
+		width = Math.max(minW, width);
+		height = Math.max(minH, height);
+
+		let x = data.x;
+		let y = data.y;
+		if (handle.includes("w")) x = data.x + (data.width - width);
+		if (handle.includes("n")) y = data.y + (data.height - height);
+		if (usesVertical) x = data.x + (data.width - width) / 2;
+		if (handle === "e" || handle === "w") y = data.y + (data.height - height) / 2;
+
+		return { ...data, x, y, width, height };
+	};
+}

--- a/plugins/usketch-plugin-shape-card/src/index.ts
+++ b/plugins/usketch-plugin-shape-card/src/index.ts
@@ -10,7 +10,7 @@ export { unoCardType } from "./card-types/uno.js";
 export { drawTop, shuffle } from "./deck.js";
 export type { CreateCardPluginOptions } from "./plugin.js";
 export { createCardPlugin } from "./plugin.js";
-export { BUILTIN_CARD_TYPES, createCardTypeRegistry } from "./registry.js";
+export { createCardTypeRegistry, EXAMPLE_CARD_TYPES } from "./registry.js";
 export type {
 	CardFace,
 	CardMeta,

--- a/plugins/usketch-plugin-shape-card/src/index.ts
+++ b/plugins/usketch-plugin-shape-card/src/index.ts
@@ -8,6 +8,13 @@ export { playingCardType } from "./card-types/playing-card.js";
 export type { UnoCardFields, UnoColor } from "./card-types/uno.js";
 export { unoCardType } from "./card-types/uno.js";
 export { drawTop, shuffle } from "./deck.js";
+export {
+	CARD_TYPE,
+	createBareCardShape,
+	createCardShape,
+	createDeckShape,
+	DECK_TYPE,
+} from "./factory.js";
 export type { CreateCardPluginOptions } from "./plugin.js";
 export { createCardPlugin } from "./plugin.js";
 export { createCardTypeRegistry, EXAMPLE_CARD_TYPES } from "./registry.js";

--- a/plugins/usketch-plugin-shape-card/src/index.ts
+++ b/plugins/usketch-plugin-shape-card/src/index.ts
@@ -1,3 +1,6 @@
+export { anchorTranslate, faceTextureStyle, renderFace } from "./card-face.js";
+export type { CustomCardFields } from "./card-types/custom.js";
+export { customCardType } from "./card-types/custom.js";
 export type { MediaCardFields } from "./card-types/media.js";
 export { mediaCardType } from "./card-types/media.js";
 export type { PlayingCardFields, Suit } from "./card-types/playing-card.js";
@@ -9,8 +12,11 @@ export type { CreateCardPluginOptions } from "./plugin.js";
 export { createCardPlugin } from "./plugin.js";
 export { BUILTIN_CARD_TYPES, createCardTypeRegistry } from "./registry.js";
 export type {
+	CardFace,
 	CardMeta,
 	CardShape,
+	CardText,
+	CardTexture,
 	CardTypeDefinition,
 	DeckMeta,
 	DeckShape,

--- a/plugins/usketch-plugin-shape-card/src/index.ts
+++ b/plugins/usketch-plugin-shape-card/src/index.ts
@@ -1,0 +1,20 @@
+export type { MediaCardFields } from "./card-types/media.js";
+export { mediaCardType } from "./card-types/media.js";
+export type { PlayingCardFields, Suit } from "./card-types/playing-card.js";
+export { playingCardType } from "./card-types/playing-card.js";
+export type { UnoCardFields, UnoColor } from "./card-types/uno.js";
+export { unoCardType } from "./card-types/uno.js";
+export { drawTop, shuffle } from "./deck.js";
+export type { CreateCardPluginOptions } from "./plugin.js";
+export { createCardPlugin } from "./plugin.js";
+export { BUILTIN_CARD_TYPES, createCardTypeRegistry } from "./registry.js";
+export type {
+	CardMeta,
+	CardShape,
+	CardTypeDefinition,
+	DeckMeta,
+	DeckShape,
+	PlacementAnimation,
+	PlacementPreset,
+} from "./types.js";
+export { readCardMeta, readDeckMeta } from "./types.js";

--- a/plugins/usketch-plugin-shape-card/src/placement.tsx
+++ b/plugins/usketch-plugin-shape-card/src/placement.tsx
@@ -1,0 +1,99 @@
+import type { TransientObject } from "@edv4h/usketch-shared";
+import type { PlacementAnimation, PlacementPreset } from "./types.js";
+
+export const PLACEMENT_TRANSIENT_TYPE = "card-placement";
+
+/** プリセットごとの keyframes 名と既定再生時間。 */
+const PRESET_KEYFRAMES: Record<
+	Exclude<PlacementPreset, "none">,
+	{ name: string; durationMs: number; easing: string }
+> = {
+	deal: { name: "usketch-card-deal", durationMs: 350, easing: "cubic-bezier(0.2, 0.9, 0.3, 1)" },
+	drop: { name: "usketch-card-drop", durationMs: 320, easing: "cubic-bezier(0.2, 0.8, 0.2, 1)" },
+	bounce: {
+		name: "usketch-card-bounce",
+		durationMs: 450,
+		easing: "cubic-bezier(0.34, 1.56, 0.64, 1)",
+	},
+};
+
+/** transient.emit に載せる解決済みアニメ情報。 */
+export interface ResolvedPlacement {
+	name: string;
+	durationMs: number;
+	easing: string;
+}
+
+/**
+ * card-type 個別 → プラグイン既定の順で配置アニメを解決する。
+ * `none` または該当なしの場合は null（＝アニメを出さない）。
+ */
+export function resolvePlacementAnimation(
+	cardTypeAnim: PlacementAnimation | undefined,
+	pluginDefault: PlacementAnimation | undefined,
+): ResolvedPlacement | null {
+	const anim = cardTypeAnim ?? pluginDefault ?? { preset: "drop" };
+	if ("keyframes" in anim) {
+		return { name: anim.keyframes, durationMs: anim.durationMs, easing: anim.easing ?? "ease-out" };
+	}
+	if (anim.preset === "none") return null;
+	return PRESET_KEYFRAMES[anim.preset];
+}
+
+let styleInjected = false;
+/** プリセット keyframes を一度だけ document.head に注入する（ripple と同じ手法）。 */
+export function injectPlacementStyles() {
+	if (styleInjected || typeof document === "undefined") return;
+	styleInjected = true;
+	const style = document.createElement("style");
+	style.textContent = `
+		@keyframes usketch-card-deal {
+			0%   { transform: translate(-40px, -24px) rotate(-10deg) scale(0.92); opacity: 0.0; }
+			60%  { opacity: 0.55; }
+			100% { transform: translate(0, 0) rotate(0deg) scale(1); opacity: 0; }
+		}
+		@keyframes usketch-card-drop {
+			0%   { transform: translateY(-24px) scale(1.12); opacity: 0.0; }
+			55%  { opacity: 0.55; }
+			100% { transform: translateY(0) scale(1); opacity: 0; }
+		}
+		@keyframes usketch-card-bounce {
+			0%   { transform: scale(0.6); opacity: 0.0; }
+			50%  { transform: scale(1.12); opacity: 0.5; }
+			75%  { transform: scale(0.96); opacity: 0.3; }
+			100% { transform: scale(1); opacity: 0; }
+		}
+	`;
+	document.head.appendChild(style);
+}
+
+/**
+ * 配置アニメの transient 描画。カードのシルエット（角丸の発光枠）を着地位置に重ね、
+ * 指定 keyframes で再生して fade out する。永続データ / Undo には触れない。
+ */
+export function PlacementEffect({ obj }: { obj: TransientObject }) {
+	const width = (obj.data.width as number) ?? 120;
+	const height = (obj.data.height as number) ?? 168;
+	const name = (obj.data.name as string) ?? "usketch-card-drop";
+	const durationMs = (obj.data.durationMs as number) ?? 320;
+	const easing = (obj.data.easing as string) ?? "ease-out";
+	const accent = (obj.data.accent as string) ?? "rgba(79, 140, 255, 0.9)";
+
+	return (
+		<div
+			style={{
+				position: "absolute",
+				left: -width / 2,
+				top: -height / 2,
+				width,
+				height,
+				borderRadius: 10,
+				boxSizing: "border-box",
+				border: `2px solid ${accent}`,
+				boxShadow: `0 0 16px ${accent}`,
+				animation: `${name} ${durationMs}ms ${easing} forwards`,
+				pointerEvents: "none",
+			}}
+		/>
+	);
+}

--- a/plugins/usketch-plugin-shape-card/src/placement.tsx
+++ b/plugins/usketch-plugin-shape-card/src/placement.tsx
@@ -37,9 +37,9 @@ const SLAM_PARAMS: Record<
 > = {
 	// design 比 dur 2.3 : 3.3 : 4.6 ≈ 0.5 : 0.72 : 1.0 を一発再生用に圧縮。
 	// lift / liftScale は design の --lift(52/94/142) の比を踏襲。
-	light: { durationMs: 380, lift: 8, liftScale: 1.07, ring: 0.95, spray: 0.55, particle: 5 },
-	medium: { durationMs: 560, lift: 16, liftScale: 1.13, ring: 1.25, spray: 0.85, particle: 6 },
-	heavy: { durationMs: 780, lift: 26, liftScale: 1.2, ring: 1.6, spray: 1.2, particle: 7 },
+	light: { durationMs: 380, lift: 8, liftScale: 1.07, ring: 0.9, spray: 0.5, particle: 3 },
+	medium: { durationMs: 560, lift: 16, liftScale: 1.13, ring: 1.15, spray: 0.7, particle: 4 },
+	heavy: { durationMs: 780, lift: 26, liftScale: 1.2, ring: 1.45, spray: 0.95, particle: 5 },
 };
 
 /** transient.emit に載せる解決済みアニメ情報。 */
@@ -131,12 +131,12 @@ export function injectPlacementStyles() {
 		/* 衝撃エフェクトは着地（≈40-46%, 実カードの着地と同期）に合わせて発火 */
 		@keyframes usketch-slam-ring {
 			0%, 36% { opacity: 0; transform: scale(0.4); }
-			44%     { opacity: 0.85; transform: scale(0.55); }
-			100%    { opacity: 0; transform: scale(1.6); }
+			44%     { opacity: 0.4; transform: scale(0.55); }
+			100%    { opacity: 0; transform: scale(1.45); }
 		}
 		@keyframes usketch-slam-splash {
 			0%, 38% { opacity: 0; transform: translate(0, 0) scale(0.4); }
-			46%     { opacity: 0.9; transform: translate(calc(var(--tx) * 0.45), calc(var(--ty) * 0.45)) scale(1); }
+			46%     { opacity: 0.45; transform: translate(calc(var(--tx) * 0.45), calc(var(--ty) * 0.45)) scale(1); }
 			100%    { opacity: 0; transform: translate(var(--tx), var(--ty)) scale(0.7); }
 		}
 	${slamCardKeyframes()}`;
@@ -191,7 +191,7 @@ function SlamBurst({ obj }: { obj: TransientObject }) {
 			{/* 衝撃リング */}
 			<div
 				style={circle(ringSize, {
-					border: "2px solid rgba(16,18,40,0.32)",
+					border: "1.5px solid rgba(16,18,40,0.18)",
 					animation: `usketch-slam-ring ${durationMs}ms ease-out forwards`,
 				})}
 			/>
@@ -203,7 +203,7 @@ function SlamBurst({ obj }: { obj: TransientObject }) {
 				const size = i % 2 === 0 ? p.particle + 1 : p.particle - 1;
 				const style: Record<string, string | number> = {
 					...circle(size, {
-						background: "#16182a",
+						background: "rgba(16,18,40,0.5)",
 						animation: `usketch-slam-splash ${durationMs}ms ease-out forwards`,
 					}),
 					"--tx": `${tx}px`,

--- a/plugins/usketch-plugin-shape-card/src/placement.tsx
+++ b/plugins/usketch-plugin-shape-card/src/placement.tsx
@@ -31,44 +31,15 @@ const SLAM_PARAMS: Record<
 		lift: number; // 着地前に一瞬持ち上がる量(px)
 		liftScale: number; // 持ち上がり時のスケール（手前=大きく）
 		ring: number; // カード最大辺に対するリング径の係数
-		shadow: number; // 接地シャドウ径の係数
-		shadowOpacity: number;
 		spray: number; // 飛沫の到達距離（カード最大辺に対する係数）
 		particle: number; // 粒の基準サイズ(px)
 	}
 > = {
 	// design 比 dur 2.3 : 3.3 : 4.6 ≈ 0.5 : 0.72 : 1.0 を一発再生用に圧縮。
 	// lift / liftScale は design の --lift(52/94/142) の比を踏襲。
-	light: {
-		durationMs: 380,
-		lift: 8,
-		liftScale: 1.07,
-		ring: 0.95,
-		shadow: 1.0,
-		shadowOpacity: 0.28,
-		spray: 0.55,
-		particle: 5,
-	},
-	medium: {
-		durationMs: 560,
-		lift: 16,
-		liftScale: 1.13,
-		ring: 1.25,
-		shadow: 1.25,
-		shadowOpacity: 0.5,
-		spray: 0.85,
-		particle: 6,
-	},
-	heavy: {
-		durationMs: 780,
-		lift: 26,
-		liftScale: 1.2,
-		ring: 1.6,
-		shadow: 1.6,
-		shadowOpacity: 0.62,
-		spray: 1.2,
-		particle: 7,
-	},
+	light: { durationMs: 380, lift: 8, liftScale: 1.07, ring: 0.95, spray: 0.55, particle: 5 },
+	medium: { durationMs: 560, lift: 16, liftScale: 1.13, ring: 1.25, spray: 0.85, particle: 6 },
+	heavy: { durationMs: 780, lift: 26, liftScale: 1.2, ring: 1.6, spray: 1.2, particle: 7 },
 };
 
 /** transient.emit に載せる解決済みアニメ情報。 */
@@ -163,13 +134,6 @@ export function injectPlacementStyles() {
 			44%     { opacity: 0.85; transform: scale(0.55); }
 			100%    { opacity: 0; transform: scale(1.6); }
 		}
-		@keyframes usketch-slam-shadow {
-			0%   { opacity: 0.3; transform: scale(1.55); }
-			30%  { opacity: 0.35; transform: scale(1.6); }
-			40%  { opacity: 1; transform: scale(0.86); }
-			70%  { opacity: 0.7; transform: scale(1); }
-			100% { opacity: 0; transform: scale(1.4); }
-		}
 		@keyframes usketch-slam-splash {
 			0%, 38% { opacity: 0; transform: translate(0, 0) scale(0.4); }
 			46%     { opacity: 0.9; transform: translate(calc(var(--tx) * 0.45), calc(var(--ty) * 0.45)) scale(1); }
@@ -197,7 +161,7 @@ function slamCardKeyframes(): string {
 /** 8 方向の放射状飛沫。 */
 const SPRAY_DIRS = [0, 45, 90, 135, 180, 225, 270, 315];
 
-/** 「ドン！」着地の衝撃エフェクト: 接地シャドウ + 衝撃リング + 放射状飛沫。 */
+/** 「ドン！」着地の衝撃エフェクト: 衝撃リング + 放射状飛沫（カードの外側に広がる）。 */
 function SlamBurst({ obj }: { obj: TransientObject }) {
 	const width = (obj.data.width as number) ?? 120;
 	const height = (obj.data.height as number) ?? 168;
@@ -206,7 +170,6 @@ function SlamBurst({ obj }: { obj: TransientObject }) {
 	const p = SLAM_PARAMS[weight];
 	const cardMax = Math.max(width, height);
 	const ringSize = cardMax * p.ring;
-	const shadowSize = cardMax * p.shadow;
 	const dist = cardMax * p.spray;
 
 	const circle = (size: number, style: CSSProperties) => ({
@@ -221,17 +184,10 @@ function SlamBurst({ obj }: { obj: TransientObject }) {
 	});
 
 	// 実カード自身が持ち上がり→着地する（render 側の slamWrapper）。ここは着地の衝撃のみ。
+	// transient レイヤーはカードより手前なので、カードに被る接地シャドウは出さず、
+	// カードの外側に広がるリングと飛沫だけで衝撃を表現する。
 	return (
 		<div style={{ position: "absolute", left: 0, top: 0, pointerEvents: "none" }}>
-			{/* 接地シャドウ（持ち上がり時は大きく淡く→着地でキュッと締まる） */}
-			<div
-				style={circle(shadowSize, {
-					background: `radial-gradient(circle, rgba(16,18,40,${p.shadowOpacity}), rgba(16,18,40,0) 66%)`,
-					filter: "blur(7px)",
-					opacity: 0,
-					animation: `usketch-slam-shadow ${durationMs}ms ease-in-out forwards`,
-				})}
-			/>
 			{/* 衝撃リング */}
 			<div
 				style={circle(ringSize, {

--- a/plugins/usketch-plugin-shape-card/src/placement.tsx
+++ b/plugins/usketch-plugin-shape-card/src/placement.tsx
@@ -28,6 +28,8 @@ const SLAM_PARAMS: Record<
 	SlamWeight,
 	{
 		durationMs: number;
+		lift: number; // 着地前に一瞬持ち上がる量(px)
+		liftScale: number; // 持ち上がり時のスケール（手前=大きく）
 		ring: number; // カード最大辺に対するリング径の係数
 		shadow: number; // 接地シャドウ径の係数
 		shadowOpacity: number;
@@ -35,9 +37,12 @@ const SLAM_PARAMS: Record<
 		particle: number; // 粒の基準サイズ(px)
 	}
 > = {
-	// design 比 dur 2.3 : 3.3 : 4.6 ≈ 0.5 : 0.72 : 1.0 を一発再生用に圧縮
+	// design 比 dur 2.3 : 3.3 : 4.6 ≈ 0.5 : 0.72 : 1.0 を一発再生用に圧縮。
+	// lift / liftScale は design の --lift(52/94/142) の比を踏襲。
 	light: {
 		durationMs: 380,
+		lift: 8,
+		liftScale: 1.07,
 		ring: 0.95,
 		shadow: 1.0,
 		shadowOpacity: 0.28,
@@ -45,14 +50,25 @@ const SLAM_PARAMS: Record<
 		particle: 5,
 	},
 	medium: {
-		durationMs: 540,
+		durationMs: 560,
+		lift: 16,
+		liftScale: 1.13,
 		ring: 1.25,
 		shadow: 1.25,
 		shadowOpacity: 0.5,
 		spray: 0.85,
 		particle: 6,
 	},
-	heavy: { durationMs: 760, ring: 1.6, shadow: 1.6, shadowOpacity: 0.62, spray: 1.2, particle: 7 },
+	heavy: {
+		durationMs: 780,
+		lift: 26,
+		liftScale: 1.2,
+		ring: 1.6,
+		shadow: 1.6,
+		shadowOpacity: 0.62,
+		spray: 1.2,
+		particle: 7,
+	},
 };
 
 /** transient.emit に載せる解決済みアニメ情報。 */
@@ -112,21 +128,32 @@ export function injectPlacementStyles() {
 			75%  { transform: scale(0.96); opacity: 0.3; }
 			100% { transform: scale(1); opacity: 0; }
 		}
+		/* カード本体: 一瞬持ち上がってから加速して着地（ズドン）→ フェードして実カードを見せる */
+		@keyframes usketch-slam-card {
+			0%   { opacity: 0; transform: translateY(var(--ly)) scale(var(--ls)); }
+			10%  { opacity: 0.92; }
+			30%  { transform: translateY(var(--ly)) scale(var(--ls)); animation-timing-function: cubic-bezier(0.55, 0, 0.9, 0.25); }
+			40%  { transform: translateY(0) scale(1); opacity: 0.92; }
+			72%  { opacity: 0.4; }
+			100% { opacity: 0; transform: translateY(0) scale(1); }
+		}
+		/* 以下の衝撃エフェクトは着地（≈40%）に合わせて発火 */
 		@keyframes usketch-slam-ring {
-			0%   { opacity: 0; transform: scale(0.45); }
-			14%  { opacity: 0.85; transform: scale(0.6); }
-			100% { opacity: 0; transform: scale(1.6); }
+			0%, 36% { opacity: 0; transform: scale(0.4); }
+			44%     { opacity: 0.85; transform: scale(0.55); }
+			100%    { opacity: 0; transform: scale(1.6); }
 		}
 		@keyframes usketch-slam-shadow {
-			0%   { opacity: 0.16; transform: scale(1.5); }
-			20%  { opacity: 0.5; transform: scale(0.86); }
-			55%  { opacity: 0.34; transform: scale(1); }
+			0%   { opacity: 0.3; transform: scale(1.55); }
+			30%  { opacity: 0.35; transform: scale(1.6); }
+			40%  { opacity: 1; transform: scale(0.86); }
+			70%  { opacity: 0.7; transform: scale(1); }
 			100% { opacity: 0; transform: scale(1.4); }
 		}
 		@keyframes usketch-slam-splash {
-			0%   { opacity: 0; transform: translate(0, 0) scale(0.4); }
-			20%  { opacity: 0.9; transform: translate(calc(var(--tx) * 0.45), calc(var(--ty) * 0.45)) scale(1); }
-			100% { opacity: 0; transform: translate(var(--tx), var(--ty)) scale(0.7); }
+			0%, 38% { opacity: 0; transform: translate(0, 0) scale(0.4); }
+			46%     { opacity: 0.9; transform: translate(calc(var(--tx) * 0.45), calc(var(--ty) * 0.45)) scale(1); }
+			100%    { opacity: 0; transform: translate(var(--tx), var(--ty)) scale(0.7); }
 		}
 	`;
 	document.head.appendChild(style);
@@ -158,16 +185,38 @@ function SlamBurst({ obj }: { obj: TransientObject }) {
 		...style,
 	});
 
+	// カード本体: 一瞬持ち上がって（手前=大きく）から加速して着地するシルエット。
+	// 実カードの上に重なり、着地後にフェードして実カードを見せる。
+	const cardStyle: Record<string, string | number> = {
+		position: "absolute",
+		left: -width / 2,
+		top: -height / 2,
+		width,
+		height,
+		borderRadius: 12,
+		boxSizing: "border-box",
+		background: "linear-gradient(160deg, rgba(255,255,255,0.5), rgba(238,240,245,0.4))",
+		border: "1px solid rgba(16,18,40,0.16)",
+		boxShadow: "0 14px 34px rgba(16,18,40,0.3)",
+		pointerEvents: "none",
+		animation: `usketch-slam-card ${durationMs}ms ease-out forwards`,
+		"--ly": `${-p.lift}px`,
+		"--ls": p.liftScale,
+	};
+
 	return (
 		<div style={{ position: "absolute", left: 0, top: 0, pointerEvents: "none" }}>
-			{/* 接地シャドウ（接触でキュッと締まる） */}
+			{/* 接地シャドウ（持ち上がり時は大きく淡く→着地でキュッと締まる） */}
 			<div
 				style={circle(shadowSize, {
 					background: `radial-gradient(circle, rgba(16,18,40,${p.shadowOpacity}), rgba(16,18,40,0) 66%)`,
 					filter: "blur(7px)",
+					opacity: 0,
 					animation: `usketch-slam-shadow ${durationMs}ms ease-in-out forwards`,
 				})}
 			/>
+			{/* カード本体（持ち上がり→ズドン） */}
+			<div style={cardStyle as CSSProperties} />
 			{/* 衝撃リング */}
 			<div
 				style={circle(ringSize, {

--- a/plugins/usketch-plugin-shape-card/src/placement.tsx
+++ b/plugins/usketch-plugin-shape-card/src/placement.tsx
@@ -76,6 +76,35 @@ export type ResolvedPlacement =
 	| { kind: "css"; name: string; durationMs: number; easing: string }
 	| { kind: "slam"; weight: SlamWeight; durationMs: number };
 
+/** slam 中の実カードに適用する再生情報（render 側が参照）。 */
+export interface SlamPlay {
+	weight: SlamWeight;
+	durationMs: number;
+	/** 同じカードを再度 slam したときにアニメを確実に再生させるための識別子。 */
+	nonce: number;
+}
+
+/**
+ * 実カード（card / deck）の root に被せる slam ラッパの props。
+ * 「一瞬持ち上がってから加速して着地」する transform アニメを**実カード自身**に当てるので、
+ * シルエットの二重描画（持ち上がり前のカードと被る問題）が起きない。
+ */
+export function slamWrapper(slam: SlamPlay | undefined): {
+	key: string;
+	style: CSSProperties;
+} {
+	if (!slam) return { key: "rest", style: { width: "100%", height: "100%" } };
+	return {
+		key: `slam-${slam.nonce}`,
+		style: {
+			width: "100%",
+			height: "100%",
+			transformOrigin: "center center",
+			animation: `usketch-card-slam-${slam.weight} ${slam.durationMs}ms cubic-bezier(0.2,0.7,0.3,1) both`,
+		},
+	};
+}
+
 function isSlam(preset: PlacementPreset): preset is `slam-${SlamWeight}` {
 	return preset === "slam-light" || preset === "slam-medium" || preset === "slam-heavy";
 }
@@ -128,16 +157,7 @@ export function injectPlacementStyles() {
 			75%  { transform: scale(0.96); opacity: 0.3; }
 			100% { transform: scale(1); opacity: 0; }
 		}
-		/* カード本体: 一瞬持ち上がってから加速して着地（ズドン）→ フェードして実カードを見せる */
-		@keyframes usketch-slam-card {
-			0%   { opacity: 0; transform: translateY(var(--ly)) scale(var(--ls)); }
-			10%  { opacity: 0.92; }
-			30%  { transform: translateY(var(--ly)) scale(var(--ls)); animation-timing-function: cubic-bezier(0.55, 0, 0.9, 0.25); }
-			40%  { transform: translateY(0) scale(1); opacity: 0.92; }
-			72%  { opacity: 0.4; }
-			100% { opacity: 0; transform: translateY(0) scale(1); }
-		}
-		/* 以下の衝撃エフェクトは着地（≈40%）に合わせて発火 */
+		/* 衝撃エフェクトは着地（≈40-46%, 実カードの着地と同期）に合わせて発火 */
 		@keyframes usketch-slam-ring {
 			0%, 36% { opacity: 0; transform: scale(0.4); }
 			44%     { opacity: 0.85; transform: scale(0.55); }
@@ -155,8 +175,23 @@ export function injectPlacementStyles() {
 			46%     { opacity: 0.9; transform: translate(calc(var(--tx) * 0.45), calc(var(--ty) * 0.45)) scale(1); }
 			100%    { opacity: 0; transform: translate(var(--tx), var(--ty)) scale(0.7); }
 		}
-	`;
+	${slamCardKeyframes()}`;
 	document.head.appendChild(style);
+}
+
+/** 実カードに当てる「持ち上がり→加速着地（ズドン）」keyframes（重さ別、弾性なし）。 */
+function slamCardKeyframes(): string {
+	return (Object.keys(SLAM_PARAMS) as SlamWeight[])
+		.map((w) => {
+			const { lift, liftScale } = SLAM_PARAMS[w];
+			return `@keyframes usketch-card-slam-${w}{
+			0%{transform:translateY(${-lift}px) scale(${liftScale});}
+			28%{transform:translateY(${-lift}px) scale(${liftScale});animation-timing-function:cubic-bezier(0.6,0,0.95,0.2);}
+			44%{transform:translateY(0) scale(1);}
+			100%{transform:translateY(0) scale(1);}
+		}`;
+		})
+		.join("\n");
 }
 
 /** 8 方向の放射状飛沫。 */
@@ -185,25 +220,7 @@ function SlamBurst({ obj }: { obj: TransientObject }) {
 		...style,
 	});
 
-	// カード本体: 一瞬持ち上がって（手前=大きく）から加速して着地するシルエット。
-	// 実カードの上に重なり、着地後にフェードして実カードを見せる。
-	const cardStyle: Record<string, string | number> = {
-		position: "absolute",
-		left: -width / 2,
-		top: -height / 2,
-		width,
-		height,
-		borderRadius: 12,
-		boxSizing: "border-box",
-		background: "linear-gradient(160deg, rgba(255,255,255,0.5), rgba(238,240,245,0.4))",
-		border: "1px solid rgba(16,18,40,0.16)",
-		boxShadow: "0 14px 34px rgba(16,18,40,0.3)",
-		pointerEvents: "none",
-		animation: `usketch-slam-card ${durationMs}ms ease-out forwards`,
-		"--ly": `${-p.lift}px`,
-		"--ls": p.liftScale,
-	};
-
+	// 実カード自身が持ち上がり→着地する（render 側の slamWrapper）。ここは着地の衝撃のみ。
 	return (
 		<div style={{ position: "absolute", left: 0, top: 0, pointerEvents: "none" }}>
 			{/* 接地シャドウ（持ち上がり時は大きく淡く→着地でキュッと締まる） */}
@@ -215,8 +232,6 @@ function SlamBurst({ obj }: { obj: TransientObject }) {
 					animation: `usketch-slam-shadow ${durationMs}ms ease-in-out forwards`,
 				})}
 			/>
-			{/* カード本体（持ち上がり→ズドン） */}
-			<div style={cardStyle as CSSProperties} />
 			{/* 衝撃リング */}
 			<div
 				style={circle(ringSize, {

--- a/plugins/usketch-plugin-shape-card/src/placement.tsx
+++ b/plugins/usketch-plugin-shape-card/src/placement.tsx
@@ -1,11 +1,14 @@
 import type { TransientObject } from "@edv4h/usketch-shared";
+import type { CSSProperties } from "react";
 import type { PlacementAnimation, PlacementPreset } from "./types.js";
 
 export const PLACEMENT_TRANSIENT_TYPE = "card-placement";
 
-/** プリセットごとの keyframes 名と既定再生時間。 */
+export type SlamWeight = "light" | "medium" | "heavy";
+
+/** keyframe ベースのプリセット（名前 + 既定再生時間）。 */
 const PRESET_KEYFRAMES: Record<
-	Exclude<PlacementPreset, "none">,
+	"deal" | "drop" | "bounce",
 	{ name: string; durationMs: number; easing: string }
 > = {
 	deal: { name: "usketch-card-deal", durationMs: 350, easing: "cubic-bezier(0.2, 0.9, 0.3, 1)" },
@@ -17,11 +20,48 @@ const PRESET_KEYFRAMES: Record<
 	},
 };
 
+/**
+ * Slam（ドン！）の重み別パラメータ。`Card Animations.dc.html` の light/medium/heavy
+ * の比率を踏襲（重いほど大きく・濃く・遅い）。サイズはカード寸法に対する係数で表す。
+ */
+const SLAM_PARAMS: Record<
+	SlamWeight,
+	{
+		durationMs: number;
+		ring: number; // カード最大辺に対するリング径の係数
+		shadow: number; // 接地シャドウ径の係数
+		shadowOpacity: number;
+		spray: number; // 飛沫の到達距離（カード最大辺に対する係数）
+		particle: number; // 粒の基準サイズ(px)
+	}
+> = {
+	// design 比 dur 2.3 : 3.3 : 4.6 ≈ 0.5 : 0.72 : 1.0 を一発再生用に圧縮
+	light: {
+		durationMs: 380,
+		ring: 0.95,
+		shadow: 1.0,
+		shadowOpacity: 0.28,
+		spray: 0.55,
+		particle: 5,
+	},
+	medium: {
+		durationMs: 540,
+		ring: 1.25,
+		shadow: 1.25,
+		shadowOpacity: 0.5,
+		spray: 0.85,
+		particle: 6,
+	},
+	heavy: { durationMs: 760, ring: 1.6, shadow: 1.6, shadowOpacity: 0.62, spray: 1.2, particle: 7 },
+};
+
 /** transient.emit に載せる解決済みアニメ情報。 */
-export interface ResolvedPlacement {
-	name: string;
-	durationMs: number;
-	easing: string;
+export type ResolvedPlacement =
+	| { kind: "css"; name: string; durationMs: number; easing: string }
+	| { kind: "slam"; weight: SlamWeight; durationMs: number };
+
+function isSlam(preset: PlacementPreset): preset is `slam-${SlamWeight}` {
+	return preset === "slam-light" || preset === "slam-medium" || preset === "slam-heavy";
 }
 
 /**
@@ -34,10 +74,19 @@ export function resolvePlacementAnimation(
 ): ResolvedPlacement | null {
 	const anim = cardTypeAnim ?? pluginDefault ?? { preset: "drop" };
 	if ("keyframes" in anim) {
-		return { name: anim.keyframes, durationMs: anim.durationMs, easing: anim.easing ?? "ease-out" };
+		return {
+			kind: "css",
+			name: anim.keyframes,
+			durationMs: anim.durationMs,
+			easing: anim.easing ?? "ease-out",
+		};
 	}
 	if (anim.preset === "none") return null;
-	return PRESET_KEYFRAMES[anim.preset];
+	if (isSlam(anim.preset)) {
+		const weight = anim.preset.slice(5) as SlamWeight;
+		return { kind: "slam", weight, durationMs: SLAM_PARAMS[weight].durationMs };
+	}
+	return { kind: "css", ...PRESET_KEYFRAMES[anim.preset] };
 }
 
 let styleInjected = false;
@@ -63,15 +112,97 @@ export function injectPlacementStyles() {
 			75%  { transform: scale(0.96); opacity: 0.3; }
 			100% { transform: scale(1); opacity: 0; }
 		}
+		@keyframes usketch-slam-ring {
+			0%   { opacity: 0; transform: scale(0.45); }
+			14%  { opacity: 0.85; transform: scale(0.6); }
+			100% { opacity: 0; transform: scale(1.6); }
+		}
+		@keyframes usketch-slam-shadow {
+			0%   { opacity: 0.16; transform: scale(1.5); }
+			20%  { opacity: 0.5; transform: scale(0.86); }
+			55%  { opacity: 0.34; transform: scale(1); }
+			100% { opacity: 0; transform: scale(1.4); }
+		}
+		@keyframes usketch-slam-splash {
+			0%   { opacity: 0; transform: translate(0, 0) scale(0.4); }
+			20%  { opacity: 0.9; transform: translate(calc(var(--tx) * 0.45), calc(var(--ty) * 0.45)) scale(1); }
+			100% { opacity: 0; transform: translate(var(--tx), var(--ty)) scale(0.7); }
+		}
 	`;
 	document.head.appendChild(style);
 }
 
+/** 8 方向の放射状飛沫。 */
+const SPRAY_DIRS = [0, 45, 90, 135, 180, 225, 270, 315];
+
+/** 「ドン！」着地の衝撃エフェクト: 接地シャドウ + 衝撃リング + 放射状飛沫。 */
+function SlamBurst({ obj }: { obj: TransientObject }) {
+	const width = (obj.data.width as number) ?? 120;
+	const height = (obj.data.height as number) ?? 168;
+	const weight = (obj.data.slam as SlamWeight) ?? "medium";
+	const durationMs = (obj.data.durationMs as number) ?? SLAM_PARAMS[weight].durationMs;
+	const p = SLAM_PARAMS[weight];
+	const cardMax = Math.max(width, height);
+	const ringSize = cardMax * p.ring;
+	const shadowSize = cardMax * p.shadow;
+	const dist = cardMax * p.spray;
+
+	const circle = (size: number, style: CSSProperties) => ({
+		position: "absolute" as const,
+		left: -size / 2,
+		top: -size / 2,
+		width: size,
+		height: size,
+		borderRadius: "50%",
+		pointerEvents: "none" as const,
+		...style,
+	});
+
+	return (
+		<div style={{ position: "absolute", left: 0, top: 0, pointerEvents: "none" }}>
+			{/* 接地シャドウ（接触でキュッと締まる） */}
+			<div
+				style={circle(shadowSize, {
+					background: `radial-gradient(circle, rgba(16,18,40,${p.shadowOpacity}), rgba(16,18,40,0) 66%)`,
+					filter: "blur(7px)",
+					animation: `usketch-slam-shadow ${durationMs}ms ease-in-out forwards`,
+				})}
+			/>
+			{/* 衝撃リング */}
+			<div
+				style={circle(ringSize, {
+					border: "2px solid rgba(16,18,40,0.32)",
+					animation: `usketch-slam-ring ${durationMs}ms ease-out forwards`,
+				})}
+			/>
+			{/* 放射状の飛沫 */}
+			{SPRAY_DIRS.map((deg, i) => {
+				const a = (deg * Math.PI) / 180;
+				const tx = Math.cos(a) * dist;
+				const ty = Math.sin(a) * dist;
+				const size = i % 2 === 0 ? p.particle + 1 : p.particle - 1;
+				const style: Record<string, string | number> = {
+					...circle(size, {
+						background: "#16182a",
+						animation: `usketch-slam-splash ${durationMs}ms ease-out forwards`,
+					}),
+					"--tx": `${tx}px`,
+					"--ty": `${ty}px`,
+				};
+				return <div key={`spray-${deg}`} style={style as CSSProperties} />;
+			})}
+		</div>
+	);
+}
+
 /**
- * 配置アニメの transient 描画。カードのシルエット（角丸の発光枠）を着地位置に重ね、
- * 指定 keyframes で再生して fade out する。永続データ / Undo には触れない。
+ * 配置アニメの transient 描画。`slam` 系は衝撃エフェクト、それ以外はカードのシルエット
+ * （角丸の発光枠）を着地位置に重ね、指定 keyframes で再生して fade out する。
+ * いずれも永続データ / Undo には触れない。
  */
 export function PlacementEffect({ obj }: { obj: TransientObject }) {
+	if (obj.data.slam) return <SlamBurst obj={obj} />;
+
 	const width = (obj.data.width as number) ?? 120;
 	const height = (obj.data.height as number) ?? 168;
 	const name = (obj.data.name as string) ?? "usketch-card-drop";

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -151,19 +151,28 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					opts.placementAnimation,
 				);
 				if (!resolved) return;
+				const data: Record<string, unknown> =
+					resolved.kind === "slam"
+						? {
+								width: shape.width,
+								height: shape.height,
+								slam: resolved.weight,
+								durationMs: resolved.durationMs,
+							}
+						: {
+								width: shape.width,
+								height: shape.height,
+								name: resolved.name,
+								durationMs: resolved.durationMs,
+								easing: resolved.easing,
+								accent: GENERIC_ACCENT,
+							};
 				ctx.transient.emit({
 					id: generateId(),
 					type: PLACEMENT_TRANSIENT_TYPE,
 					sourceUserId: "local",
 					position: { x: shape.x + shape.width / 2, y: shape.y + shape.height / 2 },
-					data: {
-						width: shape.width,
-						height: shape.height,
-						name: resolved.name,
-						durationMs: resolved.durationMs,
-						easing: resolved.easing,
-						accent: GENERIC_ACCENT,
-					},
+					data,
 					ttl: resolved.durationMs,
 					createdAt: Date.now(),
 				});

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -111,7 +111,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 	let slamNonce = 0;
 	const getSlam = (id: string) => slamming.get(id);
 	const renderCard = createCardRenderer(registry, getSlam);
-	const renderDeck = createDeckRenderer(registry, getSlam);
+	const renderDeck = createDeckRenderer(registry);
 	const hasCardTypes = registry.size > 0;
 
 	// 既定の card-type（先頭。空なら ""）
@@ -149,7 +149,9 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 			});
 
 			function emitPlacement(shape: ShapeData) {
-				const meta = shape.type === DECK_TYPE ? readDeckMeta(shape) : readCardMeta(shape);
+				// デッキ（山札）は配置アニメ不要。
+				if (shape.type === DECK_TYPE) return;
+				const meta = readCardMeta(shape);
 				const def = meta.cardType ? registry.get(meta.cardType) : undefined;
 				const resolved = resolvePlacementAnimation(
 					def?.placementAnimation,

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -11,7 +11,7 @@ import {
 	withRotation,
 	zIndexAfterAll,
 } from "@edv4h/usketch-shared";
-import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { createAddShapeCommand, createUpdateShapeCommand } from "@edv4h/usketch-store";
 import { drawTop, shuffle } from "./deck.js";
 import {
 	CARD_TYPE,
@@ -195,7 +195,10 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				for (let i = sorted.length - 1; i >= 0; i--) {
 					const shape = sorted[i];
 					if (!isCardLike(shape.type)) continue;
-					if (rectHitTest(shape, point)) return shape;
+					// shape 登録側の hitTest（withRotation 込み）を使い、選択ツールと判定を一致させる
+					const def = ctx.shapes.get(shape.type);
+					const hit = def?.hitTest ? def.hitTest(shape, point) : rectHitTest(shape, point);
+					if (hit) return shape;
 				}
 				return null;
 			}
@@ -267,9 +270,21 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					const deck = ctx.store.getShape(id);
 					if (!deck || deck.type !== DECK_TYPE) continue;
 					const m = readDeckMeta(deck);
-					ctx.store.updateShape(id, {
-						meta: { ...m, cards: shuffle(m.cards ?? []) } as ShapeData["meta"],
-					});
+					const before: DeckMeta = {
+						cardType: m.cardType ?? "",
+						cards: m.cards ?? [],
+						faceDown: m.faceDown ?? true,
+					};
+					const after: DeckMeta = { ...before, cards: shuffle(before.cards) };
+					// Command 経由で更新し Undo/Redo 可能にする
+					ctx.commands.execute(
+						createUpdateShapeCommand(
+							ctx.store,
+							id,
+							{ meta: before } as Partial<ShapeData>,
+							{ meta: after } as Partial<ShapeData>,
+						),
+					);
 				}
 			}
 			const offShuffleShortcut = enableDeck

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -13,6 +13,13 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { drawTop, shuffle } from "./deck.js";
+import {
+	CARD_TYPE,
+	createBareCardShape,
+	createCardShape,
+	createDeckShape,
+	DECK_TYPE,
+} from "./factory.js";
 import { getBounds, makeAspectResize, rectHitTest } from "./geometry.js";
 import {
 	injectPlacementStyles,
@@ -31,8 +38,6 @@ import {
 	readDeckMeta,
 } from "./types.js";
 
-const CARD_TYPE = "card";
-const DECK_TYPE = "card-deck";
 const DOUBLE_CLICK_MS = 400;
 const GENERIC_ACCENT = "rgba(79, 140, 255, 0.9)";
 
@@ -213,17 +218,12 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				if (!fields) return;
 
 				const allZ = ctx.store.getShapesSorted().map((s) => s.zIndex);
-				const newCard: ShapeData = {
-					id: generateId(),
-					type: CARD_TYPE,
+				const newCard = createCardShape(def, {
 					x: deck.x + deck.width + 16,
 					y: deck.y,
-					width: def.defaultSize.width,
-					height: def.defaultSize.height,
-					style: { ...DEFAULT_STYLE },
+					fields,
 					zIndex: zIndexAfterAll(allZ),
-					meta: { cardType, isFlipped: false, fields } as ShapeData["meta"],
-				};
+				});
 
 				const deckBefore: DeckMeta = { cardType, cards, faceDown: meta.faceDown ?? true };
 				const deckAfter: DeckMeta = { cardType, cards: rest, faceDown: meta.faceDown ?? true };
@@ -284,20 +284,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				resize,
 				createDefault: ({ id, x, y }) => {
 					const def = resolveDef(currentCardType);
-					return {
-						id,
-						type: CARD_TYPE,
-						x,
-						y,
-						width: def?.defaultSize.width ?? 200,
-						height: def?.defaultSize.height ?? 280,
-						style: { ...DEFAULT_STYLE },
-						meta: {
-							cardType: def?.id ?? "",
-							isFlipped: false,
-							fields: def?.createDefaultFields() ?? {},
-						} as ShapeData["meta"],
-					};
+					return def ? createCardShape(def, { id, x, y }) : createBareCardShape({ id, x, y });
 				},
 				renderTarget: "html",
 				minSize: { width: 60, height: 60 },
@@ -331,22 +318,18 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
 						const def = resolveDef(currentCardType);
 						if (!def) return;
-						const id = generateId();
-						drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-						toolCtx.store.addShape({
-							id,
-							type: CARD_TYPE,
+						const draft = createCardShape(def, {
 							x: event.worldPoint.x,
 							y: event.worldPoint.y,
 							width: 0,
 							height: 0,
-							style: { ...DEFAULT_STYLE },
-							meta: {
-								cardType: def.id,
-								isFlipped: false,
-								fields: def.createDefaultFields(),
-							} as ShapeData["meta"],
 						});
+						drawState = {
+							startX: event.worldPoint.x,
+							startY: event.worldPoint.y,
+							shapeId: draft.id,
+						};
+						toolCtx.store.addShape(draft);
 					},
 					onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
 						if (!drawState) return;
@@ -371,20 +354,11 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 							emitPlacement(draft);
 						} else if (def) {
 							// クリック: 既定サイズで配置（クリック点を中心に）
-							const placed: ShapeData = {
+							const placed = createCardShape(def, {
 								id: drawState.shapeId,
-								type: CARD_TYPE,
 								x: drawState.startX - def.defaultSize.width / 2,
 								y: drawState.startY - def.defaultSize.height / 2,
-								width: def.defaultSize.width,
-								height: def.defaultSize.height,
-								style: { ...DEFAULT_STYLE },
-								meta: {
-									cardType: def.id,
-									isFlipped: false,
-									fields: def.createDefaultFields(),
-								} as ShapeData["meta"],
-							};
+							});
 							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, placed));
 							toolCtx.store.setSelection([placed.id]);
 							emitPlacement(placed);
@@ -403,20 +377,18 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					resize,
 					createDefault: ({ id, x, y }) => {
 						const def = resolveDef(currentCardType);
-						return {
-							id,
-							type: DECK_TYPE,
-							x,
-							y,
-							width: def?.defaultSize.width ?? 200,
-							height: def?.defaultSize.height ?? 280,
-							style: { ...DEFAULT_STYLE },
-							meta: {
-								cardType: def?.id ?? "",
-								cards: def?.buildDeck?.() ?? [],
-								faceDown: true,
-							} as ShapeData["meta"],
-						};
+						return def
+							? createDeckShape(def, { id, x, y })
+							: {
+									id,
+									type: DECK_TYPE,
+									x,
+									y,
+									width: 200,
+									height: 280,
+									style: { ...DEFAULT_STYLE },
+									meta: { cardType: "", cards: [], faceDown: true },
+								};
 					},
 					renderTarget: "html",
 					minSize: { width: 60, height: 60 },
@@ -438,23 +410,12 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 						onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
 							const def = resolveDef(currentCardType);
 							if (!def) return;
-							const id = generateId();
-							const deck: ShapeData = {
-								id,
-								type: DECK_TYPE,
+							const deck = createDeckShape(def, {
 								x: event.worldPoint.x - def.defaultSize.width / 2,
 								y: event.worldPoint.y - def.defaultSize.height / 2,
-								width: def.defaultSize.width,
-								height: def.defaultSize.height,
-								style: { ...DEFAULT_STYLE },
-								meta: {
-									cardType: def.id,
-									cards: def.buildDeck?.() ?? [],
-									faceDown: true,
-								} as ShapeData["meta"],
-							};
+							});
 							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, deck));
-							toolCtx.store.setSelection([id]);
+							toolCtx.store.setSelection([deck.id]);
 							emitPlacement(deck);
 							toolCtx.store.resetToDefaultTool();
 						},

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -1,0 +1,461 @@
+import {
+	type CanvasPointerEvent,
+	type Command,
+	DEFAULT_STYLE,
+	generateId,
+	type PluginContext,
+	type Point,
+	type ShapeData,
+	type ToolContext,
+	type UsketchPlugin,
+	withRotation,
+	zIndexAfterAll,
+} from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { drawTop, shuffle } from "./deck.js";
+import { getBounds, makeAspectResize, rectHitTest } from "./geometry.js";
+import {
+	injectPlacementStyles,
+	PLACEMENT_TRANSIENT_TYPE,
+	PlacementEffect,
+	resolvePlacementAnimation,
+} from "./placement.js";
+import { BUILTIN_CARD_TYPES, createCardTypeRegistry } from "./registry.js";
+import { createCardRenderer } from "./render-card.js";
+import { createDeckRenderer } from "./render-deck.js";
+import {
+	type CardTypeDefinition,
+	type DeckMeta,
+	type PlacementAnimation,
+	readCardMeta,
+	readDeckMeta,
+} from "./types.js";
+
+const CARD_TYPE = "card";
+const DECK_TYPE = "card-deck";
+const DOUBLE_CLICK_MS = 400;
+const GENERIC_ACCENT = "rgba(79, 140, 255, 0.9)";
+
+export interface CreateCardPluginOptions {
+	/** 組込に加えて使用する独自 card-type。 */
+	cardTypes?: CardTypeDefinition[];
+	/** 既定の配置アニメ（card-type 個別指定が優先される）。 */
+	placementAnimation?: PlacementAnimation;
+	/** デッキ機構を有効にするか。既定 true。 */
+	enableDeck?: boolean;
+}
+
+// ── icons ──
+
+function CardIcon() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20">
+			<title>Card</title>
+			<rect
+				x="5"
+				y="3"
+				width="10"
+				height="14"
+				rx="2"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.5"
+			/>
+			<line x1="7" y1="7" x2="13" y2="7" stroke="currentColor" strokeWidth="1.2" />
+		</svg>
+	);
+}
+
+function DeckIcon() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20">
+			<title>Deck</title>
+			<rect
+				x="4"
+				y="6"
+				width="9"
+				height="12"
+				rx="1.5"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.3"
+			/>
+			<rect
+				x="7"
+				y="3"
+				width="9"
+				height="12"
+				rx="1.5"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.3"
+			/>
+		</svg>
+	);
+}
+
+export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlugin {
+	const registry = createCardTypeRegistry(opts.cardTypes);
+	const enableDeck = opts.enableDeck ?? true;
+	const renderCard = createCardRenderer(registry);
+	const renderDeck = createDeckRenderer(registry);
+
+	// 既定の card-type（先頭の組込 or 追加分の先頭）
+	const firstType = (opts.cardTypes?.[0] ?? BUILTIN_CARD_TYPES[0]).id;
+
+	function getCardAspect(data: ShapeData): number {
+		const meta = data.type === DECK_TYPE ? readDeckMeta(data) : readCardMeta(data);
+		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+		return def?.aspectRatio ?? data.width / data.height;
+	}
+	const resize = makeAspectResize(getCardAspect);
+
+	return {
+		id: "usketch-plugin-shape-card",
+		name: "カード",
+
+		setup(ctx: PluginContext) {
+			injectPlacementStyles();
+
+			let currentCardType = firstType;
+
+			// ── card-type 切替（ツールバーのピッカーから） ──
+			const offSelectType = ctx.events.on<{ id: string }>("card:select-type", (data) => {
+				if (registry.has(data.id)) currentCardType = data.id;
+			});
+
+			// ── 配置アニメーション（transient） ──
+			ctx.transient.registerType(PLACEMENT_TRANSIENT_TYPE, {
+				render: (obj) => <PlacementEffect obj={obj} />,
+			});
+
+			function emitPlacement(shape: ShapeData) {
+				const meta = shape.type === DECK_TYPE ? readDeckMeta(shape) : readCardMeta(shape);
+				const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+				const resolved = resolvePlacementAnimation(
+					def?.placementAnimation,
+					opts.placementAnimation,
+				);
+				if (!resolved) return;
+				ctx.transient.emit({
+					id: generateId(),
+					type: PLACEMENT_TRANSIENT_TYPE,
+					sourceUserId: "local",
+					position: { x: shape.x + shape.width / 2, y: shape.y + shape.height / 2 },
+					data: {
+						width: shape.width,
+						height: shape.height,
+						name: resolved.name,
+						durationMs: resolved.durationMs,
+						easing: resolved.easing,
+						accent: GENERIC_ACCENT,
+					},
+					ttl: resolved.durationMs,
+					createdAt: Date.now(),
+				});
+			}
+
+			function isCardLike(type: string): boolean {
+				return type === CARD_TYPE || (enableDeck && type === DECK_TYPE);
+			}
+
+			// 新規配置時のアニメは描画ツール / デッキ操作の確定点で明示的に emit する
+			// （shape:added を購読すると、保存済みボードのロード時に全カードが一斉に
+			// アニメしてしまうため、対話的な配置だけに絞る）。
+
+			// 移動後: shapes:move-end
+			const offMoveEnd = ctx.events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
+				if (!data?.shapeIds) return;
+				for (const id of data.shapeIds) {
+					const shape = ctx.store.getShape(id);
+					if (shape && isCardLike(shape.type)) emitPlacement(shape);
+				}
+			});
+
+			// ── flip / deck-draw インタラクション（ダブルクリック検出） ──
+			let lastClickTime = 0;
+			let lastClickId: string | null = null;
+
+			function topHitAt(point: Point): ShapeData | null {
+				const sorted = ctx.store.getShapesSorted();
+				for (let i = sorted.length - 1; i >= 0; i--) {
+					const shape = sorted[i];
+					if (!isCardLike(shape.type)) continue;
+					if (rectHitTest(shape, point)) return shape;
+				}
+				return null;
+			}
+
+			function flipCard(shape: ShapeData) {
+				const m = readCardMeta(shape);
+				// view 状態なので command 履歴には積まない（sticky の isEditing と同様）
+				ctx.store.updateShape(shape.id, {
+					meta: { ...m, isFlipped: !(m.isFlipped ?? false) } as ShapeData["meta"],
+				});
+			}
+
+			function drawFromDeck(deck: ShapeData) {
+				const meta = readDeckMeta(deck);
+				const cardType = meta.cardType;
+				const def = cardType ? registry.get(cardType) : undefined;
+				if (!def || !cardType) return;
+				const cards = meta.cards ?? [];
+				const { card: fields, rest } = drawTop(cards);
+				if (!fields) return;
+
+				const allZ = ctx.store.getShapesSorted().map((s) => s.zIndex);
+				const newCard: ShapeData = {
+					id: generateId(),
+					type: CARD_TYPE,
+					x: deck.x + deck.width + 16,
+					y: deck.y,
+					width: def.defaultSize.width,
+					height: def.defaultSize.height,
+					style: { ...DEFAULT_STYLE },
+					zIndex: zIndexAfterAll(allZ),
+					meta: { cardType, isFlipped: false, fields } as ShapeData["meta"],
+				};
+
+				const deckBefore: DeckMeta = { cardType, cards, faceDown: meta.faceDown ?? true };
+				const deckAfter: DeckMeta = { cardType, cards: rest, faceDown: meta.faceDown ?? true };
+
+				const command: Command = {
+					execute() {
+						ctx.store.updateShape(deck.id, { meta: deckAfter as ShapeData["meta"] });
+						ctx.store.addShape(newCard);
+					},
+					undo() {
+						ctx.store.deleteShape(newCard.id);
+						ctx.store.updateShape(deck.id, { meta: deckBefore as ShapeData["meta"] });
+					},
+				};
+				ctx.commands.execute(command);
+				ctx.store.setSelection([newCard.id]);
+				emitPlacement(newCard);
+			}
+
+			const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+				const hit = topHitAt(event.worldPoint);
+				const now = Date.now();
+				if (hit && now - lastClickTime < DOUBLE_CLICK_MS && lastClickId === hit.id) {
+					if (hit.type === CARD_TYPE) flipCard(hit);
+					else if (enableDeck && hit.type === DECK_TYPE) drawFromDeck(hit);
+					lastClickTime = 0;
+					lastClickId = null;
+					return;
+				}
+				lastClickTime = now;
+				lastClickId = hit?.id ?? null;
+			});
+
+			// ── シャッフル（選択中のデッキを Shift+S） ──
+			const offShuffleEvent = ctx.events.on<{ id?: string }>("card-deck:shuffle", (data) => {
+				const ids = data?.id ? [data.id] : [...ctx.store.getSelection()];
+				shuffleDecks(ids);
+			});
+			function shuffleDecks(ids: string[]) {
+				for (const id of ids) {
+					const deck = ctx.store.getShape(id);
+					if (!deck || deck.type !== DECK_TYPE) continue;
+					const m = readDeckMeta(deck);
+					ctx.store.updateShape(id, {
+						meta: { ...m, cards: shuffle(m.cards ?? []) } as ShapeData["meta"],
+					});
+				}
+			}
+			const offShuffleShortcut = enableDeck
+				? ctx.shortcuts.register("Shift+S", () => shuffleDecks([...ctx.store.getSelection()]))
+				: undefined;
+
+			// ── shape 登録: card ──
+			ctx.shapes.register(CARD_TYPE, {
+				render: renderCard,
+				getBounds,
+				hitTest: withRotation(rectHitTest),
+				resize,
+				createDefault: ({ id, x, y }) => {
+					const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
+					return {
+						id,
+						type: CARD_TYPE,
+						x,
+						y,
+						width: def.defaultSize.width,
+						height: def.defaultSize.height,
+						style: { ...DEFAULT_STYLE },
+						meta: {
+							cardType: def.id,
+							isFlipped: false,
+							fields: def.createDefaultFields(),
+						} as ShapeData["meta"],
+					};
+				},
+				renderTarget: "html",
+				minSize: { width: 60, height: 60 },
+				serializeForAi: (shape) => {
+					const m = readCardMeta(shape);
+					const f = (m.fields ?? {}) as Record<string, unknown>;
+					const text = [f.title, f.body, f.rank, f.suit, f.value]
+						.filter((v) => typeof v === "string" && v)
+						.join(" ");
+					return { cardType: m.cardType ?? "", text, isFlipped: m.isFlipped ?? false };
+				},
+				debugFields: (shape) => {
+					const m = readCardMeta(shape);
+					return {
+						cardType: m.cardType ?? "",
+						isFlipped: m.isFlipped ?? false,
+						fields: m.fields ?? {},
+					};
+				},
+			});
+
+			// ── 描画ツール: card-draw ──
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+
+			ctx.tools.register("card-draw", {
+				icon: CardIcon,
+				cursor: "crosshair",
+				shortcut: "k",
+				order: 27,
+				onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
+					const id = generateId();
+					drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+					toolCtx.store.addShape({
+						id,
+						type: CARD_TYPE,
+						x: event.worldPoint.x,
+						y: event.worldPoint.y,
+						width: 0,
+						height: 0,
+						style: { ...DEFAULT_STYLE },
+						meta: {
+							cardType: def.id,
+							isFlipped: false,
+							fields: def.createDefaultFields(),
+						} as ShapeData["meta"],
+					});
+				},
+				onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					if (!drawState) return;
+					const aspect = (registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0]).aspectRatio;
+					const dx = event.worldPoint.x - drawState.startX;
+					const dy = event.worldPoint.y - drawState.startY;
+					const width = Math.abs(dx);
+					const height = width / aspect;
+					const x = dx >= 0 ? drawState.startX : drawState.startX - width;
+					const y = dy >= 0 ? drawState.startY : drawState.startY - height;
+					toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+				},
+				onPointerUp(toolCtx: ToolContext) {
+					if (!drawState) return;
+					const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
+					const draft = toolCtx.store.getShape(drawState.shapeId);
+					toolCtx.store.deleteShape(drawState.shapeId);
+
+					if (draft && draft.width > 2 && draft.height > 2) {
+						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, draft));
+						toolCtx.store.setSelection([draft.id]);
+						emitPlacement(draft);
+					} else {
+						// クリック: 既定サイズで配置（クリック点を中心に）
+						const placed: ShapeData = {
+							id: drawState.shapeId,
+							type: CARD_TYPE,
+							x: drawState.startX - def.defaultSize.width / 2,
+							y: drawState.startY - def.defaultSize.height / 2,
+							width: def.defaultSize.width,
+							height: def.defaultSize.height,
+							style: { ...DEFAULT_STYLE },
+							meta: {
+								cardType: def.id,
+								isFlipped: false,
+								fields: def.createDefaultFields(),
+							} as ShapeData["meta"],
+						};
+						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, placed));
+						toolCtx.store.setSelection([placed.id]);
+						emitPlacement(placed);
+					}
+					drawState = null;
+					toolCtx.store.resetToDefaultTool();
+				},
+			});
+
+			// ── shape 登録 + ツール: deck ──
+			if (enableDeck) {
+				ctx.shapes.register(DECK_TYPE, {
+					render: renderDeck,
+					getBounds,
+					hitTest: withRotation(rectHitTest),
+					resize,
+					createDefault: ({ id, x, y }) => {
+						const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
+						return {
+							id,
+							type: DECK_TYPE,
+							x,
+							y,
+							width: def.defaultSize.width,
+							height: def.defaultSize.height,
+							style: { ...DEFAULT_STYLE },
+							meta: {
+								cardType: def.id,
+								cards: def.buildDeck?.() ?? [],
+								faceDown: true,
+							} as ShapeData["meta"],
+						};
+					},
+					renderTarget: "html",
+					minSize: { width: 60, height: 60 },
+					debugFields: (shape) => {
+						const m = readDeckMeta(shape);
+						return {
+							cardType: m.cardType ?? "",
+							count: (m.cards ?? []).length,
+							faceDown: m.faceDown ?? true,
+						};
+					},
+				});
+
+				ctx.tools.register("card-deck-draw", {
+					icon: DeckIcon,
+					cursor: "crosshair",
+					order: 28,
+					onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+						const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
+						const id = generateId();
+						const deck: ShapeData = {
+							id,
+							type: DECK_TYPE,
+							x: event.worldPoint.x - def.defaultSize.width / 2,
+							y: event.worldPoint.y - def.defaultSize.height / 2,
+							width: def.defaultSize.width,
+							height: def.defaultSize.height,
+							style: { ...DEFAULT_STYLE },
+							meta: {
+								cardType: def.id,
+								cards: def.buildDeck?.() ?? [],
+								faceDown: true,
+							} as ShapeData["meta"],
+						};
+						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, deck));
+						toolCtx.store.setSelection([id]);
+						emitPlacement(deck);
+						toolCtx.store.resetToDefaultTool();
+					},
+				});
+			}
+
+			// ── teardown ──
+			return () => {
+				offSelectType();
+				offMoveEnd();
+				offPointerDown();
+				offShuffleEvent();
+				offShuffleShortcut?.();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -26,6 +26,7 @@ import {
 	PLACEMENT_TRANSIENT_TYPE,
 	PlacementEffect,
 	resolvePlacementAnimation,
+	type SlamPlay,
 } from "./placement.js";
 import { createCardTypeRegistry } from "./registry.js";
 import { createCardRenderer } from "./render-card.js";
@@ -105,8 +106,12 @@ function DeckIcon() {
 export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlugin {
 	const registry = createCardTypeRegistry(opts.cardTypes);
 	const enableDeck = opts.enableDeck ?? true;
-	const renderCard = createCardRenderer(registry);
-	const renderDeck = createDeckRenderer(registry);
+	// slam 中の実カード（card/deck）を持ち上げ→着地アニメさせるための再生状態。
+	const slamming = new Map<string, SlamPlay>();
+	let slamNonce = 0;
+	const getSlam = (id: string) => slamming.get(id);
+	const renderCard = createCardRenderer(registry, getSlam);
+	const renderDeck = createDeckRenderer(registry, getSlam);
 	const hasCardTypes = registry.size > 0;
 
 	// 既定の card-type（先頭。空なら ""）
@@ -176,6 +181,20 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					ttl: resolved.durationMs,
 					createdAt: Date.now(),
 				});
+
+				// slam は実カード自身を持ち上げ→着地アニメさせる。
+				// render が getSlam を参照するので、状態をセットしてから再レンダを促す。
+				if (resolved.kind === "slam") {
+					slamNonce += 1;
+					slamming.set(shape.id, {
+						weight: resolved.weight,
+						durationMs: resolved.durationMs,
+						nonce: slamNonce,
+					});
+					// 移動後（既にレンダ済み）でも再生されるよう、無害な更新で再レンダを発火。
+					ctx.store.updateShape(shape.id, {});
+					setTimeout(() => slamming.delete(shape.id), resolved.durationMs + 200);
+				}
 			}
 
 			function isCardLike(type: string): boolean {

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -20,7 +20,7 @@ import {
 	PlacementEffect,
 	resolvePlacementAnimation,
 } from "./placement.js";
-import { BUILTIN_CARD_TYPES, createCardTypeRegistry } from "./registry.js";
+import { createCardTypeRegistry } from "./registry.js";
 import { createCardRenderer } from "./render-card.js";
 import { createDeckRenderer } from "./render-deck.js";
 import {
@@ -37,7 +37,10 @@ const DOUBLE_CLICK_MS = 400;
 const GENERIC_ACCENT = "rgba(79, 140, 255, 0.9)";
 
 export interface CreateCardPluginOptions {
-	/** 組込に加えて使用する独自 card-type。 */
+	/**
+	 * 使用する card-type。**既定は空**で、空でもプラグインは生成できる（描画ツールは出ない）。
+	 * トランプ等のサンプルを使うには `EXAMPLE_CARD_TYPES` を渡す。
+	 */
 	cardTypes?: CardTypeDefinition[];
 	/** 既定の配置アニメ（card-type 個別指定が優先される）。 */
 	placementAnimation?: PlacementAnimation;
@@ -99,9 +102,15 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 	const enableDeck = opts.enableDeck ?? true;
 	const renderCard = createCardRenderer(registry);
 	const renderDeck = createDeckRenderer(registry);
+	const hasCardTypes = registry.size > 0;
 
-	// 既定の card-type（先頭の組込 or 追加分の先頭）
-	const firstType = (opts.cardTypes?.[0] ?? BUILTIN_CARD_TYPES[0]).id;
+	// 既定の card-type（先頭。空なら ""）
+	const firstType = opts.cardTypes?.[0]?.id ?? "";
+
+	/** 現在の card-type を解決。無ければ登録順の先頭にフォールバック（空なら undefined）。 */
+	function resolveDef(id: string): CardTypeDefinition | undefined {
+		return registry.get(id) ?? registry.values().next().value;
+	}
 
 	function getCardAspect(data: ShapeData): number {
 		const meta = data.type === DECK_TYPE ? readDeckMeta(data) : readCardMeta(data);
@@ -274,19 +283,19 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				hitTest: withRotation(rectHitTest),
 				resize,
 				createDefault: ({ id, x, y }) => {
-					const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
+					const def = resolveDef(currentCardType);
 					return {
 						id,
 						type: CARD_TYPE,
 						x,
 						y,
-						width: def.defaultSize.width,
-						height: def.defaultSize.height,
+						width: def?.defaultSize.width ?? 200,
+						height: def?.defaultSize.height ?? 280,
 						style: { ...DEFAULT_STYLE },
 						meta: {
-							cardType: def.id,
+							cardType: def?.id ?? "",
 							isFlipped: false,
-							fields: def.createDefaultFields(),
+							fields: def?.createDefaultFields() ?? {},
 						} as ShapeData["meta"],
 					};
 				},
@@ -310,80 +319,82 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				},
 			});
 
-			// ── 描画ツール: card-draw ──
+			// ── 描画ツール: card-draw（card-type が1つ以上ある時だけ登録） ──
 			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
 
-			ctx.tools.register("card-draw", {
-				icon: CardIcon,
-				cursor: "crosshair",
-				shortcut: "k",
-				order: 27,
-				onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-					const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
-					const id = generateId();
-					drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-					toolCtx.store.addShape({
-						id,
-						type: CARD_TYPE,
-						x: event.worldPoint.x,
-						y: event.worldPoint.y,
-						width: 0,
-						height: 0,
-						style: { ...DEFAULT_STYLE },
-						meta: {
-							cardType: def.id,
-							isFlipped: false,
-							fields: def.createDefaultFields(),
-						} as ShapeData["meta"],
-					});
-				},
-				onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
-					if (!drawState) return;
-					const aspect = (registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0]).aspectRatio;
-					const dx = event.worldPoint.x - drawState.startX;
-					const dy = event.worldPoint.y - drawState.startY;
-					const width = Math.abs(dx);
-					const height = width / aspect;
-					const x = dx >= 0 ? drawState.startX : drawState.startX - width;
-					const y = dy >= 0 ? drawState.startY : drawState.startY - height;
-					toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
-				},
-				onPointerUp(toolCtx: ToolContext) {
-					if (!drawState) return;
-					const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
-					const draft = toolCtx.store.getShape(drawState.shapeId);
-					toolCtx.store.deleteShape(drawState.shapeId);
-
-					if (draft && draft.width > 2 && draft.height > 2) {
-						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, draft));
-						toolCtx.store.setSelection([draft.id]);
-						emitPlacement(draft);
-					} else {
-						// クリック: 既定サイズで配置（クリック点を中心に）
-						const placed: ShapeData = {
-							id: drawState.shapeId,
+			if (hasCardTypes)
+				ctx.tools.register("card-draw", {
+					icon: CardIcon,
+					cursor: "crosshair",
+					shortcut: "k",
+					order: 27,
+					onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+						const def = resolveDef(currentCardType);
+						if (!def) return;
+						const id = generateId();
+						drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+						toolCtx.store.addShape({
+							id,
 							type: CARD_TYPE,
-							x: drawState.startX - def.defaultSize.width / 2,
-							y: drawState.startY - def.defaultSize.height / 2,
-							width: def.defaultSize.width,
-							height: def.defaultSize.height,
+							x: event.worldPoint.x,
+							y: event.worldPoint.y,
+							width: 0,
+							height: 0,
 							style: { ...DEFAULT_STYLE },
 							meta: {
 								cardType: def.id,
 								isFlipped: false,
 								fields: def.createDefaultFields(),
 							} as ShapeData["meta"],
-						};
-						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, placed));
-						toolCtx.store.setSelection([placed.id]);
-						emitPlacement(placed);
-					}
-					drawState = null;
-					toolCtx.store.resetToDefaultTool();
-				},
-			});
+						});
+					},
+					onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+						if (!drawState) return;
+						const aspect = resolveDef(currentCardType)?.aspectRatio ?? 1;
+						const dx = event.worldPoint.x - drawState.startX;
+						const dy = event.worldPoint.y - drawState.startY;
+						const width = Math.abs(dx);
+						const height = width / aspect;
+						const x = dx >= 0 ? drawState.startX : drawState.startX - width;
+						const y = dy >= 0 ? drawState.startY : drawState.startY - height;
+						toolCtx.store.updateShape(drawState.shapeId, { x, y, width, height });
+					},
+					onPointerUp(toolCtx: ToolContext) {
+						if (!drawState) return;
+						const def = resolveDef(currentCardType);
+						const draft = toolCtx.store.getShape(drawState.shapeId);
+						toolCtx.store.deleteShape(drawState.shapeId);
 
-			// ── shape 登録 + ツール: deck ──
+						if (draft && draft.width > 2 && draft.height > 2) {
+							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, draft));
+							toolCtx.store.setSelection([draft.id]);
+							emitPlacement(draft);
+						} else if (def) {
+							// クリック: 既定サイズで配置（クリック点を中心に）
+							const placed: ShapeData = {
+								id: drawState.shapeId,
+								type: CARD_TYPE,
+								x: drawState.startX - def.defaultSize.width / 2,
+								y: drawState.startY - def.defaultSize.height / 2,
+								width: def.defaultSize.width,
+								height: def.defaultSize.height,
+								style: { ...DEFAULT_STYLE },
+								meta: {
+									cardType: def.id,
+									isFlipped: false,
+									fields: def.createDefaultFields(),
+								} as ShapeData["meta"],
+							};
+							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, placed));
+							toolCtx.store.setSelection([placed.id]);
+							emitPlacement(placed);
+						}
+						drawState = null;
+						toolCtx.store.resetToDefaultTool();
+					},
+				});
+
+			// ── shape 登録 + ツール: deck（card-type がある時だけツールを出す） ──
 			if (enableDeck) {
 				ctx.shapes.register(DECK_TYPE, {
 					render: renderDeck,
@@ -391,18 +402,18 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					hitTest: withRotation(rectHitTest),
 					resize,
 					createDefault: ({ id, x, y }) => {
-						const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
+						const def = resolveDef(currentCardType);
 						return {
 							id,
 							type: DECK_TYPE,
 							x,
 							y,
-							width: def.defaultSize.width,
-							height: def.defaultSize.height,
+							width: def?.defaultSize.width ?? 200,
+							height: def?.defaultSize.height ?? 280,
 							style: { ...DEFAULT_STYLE },
 							meta: {
-								cardType: def.id,
-								cards: def.buildDeck?.() ?? [],
+								cardType: def?.id ?? "",
+								cards: def?.buildDeck?.() ?? [],
 								faceDown: true,
 							} as ShapeData["meta"],
 						};
@@ -419,33 +430,35 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					},
 				});
 
-				ctx.tools.register("card-deck-draw", {
-					icon: DeckIcon,
-					cursor: "crosshair",
-					order: 28,
-					onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
-						const def = registry.get(currentCardType) ?? BUILTIN_CARD_TYPES[0];
-						const id = generateId();
-						const deck: ShapeData = {
-							id,
-							type: DECK_TYPE,
-							x: event.worldPoint.x - def.defaultSize.width / 2,
-							y: event.worldPoint.y - def.defaultSize.height / 2,
-							width: def.defaultSize.width,
-							height: def.defaultSize.height,
-							style: { ...DEFAULT_STYLE },
-							meta: {
-								cardType: def.id,
-								cards: def.buildDeck?.() ?? [],
-								faceDown: true,
-							} as ShapeData["meta"],
-						};
-						toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, deck));
-						toolCtx.store.setSelection([id]);
-						emitPlacement(deck);
-						toolCtx.store.resetToDefaultTool();
-					},
-				});
+				if (hasCardTypes)
+					ctx.tools.register("card-deck-draw", {
+						icon: DeckIcon,
+						cursor: "crosshair",
+						order: 28,
+						onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+							const def = resolveDef(currentCardType);
+							if (!def) return;
+							const id = generateId();
+							const deck: ShapeData = {
+								id,
+								type: DECK_TYPE,
+								x: event.worldPoint.x - def.defaultSize.width / 2,
+								y: event.worldPoint.y - def.defaultSize.height / 2,
+								width: def.defaultSize.width,
+								height: def.defaultSize.height,
+								style: { ...DEFAULT_STYLE },
+								meta: {
+									cardType: def.id,
+									cards: def.buildDeck?.() ?? [],
+									faceDown: true,
+								} as ShapeData["meta"],
+							};
+							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, deck));
+							toolCtx.store.setSelection([id]);
+							emitPlacement(deck);
+							toolCtx.store.resetToDefaultTool();
+						},
+					});
 			}
 
 			// ── teardown ──

--- a/plugins/usketch-plugin-shape-card/src/registry.tsx
+++ b/plugins/usketch-plugin-shape-card/src/registry.tsx
@@ -1,3 +1,4 @@
+import { customCardType } from "./card-types/custom.js";
 import { mediaCardType } from "./card-types/media.js";
 import { playingCardType } from "./card-types/playing-card.js";
 import { unoCardType } from "./card-types/uno.js";
@@ -8,6 +9,7 @@ export const BUILTIN_CARD_TYPES: CardTypeDefinition[] = [
 	mediaCardType,
 	playingCardType,
 	unoCardType,
+	customCardType,
 ];
 
 /**

--- a/plugins/usketch-plugin-shape-card/src/registry.tsx
+++ b/plugins/usketch-plugin-shape-card/src/registry.tsx
@@ -4,8 +4,12 @@ import { playingCardType } from "./card-types/playing-card.js";
 import { unoCardType } from "./card-types/uno.js";
 import type { CardTypeDefinition } from "./types.js";
 
-/** 組込 card-type。拡張の手本でもある。 */
-export const BUILTIN_CARD_TYPES: CardTypeDefinition[] = [
+/**
+ * 同梱のサンプル card-type。**既定では登録されない**（`createCardPlugin()` は空で動く）。
+ * 使いたい場合は明示的に渡す: `createCardPlugin({ cardTypes: EXAMPLE_CARD_TYPES })`。
+ * 独自 card-type を作る際の手本でもある。
+ */
+export const EXAMPLE_CARD_TYPES: CardTypeDefinition[] = [
 	mediaCardType,
 	playingCardType,
 	unoCardType,
@@ -13,17 +17,15 @@ export const BUILTIN_CARD_TYPES: CardTypeDefinition[] = [
 ];
 
 /**
- * 組込 + 追加 card-type をマージした `Map<id, def>` を返す。
- * id が衝突した場合は追加（extra）側で上書きする。
+ * 渡された card-type 群から `Map<id, def>` を作る。組込は自動では含めない
+ * （サンプルが必要なら呼び出し側で `EXAMPLE_CARD_TYPES` を渡す）。
+ * id が衝突した場合は後勝ち。
  */
 export function createCardTypeRegistry(
-	extra: CardTypeDefinition[] = [],
+	cardTypes: CardTypeDefinition[] = [],
 ): Map<string, CardTypeDefinition> {
 	const map = new Map<string, CardTypeDefinition>();
-	for (const def of BUILTIN_CARD_TYPES) {
-		map.set(def.id, def);
-	}
-	for (const def of extra) {
+	for (const def of cardTypes) {
 		map.set(def.id, def);
 	}
 	return map;

--- a/plugins/usketch-plugin-shape-card/src/registry.tsx
+++ b/plugins/usketch-plugin-shape-card/src/registry.tsx
@@ -1,0 +1,28 @@
+import { mediaCardType } from "./card-types/media.js";
+import { playingCardType } from "./card-types/playing-card.js";
+import { unoCardType } from "./card-types/uno.js";
+import type { CardTypeDefinition } from "./types.js";
+
+/** 組込 card-type。拡張の手本でもある。 */
+export const BUILTIN_CARD_TYPES: CardTypeDefinition[] = [
+	mediaCardType,
+	playingCardType,
+	unoCardType,
+];
+
+/**
+ * 組込 + 追加 card-type をマージした `Map<id, def>` を返す。
+ * id が衝突した場合は追加（extra）側で上書きする。
+ */
+export function createCardTypeRegistry(
+	extra: CardTypeDefinition[] = [],
+): Map<string, CardTypeDefinition> {
+	const map = new Map<string, CardTypeDefinition>();
+	for (const def of BUILTIN_CARD_TYPES) {
+		map.set(def.id, def);
+	}
+	for (const def of extra) {
+		map.set(def.id, def);
+	}
+	return map;
+}

--- a/plugins/usketch-plugin-shape-card/src/render-card.tsx
+++ b/plugins/usketch-plugin-shape-card/src/render-card.tsx
@@ -1,0 +1,94 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import type { CSSProperties } from "react";
+import { type CardTypeDefinition, readCardMeta } from "./types.js";
+
+const FLIP_MS = 400;
+
+const faceStyle: CSSProperties = {
+	position: "absolute",
+	inset: 0,
+	borderRadius: 10,
+	overflow: "hidden",
+	boxShadow: "0 2px 8px rgba(0,0,0,0.18)",
+	background: "#fff",
+	// 3D flip 用: 裏返ったときに背面を隠す
+	backfaceVisibility: "hidden",
+	WebkitBackfaceVisibility: "hidden",
+};
+
+function UnknownCard({ cardType }: { cardType?: string }) {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				borderRadius: 10,
+				border: "1px dashed #aaa",
+				color: "#888",
+				fontSize: 12,
+				fontFamily: "system-ui, sans-serif",
+				background: "#f5f5f5",
+				boxSizing: "border-box",
+				padding: 8,
+				textAlign: "center",
+			}}
+		>
+			unknown card-type:
+			<br />
+			{cardType ?? "(none)"}
+		</div>
+	);
+}
+
+/**
+ * card shape の render を生成する。card-type レジストリを引いて front/back を描画し、
+ * `isFlipped` に応じて Y 軸 3D フリップする。
+ */
+export function createCardRenderer(registry: Map<string, CardTypeDefinition>) {
+	return function renderCard(shape: ShapeData) {
+		const meta = readCardMeta(shape);
+		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+		const opacity = shape.style?.opacity ?? 1;
+
+		if (!def) {
+			return (
+				<div style={{ width: "100%", height: "100%", opacity, pointerEvents: "none" }}>
+					<UnknownCard cardType={meta.cardType} />
+				</div>
+			);
+		}
+
+		const fields = meta.fields ?? def.createDefaultFields();
+		const flipped = meta.isFlipped ?? false;
+
+		return (
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					perspective: 1000,
+					opacity,
+					pointerEvents: "none",
+					userSelect: "none",
+				}}
+			>
+				<div
+					style={{
+						position: "relative",
+						width: "100%",
+						height: "100%",
+						transformStyle: "preserve-3d",
+						transition: `transform ${FLIP_MS}ms`,
+						transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
+					}}
+				>
+					<div style={faceStyle}>{def.renderFront(fields)}</div>
+					<div style={{ ...faceStyle, transform: "rotateY(180deg)" }}>{def.renderBack(fields)}</div>
+				</div>
+			</div>
+		);
+	};
+}

--- a/plugins/usketch-plugin-shape-card/src/render-card.tsx
+++ b/plugins/usketch-plugin-shape-card/src/render-card.tsx
@@ -1,5 +1,6 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import type { CSSProperties } from "react";
+import { type SlamPlay, slamWrapper } from "./placement.js";
 import { type CardTypeDefinition, readCardMeta } from "./types.js";
 
 const FLIP_MS = 400;
@@ -47,7 +48,10 @@ function UnknownCard({ cardType }: { cardType?: string }) {
  * card shape の render を生成する。card-type レジストリを引いて front/back を描画し、
  * `isFlipped` に応じて Y 軸 3D フリップする。
  */
-export function createCardRenderer(registry: Map<string, CardTypeDefinition>) {
+export function createCardRenderer(
+	registry: Map<string, CardTypeDefinition>,
+	getSlam?: (shapeId: string) => SlamPlay | undefined,
+) {
 	return function renderCard(shape: ShapeData) {
 		const meta = readCardMeta(shape);
 		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
@@ -63,6 +67,8 @@ export function createCardRenderer(registry: Map<string, CardTypeDefinition>) {
 
 		const fields = meta.fields ?? def.createDefaultFields();
 		const flipped = meta.isFlipped ?? false;
+		// slam 中は実カード自身を持ち上げ→着地アニメさせる（二重描画なし）。
+		const sw = slamWrapper(getSlam?.(shape.id));
 
 		return (
 			<div
@@ -75,18 +81,22 @@ export function createCardRenderer(registry: Map<string, CardTypeDefinition>) {
 					userSelect: "none",
 				}}
 			>
-				<div
-					style={{
-						position: "relative",
-						width: "100%",
-						height: "100%",
-						transformStyle: "preserve-3d",
-						transition: `transform ${FLIP_MS}ms`,
-						transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
-					}}
-				>
-					<div style={faceStyle}>{def.renderFront(fields)}</div>
-					<div style={{ ...faceStyle, transform: "rotateY(180deg)" }}>{def.renderBack(fields)}</div>
+				<div key={sw.key} style={sw.style}>
+					<div
+						style={{
+							position: "relative",
+							width: "100%",
+							height: "100%",
+							transformStyle: "preserve-3d",
+							transition: `transform ${FLIP_MS}ms`,
+							transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
+						}}
+					>
+						<div style={faceStyle}>{def.renderFront(fields)}</div>
+						<div style={{ ...faceStyle, transform: "rotateY(180deg)" }}>
+							{def.renderBack(fields)}
+						</div>
+					</div>
 				</div>
 			</div>
 		);

--- a/plugins/usketch-plugin-shape-card/src/render-card.tsx
+++ b/plugins/usketch-plugin-shape-card/src/render-card.tsx
@@ -38,7 +38,7 @@ function UnknownCard({ cardType }: { cardType?: string }) {
 		>
 			unknown card-type:
 			<br />
-			{cardType ?? "(none)"}
+			{cardType || "(none)"}
 		</div>
 	);
 }

--- a/plugins/usketch-plugin-shape-card/src/render-deck.tsx
+++ b/plugins/usketch-plugin-shape-card/src/render-deck.tsx
@@ -1,5 +1,4 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
-import { type SlamPlay, slamWrapper } from "./placement.js";
 import { type CardTypeDefinition, readDeckMeta } from "./types.js";
 
 /** 山札の厚みを表現する後背レイヤーの最大枚数。 */
@@ -10,10 +9,7 @@ const LAYER_OFFSET = 3;
  * card-deck shape の render を生成する。card-type を引いて山札の見た目（積み重ね +
  * 一番上のカード + 残枚数バッジ）を描画する。
  */
-export function createDeckRenderer(
-	registry: Map<string, CardTypeDefinition>,
-	getSlam?: (shapeId: string) => SlamPlay | undefined,
-) {
+export function createDeckRenderer(registry: Map<string, CardTypeDefinition>) {
 	return function renderDeck(shape: ShapeData) {
 		const meta = readDeckMeta(shape);
 		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
@@ -29,11 +25,8 @@ export function createDeckRenderer(
 			return meta.faceDown ? def.renderBack(top) : def.renderFront(top);
 		})();
 
-		const sw = slamWrapper(getSlam?.(shape.id));
-
 		return (
 			<div
-				key={sw.key}
 				style={{
 					position: "relative",
 					width: "100%",
@@ -41,7 +34,6 @@ export function createDeckRenderer(
 					opacity,
 					pointerEvents: "none",
 					userSelect: "none",
-					...sw.style,
 				}}
 			>
 				{/* 厚み表現: 後ろにずらした空レイヤー */}

--- a/plugins/usketch-plugin-shape-card/src/render-deck.tsx
+++ b/plugins/usketch-plugin-shape-card/src/render-deck.tsx
@@ -1,0 +1,120 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { type CardTypeDefinition, readDeckMeta } from "./types.js";
+
+/** 山札の厚みを表現する後背レイヤーの最大枚数。 */
+const MAX_STACK_LAYERS = 4;
+const LAYER_OFFSET = 3;
+
+/**
+ * card-deck shape の render を生成する。card-type を引いて山札の見た目（積み重ね +
+ * 一番上のカード + 残枚数バッジ）を描画する。
+ */
+export function createDeckRenderer(registry: Map<string, CardTypeDefinition>) {
+	return function renderDeck(shape: ShapeData) {
+		const meta = readDeckMeta(shape);
+		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+		const cards = meta.cards ?? [];
+		const count = cards.length;
+		const opacity = shape.style?.opacity ?? 1;
+
+		const layers = Math.min(MAX_STACK_LAYERS, Math.max(0, count - 1));
+
+		const topFace = (() => {
+			if (!def || count === 0) return null;
+			const top = cards[0] as Record<string, unknown>;
+			return meta.faceDown ? def.renderBack(top) : def.renderFront(top);
+		})();
+
+		return (
+			<div
+				style={{
+					position: "relative",
+					width: "100%",
+					height: "100%",
+					opacity,
+					pointerEvents: "none",
+					userSelect: "none",
+				}}
+			>
+				{/* 厚み表現: 後ろにずらした空レイヤー */}
+				{Array.from({ length: layers }, (_, i) => {
+					const d = (layers - i) * LAYER_OFFSET;
+					return (
+						<div
+							key={`layer-${shape.id}-${i}`}
+							style={{
+								position: "absolute",
+								left: d,
+								top: d,
+								right: -d,
+								bottom: -d,
+								borderRadius: 10,
+								background: "#fff",
+								border: "1px solid rgba(0,0,0,0.15)",
+								boxShadow: "0 1px 2px rgba(0,0,0,0.12)",
+							}}
+						/>
+					);
+				})}
+
+				{/* 一番上のカード or 空表示 */}
+				<div
+					style={{
+						position: "absolute",
+						inset: 0,
+						borderRadius: 10,
+						overflow: "hidden",
+						background: "#fff",
+						boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+						border: count === 0 ? "2px dashed #bbb" : "1px solid rgba(0,0,0,0.2)",
+					}}
+				>
+					{count === 0 ? (
+						<div
+							style={{
+								width: "100%",
+								height: "100%",
+								display: "flex",
+								alignItems: "center",
+								justifyContent: "center",
+								color: "#999",
+								fontSize: 12,
+								fontFamily: "system-ui, sans-serif",
+							}}
+						>
+							空
+						</div>
+					) : (
+						topFace
+					)}
+				</div>
+
+				{/* 残枚数バッジ */}
+				{count > 0 && (
+					<div
+						style={{
+							position: "absolute",
+							right: -6,
+							top: -6,
+							minWidth: 22,
+							height: 22,
+							padding: "0 6px",
+							borderRadius: 11,
+							background: "#1e1e1e",
+							color: "#fff",
+							fontSize: 12,
+							fontWeight: 700,
+							fontFamily: "system-ui, sans-serif",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							boxShadow: "0 1px 3px rgba(0,0,0,0.3)",
+						}}
+					>
+						{count}
+					</div>
+				)}
+			</div>
+		);
+	};
+}

--- a/plugins/usketch-plugin-shape-card/src/render-deck.tsx
+++ b/plugins/usketch-plugin-shape-card/src/render-deck.tsx
@@ -1,4 +1,5 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
+import { type SlamPlay, slamWrapper } from "./placement.js";
 import { type CardTypeDefinition, readDeckMeta } from "./types.js";
 
 /** 山札の厚みを表現する後背レイヤーの最大枚数。 */
@@ -9,7 +10,10 @@ const LAYER_OFFSET = 3;
  * card-deck shape の render を生成する。card-type を引いて山札の見た目（積み重ね +
  * 一番上のカード + 残枚数バッジ）を描画する。
  */
-export function createDeckRenderer(registry: Map<string, CardTypeDefinition>) {
+export function createDeckRenderer(
+	registry: Map<string, CardTypeDefinition>,
+	getSlam?: (shapeId: string) => SlamPlay | undefined,
+) {
 	return function renderDeck(shape: ShapeData) {
 		const meta = readDeckMeta(shape);
 		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
@@ -25,8 +29,11 @@ export function createDeckRenderer(registry: Map<string, CardTypeDefinition>) {
 			return meta.faceDown ? def.renderBack(top) : def.renderFront(top);
 		})();
 
+		const sw = slamWrapper(getSlam?.(shape.id));
+
 		return (
 			<div
+				key={sw.key}
 				style={{
 					position: "relative",
 					width: "100%",
@@ -34,6 +41,7 @@ export function createDeckRenderer(registry: Map<string, CardTypeDefinition>) {
 					opacity,
 					pointerEvents: "none",
 					userSelect: "none",
+					...sw.style,
 				}}
 			>
 				{/* 厚み表現: 後ろにずらした空レイヤー */}

--- a/plugins/usketch-plugin-shape-card/src/types.ts
+++ b/plugins/usketch-plugin-shape-card/src/types.ts
@@ -9,7 +9,16 @@ export type PlacementAnimation =
 	| { preset: PlacementPreset }
 	| { keyframes: string; durationMs: number; easing?: string };
 
-export type PlacementPreset = "deal" | "drop" | "bounce" | "none";
+export type PlacementPreset =
+	| "deal"
+	| "drop"
+	| "bounce"
+	| "none"
+	// 「ドン！」と重みのある着地（衝撃リング + 接地シャドウ + 放射状の飛沫）。
+	// 重いほど大きく・ゆっくり（light < medium < heavy）。
+	| "slam-light"
+	| "slam-medium"
+	| "slam-heavy";
 
 /**
  * 面（表 / 裏）のテクスチャ（背景）。画像 URL と収め方、背景色（CSS グラデーション可）を指定できる。

--- a/plugins/usketch-plugin-shape-card/src/types.ts
+++ b/plugins/usketch-plugin-shape-card/src/types.ts
@@ -1,0 +1,84 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import type { ReactElement } from "react";
+
+/**
+ * 配置（placement）アニメーション設定。カードが新規配置 / 移動された後に再生する。
+ * プリセット名を指定するか、独自の CSS keyframes 名と再生時間を指定する。
+ */
+export type PlacementAnimation =
+	| { preset: PlacementPreset }
+	| { keyframes: string; durationMs: number; easing?: string };
+
+export type PlacementPreset = "deal" | "drop" | "bounce" | "none";
+
+/**
+ * card-type の拡張ポイント。トランプ / UNO / メディアカード等を表現するための定義。
+ * `TFields` はその card-type 固有のデータ形（render 側で narrow する）。
+ *
+ * 新しい card-type を追加するには、この interface を満たすオブジェクトを作って
+ * `createCardPlugin({ cardTypes: [myCardType] })` に渡す。
+ */
+export interface CardTypeDefinition<TFields = Record<string, unknown>> {
+	/** 一意な id。`media` / `playing-card` / `uno` 等。CardMeta.cardType に格納される。 */
+	id: string;
+	/** ツールバー / ピッカー用の表示名。 */
+	label: string;
+	/** リサイズ時に固定するアスペクト比 (width / height)。 */
+	aspectRatio: number;
+	/** 新規カードの既定サイズ。 */
+	defaultSize: { width: number; height: number };
+	/** この card-type 固有の配置アニメ。省略時はプラグイン既定を使用。 */
+	placementAnimation?: PlacementAnimation;
+	// 関数は method 構文（bivariant）にして、具象 TFields の定義を
+	// CardTypeDefinition<Record<string, unknown>> として束ねられるようにする。
+	/** ツールバー / ピッカー用アイコン。 */
+	icon(): ReactElement;
+	/** 新規カードの初期 fields を生成する。 */
+	createDefaultFields(): TFields;
+	/** 表面の描画。 */
+	renderFront(fields: TFields): ReactElement;
+	/** 裏面の描画（共通カードバックでも可）。 */
+	renderBack(fields: TFields): ReactElement;
+	/** デッキ（山札）の初期内容を生成する。例: トランプ52枚 / UNO108枚。 */
+	buildDeck?(): TFields[];
+}
+
+/** `card` shape の meta（generic 方式: ShapeData<CardMeta>）。 */
+export type CardMeta = {
+	/** 参照する CardTypeDefinition.id。 */
+	cardType: string;
+	/** 表 / 裏の view 状態。 */
+	isFlipped: boolean;
+	/** card-type 固有データ。型は各 card-type 側で narrow する。 */
+	fields: Record<string, unknown>;
+};
+
+export type CardShape = ShapeData<CardMeta>;
+
+/**
+ * `card-deck` shape の meta。card データの配列を保持する「データパイル」方式
+ * （52枚を52 shape にせず配列で持つ＝軽量 & シャッフル容易）。
+ */
+export type DeckMeta = {
+	/** デッキが配る card-type の id。 */
+	cardType: string;
+	/** 山札の中身。index 0 = 一番上（次に配られる）。 */
+	cards: Record<string, unknown>[];
+	/** 伏せ置きかどうか（描画で裏面を見せる）。 */
+	faceDown: boolean;
+};
+
+export type DeckShape = ShapeData<DeckMeta>;
+
+/**
+ * generic 共変性の制約で render 側は unknown 経由のキャストが要る。その escape を
+ * helper 1 箇所に閉じ込め、利用側は型付きアクセスだけで済むようにする
+ * （`plugins/usketch-plugin-domain-design/src/types.ts` の readMeta と同じ方針）。
+ */
+export function readCardMeta(shape: ShapeData): Partial<CardMeta> {
+	return (shape.meta ?? {}) as unknown as Partial<CardMeta>;
+}
+
+export function readDeckMeta(shape: ShapeData): Partial<DeckMeta> {
+	return (shape.meta ?? {}) as unknown as Partial<DeckMeta>;
+}

--- a/plugins/usketch-plugin-shape-card/src/types.ts
+++ b/plugins/usketch-plugin-shape-card/src/types.ts
@@ -12,6 +12,54 @@ export type PlacementAnimation =
 export type PlacementPreset = "deal" | "drop" | "bounce" | "none";
 
 /**
+ * 面（表 / 裏）のテクスチャ（背景）。画像 URL と収め方、背景色（CSS グラデーション可）を指定できる。
+ * `image` が無ければ `color` のみが背景になる。
+ */
+export type CardTexture = {
+	/** 背景画像 URL（data URL も可）。 */
+	image?: string;
+	/** 画像の収め方。`tile` は繰り返し。既定 `cover`。 */
+	fit?: "cover" | "contain" | "fill" | "tile";
+	/** 背景色 / グラデーション（画像が無い部分・透過部分に出る）。 */
+	color?: string;
+};
+
+/**
+ * 面上に配置する1つのテキスト要素。位置は割合（0..1, カードに対する相対）または px で指定でき、
+ * アンカー（基準点）・回転・フォントなどを細かく指定できる。
+ */
+export type CardText = {
+	text: string;
+	/** 基準位置 x。`unit` が ratio なら 0..1、px なら px。 */
+	x: number;
+	/** 基準位置 y。 */
+	y: number;
+	/** 位置の単位。既定 `ratio`（リサイズ追従）。 */
+	unit?: "ratio" | "px";
+	/** x,y がテキストのどこを指すか（水平）。既定 `center`。 */
+	align?: "left" | "center" | "right";
+	/** x,y がテキストのどこを指すか（垂直）。既定 `middle`。 */
+	vAlign?: "top" | "middle" | "bottom";
+	/** 回転（度）。アンカー位置を中心に回す。 */
+	rotation?: number;
+	fontSize?: number;
+	fontFamily?: string;
+	fontWeight?: number | string;
+	italic?: boolean;
+	color?: string;
+	letterSpacing?: number;
+	lineHeight?: number;
+	/** 折り返し幅（px）。指定すると複数行に折り返す。未指定は折り返さない（pre）。 */
+	maxWidth?: number;
+};
+
+/** 1つの面（表 or 裏）の定義: テクスチャ + テキスト配置。 */
+export type CardFace = {
+	texture?: CardTexture;
+	texts?: CardText[];
+};
+
+/**
  * card-type の拡張ポイント。トランプ / UNO / メディアカード等を表現するための定義。
  * `TFields` はその card-type 固有のデータ形（render 側で narrow する）。
  *

--- a/plugins/usketch-plugin-shape-card/tsconfig.json
+++ b/plugins/usketch-plugin-shape-card/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
       '@edv4h/usketch-plugin-shape-board-portal':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-board-portal
+      '@edv4h/usketch-plugin-shape-card':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-shape-card
       '@edv4h/usketch-plugin-shape-community-region':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-community-region
@@ -1396,6 +1399,31 @@ importers:
 
   plugins/usketch-plugin-shape-board-portal:
     dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      react:
+        specifier: 19.2.4
+        version: 19.2.4
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  plugins/usketch-plugin-shape-card:
+    dependencies:
+      '@edv4h/usketch-core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@edv4h/usketch-shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## 概要

トランプ・UNO・メディアカード等を表現できる **card-type 拡張ポイント**を中心に据えたカードシェイプ・プラグイン **`@edv4h/usketch-plugin-shape-card`** を追加します。`usketch-plugin-shape-basic`（サブタイプ・レジストリ + 単一描画ツール）/ `usketch-plugin-shape-sticky`（HTML描画 + ダブルクリック検出）/ `effect-ripple`（transient）の既存パターンを踏襲しています。

## 機能

- **card-type 拡張ポイント**（`CardTypeDefinition`）— `createCardPlugin({ cardTypes })` で独自カードを定義・追加可能。
- **コアとサンプルの分離** — プラグインはコア機構のみを提供し、card-type は**既定で空**。トランプ等は同梱サンプル `EXAMPLE_CARD_TYPES`（`media` / `playing-card` / `uno` / `custom`）で、明示的に渡したときだけ有効（未使用ならtree-shakeで除外）。card-type が無いときは描画ツールも出ません。
- **生成ファクトリ**（`createCardShape` / `createDeckShape`）— カード/デッキの生成は純ファクトリに分離。`cards` を明示すれば**可変デッキ（TCG の構築済みデッキ等）**も表現可能。
- **表/裏のテクスチャ + テキスト配置**（`CardFace`）— コードを書かずに各面の背景画像/色/グラデーションと、テキストの位置（ratio/px）・アンカー・回転・フォント・折り返しを細かく指定可能。`custom` card-type と `renderFace()` で提供。
- **トランプのピップ配置** — 表面はランクに応じてスート記号の数・配置が変化（2〜10 は本物準拠、下半分は180°回転 / A は中央大 / J・Q・K は文字）。container query 単位で追従。
- **裏返し（flip）** — カードをダブルクリックで 0.4s の 3D `rotateY` フリップ。
- **アスペクト比固定リサイズ** — card-type ごとの比率を保ったままのみ拡縮。
- **配置アニメーション（カスタマイズ可）** — `ctx.transient` で実装。プリセット `deal/drop/bounce/none`、独自 keyframes、または **Slam（ドン！, 重み3段階）** を、①プラグイン既定 ②card-type 個別 の2層で指定。描画/ドロー/移動後（`shapes:move-end`）に再生。**デッキ（山札）には配置アニメを出さない**。
  - **Slam（ドン！）** — Claude Design「Card Animations」ショーケースの Slam Place を移植。**実カードが一瞬持ち上がってから加速して着地**し、カード外側に広がる衝撃リング + 放射状飛沫が弾ける。`slam-light / slam-medium / slam-heavy` の3段階で**重いほど大きく・ゆっくり**。組込例は playing-card = slam-medium、uno = slam-heavy。
- **デッキ（山札）機構** — データパイル方式の `card-deck` shape。ダブルクリックでドロー（最前面配置）、Shift+S でシャッフル、いずれも Undo 対応。
- **ツールバー card-type ピッカー** — カード/デッキツール選択時に種別（media/トランプ/UNO/カスタム）を切替（`card:select-type`）。

## API / プロパティ

### `createCardPlugin(opts?)` — `CreateCardPluginOptions`

| プロパティ | 型 | 既定 | 説明 |
|---|---|---|---|
| `cardTypes` | `CardTypeDefinition[]` | `[]`（空） | 使用する card-type。空でも生成可（描画ツールは出ない）。サンプルは `EXAMPLE_CARD_TYPES` を渡す。 |
| `placementAnimation` | `PlacementAnimation` | `{ preset: "drop" }` | 既定の配置アニメ（card-type 個別指定が優先）。 |
| `enableDeck` | `boolean` | `true` | デッキ（山札）機構の ON/OFF。 |

### `CardTypeDefinition<TFields>` — card-type 拡張ポイント

`id` / `label` / `aspectRatio` / `defaultSize` / `placementAnimation?` / `icon()` / `createDefaultFields()` / `renderFront(fields)` / `renderBack(fields)` / `buildDeck?()`。

### 生成ファクトリ（純関数・store 非依存）

| 関数 | 説明 |
|---|---|
| `createCardShape(def, { x, y, fields?, ... })` | カード shape データを生成。 |
| `createDeckShape(def, { x, y, cards?, ... })` | デッキ shape データを生成。`cards` 明示で可変デッキ（TCG）。 |

### `CardFace` / `CardTexture` / `CardText`

- **`CardTexture`**: `image?` / `fit?`（cover\|contain\|fill\|tile）/ `color?`。
- **`CardText`**: `text` / `x`,`y` / `unit?`（ratio\|px）/ `align?`,`vAlign?` / `rotation?` / フォント各種 / `maxWidth?`。

### `PlacementAnimation`

`{ preset: "deal" | "drop" | "bounce" | "none" | "slam-light" | "slam-medium" | "slam-heavy" }` または `{ keyframes: string; durationMs: number; easing?: string }`。

### データモデル（generic meta）

- **`CardMeta`**（`ShapeData<CardMeta>`）: `cardType` / `isFlipped` / `fields`。
- **`DeckMeta`**（`ShapeData<DeckMeta>`）: `cardType` / `cards`（index 0 が一番上）/ `faceDown`。
- ヘルパ `readCardMeta` / `readDeckMeta`。

### イベント

- `card:select-type`（`{ id }`）/ `card-deck:shuffle`（`{ id? }`）/ 購読 `shapes:move-end`。

## 設計方針

- シェイプ固有データは `extends ShapeData` ではなく **`ShapeData<TMeta>` の generic（meta）** 方式。
- 単一 `card` shape type + `meta.cardType` ディスクリミネータ + 内部 card-type レジストリ。
- 生成は純ファクトリ、`shuffle` / `drawTop` は生成済みシェイプへの操作として保持。
- Slam の持ち上がりは**実カード自身**にアニメを当て（シルエットの二重描画を回避）、衝撃はカード外側のみ（transient はカードより手前のため接地シャドウは出さない）。
- 配置アニメは保存済みボードのロード時に一斉再生しないよう、対話的な配置点で明示 emit + `shapes:move-end` に限定。

## コミット構成

1. プラグイン追加（コア機構 + 組込 card-type + flip + 配置アニメ + デッキ）
2. 表/裏テクスチャ + テキスト配置（`CardFace` / `renderFace` / `custom`）
3. ツールバー card-type ピッカー
4. トランプのピップ配置（ランク連動）
5. card-type を既定空にしサンプル（`EXAMPLE_CARD_TYPES`）化
6. カード/デッキ生成を純ファクトリに切り出し（可変デッキ対応）
7. Copilot レビュー指摘対応（shuffle の Undo 化 / 回転考慮 hit-test / URL エスケープ 等）
8. Slam（ドン！）配置アニメを3段階の重みで追加（デザイン「Card Animations」移植）+ 二重描画/接地シャドウ/強度の調整、デッキは対象外

## テスト

- ユニットテスト **30 件**（`shuffle`/`drawTop`、生成ファクトリ、アスペクト比固定リサイズ、hit-test、registry の空既定/opt-in、テクスチャ→CSS変換、アンカー→translate、配置アニメ解決（slam の重さ順 duration））
- `pnpm build` / `typecheck`（プラグイン・web アプリとも）/ Biome / `pnpm dev` 起動・Vite トランスフォーム いずれもエラーなし

## スコープ外（将来拡張）

- front/back のインライン編集（sticky の zag-js 状態マシン流用）
- 山札へのドロップ回収、配布/手札エリア等の高次カードゲーム機構、GPUレンダリング
- ショーケースのギャラリー専用エフェクト（hover浮上 / 3D tilt / ホロ・フォイル・グレア / 扇展開 等）— 2Dキャンバス上の flat カードには対応トリガーが無いため

🤖 Generated with [Claude Code](https://claude.com/claude-code)