### PR TITLE
🐛 fix(tool-helpers): findHandleAtScreenPoint が resizable:false を尊重 (#625)

### DIFF
--- a/.changeset/resize-handle-respect-resizable.md
+++ b/.changeset/resize-handle-respect-resizable.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-tool-helpers": patch
+---
+
+`findHandleAtScreenPoint` が `ShapeDefinition.resizable: false` を尊重するように修正（#625）。これまでは `resizable:false` でも shape の端でリサイズカーソルに変わり、ドラッグでリサイズ操作が走っていた（選択オーバーレイはハンドル描画を消すだけで、当たり判定・カーソル・操作は止まっていなかった）。回転判定 `findRotationHandleAtScreenPoint` と同じく、`def?.resizable === false` のとき `null` を返すガードを追加。これにより `resizable:false` だけでカーソル・リサイズ操作の両方が無効になり、利用側で `resize`/`applyBounds` を no-op にする回避策が不要になる。

--- a/packages/usketch-tool-helpers/src/__tests__/resize-handles.test.ts
+++ b/packages/usketch-tool-helpers/src/__tests__/resize-handles.test.ts
@@ -1,0 +1,56 @@
+import type { ShapeData, ShapeDefinition, Viewport } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { findHandleAtScreenPoint } from "../internal/resize-handles.js";
+import { createTestToolContext, makeShape } from "./test-helpers.js";
+
+const VIEWPORT: Viewport = { x: 0, y: 0, zoom: 1 };
+
+function rectLikeDef(type: string, resizable?: boolean): ShapeDefinition {
+	return {
+		type,
+		minSize: { width: 1, height: 1 },
+		...(resizable === undefined ? {} : { resizable }),
+		hitTest: (data: ShapeData, point: { x: number; y: number }) =>
+			point.x >= data.x &&
+			point.x <= data.x + data.width &&
+			point.y >= data.y &&
+			point.y <= data.y + data.height,
+		getBounds: (data: ShapeData) => ({
+			x: data.x,
+			y: data.y,
+			width: data.width,
+			height: data.height,
+		}),
+		render: () => null,
+	} as unknown as ShapeDefinition;
+}
+
+describe("findHandleAtScreenPoint", () => {
+	it("returns the SE handle when the cursor is on a resizable shape's corner", () => {
+		const ctx = createTestToolContext();
+		ctx.store.addShape(makeShape({ id: "a", x: 0, y: 0, width: 100, height: 100 }));
+		ctx.store.setSelection(["a"]);
+		// SE corner of a 100x100 shape at origin, zoom 1 → screen (100, 100).
+		const hit = findHandleAtScreenPoint({ x: 100, y: 100 }, ctx.shapes, ctx.store, VIEWPORT);
+		expect(hit).toEqual({ shapeId: "a", handle: "se" });
+	});
+
+	it("returns null for a shape whose definition declares resizable: false", () => {
+		const ctx = createTestToolContext();
+		ctx.shapes.register("fixed", rectLikeDef("fixed", false));
+		ctx.store.addShape(makeShape({ id: "a", type: "fixed", x: 0, y: 0, width: 100, height: 100 }));
+		ctx.store.setSelection(["a"]);
+		// Same corner that would hit for a resizable shape — must be ignored.
+		const hit = findHandleAtScreenPoint({ x: 100, y: 100 }, ctx.shapes, ctx.store, VIEWPORT);
+		expect(hit).toBeNull();
+	});
+
+	it("still returns a handle when resizable is omitted (defaults to resizable)", () => {
+		const ctx = createTestToolContext();
+		ctx.shapes.register("plain", rectLikeDef("plain"));
+		ctx.store.addShape(makeShape({ id: "a", type: "plain", x: 0, y: 0, width: 100, height: 100 }));
+		ctx.store.setSelection(["a"]);
+		const hit = findHandleAtScreenPoint({ x: 100, y: 100 }, ctx.shapes, ctx.store, VIEWPORT);
+		expect(hit).toEqual({ shapeId: "a", handle: "se" });
+	});
+});

--- a/packages/usketch-tool-helpers/src/internal/resize-handles.ts
+++ b/packages/usketch-tool-helpers/src/internal/resize-handles.ts
@@ -54,6 +54,11 @@ export function findHandleAtScreenPoint(
 	if (!shape) return null;
 
 	const def = shapes.get(shape.type);
+	// Respect `resizable: false` — same guard as findRotationHandleAtScreenPoint.
+	// Without this, the resize cursor and a resize session would still start even
+	// though selection-overlay hides the handles, leaving operation alive while
+	// the affordance is gone.
+	if (def?.resizable === false) return null;
 	const bounds = def
 		? def.getBounds(shape)
 		: { x: shape.x, y: shape.y, width: shape.width, height: shape.height };


### PR DESCRIPTION
## Summary

Closes #625.

`ShapeDefinition.resizable: false` のとき、`selection-overlay` はリサイズハンドルの**描画**を消していましたが、`findHandleAtScreenPoint`（単一リサイズの当たり判定）が `resizable` を見ておらず、shape の端でリサイズカーソルに変わり・ドラッグでリサイズ操作が走っていました。

回転判定 `findRotationHandleAtScreenPoint` は既に `def?.resizable === false` を尊重しているため、それと同じガードを `findHandleAtScreenPoint` にも追加して一貫させます。

```js
const def = shapes.get(shape.type);
if (def?.resizable === false) return null;   // 追加
```

これで `resizable:false` だけでカーソル変化・リサイズ操作の両方が止まり、利用側で `resize`/`applyBounds` を no-op に差し替える回避策が不要になります（#626 のカード固定サイズ化の前提）。

## スコープ（マルチリサイズについて）
Issue では「マルチリサイズ側も揃えると一貫」とありますが、今回は**単一選択のみ**に限定しました:
- `findMultiHandleAtScreenPoint` は `(screenPoint, groupBounds, viewport)` のみを受け取り、選択内の各 shape 定義にアクセスできない（グループ内で `resizable` が混在しうる）。
- `selection-overlay` の `hideHandles` も単一選択時 (`selection.size === 1`) のみで、マルチ選択ではハンドルを消していない。
- 対応済みの `findRotationHandleAtScreenPoint` も `selection.size !== 1` で早期 return しており、**単一選択前提**。今回の修正はその先例に正確に一致します。

マルチ選択時の resizable 混在の扱いは別途の設計判断のため、本 PR の対象外としています。

## Test plan
- 新規 `resize-handles.test.ts`: (1) resizable な shape の角でハンドルがヒット、(2) `resizable:false` で `null`、(3) `resizable` 省略時は従来どおりヒット。
- `pnpm --filter @edv4h/usketch-tool-helpers test`（36 passed）/ `typecheck` グリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)