### PR TITLE
✨ feat(shape-card): カード/デッキのリサイズ不可オプション (resizable) (#626)

### DIFF
--- a/.changeset/card-resizable-option.md
+++ b/.changeset/card-resizable-option.md
@@ -1,0 +1,15 @@
+---
+"@edv4h/usketch-plugin-shape-card": minor
+"@edv4h/usketch-shared": minor
+"@edv4h/usketch-tool-helpers": patch
+"@edv4h/usketch-plugin-tool-select": patch
+---
+
+カード / デッキをリサイズ不可（サイズ固定）にできるオプションを追加（#626）。
+
+- `@edv4h/usketch-plugin-shape-card`:
+  - `createCardPlugin({ resizable?: boolean })` — プラグイン全体の既定（既定 `true`）。
+  - `CardTypeDefinition.resizable?: boolean` — card-type 単位の指定（プラグイン全体より優先）。「value カードは固定、トランプは可変」のような出し分けが可能。
+  - 指定時、`card` / `card-deck` の `ShapeDefinition.resizable` に per-instance で反映される。利用側で `resize` / `applyBounds` を no-op に差し替えるハックが不要になる。
+- `@edv4h/usketch-shared`: `ShapeDefinition.resizable` が `boolean` に加えて述語 `(data) => boolean` を受け付けるようになり、単一 shape type でもインスタンスごとにリサイズ可否を変えられる（後方互換）。判定を一本化する `isShapeResizable(def, shape)` を追加・エクスポート。
+- `@edv4h/usketch-tool-helpers` / `@edv4h/usketch-plugin-tool-select`: リサイズハンドルの当たり判定・カーソル・選択オーバーレイのハンドル表示が `isShapeResizable` 経由で述語形式を尊重するように更新。

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,3 @@
+{
+	"enableAllProjectMcpServers": true
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,3 +1,0 @@
-{
-	"enableAllProjectMcpServers": true
-}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -75,6 +75,8 @@ export type {
 	MinimapViewportRect,
 } from "./utils/minimap.js";
 export { computeMinimap, minimapToSvg } from "./utils/minimap.js";
+// Resizable resolution
+export { isShapeResizable } from "./utils/resizable.js";
 // Rotation
 export {
 	deltaToLocal,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -230,8 +230,14 @@ export interface ShapeDefinition {
 	createDefault: (params: { id: string; x: number; y: number }) => ShapeData;
 	renderTarget?: RenderTarget;
 	minSize?: { width: number; height: number };
-	/** Whether the shape can be resized by the user. Default: true. */
-	resizable?: boolean;
+	/**
+	 * Whether the shape can be resized by the user. Default: `true`.
+	 *
+	 * Accepts a predicate `(data) => boolean` so a single shape type can vary
+	 * resizability per instance (e.g. a `card` type whose `meta.cardType`
+	 * decides it). Use {@link isShapeResizable} to evaluate it.
+	 */
+	resizable?: boolean | ((data: ShapeData) => boolean);
 	/** Shape-specific move logic (e.g. updating absolute point arrays). Default: update x/y only. */
 	move?: (data: ShapeData, dx: number, dy: number) => Partial<ShapeData>;
 	/** Fit shape data to new bounding box (for multi-resize). Default: apply newBounds as-is. */

--- a/packages/shared/src/utils/resizable.ts
+++ b/packages/shared/src/utils/resizable.ts
@@ -1,0 +1,19 @@
+import type { ShapeDefinition } from "../types/plugin.js";
+import type { ShapeData } from "../types/shape.js";
+
+/**
+ * Resolve whether a shape is resizable, honoring both the boolean and the
+ * predicate form of {@link ShapeDefinition.resizable}.
+ *
+ * - `undefined` → `true` (default: resizable)
+ * - `boolean`   → that value
+ * - `(data) => boolean` → evaluated against the shape instance
+ *
+ * Centralizes the rule so the selection overlay and the resize/rotation
+ * hit-tests stay consistent.
+ */
+export function isShapeResizable(def: ShapeDefinition | undefined, shape: ShapeData): boolean {
+	const r = def?.resizable;
+	if (typeof r === "function") return r(shape);
+	return r !== false;
+}

--- a/packages/usketch-tool-helpers/src/__tests__/resize-handles.test.ts
+++ b/packages/usketch-tool-helpers/src/__tests__/resize-handles.test.ts
@@ -53,4 +53,37 @@ describe("findHandleAtScreenPoint", () => {
 		const hit = findHandleAtScreenPoint({ x: 100, y: 100 }, ctx.shapes, ctx.store, VIEWPORT);
 		expect(hit).toEqual({ shapeId: "a", handle: "se" });
 	});
+
+	it("honors the predicate form of resizable per shape instance", () => {
+		const ctx = createTestToolContext();
+		// resizable depends on the shape: those tagged meta.locked are not resizable.
+		const def = rectLikeDef("dynamic");
+		(def as { resizable: (s: ShapeData) => boolean }).resizable = (s) =>
+			(s.meta as { locked?: boolean } | undefined)?.locked !== true;
+		ctx.shapes.register("dynamic", def);
+
+		ctx.store.addShape(
+			makeShape({ id: "free", type: "dynamic", x: 0, y: 0, width: 100, height: 100 }),
+		);
+		ctx.store.setSelection(["free"]);
+		expect(findHandleAtScreenPoint({ x: 100, y: 100 }, ctx.shapes, ctx.store, VIEWPORT)).toEqual({
+			shapeId: "free",
+			handle: "se",
+		});
+
+		ctx.store.deleteShape("free");
+		ctx.store.addShape(
+			makeShape({
+				id: "locked",
+				type: "dynamic",
+				x: 0,
+				y: 0,
+				width: 100,
+				height: 100,
+				meta: { locked: true },
+			}),
+		);
+		ctx.store.setSelection(["locked"]);
+		expect(findHandleAtScreenPoint({ x: 100, y: 100 }, ctx.shapes, ctx.store, VIEWPORT)).toBeNull();
+	});
 });

--- a/packages/usketch-tool-helpers/src/internal/resize-handles.ts
+++ b/packages/usketch-tool-helpers/src/internal/resize-handles.ts
@@ -8,6 +8,7 @@ import type {
 } from "@edv4h/usketch-shared";
 import {
 	getSelectionBounds,
+	isShapeResizable,
 	normalizeAngle,
 	safeRotation,
 	unrotatePoint,
@@ -58,7 +59,7 @@ export function findHandleAtScreenPoint(
 	// Without this, the resize cursor and a resize session would still start even
 	// though selection-overlay hides the handles, leaving operation alive while
 	// the affordance is gone.
-	if (def?.resizable === false) return null;
+	if (!isShapeResizable(def, shape)) return null;
 	const bounds = def
 		? def.getBounds(shape)
 		: { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
@@ -111,7 +112,7 @@ export function findRotationHandleAtScreenPoint(
 	if (!shape) return null;
 
 	const def = shapes.get(shape.type);
-	if (def?.resizable === false) return null;
+	if (!isShapeResizable(def, shape)) return null;
 
 	const bounds = def
 		? def.getBounds(shape)

--- a/plugins/usketch-plugin-shape-card/src/__tests__/plugin-resizable.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/plugin-resizable.test.ts
@@ -1,0 +1,105 @@
+import type { PluginContext, ShapeData, ShapeDefinition } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { CARD_TYPE, DECK_TYPE } from "../factory.js";
+import { type CreateCardPluginOptions, createCardPlugin } from "../plugin.js";
+import type { CardTypeDefinition } from "../types.js";
+
+function makeCardType(id: string, resizable?: boolean): CardTypeDefinition {
+	return {
+		id,
+		label: id,
+		aspectRatio: 2 / 3,
+		defaultSize: { width: 100, height: 150 },
+		...(resizable === undefined ? {} : { resizable }),
+		icon: () => null as never,
+		createDefaultFields: () => ({}),
+		renderFront: () => null as never,
+		renderBack: () => null as never,
+		buildDeck: () => [{}, {}],
+	};
+}
+
+/**
+ * Run the plugin's setup with a minimal mock context and return the
+ * ShapeDefinitions it registered (keyed by type).
+ */
+function registeredDefs(opts: CreateCardPluginOptions): Map<string, ShapeDefinition> {
+	const defs = new Map<string, ShapeDefinition>();
+	const noop = () => {};
+	const off = () => () => {};
+	const ctx = {
+		events: { on: off, emit: noop, off: noop },
+		transient: { registerType: noop, emit: noop },
+		shapes: {
+			register: (type: string, def: ShapeDefinition) => defs.set(type, def),
+			get: () => undefined,
+		},
+		tools: { register: noop },
+		shortcuts: { register: off },
+		store: {
+			getShape: () => undefined,
+			getShapesSorted: () => [],
+			getSelection: () => new Set<string>(),
+			updateShape: noop,
+			addShape: noop,
+			deleteShape: noop,
+			setSelection: noop,
+			resetToDefaultTool: noop,
+		},
+		commands: { execute: noop },
+	} as unknown as PluginContext;
+
+	createCardPlugin(opts).setup(ctx);
+	return defs;
+}
+
+function cardShape(cardType: string): ShapeData {
+	return {
+		id: "c1",
+		type: CARD_TYPE,
+		x: 0,
+		y: 0,
+		width: 100,
+		height: 150,
+		style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		meta: { cardType, isFlipped: false, fields: {} },
+	} as ShapeData;
+}
+
+function resolve(def: ShapeDefinition | undefined, shape: ShapeData): boolean {
+	const r = def?.resizable;
+	return typeof r === "function" ? r(shape) : r !== false;
+}
+
+describe("createCardPlugin resizable option", () => {
+	it("defaults to resizable when nothing is configured", () => {
+		const defs = registeredDefs({ cardTypes: [makeCardType("plain")] });
+		expect(resolve(defs.get(CARD_TYPE), cardShape("plain"))).toBe(true);
+	});
+
+	it("plugin-wide resizable:false makes cards and decks fixed", () => {
+		const defs = registeredDefs({ cardTypes: [makeCardType("plain")], resizable: false });
+		expect(resolve(defs.get(CARD_TYPE), cardShape("plain"))).toBe(false);
+		// decks follow the same resolver
+		expect(defs.get(DECK_TYPE)).toBeDefined();
+		expect(resolve(defs.get(DECK_TYPE), { ...cardShape("plain"), type: DECK_TYPE })).toBe(false);
+	});
+
+	it("per-card-type resizable overrides the plugin-wide default", () => {
+		const defs = registeredDefs({
+			// value cards fixed, playing cards resizable — plugin default false.
+			cardTypes: [makeCardType("value", false), makeCardType("playing", true)],
+			resizable: false,
+		});
+		expect(resolve(defs.get(CARD_TYPE), cardShape("value"))).toBe(false);
+		expect(resolve(defs.get(CARD_TYPE), cardShape("playing"))).toBe(true);
+	});
+
+	it("per-card-type resizable:false works even when plugin default is true", () => {
+		const defs = registeredDefs({
+			cardTypes: [makeCardType("value", false), makeCardType("playing")],
+		});
+		expect(resolve(defs.get(CARD_TYPE), cardShape("value"))).toBe(false);
+		expect(resolve(defs.get(CARD_TYPE), cardShape("playing"))).toBe(true);
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -52,6 +52,12 @@ export interface CreateCardPluginOptions {
 	placementAnimation?: PlacementAnimation;
 	/** デッキ機構を有効にするか。既定 true。 */
 	enableDeck?: boolean;
+	/**
+	 * カード / デッキをリサイズ可能にするか（プラグイン全体の既定）。既定 `true`。
+	 * `CardTypeDefinition.resizable` が指定されていれば card-type 単位でそちらが優先される。
+	 * `false` にすると、対象カード・デッキはハンドル非表示・リサイズ操作無効（サイズ固定）になる。
+	 */
+	resizable?: boolean;
 }
 
 // ── icons ──
@@ -128,6 +134,17 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 		return def?.aspectRatio ?? data.width / data.height;
 	}
 	const resize = makeAspectResize(getCardAspect);
+
+	// resizable は card-type 単位 (CardTypeDefinition.resizable) を最優先、無ければ
+	// プラグイン全体既定 (opts.resizable)、それも無ければ true。card / card-deck は
+	// 単一 shape type なので、shape の cardType を見て per-instance で解決する。
+	function resolveResizable(data: ShapeData): boolean {
+		const meta = data.type === DECK_TYPE ? readDeckMeta(data) : readCardMeta(data);
+		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+		if (typeof def?.resizable === "boolean") return def.resizable;
+		if (typeof opts.resizable === "boolean") return opts.resizable;
+		return true;
+	}
 
 	return {
 		id: "usketch-plugin-shape-card",
@@ -327,6 +344,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				getBounds,
 				hitTest: withRotation(rectHitTest),
 				resize,
+				resizable: resolveResizable,
 				createDefault: ({ id, x, y }) => {
 					const def = resolveDef(currentCardType);
 					return def ? createCardShape(def, { id, x, y }) : createBareCardShape({ id, x, y });
@@ -420,6 +438,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					getBounds,
 					hitTest: withRotation(rectHitTest),
 					resize,
+					resizable: resolveResizable,
 					createDefault: ({ id, x, y }) => {
 						const def = resolveDef(currentCardType);
 						return def

--- a/plugins/usketch-plugin-shape-card/src/types.ts
+++ b/plugins/usketch-plugin-shape-card/src/types.ts
@@ -84,6 +84,12 @@ export interface CardTypeDefinition<TFields = Record<string, unknown>> {
 	aspectRatio: number;
 	/** 新規カードの既定サイズ。 */
 	defaultSize: { width: number; height: number };
+	/**
+	 * この card-type のカード / デッキをリサイズ可能にするか。既定 `true`。
+	 * `false` にすると、その card-type のカード・デッキはハンドル非表示・リサイズ操作無効
+	 * （サイズ固定）になる。`createCardPlugin({ resizable })` のプラグイン全体既定より優先される。
+	 */
+	resizable?: boolean;
 	/** この card-type 固有の配置アニメ。省略時はプラグイン既定を使用。 */
 	placementAnimation?: PlacementAnimation;
 	// 関数は method 構文（bivariant）にして、具象 TFields の定義を

--- a/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
+++ b/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
@@ -1,5 +1,5 @@
 import type { BoardStore, ShapeRegistry, Viewport } from "@edv4h/usketch-shared";
-import { safeRotation } from "@edv4h/usketch-shared";
+import { isShapeResizable, safeRotation } from "@edv4h/usketch-shared";
 import { useSyncExternalStore } from "react";
 import { getMovingSelection, subscribeMovingSelection } from "./drag-state.js";
 import { getDropTargetId, subscribeDropTarget } from "./drop-target-state.js";
@@ -176,8 +176,8 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 		const screenCx = sx + sw / 2;
 		const screenCy = sy + sh / 2;
 
-		// Hide resize handles when shape definition declares resizable: false
-		const hideHandles = def?.resizable === false;
+		// Hide resize handles when the shape is not resizable (boolean or predicate)
+		const hideHandles = !isShapeResizable(def, shape);
 		const positions = getHandlePositions(bounds, viewport);
 		const half = HANDLE_SIZE / 2;
 


### PR DESCRIPTION
## Summary

Closes #626.（#625 のマージ後に main から分岐。`resizable:false` が当たり判定・カーソル・操作まで効くようになった #625 の修正が前提）

カード / デッキを **リサイズ不可（サイズ固定）** にできるオプションを追加しました。利用側で `resize` / `applyBounds` を no-op に差し替える脆いハックが不要になります。

### `@edv4h/usketch-plugin-shape-card`
- `createCardPlugin({ resizable?: boolean })` — プラグイン全体の既定（既定 `true`）。
- `CardTypeDefinition.resizable?: boolean` — **card-type 単位**の指定。プラグイン全体より優先。「value カードは固定、トランプは可変」の出し分けが可能。
- 解決順: card-type 個別 → プラグイン全体 → 既定 `true`。shape の `meta.cardType` を見て **per-instance** で解決し、`card` / `card-deck` の `ShapeDefinition.resizable` に反映。

### `@edv4h/usketch-shared`
- `card` は単一 shape type なので、静的 boolean だけでは card-type ごとに出し分けできません。そこで `ShapeDefinition.resizable` が `boolean` に加えて **述語 `(data) => boolean`** を受け付けるよう拡張（後方互換）。単一 type でもインスタンスごとにリサイズ可否を変えられます。
- 判定を一本化する `isShapeResizable(def, shape)` を追加・エクスポート。

### `@edv4h/usketch-tool-helpers` / `@edv4h/usketch-plugin-tool-select`
- リサイズ/回転ハンドルの当たり判定（`findHandleAtScreenPoint` / `findRotationHandleAtScreenPoint`）と選択オーバーレイのハンドル表示を `isShapeResizable` 経由に変更し、述語形式を尊重。

## Test plan
- `resize-handles.test.ts`: 述語形式の resizable がインスタンス単位で効く（locked な shape はハンドル無し）ケースを追加。
- `plugin-resizable.test.ts`（新規）: 既定 true / プラグイン全体 false / card-type 個別が全体を上書き / 全体 true でも card-type false が効く、の4ケース。
- `pnpm turbo typecheck`（143 tasks）グリーン、tool-helpers（37）・shape-card（34）テスト通過。

## 後方互換
- `resizable` の述語形式は追加のみ（既存の `boolean` / 省略はそのまま）。`@edv4h/usketch-shared` は minor。

🤖 Generated with [Claude Code](https://claude.com/claude-code)