### PR TITLE
🐛 fix(changeset): unblock Release workflow (mixed ignored package)

### DIFF
--- a/.changeset/add-shape-card-plugin.md
+++ b/.changeset/add-shape-card-plugin.md
@@ -1,6 +1,5 @@
 ---
 "@edv4h/usketch-plugin-shape-card": minor
-"@edv4h/usketch-web": patch
 ---
 
 新規プラグイン `@edv4h/usketch-plugin-shape-card` を追加。トランプ・UNO・メディアカード等を表現できる **card-type 拡張ポイント**を持つカードシェイプ。カードは表/裏を持ちダブルクリックで裏返せる（3D フリップ）。配置時アニメーション（カスタマイズ可）とデッキ（山札）機構（ドロー / シャッフル）を備える。リサイズは card-type ごとのアスペクト比固定。データモデルは `ShapeData<TMeta>` の generic（meta）方式。


### PR DESCRIPTION
## Summary

`main` への push ごとに **Release ワークフローが失敗** しており、changesets の "Version Packages" リリース PR が作成されていませんでした。

原因は `add-shape-card-plugin` の changeset が、公開対象の `@edv4h/usketch-plugin-shape-card` と、changeset の `ignore` に入っている `@edv4h/usketch-web` を**同一 changeset 内で混在**させていたためです。changesets は ignored / not-ignored の混在を許可しません:

```
🦋 error Mixed changesets that contain both ignored and not ignored packages are not allowed
🦋 error Found ignored packages: @edv4h/usketch-web
🦋 error Found not ignored packages: @edv4h/usketch-plugin-shape-card
```

`@edv4h/usketch-web` は未公開のアプリ（`ignore` 対象）なので bump しても無意味でした。該当行を削除します。

## Test plan

- `pnpm changeset status` が mixed エラーなく解決することを確認済み（shared/store: major、plugin-shape-card/tool-helpers: minor 等が bump 対象として表示）。
- このPRが main にマージされると Release ワークフローが成功し、"🎉 release: Version Packages" PR が自動生成される見込み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)