### PR TITLE
📝 chore: add missing changeset for #640 fix

### DIFF
--- a/.changeset/fix-overlay-colors-instance.md
+++ b/.changeset/fix-overlay-colors-instance.md
@@ -1,0 +1,9 @@
+---
+"@edv4h/usketch-plugin-tool-select": patch
+---
+
+選択オーバーレイ色をモジュール共有シングルトンから setup(インスタンス)スコープへ変更（#640）。
+複数 App 同時生成（React StrictMode / 非同期 createApp の二重マウント）で、破棄された
+インスタンスの teardown が生存インスタンスの色を既定へ戻す不具合を修正。`createOverlayColorStore`
+を setup 内で生成し overlay に props で渡す（teardown reset は撤去）。`createSelectToolPlugin`
+/ `select:configure` の API は不変。


### PR DESCRIPTION
PR #641（#640 の overlay 色インスタンススコープ化）が changeset を含まずにマージされたため、欠けていた changeset を追加します。

- `@edv4h/usketch-plugin-tool-select` を patch bump（次回リリースで 3.1.1 を想定）。
- コード変更は無し（#641 で既に main にマージ済み）。差分は changeset ファイルのみ。

関連: #640