### PR TITLE
✨ feat: snap Alt挙動の選択 & 選択オーバーレイ色の設定 (#636, #637)

### DIFF
--- a/.changeset/select-overlay-colors.md
+++ b/.changeset/select-overlay-colors.md
@@ -1,0 +1,10 @@
+---
+"@edv4h/usketch-plugin-tool-select": minor
+---
+
+選択オーバーレイ（選択枠/ハンドル）の色を設定可能に（#637）。固定の青 `#2680eb` から
+ホストのテーマ色へ追従できる。
+
+- `createSelectToolPlugin({ overlay: { strokeColor, handleFillColor } })` で初期色を指定。
+- 実行時は `select:configure`（snap の `snap:configure` と対）イベントで変更可能。
+- 色はインライン `style` で適用するため `var(--colors-primary)` のような CSS 変数も渡せる。

--- a/.changeset/snap-alt-invert.md
+++ b/.changeset/snap-alt-invert.md
@@ -1,0 +1,10 @@
+---
+"@edv4h/usketch-plugin-snap": minor
+---
+
+Alt(Option) キーの挙動を選べる `altBehavior` を追加（#636）。`"invert"` にすると、
+`enabled: false`（スナップ無効）でも Alt 押下中だけ一時的にスナップを効かせられる。
+
+- `createSnapPlugin({ altBehavior: "invert" })` または `snap:configure({ altBehavior })` で設定。
+- 既定は `"suppress"`（従来どおり Alt 押下中は無条件抑止）で後方互換。
+- `SnapSettings.altBehavior` を追加。

--- a/plugins/usketch-plugin-snap/src/alt-behavior.test.ts
+++ b/plugins/usketch-plugin-snap/src/alt-behavior.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { effectiveSnapEnabled } from "./alt-behavior.js";
+
+describe("effectiveSnapEnabled", () => {
+	it("Alt 非押下なら enabled のまま", () => {
+		expect(effectiveSnapEnabled(true, false, "suppress")).toBe(true);
+		expect(effectiveSnapEnabled(false, false, "invert")).toBe(false);
+	});
+
+	it("suppress: Alt 押下中は常に無効（従来）", () => {
+		expect(effectiveSnapEnabled(true, true, "suppress")).toBe(false);
+		expect(effectiveSnapEnabled(false, true, "suppress")).toBe(false);
+	});
+
+	it("invert: Alt 押下中は enabled を反転", () => {
+		// 有効 → 一時無効（従来と同じ体感）
+		expect(effectiveSnapEnabled(true, true, "invert")).toBe(false);
+		// 無効 → 一時有効（新規。これが #636 の要望）
+		expect(effectiveSnapEnabled(false, true, "invert")).toBe(true);
+	});
+});

--- a/plugins/usketch-plugin-snap/src/alt-behavior.ts
+++ b/plugins/usketch-plugin-snap/src/alt-behavior.ts
@@ -1,0 +1,16 @@
+import type { AltBehavior } from "./engine/types.js";
+
+/**
+ * Alt(Option) キー押下を考慮した実効スナップ有効状態。
+ * - 非押下: `enabled` のまま
+ * - 押下 + `"suppress"`: 常に false（従来挙動）
+ * - 押下 + `"invert"`: `!enabled`（無効→一時有効 / 有効→一時無効）
+ */
+export function effectiveSnapEnabled(
+	enabled: boolean,
+	altKeyHeld: boolean,
+	altBehavior: AltBehavior,
+): boolean {
+	if (!altKeyHeld) return enabled;
+	return altBehavior === "invert" ? !enabled : false;
+}

--- a/plugins/usketch-plugin-snap/src/engine/types.ts
+++ b/plugins/usketch-plugin-snap/src/engine/types.ts
@@ -40,6 +40,13 @@ export interface GuideStyle {
 	diamondSize: number;
 }
 
+/**
+ * Alt(Option) キー押下中の挙動。
+ * - `"suppress"`（既定・従来）: 押下中は無条件にスナップ抑止。
+ * - `"invert"`: 押下中は `enabled` を一時反転（無効時に一時有効、有効時に一時無効）。
+ */
+export type AltBehavior = "suppress" | "invert";
+
 export interface SnapSettings {
 	enabled: boolean;
 	threshold: number;
@@ -47,4 +54,6 @@ export interface SnapSettings {
 	centerSnap: boolean;
 	viewportOnly: boolean;
 	guideStyle: GuideStyle;
+	/** Alt(Option) キーの挙動（既定 `"suppress"`）。 */
+	altBehavior: AltBehavior;
 }

--- a/plugins/usketch-plugin-snap/src/index.ts
+++ b/plugins/usketch-plugin-snap/src/index.ts
@@ -1,2 +1,8 @@
-export type { GuideStyle, SnapLine, SnapResult, SnapSettings } from "./engine/types.js";
-export { createSnapPlugin } from "./plugin.js";
+export type {
+	AltBehavior,
+	GuideStyle,
+	SnapLine,
+	SnapResult,
+	SnapSettings,
+} from "./engine/types.js";
+export { createSnapPlugin, type SnapPluginOptions } from "./plugin.js";

--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -8,9 +8,17 @@ import type {
 	Viewport,
 } from "@edv4h/usketch-shared";
 import { useSyncExternalStore } from "react";
+import { effectiveSnapEnabled } from "./alt-behavior.js";
 import { DEFAULT_GUIDE_STYLE, DEFAULT_SNAP_THRESHOLD } from "./constants.js";
 import { calculateSnap, type SnapEdgeFilter } from "./engine/snap-engine.js";
-import type { GuideStyle, SnapEdge, SnapLine, SnapResult, SnapSettings } from "./engine/types.js";
+import type {
+	AltBehavior,
+	GuideStyle,
+	SnapEdge,
+	SnapLine,
+	SnapResult,
+	SnapSettings,
+} from "./engine/types.js";
 import { GuideLayer } from "./guide-layer.js";
 
 // ── Shared mutable state for the plugin ──
@@ -91,19 +99,27 @@ function SnapGuideOverlay({ viewport }: SnapGuideOverlayProps) {
 
 // ── Plugin ──
 
-export function createSnapPlugin(): UsketchPlugin {
+export interface SnapPluginOptions {
+	/** 初期のスナップ有効状態（既定 true）。 */
+	enabled?: boolean;
+	/** Alt(Option) キーの挙動（既定 "suppress"）。"invert" で無効時も Alt で一時スナップ。 */
+	altBehavior?: AltBehavior;
+}
+
+export function createSnapPlugin(options: SnapPluginOptions = {}): UsketchPlugin {
 	return {
 		id: "usketch-plugin-snap",
 		name: "スナップ",
 
 		setup(ctx: PluginContext) {
 			const settings: SnapSettings = {
-				enabled: true,
+				enabled: options.enabled ?? true,
 				threshold: DEFAULT_SNAP_THRESHOLD,
 				edgeSnap: true,
 				centerSnap: true,
 				viewportOnly: true,
 				guideStyle: { ...DEFAULT_GUIDE_STYLE },
+				altBehavior: options.altBehavior ?? "suppress",
 			};
 
 			// Sync initial guide style to shared state
@@ -168,13 +184,17 @@ export function createSnapPlugin(): UsketchPlugin {
 			const originalUpdateShape = ctx.store.updateShape.bind(ctx.store);
 
 			function patchedUpdateShape(id: string, updates: Partial<ShapeData>) {
-				// Only snap during pointer-down, when enabled, and Alt not held
-				const shouldSnap =
-					pointerDown && settings.enabled && !altKeyHeld && hasPositionUpdate(updates);
+				const effectiveEnabled = effectiveSnapEnabled(
+					settings.enabled,
+					altKeyHeld,
+					settings.altBehavior,
+				);
+				const shouldSnap = pointerDown && effectiveEnabled && hasPositionUpdate(updates);
 
 				if (!shouldSnap) {
 					originalUpdateShape(id, updates);
-					if (pointerDown && altKeyHeld) {
+					// スナップしないドラッグ中はガイドを消す。
+					if (pointerDown) {
 						setState({ lines: [] });
 					}
 					return;

--- a/plugins/usketch-plugin-tool-select/src/index.ts
+++ b/plugins/usketch-plugin-tool-select/src/index.ts
@@ -1,1 +1,2 @@
-export { createSelectToolPlugin } from "./plugin.js";
+export type { OverlayColors } from "./overlay-colors.js";
+export { createSelectToolPlugin, type SelectToolPluginOptions } from "./plugin.js";

--- a/plugins/usketch-plugin-tool-select/src/overlay-colors.test.ts
+++ b/plugins/usketch-plugin-tool-select/src/overlay-colors.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	getOverlayColors,
+	resetOverlayColors,
+	setOverlayColors,
+	subscribeOverlayColors,
+} from "./overlay-colors.js";
+
+afterEach(() => resetOverlayColors());
+
+describe("overlay-colors store", () => {
+	it("既定色（#2680eb / #ffffff）", () => {
+		expect(getOverlayColors()).toEqual({ strokeColor: "#2680eb", handleFillColor: "#ffffff" });
+	});
+
+	it("部分更新でき、未指定キーは保持。CSS 変数も格納できる", () => {
+		setOverlayColors({ strokeColor: "var(--colors-primary)" });
+		expect(getOverlayColors().strokeColor).toBe("var(--colors-primary)");
+		expect(getOverlayColors().handleFillColor).toBe("#ffffff");
+		setOverlayColors({ handleFillColor: "#222" });
+		expect(getOverlayColors()).toEqual({
+			strokeColor: "var(--colors-primary)",
+			handleFillColor: "#222",
+		});
+	});
+
+	it("undefined / 空 patch は無視", () => {
+		setOverlayColors({ strokeColor: "#abc" });
+		setOverlayColors(undefined);
+		setOverlayColors({ strokeColor: undefined });
+		expect(getOverlayColors().strokeColor).toBe("#abc");
+	});
+
+	it("subscribe が変更で通知され、reset で既定に戻る", () => {
+		let n = 0;
+		const off = subscribeOverlayColors(() => n++);
+		setOverlayColors({ strokeColor: "#111" });
+		expect(n).toBe(1);
+		resetOverlayColors();
+		expect(getOverlayColors().strokeColor).toBe("#2680eb");
+		off();
+	});
+});

--- a/plugins/usketch-plugin-tool-select/src/overlay-colors.ts
+++ b/plugins/usketch-plugin-tool-select/src/overlay-colors.ts
@@ -1,0 +1,43 @@
+import { useSyncExternalStore } from "react";
+
+export interface OverlayColors {
+	/** 選択枠・ハンドルの線色。CSS 変数（例 `var(--colors-primary)`）も可。 */
+	strokeColor: string;
+	/** リサイズ/回転ハンドルの塗り色。 */
+	handleFillColor: string;
+}
+
+const DEFAULTS: OverlayColors = { strokeColor: "#2680eb", handleFillColor: "#ffffff" };
+
+// このプラグインの drag-state / marquee-state と同様、モジュールレベルの共有状態。
+let colors: OverlayColors = { ...DEFAULTS };
+const listeners = new Set<() => void>();
+
+export function getOverlayColors(): OverlayColors {
+	return colors;
+}
+
+export function setOverlayColors(patch: Partial<OverlayColors> | undefined): void {
+	if (!patch) return;
+	const next = { ...colors };
+	if (patch.strokeColor != null) next.strokeColor = patch.strokeColor;
+	if (patch.handleFillColor != null) next.handleFillColor = patch.handleFillColor;
+	colors = next;
+	for (const l of listeners) l();
+}
+
+/** 既定色へ戻す（プラグイン teardown 用、StrictMode 再マウント時の漏れ防止）。 */
+export function resetOverlayColors(): void {
+	colors = { ...DEFAULTS };
+	for (const l of listeners) l();
+}
+
+export function subscribeOverlayColors(listener: () => void): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+/** React コンポーネントから現在の色を購読する。 */
+export function useOverlayColors(): OverlayColors {
+	return useSyncExternalStore(subscribeOverlayColors, getOverlayColors, getOverlayColors);
+}

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -30,6 +30,7 @@ import {
 import { clearHoveredShapeListeners, setHoveredShapeId } from "./hover-state.js";
 import type { MarqueeRect } from "./marquee-state.js";
 import { clearMarqueeListeners, setMarquee, setMarqueeMode } from "./marquee-state.js";
+import { type OverlayColors, resetOverlayColors, setOverlayColors } from "./overlay-colors.js";
 import { SelectionOverlay } from "./selection-overlay.js";
 
 // Hit-test helpers used to live here; they were extracted to
@@ -101,12 +102,20 @@ type DragState =
 
 // ── Plugin ──
 
-export function createSelectToolPlugin(): UsketchPlugin {
+export interface SelectToolPluginOptions {
+	/** 選択オーバーレイ（選択枠/ハンドル）の色。CSS 変数（例 `var(--colors-primary)`）も可。 */
+	overlay?: Partial<OverlayColors>;
+}
+
+export function createSelectToolPlugin(options: SelectToolPluginOptions = {}): UsketchPlugin {
 	return {
 		id: "usketch-plugin-tool-select",
 		name: "選択",
 
 		setup(ctx: PluginContext) {
+			// 選択オーバーレイの色を初期化（指定が無ければ既定の青のまま）。
+			setOverlayColors(options.overlay);
+
 			// Wrap setDropTargetId to also emit on EventBus for DomShapeLayer
 			function updateDropTarget(id: string | null) {
 				setDropTargetId(id);
@@ -463,8 +472,16 @@ export function createSelectToolPlugin(): UsketchPlugin {
 			ctx.shortcuts.register("Delete", () => deleteSelectedShapes(ctx));
 			ctx.shortcuts.register("Backspace", () => deleteSelectedShapes(ctx));
 
+			// 実行時に色を変更（snap:configure と対になる select:configure）。
+			// `{ overlay: { strokeColor, handleFillColor } }` も平坦な形も受け付ける。
+			const offConfigure = ctx.events.on<
+				{ overlay?: Partial<OverlayColors> } & Partial<OverlayColors>
+			>("select:configure", (patch) => setOverlayColors(patch.overlay ?? patch));
+
 			// ── Teardown ──
 			return () => {
+				offConfigure();
+				resetOverlayColors();
 				setOverrideCursor("");
 				setMovingSelection(false);
 				setMarquee(null);

--- a/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
+++ b/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
@@ -11,6 +11,7 @@ import {
 	getMarqueeRect,
 	subscribeMarquee,
 } from "./marquee-state.js";
+import { useOverlayColors } from "./overlay-colors.js";
 import {
 	getHandlePositions,
 	getMultiSelectionBounds,
@@ -24,8 +25,6 @@ interface SelectionOverlayProps {
 	viewport: Viewport;
 }
 
-const STROKE_COLOR = "#2680eb";
-
 function ShapeBoundingBox({
 	store,
 	shapes,
@@ -37,6 +36,7 @@ function ShapeBoundingBox({
 	viewport: Viewport;
 	shapeId: string;
 }) {
+	const { strokeColor } = useOverlayColors();
 	const bounds = getShapeBounds(store, shapes, shapeId);
 	if (!bounds) return null;
 	const shape = store.getShape(shapeId);
@@ -55,14 +55,15 @@ function ShapeBoundingBox({
 				width={bw}
 				height={bh}
 				fill="none"
-				stroke={STROKE_COLOR}
 				strokeWidth={1}
+				style={{ stroke: strokeColor }}
 			/>
 		</g>
 	);
 }
 
 export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayProps) {
+	const { strokeColor, handleFillColor } = useOverlayColors();
 	const selection = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
 		() => store.getSelection(),
@@ -118,8 +119,8 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 				width={dropBounds.width * viewport.zoom}
 				height={dropBounds.height * viewport.zoom}
 				fill="none"
-				stroke={STROKE_COLOR}
 				strokeWidth={2}
+				style={{ stroke: strokeColor }}
 			/>
 		</svg>
 	) : null;
@@ -147,7 +148,7 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 							width={hw}
 							height={hh}
 							fill="none"
-							stroke={STROKE_COLOR}
+							style={{ stroke: strokeColor }}
 							strokeWidth={2}
 							opacity={0.8}
 						/>
@@ -201,7 +202,7 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 						width={sw}
 						height={sh}
 						fill="none"
-						stroke={STROKE_COLOR}
+						style={{ stroke: strokeColor }}
 						strokeWidth={1}
 					/>
 					{!hideHandles &&
@@ -212,9 +213,8 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 								y={pos.y - half}
 								width={HANDLE_SIZE}
 								height={HANDLE_SIZE}
-								fill="#ffffff"
-								stroke={STROKE_COLOR}
 								strokeWidth={1}
+								style={{ fill: handleFillColor, stroke: strokeColor }}
 							/>
 						))}
 				</g>
@@ -261,7 +261,7 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 						width={multiBounds.width * viewport.zoom}
 						height={multiBounds.height * viewport.zoom}
 						fill="none"
-						stroke={STROKE_COLOR}
+						style={{ stroke: strokeColor }}
 						strokeWidth={1}
 						strokeDasharray="4 2"
 					/>
@@ -272,9 +272,8 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 							y={pos.y - HANDLE_SIZE / 2}
 							width={HANDLE_SIZE}
 							height={HANDLE_SIZE}
-							fill="#ffffff"
-							stroke={STROKE_COLOR}
 							strokeWidth={1}
+							style={{ fill: handleFillColor, stroke: strokeColor }}
 						/>
 					))}
 				</>
@@ -298,7 +297,7 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 					width={marqueeRect.width * viewport.zoom}
 					height={marqueeRect.height * viewport.zoom}
 					fill={marqueeMode === "contain" ? "rgba(38, 128, 235, 0.08)" : "rgba(38, 128, 235, 0.1)"}
-					stroke={STROKE_COLOR}
+					style={{ stroke: strokeColor }}
 					strokeWidth={1}
 					strokeDasharray={marqueeMode === "contain" ? undefined : "4 2"}
 				/>


### PR DESCRIPTION
最新 Issue 2件に対応しました。いずれも既定値は従来と同一で**後方互換**です。

## #636 snap: Alt(Option) キーの挙動を選択可能に
現状 Alt 押下中は無条件スナップ抑止のため、スナップ無効時に「揃えたい瞬間だけ Alt で一時スナップ」ができませんでした。

- `SnapSettings.altBehavior: "suppress" | "invert"` を追加（既定 `"suppress"`）。
- `"invert"`: Alt 押下中は `enabled` を**一時反転**（無効→一時有効 / 有効→一時無効）。
- `createSnapPlugin({ altBehavior: "invert" })` または `snap:configure({ altBehavior })` で設定。
- ロジックは純関数 `effectiveSnapEnabled` に切り出し、ガイド表示も非スナップ時に消えるよう整合。

## #637 tool-select: 選択オーバーレイ（選択枠/ハンドル）の色を設定可能に
固定の青 `#2680eb` をホストのテーマ色へ追従できるように。

- `createSelectToolPlugin({ overlay: { strokeColor, handleFillColor } })` で初期色を指定。
- 実行時は `select:configure` イベント（snap の `snap:configure` と対）で変更可能。
- 色はインライン `style` で適用するため **`var(--colors-primary)` などの CSS 変数も渡せる**。
- 色はモジュールレベルのストア（既存の drag-state / marquee-state と同じ慣習）で保持し、live 更新。

## テスト
- snap: `effectiveSnapEnabled` のユニットテスト（suppress/invert × enabled）
- tool-select: `overlay-colors` ストアのテスト（部分更新 / CSS変数格納 / reset / subscribe）
- 既存テスト含め snap 20件 / select 4件 パス。typecheck（snap/select/web）・Biome・build クリーン

## 動作確認
- snap: `createSnapPlugin({ altBehavior: "invert", enabled: false })` で Alt 押下中だけスナップ。
- select: `events.emit("select:configure", { strokeColor: "var(--colors-primary)" })` で選択枠色が変わる。

Closes #636
Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)