### PR TITLE
✨ feat(shape-card): card-type ごとの LOD 簡易表示 (renderSimplified) (#631)

### DIFF
--- a/.changeset/card-lod-simplified.md
+++ b/.changeset/card-lod-simplified.md
@@ -1,0 +1,14 @@
+---
+"@edv4h/usketch-plugin-shape-card": minor
+---
+
+card-type ごとに LOD（低ズーム）簡易表示を渡せるようにした（#631）。
+
+- `CardTypeDefinition.renderSimplified?(fields)` を追加。指定すると、その card-type のカード / デッキの低ズーム表示に使われる。`renderFront` と同様、plugin がカード枠（world 座標へ self-position）を用意するので、card-type 側は枠内の中身だけを返せばよい。
+- plugin が `card` / `card-deck` の `ShapeDefinition.simplifiedComponent` へ配線:
+  - `card`: その shape の `meta.cardType` の `renderSimplified` を使用。
+  - `card-deck`: 一番上のカード（`cards[0]`）の fields で `renderSimplified` を呼ぶ。
+  - `renderSimplified` 未定義 / 空デッキ / 未知 card-type のときは従来どおりグレー矩形（`shape.style.fill`）にフォールバック。
+- 組込みの EXAMPLE card-type（media / playing-card / uno）に `renderSimplified` を実装し、引きでも種別が判別できるようにした。
+
+これにより、LOD 簡易表示のために利用側が shape 定義を再 register する回避策が不要になる（#625 / #626 と合わせて、カード関連の shape 定義上書きは解消）。

--- a/plugins/usketch-plugin-shape-card/src/__tests__/render-simplified.test.tsx
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/render-simplified.test.tsx
@@ -1,0 +1,112 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { CARD_TYPE, DECK_TYPE } from "../factory.js";
+import { createCardSimplified, createDeckSimplified } from "../render-simplified.js";
+import type { CardTypeDefinition } from "../types.js";
+
+function makeCardType(id: string, withSimplified: boolean): CardTypeDefinition {
+	return {
+		id,
+		label: id,
+		aspectRatio: 2 / 3,
+		defaultSize: { width: 100, height: 150 },
+		icon: () => null as never,
+		createDefaultFields: () => ({ label: "DEF" }),
+		renderFront: () => null as never,
+		renderBack: () => null as never,
+		...(withSimplified
+			? {
+					renderSimplified: (fields: Record<string, unknown>) =>
+						(<span data-kind="simplified">{String(fields.label)}</span>) as ReactElement,
+				}
+			: {}),
+	};
+}
+
+function registry(...defs: CardTypeDefinition[]): Map<string, CardTypeDefinition> {
+	return new Map(defs.map((d) => [d.id, d]));
+}
+
+function cardShape(cardType: string, fields?: Record<string, unknown>): ShapeData {
+	return {
+		id: "c1",
+		type: CARD_TYPE,
+		x: 12,
+		y: 34,
+		width: 100,
+		height: 150,
+		style: { fill: "#abcdef", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		meta: { cardType, isFlipped: false, fields: fields ?? { label: "ACE" } },
+	} as ShapeData;
+}
+
+describe("createCardSimplified", () => {
+	it("positions a card frame in world coords and renders the card-type's content", () => {
+		const Comp = createCardSimplified(registry(makeCardType("media", true)));
+		const el = Comp({ shape: cardShape("media") }) as ReactElement<Record<string, unknown>>;
+		const style = el.props.style as Record<string, unknown>;
+		expect(style.left).toBe(12);
+		expect(style.top).toBe(34);
+		expect(style.width).toBe(100);
+		expect(style.height).toBe(150);
+		expect(style.position).toBe("absolute");
+		// No gray fill when card-type provides its own simplified content.
+		expect(style.backgroundColor).toBeUndefined();
+		const inner = el.props.children as ReactElement<Record<string, unknown>>;
+		expect(inner.props["data-kind"]).toBe("simplified");
+		expect(inner.props.children).toBe("ACE");
+	});
+
+	it("falls back to a fill rect when the card-type has no renderSimplified", () => {
+		const Comp = createCardSimplified(registry(makeCardType("plain", false)));
+		const el = Comp({ shape: cardShape("plain") }) as ReactElement<Record<string, unknown>>;
+		const style = el.props.style as Record<string, unknown>;
+		expect(style.backgroundColor).toBe("#abcdef");
+		expect(el.props.children).toBeUndefined();
+	});
+
+	it("falls back to default gray when style.fill and renderSimplified are absent", () => {
+		const Comp = createCardSimplified(registry(makeCardType("plain", false)));
+		const shape = { ...cardShape("plain"), style: undefined } as unknown as ShapeData;
+		const el = Comp({ shape }) as ReactElement<Record<string, unknown>>;
+		expect((el.props.style as Record<string, unknown>).backgroundColor).toBe("#cccccc");
+	});
+
+	it("falls back when the card-type is unknown", () => {
+		const Comp = createCardSimplified(registry(makeCardType("media", true)));
+		const el = Comp({ shape: cardShape("nope") }) as ReactElement<Record<string, unknown>>;
+		expect((el.props.style as Record<string, unknown>).backgroundColor).toBe("#abcdef");
+	});
+});
+
+describe("createDeckSimplified", () => {
+	function deckShape(cardType: string, cards: Record<string, unknown>[]): ShapeData {
+		return {
+			id: "d1",
+			type: DECK_TYPE,
+			x: 5,
+			y: 6,
+			width: 100,
+			height: 150,
+			style: { fill: "#abcdef", stroke: "#000", strokeWidth: 1, opacity: 1 },
+			meta: { cardType, cards, faceDown: true },
+		} as ShapeData;
+	}
+
+	it("renders the top card's simplified content", () => {
+		const Comp = createDeckSimplified(registry(makeCardType("media", true)));
+		const el = Comp({
+			shape: deckShape("media", [{ label: "TOP" }, { label: "next" }]),
+		}) as ReactElement<Record<string, unknown>>;
+		const inner = el.props.children as ReactElement<Record<string, unknown>>;
+		expect(inner.props.children).toBe("TOP");
+	});
+
+	it("falls back to a fill rect for an empty deck", () => {
+		const Comp = createDeckSimplified(registry(makeCardType("media", true)));
+		const el = Comp({ shape: deckShape("media", []) }) as ReactElement<Record<string, unknown>>;
+		expect((el.props.style as Record<string, unknown>).backgroundColor).toBe("#abcdef");
+		expect(el.props.children).toBeUndefined();
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/card-types/media.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/media.tsx
@@ -124,6 +124,51 @@ function renderBack(fields: MediaCardFields) {
 	);
 }
 
+/** 低ズーム表示: アクセント帯 + タイトルだけの軽量表示。 */
+function renderSimplified(fields: MediaCardFields) {
+	const accent = fields.accentColor ?? DEFAULT_ACCENT;
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				fontFamily: "system-ui, sans-serif",
+				background: "#fff",
+				containerType: "size",
+			}}
+		>
+			<div style={{ flex: "0 0 45%", background: accent }} />
+			<div
+				style={{
+					flex: "1 1 auto",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					padding: "0 8%",
+					color: "#1e1e1e",
+					fontWeight: 700,
+					fontSize: "14cqh",
+					textAlign: "center",
+					overflow: "hidden",
+				}}
+			>
+				<span
+					style={{
+						display: "-webkit-box",
+						WebkitBoxOrient: "vertical",
+						WebkitLineClamp: 2,
+						overflow: "hidden",
+					}}
+				>
+					{fields.title}
+				</span>
+			</div>
+		</div>
+	);
+}
+
 export const mediaCardType: CardTypeDefinition<MediaCardFields> = {
 	id: "media",
 	label: "メディアカード",
@@ -138,5 +183,6 @@ export const mediaCardType: CardTypeDefinition<MediaCardFields> = {
 	}),
 	renderFront,
 	renderBack,
+	renderSimplified,
 	placementAnimation: { preset: "drop" },
 };

--- a/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/playing-card.tsx
@@ -230,6 +230,33 @@ function renderBack(_fields: PlayingCardFields) {
 	);
 }
 
+/** 低ズーム表示: 大きな rank + suit を中央に置き、引きでも識別できるようにする。 */
+function renderSimplified(fields: PlayingCardFields) {
+	const color = isRed(fields.suit) ? "#d4233b" : "#1e1e1e";
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				background: "#fff",
+				color,
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				gap: "4%",
+				fontFamily: "Georgia, 'Times New Roman', serif",
+				fontWeight: 700,
+				fontSize: "42cqh",
+				containerType: "size",
+				lineHeight: 1,
+			}}
+		>
+			<span>{fields.rank}</span>
+			<span>{fields.suit}</span>
+		</div>
+	);
+}
+
 export const playingCardType: CardTypeDefinition<PlayingCardFields> = {
 	id: "playing-card",
 	label: "トランプ",
@@ -239,6 +266,7 @@ export const playingCardType: CardTypeDefinition<PlayingCardFields> = {
 	createDefaultFields: () => ({ suit: "♠", rank: "A" }),
 	renderFront,
 	renderBack,
+	renderSimplified,
 	placementAnimation: { preset: "slam-medium" },
 	buildDeck: () => {
 		const deck: PlayingCardFields[] = [];

--- a/plugins/usketch-plugin-shape-card/src/card-types/uno.tsx
+++ b/plugins/usketch-plugin-shape-card/src/card-types/uno.tsx
@@ -132,6 +132,44 @@ function renderBack(_fields: UnoCardFields) {
 	);
 }
 
+/** 低ズーム表示: 色ベタ地に中央の白丸＋値だけ。引きでも色と値が分かる。 */
+function renderSimplified(fields: UnoCardFields) {
+	const bg = COLOR_HEX[fields.color];
+	const label = valueLabel(fields.value);
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				background: bg,
+				display: "flex",
+				alignItems: "center",
+				justifyContent: "center",
+				fontFamily: "system-ui, sans-serif",
+				containerType: "size",
+			}}
+		>
+			<div
+				style={{
+					width: "70%",
+					height: "60%",
+					background: "#fff",
+					borderRadius: "50%",
+					transform: "rotate(-20deg)",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "center",
+					color: bg,
+					fontWeight: 800,
+					fontSize: "40cqh",
+				}}
+			>
+				{label}
+			</div>
+		</div>
+	);
+}
+
 export const unoCardType: CardTypeDefinition<UnoCardFields> = {
 	id: "uno",
 	label: "UNO",
@@ -141,6 +179,7 @@ export const unoCardType: CardTypeDefinition<UnoCardFields> = {
 	createDefaultFields: () => ({ color: "red", value: "0" }),
 	renderFront,
 	renderBack,
+	renderSimplified,
 	placementAnimation: { preset: "slam-heavy" },
 	buildDeck: () => {
 		const deck: UnoCardFields[] = [];

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -31,6 +31,7 @@ import {
 import { createCardTypeRegistry } from "./registry.js";
 import { createCardRenderer } from "./render-card.js";
 import { createDeckRenderer } from "./render-deck.js";
+import { createCardSimplified, createDeckSimplified } from "./render-simplified.js";
 import {
 	type CardTypeDefinition,
 	type DeckMeta,
@@ -118,6 +119,8 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 	const getSlam = (id: string) => slamming.get(id);
 	const renderCard = createCardRenderer(registry, getSlam);
 	const renderDeck = createDeckRenderer(registry);
+	const cardSimplified = createCardSimplified(registry);
+	const deckSimplified = createDeckSimplified(registry);
 	const hasCardTypes = registry.size > 0;
 
 	// 既定の card-type（先頭。空なら ""）
@@ -345,6 +348,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				hitTest: withRotation(rectHitTest),
 				resize,
 				resizable: resolveResizable,
+				simplifiedComponent: cardSimplified,
 				createDefault: ({ id, x, y }) => {
 					const def = resolveDef(currentCardType);
 					return def ? createCardShape(def, { id, x, y }) : createBareCardShape({ id, x, y });
@@ -439,6 +443,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					hitTest: withRotation(rectHitTest),
 					resize,
 					resizable: resolveResizable,
+					simplifiedComponent: deckSimplified,
 					createDefault: ({ id, x, y }) => {
 						const def = resolveDef(currentCardType);
 						return def

--- a/plugins/usketch-plugin-shape-card/src/render-simplified.tsx
+++ b/plugins/usketch-plugin-shape-card/src/render-simplified.tsx
@@ -1,0 +1,61 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { safeRotation } from "@edv4h/usketch-shared";
+import type { CSSProperties, ReactElement } from "react";
+import { type CardTypeDefinition, readCardMeta, readDeckMeta } from "./types.js";
+
+/**
+ * LOD（低ズーム）時の簡易表示は `dom-renderer` 側でラップされず、world 座標へ
+ * self-position する必要がある（`LodFallback` と同じ規約）。card-type 側は枠内の
+ * 中身だけを返せばよいよう、この枠付けを plugin に閉じ込める。
+ */
+function frameStyle(shape: ShapeData): CSSProperties {
+	const rotation = safeRotation(shape.rotation);
+	return {
+		position: "absolute",
+		left: shape.x,
+		top: shape.y,
+		width: shape.width,
+		height: shape.height,
+		borderRadius: 10,
+		overflow: "hidden",
+		pointerEvents: "none",
+		transform: rotation ? `rotate(${rotation}deg)` : undefined,
+		transformOrigin: "center center",
+	};
+}
+
+/** renderSimplified が無い card-type 用の既定簡易表示（LodFallback 相当のグレー矩形）。 */
+function fallbackFill(shape: ShapeData): CSSProperties {
+	const fill = (shape.style as { fill?: string } | undefined)?.fill;
+	return { ...frameStyle(shape), backgroundColor: fill || "#cccccc" };
+}
+
+/**
+ * `card` shape の `simplifiedComponent` を生成する。card-type の `renderSimplified`
+ * があればカード枠に配置し、無ければグレー矩形にフォールバックする。
+ */
+export function createCardSimplified(registry: Map<string, CardTypeDefinition>) {
+	return function CardSimplified({ shape }: { shape: ShapeData }): ReactElement {
+		const meta = readCardMeta(shape);
+		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+		const inner = def?.renderSimplified?.(meta.fields ?? def.createDefaultFields());
+		if (!inner) return <div style={fallbackFill(shape)} />;
+		return <div style={frameStyle(shape)}>{inner}</div>;
+	};
+}
+
+/**
+ * `card-deck` shape の `simplifiedComponent` を生成する。一番上のカード（`cards[0]`）の
+ * fields で card-type の `renderSimplified` を呼ぶ。空デッキや renderSimplified 未定義時は
+ * グレー矩形にフォールバックする。
+ */
+export function createDeckSimplified(registry: Map<string, CardTypeDefinition>) {
+	return function DeckSimplified({ shape }: { shape: ShapeData }): ReactElement {
+		const meta = readDeckMeta(shape);
+		const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+		const top = meta.cards?.[0];
+		const inner = top ? def?.renderSimplified?.(top) : undefined;
+		if (!inner) return <div style={fallbackFill(shape)} />;
+		return <div style={frameStyle(shape)}>{inner}</div>;
+	};
+}

--- a/plugins/usketch-plugin-shape-card/src/types.ts
+++ b/plugins/usketch-plugin-shape-card/src/types.ts
@@ -102,6 +102,12 @@ export interface CardTypeDefinition<TFields = Record<string, unknown>> {
 	renderFront(fields: TFields): ReactElement;
 	/** 裏面の描画（共通カードバックでも可）。 */
 	renderBack(fields: TFields): ReactElement;
+	/**
+	 * 低ズーム (LOD) 時の簡易表示。`renderFront` と同様、plugin がカード枠（world 座標）に
+	 * 配置するので、ここでは枠内に収まる中身だけを返せばよい。省略時は通常のフォールバック
+	 * （`shape.style.fill` のグレー矩形）になる。引きでも card-type が判別できる軽量表示を想定。
+	 */
+	renderSimplified?(fields: TFields): ReactElement;
 	/** デッキ（山札）の初期内容を生成する。例: トランプ52枚 / UNO108枚。 */
 	buildDeck?(): TFields[];
 }


### PR DESCRIPTION
## Summary

Closes #631.

`card` / `card-deck` には `simplifiedComponent` が無く、低ズーム (LOD) 時はデフォルトの `LodFallback`（グレー矩形）になって引きでカード種別が分かりませんでした。card-type ごとに LOD 簡易表示を宣言できる hook を追加し、利用側の shape 定義上書きを不要にします。

### 変更
- **`CardTypeDefinition.renderSimplified?(fields)`** を追加。`renderFront` と同様、plugin がカード枠（world 座標へ self-position）を用意するので、card-type 側は枠内の中身だけ返せばよい。
- plugin が `card` / `card-deck` の `ShapeDefinition.simplifiedComponent` を配線:
  - `card`: その shape の `meta.cardType` の `renderSimplified` を使用。
  - `card-deck`: 一番上のカード (`cards[0]`) の fields で `renderSimplified`。
  - 未定義 / 空デッキ / 未知 card-type → 従来どおりグレー矩形 (`shape.style.fill`) にフォールバック。
- 組込み EXAMPLE card-type（media / playing-card / uno）に `renderSimplified` を実装し、引きでも種別が判別できるように。

### 設計メモ
- `simplifiedComponent` は `dom-renderer` 側でラップされず world 座標へ self-position する必要がある（`LodFallback` と同じ規約）ため、枠付け（位置・サイズ・回転・角丸）を plugin に閉じ込め、card-type は中身だけを返す形にしました（`renderFront` と対称）。

### #625 / #626 との関係
- #625（tool-helpers の resizable 対応）+ #626（`CardTypeDefinition.resizable`）でサイズ固定は宣言だけで済むようになりました。
- 本 PR で LOD 簡易表示も宣言できるようになり、**利用側の shape 定義上書きプラグインを完全に撤去できます**。

## Test plan
- `render-simplified.test.tsx`（新規）: 枠の world 座標配置 / card-type の中身描画 / renderSimplified 無し・style.fill 無し・未知 type のフォールバック / デッキ top カード / 空デッキ、を検証（React レンダリングは使わず返り要素ツリーを直接検査）。
- `pnpm turbo typecheck`（143）グリーン、shape-card テスト 40 passed、Biome クリーン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)