### PR TITLE
🐛 fix(tool-select): overlay色をインスタンススコープ化 (#640)

### DIFF
--- a/plugins/usketch-plugin-tool-select/src/overlay-colors.test.ts
+++ b/plugins/usketch-plugin-tool-select/src/overlay-colors.test.ts
@@ -1,43 +1,50 @@
-import { afterEach, describe, expect, it } from "vitest";
-import {
-	getOverlayColors,
-	resetOverlayColors,
-	setOverlayColors,
-	subscribeOverlayColors,
-} from "./overlay-colors.js";
+import { describe, expect, it } from "vitest";
+import { createOverlayColorStore } from "./overlay-colors.js";
 
-afterEach(() => resetOverlayColors());
-
-describe("overlay-colors store", () => {
+describe("createOverlayColorStore", () => {
 	it("既定色（#2680eb / #ffffff）", () => {
-		expect(getOverlayColors()).toEqual({ strokeColor: "#2680eb", handleFillColor: "#ffffff" });
-	});
-
-	it("部分更新でき、未指定キーは保持。CSS 変数も格納できる", () => {
-		setOverlayColors({ strokeColor: "var(--colors-primary)" });
-		expect(getOverlayColors().strokeColor).toBe("var(--colors-primary)");
-		expect(getOverlayColors().handleFillColor).toBe("#ffffff");
-		setOverlayColors({ handleFillColor: "#222" });
-		expect(getOverlayColors()).toEqual({
-			strokeColor: "var(--colors-primary)",
-			handleFillColor: "#222",
+		expect(createOverlayColorStore().getSnapshot()).toEqual({
+			strokeColor: "#2680eb",
+			handleFillColor: "#ffffff",
 		});
 	});
 
-	it("undefined / 空 patch は無視", () => {
-		setOverlayColors({ strokeColor: "#abc" });
-		setOverlayColors(undefined);
-		setOverlayColors({ strokeColor: undefined });
-		expect(getOverlayColors().strokeColor).toBe("#abc");
+	it("初期値を適用。CSS 変数も格納できる", () => {
+		const s = createOverlayColorStore({ strokeColor: "var(--colors-primary)" });
+		expect(s.getSnapshot().strokeColor).toBe("var(--colors-primary)");
+		expect(s.getSnapshot().handleFillColor).toBe("#ffffff");
 	});
 
-	it("subscribe が変更で通知され、reset で既定に戻る", () => {
+	it("部分更新でき、未指定/undefined は保持", () => {
+		const s = createOverlayColorStore();
+		s.set({ strokeColor: "#abc" });
+		s.set(undefined);
+		s.set({ strokeColor: undefined });
+		expect(s.getSnapshot().strokeColor).toBe("#abc");
+		s.set({ handleFillColor: "#222" });
+		expect(s.getSnapshot()).toEqual({ strokeColor: "#abc", handleFillColor: "#222" });
+	});
+
+	it("subscribe が変更で通知される", () => {
+		const s = createOverlayColorStore();
 		let n = 0;
-		const off = subscribeOverlayColors(() => n++);
-		setOverlayColors({ strokeColor: "#111" });
+		const off = s.subscribe(() => n++);
+		s.set({ strokeColor: "#111" });
 		expect(n).toBe(1);
-		resetOverlayColors();
-		expect(getOverlayColors().strokeColor).toBe("#2680eb");
 		off();
+		s.set({ strokeColor: "#222" });
+		expect(n).toBe(1);
+	});
+
+	it("#640: インスタンスは独立。あるストアの破棄が別ストアの色に影響しない", () => {
+		// App#1, App#2 を同色で生成 → App#1 を「teardown」しても App#2 は保持。
+		const app1 = createOverlayColorStore({ strokeColor: "var(--colors-primary)" });
+		const app2 = createOverlayColorStore({ strokeColor: "var(--colors-primary)" });
+		// 旧実装ではモジュール共有 + teardown reset で app2 が既定に戻っていた。
+		// per-instance なので app1 を捨てても app2 は不変。
+		expect(app2.getSnapshot().strokeColor).toBe("var(--colors-primary)");
+		// app1 をいじっても app2 に影響しない
+		app1.set({ strokeColor: "#000000" });
+		expect(app2.getSnapshot().strokeColor).toBe("var(--colors-primary)");
 	});
 });

--- a/plugins/usketch-plugin-tool-select/src/overlay-colors.ts
+++ b/plugins/usketch-plugin-tool-select/src/overlay-colors.ts
@@ -1,5 +1,3 @@
-import { useSyncExternalStore } from "react";
-
 export interface OverlayColors {
 	/** 選択枠・ハンドルの線色。CSS 変数（例 `var(--colors-primary)`）も可。 */
 	strokeColor: string;
@@ -9,35 +7,38 @@ export interface OverlayColors {
 
 const DEFAULTS: OverlayColors = { strokeColor: "#2680eb", handleFillColor: "#ffffff" };
 
-// このプラグインの drag-state / marquee-state と同様、モジュールレベルの共有状態。
-let colors: OverlayColors = { ...DEFAULTS };
-const listeners = new Set<() => void>();
-
-export function getOverlayColors(): OverlayColors {
-	return colors;
+/**
+ * オーバーレイ色のストア。**setup（インスタンス）スコープ**で生成する。
+ * モジュール共有にすると、複数 App 同時生成（StrictMode / 非同期 createApp）で
+ * あるインスタンスの teardown が生存中の別インスタンスの色を壊す（#640）。
+ * snap プラグインの `settings` クロージャと同様に per-setup で保持する。
+ */
+export interface OverlayColorStore {
+	getSnapshot(): OverlayColors;
+	subscribe(listener: () => void): () => void;
+	/** 部分更新。未指定/undefined のキーは保持。 */
+	set(patch: Partial<OverlayColors> | undefined): void;
 }
 
-export function setOverlayColors(patch: Partial<OverlayColors> | undefined): void {
-	if (!patch) return;
-	const next = { ...colors };
-	if (patch.strokeColor != null) next.strokeColor = patch.strokeColor;
-	if (patch.handleFillColor != null) next.handleFillColor = patch.handleFillColor;
-	colors = next;
-	for (const l of listeners) l();
-}
+export function createOverlayColorStore(initial?: Partial<OverlayColors>): OverlayColorStore {
+	let colors: OverlayColors = { ...DEFAULTS };
+	const listeners = new Set<() => void>();
 
-/** 既定色へ戻す（プラグイン teardown 用、StrictMode 再マウント時の漏れ防止）。 */
-export function resetOverlayColors(): void {
-	colors = { ...DEFAULTS };
-	for (const l of listeners) l();
-}
-
-export function subscribeOverlayColors(listener: () => void): () => void {
-	listeners.add(listener);
-	return () => listeners.delete(listener);
-}
-
-/** React コンポーネントから現在の色を購読する。 */
-export function useOverlayColors(): OverlayColors {
-	return useSyncExternalStore(subscribeOverlayColors, getOverlayColors, getOverlayColors);
+	const store: OverlayColorStore = {
+		getSnapshot: () => colors,
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		set(patch) {
+			if (!patch) return;
+			const next = { ...colors };
+			if (patch.strokeColor != null) next.strokeColor = patch.strokeColor;
+			if (patch.handleFillColor != null) next.handleFillColor = patch.handleFillColor;
+			colors = next;
+			for (const l of listeners) l();
+		},
+	};
+	store.set(initial);
+	return store;
 }

--- a/plugins/usketch-plugin-tool-select/src/plugin.tsx
+++ b/plugins/usketch-plugin-tool-select/src/plugin.tsx
@@ -30,7 +30,7 @@ import {
 import { clearHoveredShapeListeners, setHoveredShapeId } from "./hover-state.js";
 import type { MarqueeRect } from "./marquee-state.js";
 import { clearMarqueeListeners, setMarquee, setMarqueeMode } from "./marquee-state.js";
-import { type OverlayColors, resetOverlayColors, setOverlayColors } from "./overlay-colors.js";
+import { createOverlayColorStore, type OverlayColors } from "./overlay-colors.js";
 import { SelectionOverlay } from "./selection-overlay.js";
 
 // Hit-test helpers used to live here; they were extracted to
@@ -113,8 +113,9 @@ export function createSelectToolPlugin(options: SelectToolPluginOptions = {}): U
 		name: "選択",
 
 		setup(ctx: PluginContext) {
-			// 選択オーバーレイの色を初期化（指定が無ければ既定の青のまま）。
-			setOverlayColors(options.overlay);
+			// 選択オーバーレイ色は setup(インスタンス)スコープで保持する（#640）。
+			// モジュール共有だと複数 App 同時生成時に teardown が他インスタンスの色を壊す。
+			const overlayColors = createOverlayColorStore(options.overlay);
 
 			// Wrap setDropTargetId to also emit on EventBus for DomShapeLayer
 			function updateDropTarget(id: string | null) {
@@ -464,7 +465,12 @@ export function createSelectToolPlugin(options: SelectToolPluginOptions = {}): U
 				order: 80,
 				fixed: true,
 				render: (renderCtx) => (
-					<SelectionOverlay store={ctx.store} shapes={ctx.shapes} viewport={renderCtx.viewport} />
+					<SelectionOverlay
+						store={ctx.store}
+						shapes={ctx.shapes}
+						viewport={renderCtx.viewport}
+						colors={overlayColors}
+					/>
 				),
 			});
 
@@ -476,12 +482,12 @@ export function createSelectToolPlugin(options: SelectToolPluginOptions = {}): U
 			// `{ overlay: { strokeColor, handleFillColor } }` も平坦な形も受け付ける。
 			const offConfigure = ctx.events.on<
 				{ overlay?: Partial<OverlayColors> } & Partial<OverlayColors>
-			>("select:configure", (patch) => setOverlayColors(patch.overlay ?? patch));
+			>("select:configure", (patch) => overlayColors.set(patch.overlay ?? patch));
 
 			// ── Teardown ──
 			return () => {
 				offConfigure();
-				resetOverlayColors();
+				// overlayColors はインスタンス所有なので reset 不要（GC で破棄）。#640
 				setOverrideCursor("");
 				setMovingSelection(false);
 				setMarquee(null);

--- a/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
+++ b/plugins/usketch-plugin-tool-select/src/selection-overlay.tsx
@@ -11,7 +11,7 @@ import {
 	getMarqueeRect,
 	subscribeMarquee,
 } from "./marquee-state.js";
-import { useOverlayColors } from "./overlay-colors.js";
+import type { OverlayColorStore } from "./overlay-colors.js";
 import {
 	getHandlePositions,
 	getMultiSelectionBounds,
@@ -23,6 +23,7 @@ interface SelectionOverlayProps {
 	store: BoardStore;
 	shapes: ShapeRegistry;
 	viewport: Viewport;
+	colors: OverlayColorStore;
 }
 
 function ShapeBoundingBox({
@@ -30,13 +31,14 @@ function ShapeBoundingBox({
 	shapes,
 	viewport,
 	shapeId,
+	strokeColor,
 }: {
 	store: BoardStore;
 	shapes: ShapeRegistry;
 	viewport: Viewport;
 	shapeId: string;
+	strokeColor: string;
 }) {
-	const { strokeColor } = useOverlayColors();
 	const bounds = getShapeBounds(store, shapes, shapeId);
 	if (!bounds) return null;
 	const shape = store.getShape(shapeId);
@@ -62,8 +64,12 @@ function ShapeBoundingBox({
 	);
 }
 
-export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayProps) {
-	const { strokeColor, handleFillColor } = useOverlayColors();
+export function SelectionOverlay({ store, shapes, viewport, colors }: SelectionOverlayProps) {
+	const { strokeColor, handleFillColor } = useSyncExternalStore(
+		colors.subscribe,
+		colors.getSnapshot,
+		colors.getSnapshot,
+	);
 	const selection = useSyncExternalStore(
 		(cb) => store.subscribe(cb),
 		() => store.getSelection(),
@@ -250,6 +256,7 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 						shapes={shapes}
 						viewport={viewport}
 						shapeId={id}
+						strokeColor={strokeColor}
 					/>
 				))}
 			{/* Combined bounding box for confirmed selection */}
@@ -287,6 +294,7 @@ export function SelectionOverlay({ store, shapes, viewport }: SelectionOverlayPr
 						shapes={shapes}
 						viewport={viewport}
 						shapeId={id}
+						strokeColor={strokeColor}
 					/>
 				))}
 			{/* Marquee rectangle (world-space → screen-space) */}


### PR DESCRIPTION
## 背景

#637（PR #639）で追加した選択オーバーレイ色が**モジュール共有シングルテン**で、plugin teardown 時に `resetOverlayColors()` していたため、**React StrictMode + 非同期 `createApp` の二重マウント**で、破棄されたインスタンスの teardown が生存インスタンスの色を既定へ戻してしまう不具合がありました（#640）。

```
#1 setup → setOverlayColors(primary)
#2 setup → setOverlayColors(primary)
#1 destroy → resetOverlayColors()  ← 生存中の #2 の色まで青に戻る
```

## 修正

オーバーレイ色を **setup(インスタンス)スコープ**で保持するよう変更（snap プラグインの `settings` クロージャと同じ持ち方）。

- `createOverlayColorStore(initial)` を `setup` 内で生成し、`SelectionOverlay` に props で渡す。
- teardown の `resetOverlayColors()` を撤去（インスタンス所有なので GC 任せ）。
- `select:configure` は当該インスタンスのストアへ書き込み。
- モジュール共有状態を廃止したため、複数 App が同時に存在しても互いの色を壊さない。

**公開 API（`createSelectToolPlugin({overlay})` / `select:configure`）は不変**で後方互換です。

## テスト
- `overlay-colors` のインスタンス独立性テストを追加（#640 の再現シナリオ＝あるストアの破棄/変更が別ストアに影響しないこと）。
- select 5件パス、typecheck（select/web）・Biome・build クリーン。

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)