### PR TITLE
✨ feat: 最近傍の被らない位置を探す機能 (#581)

### DIFF
--- a/.changeset/free-position-581.md
+++ b/.changeset/free-position-581.md
@@ -1,0 +1,14 @@
+---
+"@edv4h/usketch-plugin-free-position": minor
+"@edv4h/usketch-shape-utils": minor
+"@edv4h/usketch-plugin-keyboard-shortcuts": minor
+---
+
+指定位置から「最も近い被らない位置」を求める機能を追加（#581）。
+
+- `@edv4h/usketch-shape-utils`: 純関数 `findFreePosition`（`ring` / `push` の2戦略）と `overlapsAny` を追加。
+- `@edv4h/usketch-plugin-free-position`（新規）: `free-position:find` イベントで問い合わせ可能。
+  ボード上の shape を**回転考慮 AABB**で避けた最近傍の空き位置を返す。
+- `@edv4h/usketch-plugin-keyboard-shortcuts`: paste/duplicate が `free-position:find` を使い、
+  複数 shape を相対配置を保ったままグループ単位で被らない位置へ自動配置（free-position 未登録時は
+  従来の +20 オフセットにフォールバック）。

--- a/.changeset/free-position-581.md
+++ b/.changeset/free-position-581.md
@@ -2,6 +2,9 @@
 "@edv4h/usketch-plugin-free-position": minor
 "@edv4h/usketch-shape-utils": minor
 "@edv4h/usketch-plugin-keyboard-shortcuts": minor
+"@edv4h/usketch-connector-anchor": minor
+"@edv4h/usketch-plugin-shape-connector": patch
+"@edv4h/usketch-plugin-domain-design": patch
 ---
 
 指定位置から「最も近い被らない位置」を求める機能を追加（#581）。
@@ -11,4 +14,10 @@
   ボード上の shape を**回転考慮 AABB**で避けた最近傍の空き位置を返す。
 - `@edv4h/usketch-plugin-keyboard-shortcuts`: paste/duplicate が `free-position:find` を使い、
   複数 shape を相対配置を保ったままグループ単位で被らない位置へ自動配置（free-position 未登録時は
-  従来の +20 オフセットにフォールバック）。
+  従来の +20 オフセットにフォールバック）。desired bounds は `ShapeDefinition.getBounds` +
+  回転考慮で算出し、平行移動は `ShapeDefinition.move` 経由で行う。
+- `@edv4h/usketch-connector-anchor`: `moveConnector`（`ShapeDefinition.move` 実装）を追加。
+  コネクタの `sourcePoint` / `targetPoint` / `controlPoint`（絶対座標）を x/y と同じオフセットで
+  平行移動する。
+- `@edv4h/usketch-plugin-shape-connector` / `@edv4h/usketch-plugin-domain-design`: コネクタ shape に
+  `move: moveConnector` を登録。paste/duplicate/移動で endpoints が取り残されて形状が崩れるのを防ぐ。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,6 +62,7 @@
 		"@edv4h/usketch-plugin-shape-sticky": "workspace:*",
 		"@edv4h/usketch-plugin-shape-text": "workspace:*",
 		"@edv4h/usketch-plugin-shape-wireframe": "workspace:*",
+		"@edv4h/usketch-plugin-free-position": "workspace:*",
 		"@edv4h/usketch-plugin-snap": "workspace:*",
 		"@edv4h/usketch-plugin-sync-localstorage-yjs": "workspace:*",
 		"@edv4h/usketch-plugin-sync-ywebsocket": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -16,6 +16,7 @@ import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
 import { createDomainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
 import { createExportPlugin } from "@edv4h/usketch-plugin-export";
 import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
+import { createFreePositionPlugin } from "@edv4h/usketch-plugin-free-position";
 import { createLaserPlugin } from "@edv4h/usketch-plugin-laser";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
 import { createPresenceEnhancedPlugin } from "@edv4h/usketch-plugin-presence-enhanced";
@@ -147,6 +148,7 @@ function createBasePlugins(): UsketchPlugin[] {
 		createWireframePlugin(),
 		createDomainDesignPlugin(),
 		createSnapPlugin(),
+		createFreePositionPlugin(),
 		createExportPlugin(),
 		createGpuRendererPlugin(),
 		createDomRendererPlugin(),

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -562,5 +562,6 @@ export interface UsketchPlugin {
 	 * return the cleanup from setup instead — each `createApp` call owns its
 	 * own closure.
 	 */
+	// biome-ignore lint/suspicious/noConfusingVoidType: setup はティアダウン関数 or 何も返さない(void)を許容する意図的な union
 	setup(ctx: PluginContext): PluginTeardown | void | Promise<PluginTeardown | void>;
 }

--- a/packages/usketch-connector-anchor/src/__tests__/move.test.ts
+++ b/packages/usketch-connector-anchor/src/__tests__/move.test.ts
@@ -1,0 +1,43 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { moveConnector } from "../move.js";
+import type { ConnectableShapeData } from "../types.js";
+
+const style = { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 };
+
+function connector(extra: Partial<ConnectableShapeData>): ShapeData {
+	return {
+		id: "c1",
+		type: "connector",
+		x: 10,
+		y: 20,
+		width: 100,
+		height: 50,
+		style,
+		...extra,
+	} as ShapeData;
+}
+
+describe("moveConnector", () => {
+	it("x/y と絶対座標の Point フィールドを同じオフセットで平行移動する", () => {
+		const shape = connector({
+			sourcePoint: { x: 10, y: 20 },
+			targetPoint: { x: 110, y: 70 },
+			controlPoint: { x: 60, y: 45 },
+		});
+		const patch = moveConnector(shape, 5, -3) as Partial<ConnectableShapeData>;
+		expect(patch.x).toBe(15);
+		expect(patch.y).toBe(17);
+		expect(patch.sourcePoint).toEqual({ x: 15, y: 17 });
+		expect(patch.targetPoint).toEqual({ x: 115, y: 67 });
+		expect(patch.controlPoint).toEqual({ x: 65, y: 42 });
+	});
+
+	it("未設定の Point フィールドは patch に含めない（x/y フォールバックと整合）", () => {
+		const shape = connector({ sourcePoint: { x: 10, y: 20 } });
+		const patch = moveConnector(shape, 8, 8) as Partial<ConnectableShapeData>;
+		expect(patch.sourcePoint).toEqual({ x: 18, y: 28 });
+		expect("targetPoint" in patch).toBe(false);
+		expect("controlPoint" in patch).toBe(false);
+	});
+});

--- a/packages/usketch-connector-anchor/src/index.ts
+++ b/packages/usketch-connector-anchor/src/index.ts
@@ -17,6 +17,7 @@ export {
 	sourceXY,
 	targetXY,
 } from "./hit-test.js";
+export { moveConnector } from "./move.js";
 export {
 	bezierBounds,
 	distanceToLineSegment,

--- a/packages/usketch-connector-anchor/src/move.ts
+++ b/packages/usketch-connector-anchor/src/move.ts
@@ -1,0 +1,26 @@
+import type { Point, ShapeData } from "@edv4h/usketch-shared";
+import type { ConnectableShapeData } from "./types.js";
+
+function shiftPoint(p: Point | undefined, dx: number, dy: number): Point | undefined {
+	return p ? { x: p.x + dx, y: p.y + dy } : undefined;
+}
+
+/**
+ * コネクタを (dx, dy) 平行移動するための差分を返す（`ShapeDefinition.move` 用）。
+ *
+ * コネクタは bounds を `sourcePoint` / `targetPoint` / `controlPoint`（絶対座標）から
+ * 導出する（{@link getBoundsConnector}）ため、x/y だけを動かすと endpoints が取り残されて
+ * 形状が崩れる。ここで x/y に加えて保持している Point フィールドも同じオフセットで移動する。
+ * 未設定の Point は省略する（`sourceXY`/`targetXY` が x/y にフォールバックするため整合する）。
+ */
+export function moveConnector(data: ShapeData, dx: number, dy: number): Partial<ShapeData> {
+	const c = data as ConnectableShapeData;
+	const patch: Partial<ConnectableShapeData> = { x: data.x + dx, y: data.y + dy };
+	const sp = shiftPoint(c.sourcePoint, dx, dy);
+	const tp = shiftPoint(c.targetPoint, dx, dy);
+	const cp = shiftPoint(c.controlPoint, dx, dy);
+	if (sp) patch.sourcePoint = sp;
+	if (tp) patch.targetPoint = tp;
+	if (cp) patch.controlPoint = cp;
+	return patch as Partial<ShapeData>;
+}

--- a/packages/usketch-shape-utils/src/__tests__/free-position.test.ts
+++ b/packages/usketch-shape-utils/src/__tests__/free-position.test.ts
@@ -1,0 +1,68 @@
+import type { BoundingBox } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { findFreePosition, overlapsAny } from "../free-position.js";
+
+const box = (x: number, y: number, w = 100, h = 80): BoundingBox => ({ x, y, width: w, height: h });
+
+describe("overlapsAny", () => {
+	it("重なり/非重なりを判定（境界接触は非重なり）", () => {
+		expect(overlapsAny(box(0, 0), [box(50, 0)])).toBe(true);
+		expect(overlapsAny(box(0, 0), [box(100, 0)])).toBe(false); // 接触のみ
+		expect(overlapsAny(box(0, 0), [box(500, 500)])).toBe(false);
+		expect(overlapsAny(box(0, 0), [])).toBe(false);
+	});
+});
+
+describe("findFreePosition", () => {
+	it("空きならそのまま（occupied 空）", () => {
+		const d = box(10, 20);
+		expect(findFreePosition({ desired: d, occupied: [] })).toEqual(d);
+	});
+
+	it("desired が空いていればそのまま", () => {
+		const d = box(0, 0);
+		expect(findFreePosition({ desired: d, occupied: [box(500, 500)] })).toEqual(d);
+	});
+
+	it("ring: 塞がれていたら重ならない位置を返す", () => {
+		const d = box(0, 0, 100, 80);
+		const occupied = [box(0, 0)]; // desired と完全重なり
+		const r = findFreePosition({ desired: d, occupied, strategy: "ring", step: 20 });
+		expect(r.width).toBe(100);
+		expect(r.height).toBe(80);
+		expect(overlapsAny(r, occupied)).toBe(false);
+	});
+
+	it("push: 重なりを解消し、最小軸方向へ押し出す", () => {
+		// occupied(0,0,100,80) と x に 20・y に 80 重なる → 最小軸 x へ押し出す。
+		const d = box(80, 0, 100, 80);
+		const occupied = [box(0, 0, 100, 80)];
+		const r = findFreePosition({ desired: d, occupied, strategy: "push" });
+		expect(overlapsAny(r, occupied)).toBe(false);
+		// y は不変、x のみ移動
+		expect(r.y).toBe(0);
+		expect(r.x).toBeGreaterThanOrEqual(100);
+	});
+
+	it("push: 複数の重なりも反復で解消", () => {
+		const d = box(0, 0, 100, 80);
+		const occupied = [box(0, 0, 100, 80), box(60, 0, 100, 80)];
+		const r = findFreePosition({ desired: d, occupied, strategy: "push" });
+		expect(overlapsAny(r, occupied)).toBe(false);
+	});
+
+	it("ring: 近い空きを優先（すぐ右が空いていれば遠くへ飛ばない）", () => {
+		// desired(0,0) は occupied と重なるが、右(120,0)は空き → だいたい右側へ
+		const d = box(0, 0, 100, 80);
+		const occupied = [box(0, 0, 100, 80)];
+		const r = findFreePosition({
+			desired: d,
+			occupied,
+			strategy: "ring",
+			step: 20,
+			maxDistance: 600,
+		});
+		const dist = Math.hypot(r.x, r.y);
+		expect(dist).toBeLessThan(300); // 近傍に収まる
+	});
+});

--- a/packages/usketch-shape-utils/src/free-position.ts
+++ b/packages/usketch-shape-utils/src/free-position.ts
@@ -1,0 +1,145 @@
+import type { BoundingBox } from "@edv4h/usketch-shared";
+
+export type FreePositionStrategy = "ring" | "push";
+
+export interface FindFreePositionOptions {
+	/** 置きたい位置・サイズ（回転 shape は回転後 AABB を渡す）。 */
+	desired: BoundingBox;
+	/** 避ける矩形（回転後 AABB）。 */
+	occupied: BoundingBox[];
+	/** 探索戦略（既定 "ring"）。 */
+	strategy?: FreePositionStrategy;
+	/** ring の半径刻み（world px、既定 20）。 */
+	step?: number;
+	/** ring の探索上限距離（world px、既定 2000）。超過時は best-effort。 */
+	maxDistance?: number;
+	/** push の反復上限（既定 50）。 */
+	maxIterations?: number;
+}
+
+const EPS = 0.01;
+
+/** 2つの AABB が重なるか（境界接触は非重なり扱い）。collision-utils.intersectsAABB と同等。 */
+function intersects(a: BoundingBox, b: BoundingBox): boolean {
+	return (
+		a.x < b.x + b.width - EPS &&
+		a.x + a.width > b.x + EPS &&
+		a.y < b.y + b.height - EPS &&
+		a.y + a.height > b.y + EPS
+	);
+}
+
+/** box がいずれかの occupied と重なるか。 */
+export function overlapsAny(box: BoundingBox, occupied: BoundingBox[]): boolean {
+	for (const o of occupied) if (intersects(box, o)) return true;
+	return false;
+}
+
+function moveTo(box: BoundingBox, x: number, y: number): BoundingBox {
+	return { x, y, width: box.width, height: box.height };
+}
+
+/**
+ * `desired` 中心からの同心リングを外側へ広げ、衝突しない最近傍の位置を返す。
+ * 各半径でサンプリングした候補のうち desired 中心に最も近いものを採用。
+ */
+function findByRing(opts: Required<Omit<FindFreePositionOptions, "maxIterations">>): BoundingBox {
+	const { desired, occupied, step, maxDistance } = opts;
+	if (!overlapsAny(desired, occupied)) return desired;
+
+	const cx = desired.x + desired.width / 2;
+	const cy = desired.y + desired.height / 2;
+
+	for (let r = step; r <= maxDistance; r += step) {
+		// 半径が大きいほど角度サンプルを増やす（密度を一定に保つ）。
+		const samples = Math.max(8, Math.round((2 * Math.PI * r) / step));
+		let best: BoundingBox | null = null;
+		let bestDist = Number.POSITIVE_INFINITY;
+		for (let i = 0; i < samples; i++) {
+			const theta = (i / samples) * Math.PI * 2;
+			const ncx = cx + Math.cos(theta) * r;
+			const ncy = cy + Math.sin(theta) * r;
+			const candidate = moveTo(desired, ncx - desired.width / 2, ncy - desired.height / 2);
+			if (overlapsAny(candidate, occupied)) continue;
+			const dist = (ncx - cx) ** 2 + (ncy - cy) ** 2;
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = candidate;
+			}
+		}
+		if (best) return best;
+	}
+	// 見つからなければ best-effort で desired を返す。
+	return desired;
+}
+
+/**
+ * `desired` を起点に、重なる occupied から最小重なり軸方向へ押し出して分離する。
+ * 連鎖的な重なりに備えて反復し、上限で打ち切り（best-effort）。
+ */
+function findByPush(
+	opts: Required<Omit<FindFreePositionOptions, "step" | "maxDistance">>,
+): BoundingBox {
+	const { occupied, maxIterations } = opts;
+	let box = opts.desired;
+	for (let iter = 0; iter < maxIterations; iter++) {
+		// 最も重なっている occupied を選ぶ。
+		let target: BoundingBox | null = null;
+		let maxOverlapArea = 0;
+		for (const o of occupied) {
+			if (!intersects(box, o)) continue;
+			const ox = Math.min(box.x + box.width, o.x + o.width) - Math.max(box.x, o.x);
+			const oy = Math.min(box.y + box.height, o.y + o.height) - Math.max(box.y, o.y);
+			const area = ox * oy;
+			if (area > maxOverlapArea) {
+				maxOverlapArea = area;
+				target = o;
+			}
+		}
+		if (!target) return box; // 重なり無し
+
+		// 最小重なり軸へ分離（接触まで）。
+		const overlapX =
+			Math.min(box.x + box.width, target.x + target.width) - Math.max(box.x, target.x);
+		const overlapY =
+			Math.min(box.y + box.height, target.y + target.height) - Math.max(box.y, target.y);
+		const boxCx = box.x + box.width / 2;
+		const boxCy = box.y + box.height / 2;
+		const tCx = target.x + target.width / 2;
+		const tCy = target.y + target.height / 2;
+		if (overlapX < overlapY) {
+			const dir = boxCx >= tCx ? 1 : -1;
+			box = moveTo(box, box.x + dir * (overlapX + EPS), box.y);
+		} else {
+			const dir = boxCy >= tCy ? 1 : -1;
+			box = moveTo(box, box.x, box.y + dir * (overlapY + EPS));
+		}
+	}
+	return box;
+}
+
+/**
+ * `desired` に最も近い、occupied と重ならない位置（同サイズ）を返す。
+ * `desired` がそのまま空いていればそのまま返す。
+ */
+export function findFreePosition(opts: FindFreePositionOptions): BoundingBox {
+	const strategy = opts.strategy ?? "ring";
+	if (opts.occupied.length === 0 || !overlapsAny(opts.desired, opts.occupied)) {
+		return opts.desired;
+	}
+	if (strategy === "push") {
+		return findByPush({
+			desired: opts.desired,
+			occupied: opts.occupied,
+			strategy,
+			maxIterations: opts.maxIterations ?? 50,
+		});
+	}
+	return findByRing({
+		desired: opts.desired,
+		occupied: opts.occupied,
+		strategy,
+		step: opts.step ?? 20,
+		maxDistance: opts.maxDistance ?? 2000,
+	});
+}

--- a/packages/usketch-shape-utils/src/free-position.ts
+++ b/packages/usketch-shape-utils/src/free-position.ts
@@ -19,7 +19,11 @@ export interface FindFreePositionOptions {
 
 const EPS = 0.01;
 
-/** 2つの AABB が重なるか（境界接触は非重なり扱い）。collision-utils.intersectsAABB と同等。 */
+/**
+ * 2つの AABB が重なるか。`collision-utils.intersectsAABB` と異なり EPS のマージンを挟むため、
+ * 境界がちょうど接するだけ（重なり幅 ≤ EPS）のケースは「重ならない」と判定する。
+ * これにより ring 探索で接触位置を空きとして採用でき、無限に外へ逃げるのを防ぐ。
+ */
 function intersects(a: BoundingBox, b: BoundingBox): boolean {
 	return (
 		a.x < b.x + b.width - EPS &&

--- a/packages/usketch-shape-utils/src/index.ts
+++ b/packages/usketch-shape-utils/src/index.ts
@@ -1,3 +1,9 @@
 export { getBounds } from "./bounds.js";
+export {
+	type FindFreePositionOptions,
+	type FreePositionStrategy,
+	findFreePosition,
+	overlapsAny,
+} from "./free-position.js";
 export { aabbHitTest, ellipseHitTest, lineHitTest, pointInPolygon } from "./hit-test.js";
 export { createResize } from "./resize.js";

--- a/plugins/usketch-plugin-domain-design/src/plugin.tsx
+++ b/plugins/usketch-plugin-domain-design/src/plugin.tsx
@@ -3,6 +3,7 @@ import {
 	createConnectorTracker,
 	getBoundsConnector,
 	hitTestConnector,
+	moveConnector,
 } from "@edv4h/usketch-connector-anchor";
 import { aabbHitTest, createResize, getBounds } from "@edv4h/usketch-shape-utils";
 import {
@@ -117,6 +118,7 @@ export function createDomainDesignPlugin(): UsketchPlugin {
 				getBounds: getBoundsConnector,
 				hitTest: hitTestConnector,
 				resize: (data) => ({ ...data }),
+				move: moveConnector,
 				resizable: false,
 				createDefault: ({ id, x, y }) =>
 					createDefaultDomainConnector({

--- a/plugins/usketch-plugin-free-position/README.md
+++ b/plugins/usketch-plugin-free-position/README.md
@@ -1,0 +1,44 @@
+# @edv4h/usketch-plugin-free-position
+
+指定した位置から**最も近い、既存 shape と被らない位置**を求める機能を提供するプラグイン（Issue #581）。
+貼り付け/複製/ドロップ/AI 生成などで新規 shape を重ねずに配置したいときに使う。UI は持たない。
+
+## 使い方
+
+```ts
+import { createFreePositionPlugin } from "@edv4h/usketch-plugin-free-position";
+
+const plugins = [
+  // ...
+  createFreePositionPlugin({ strategy: "ring" }), // "ring"（既定）| "push"
+];
+```
+
+登録すると、`free-position:find` イベントで問い合わせできる（snap の `snap:get-settings` と同じ
+同期コールバック方式）:
+
+```ts
+let result: BoundingBox | undefined;
+ctx.events.emit("free-position:find", {
+  desired: { x, y, width, height },   // 置きたい位置・サイズ
+  excludeIds: ["shape-1"],            // 任意: 衝突判定から除外（移動対象自身など）
+  strategy: "push",                   // 任意: このリクエストだけ戦略を上書き
+  onResult: (free) => { result = free; },
+});
+// result が「最も近い空き位置」（同サイズ）。プラグイン未登録なら onResult は呼ばれない。
+```
+
+## 探索戦略
+
+- **ring**（既定）: desired 中心から同心リングを外へ広げ、衝突しない最近傍を返す。
+- **push**: desired を起点に、重なる相手から最小重なり軸方向へ押し出して分離する。
+
+回転した shape は `getRotatedAABB` で外接矩形にして衝突判定する。
+
+## 連携
+
+`@edv4h/usketch-plugin-keyboard-shortcuts` の paste/duplicate はこのイベントを使い、複数 shape を
+相対配置を保ったままグループ単位で空き位置へずらす（本プラグイン未登録時は従来の +20 オフセット）。
+drop など他の配置経路も同じイベントを呼べば利用できる。
+
+純ロジックは `@edv4h/usketch-shape-utils` の `findFreePosition` / `overlapsAny` として単体でも使える。

--- a/plugins/usketch-plugin-free-position/README.md
+++ b/plugins/usketch-plugin-free-position/README.md
@@ -18,6 +18,8 @@ const plugins = [
 同期コールバック方式）:
 
 ```ts
+import type { BoundingBox } from "@edv4h/usketch-shared";
+
 let result: BoundingBox | undefined;
 ctx.events.emit("free-position:find", {
   desired: { x, y, width, height },   // 置きたい位置・サイズ

--- a/plugins/usketch-plugin-free-position/package.json
+++ b/plugins/usketch-plugin-free-position/package.json
@@ -1,0 +1,45 @@
+{
+	"name": "@edv4h/usketch-plugin-free-position",
+	"version": "0.0.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shape-utils": "workspace:*",
+		"@edv4h/usketch-shared": "workspace:*"
+	},
+	"devDependencies": {
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-free-position"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-free-position/src/__tests__/plugin.test.ts
+++ b/plugins/usketch-plugin-free-position/src/__tests__/plugin.test.ts
@@ -1,0 +1,82 @@
+import { overlapsAny } from "@edv4h/usketch-shape-utils";
+import type { BoundingBox, PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { createFreePositionPlugin, type FreePositionRequest } from "../plugin.js";
+
+const style = { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 };
+
+function shape(id: string, x: number, y: number, w = 100, h = 80, rotation?: number): ShapeData {
+	return { id, type: "rectangle", x, y, width: w, height: h, style, rotation };
+}
+
+/** findFreePosition が参照する最小限の PluginContext スタブ。 */
+function makeCtx(shapes: ShapeData[]) {
+	const map = new Map(shapes.map((s) => [s.id, s] as const));
+	const handlers = new Map<string, ((data: unknown) => void)[]>();
+	const ctx = {
+		store: { getShapes: () => map },
+		shapes: {
+			get: (_type: string) => ({
+				getBounds: (s: ShapeData): BoundingBox => ({
+					x: s.x,
+					y: s.y,
+					width: s.width,
+					height: s.height,
+				}),
+			}),
+		},
+		events: {
+			on: (e: string, h: (data: unknown) => void) => {
+				const list = handlers.get(e) ?? [];
+				list.push(h);
+				handlers.set(e, list);
+				return () => {};
+			},
+			emit: (e: string, data: unknown) => {
+				for (const h of handlers.get(e) ?? []) h(data);
+			},
+		},
+	} as unknown as PluginContext;
+	const emitFind = (req: Omit<FreePositionRequest, "onResult">): BoundingBox => {
+		let result: BoundingBox | null = null;
+		ctx.events.emit("free-position:find", { ...req, onResult: (b) => (result = b) });
+		if (!result) throw new Error("no result");
+		return result;
+	};
+	return { ctx, emitFind };
+}
+
+describe("createFreePositionPlugin", () => {
+	it("free-position:find が被らない位置を返す", () => {
+		const { ctx, emitFind } = makeCtx([shape("a", 0, 0)]);
+		createFreePositionPlugin().setup(ctx);
+		const free = emitFind({ desired: { x: 0, y: 0, width: 100, height: 80 } });
+		expect(overlapsAny(free, [{ x: 0, y: 0, width: 100, height: 80 }])).toBe(false);
+	});
+
+	it("excludeIds の shape は避けない（自身を除外）", () => {
+		const { ctx, emitFind } = makeCtx([shape("a", 0, 0)]);
+		createFreePositionPlugin().setup(ctx);
+		const free = emitFind({ desired: { x: 0, y: 0, width: 100, height: 80 }, excludeIds: ["a"] });
+		// "a" を除外したので occupied 空 → desired のまま
+		expect(free).toEqual({ x: 0, y: 0, width: 100, height: 80 });
+	});
+
+	it("回転 shape は回転後 AABB で避ける", () => {
+		// 100x80 を 45° 回転 → AABB は約 127x127 に広がる。desired(110,0) は素の bbox(100x80)とは
+		// 重ならないが、回転後 AABB(中心50,40・約127角)とは重なる → ずれる。
+		const { ctx, emitFind } = makeCtx([shape("a", 0, 0, 100, 80, 45)]);
+		createFreePositionPlugin({ strategy: "push" }).setup(ctx);
+		const desired = { x: 110, y: 0, width: 20, height: 20 };
+		const free = emitFind({ desired });
+		expect(free).not.toEqual(desired); // 回転後 AABB を避けて移動した
+	});
+
+	it("config の strategy 既定とリクエスト上書きが効く", () => {
+		const { ctx, emitFind } = makeCtx([shape("a", 0, 0)]);
+		createFreePositionPlugin({ strategy: "push" }).setup(ctx);
+		const free = emitFind({ desired: { x: 80, y: 0, width: 100, height: 80 }, strategy: "push" });
+		expect(free.y).toBe(0); // push: x 軸へ押し出し
+		expect(overlapsAny(free, [{ x: 0, y: 0, width: 100, height: 80 }])).toBe(false);
+	});
+});

--- a/plugins/usketch-plugin-free-position/src/__tests__/plugin.test.ts
+++ b/plugins/usketch-plugin-free-position/src/__tests__/plugin.test.ts
@@ -39,7 +39,12 @@ function makeCtx(shapes: ShapeData[]) {
 	} as unknown as PluginContext;
 	const emitFind = (req: Omit<FreePositionRequest, "onResult">): BoundingBox => {
 		let result: BoundingBox | null = null;
-		ctx.events.emit("free-position:find", { ...req, onResult: (b) => (result = b) });
+		ctx.events.emit("free-position:find", {
+			...req,
+			onResult: (b) => {
+				result = b;
+			},
+		});
 		if (!result) throw new Error("no result");
 		return result;
 	};

--- a/plugins/usketch-plugin-free-position/src/index.ts
+++ b/plugins/usketch-plugin-free-position/src/index.ts
@@ -1,0 +1,5 @@
+export {
+	createFreePositionPlugin,
+	type FreePositionConfig,
+	type FreePositionRequest,
+} from "./plugin.js";

--- a/plugins/usketch-plugin-free-position/src/plugin.ts
+++ b/plugins/usketch-plugin-free-position/src/plugin.ts
@@ -1,0 +1,77 @@
+import { type FreePositionStrategy, findFreePosition } from "@edv4h/usketch-shape-utils";
+import {
+	type BoundingBox,
+	getRotatedAABB,
+	type PluginContext,
+	safeRotation,
+	type UsketchPlugin,
+} from "@edv4h/usketch-shared";
+
+export interface FreePositionConfig {
+	/** 既定の探索戦略（"ring" | "push"、既定 "ring"）。 */
+	strategy?: FreePositionStrategy;
+	/** ring の半径刻み（world px）。 */
+	step?: number;
+	/** ring の探索上限距離（world px）。 */
+	maxDistance?: number;
+	/** push の反復上限。 */
+	maxIterations?: number;
+}
+
+/**
+ * `free-position:find` リクエストのペイロード。
+ * snap の `snap:get-settings` と同様、同期コールバック（`onResult`）で結果を返す。
+ */
+export interface FreePositionRequest {
+	/** 置きたい位置・サイズ（回転 shape は回転後 AABB を渡す）。 */
+	desired: BoundingBox;
+	/** 衝突判定から除外する shape ID（移動対象自身など）。 */
+	excludeIds?: string[];
+	/** この問い合わせ限定の戦略上書き。 */
+	strategy?: FreePositionStrategy;
+	/** 結果（同サイズの空き位置）を受け取るコールバック。 */
+	onResult: (free: BoundingBox) => void;
+}
+
+/**
+ * 指定位置から最も近い「被らない位置」を求める機能を提供するプラグイン（#581）。
+ * EventBus の `free-position:find` で問い合わせると、現在のボード上の shape（回転考慮 AABB）を
+ * 避けた最近傍の空き位置を返す。UI は持たない。
+ */
+export function createFreePositionPlugin(config: FreePositionConfig = {}): UsketchPlugin {
+	return {
+		id: "usketch-plugin-free-position",
+		name: "Free Position",
+
+		setup(ctx: PluginContext) {
+			function collectOccupied(exclude?: string[]): BoundingBox[] {
+				const ex = exclude && exclude.length > 0 ? new Set(exclude) : null;
+				const out: BoundingBox[] = [];
+				for (const [id, shape] of ctx.store.getShapes()) {
+					if (ex?.has(id)) continue;
+					const def = ctx.shapes.get(shape.type);
+					const bounds = def
+						? def.getBounds(shape)
+						: { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+					const rotation = safeRotation(shape.rotation);
+					out.push(rotation ? getRotatedAABB(bounds, rotation) : bounds);
+				}
+				return out;
+			}
+
+			const off = ctx.events.on<FreePositionRequest>("free-position:find", (req) => {
+				const free = findFreePosition({
+					desired: req.desired,
+					occupied: collectOccupied(req.excludeIds),
+					strategy: req.strategy ?? config.strategy,
+					step: config.step,
+					maxDistance: config.maxDistance,
+					maxIterations: config.maxIterations,
+				});
+				req.onResult(free);
+			});
+
+			return () => off();
+		},
+	};
+}

--- a/plugins/usketch-plugin-free-position/tsconfig.json
+++ b/plugins/usketch-plugin-free-position/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"]
+}

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
@@ -35,8 +35,26 @@ function collectShapes(store: BoardStore): ShapeData[] {
 	return shapes;
 }
 
+/**
+ * shape を (dx, dy) 平行移動する。`ShapeDefinition.move`（コネクタの endpoints など
+ * 絶対座標フィールドも動かす）があればそれを使い、無ければ x/y のみ更新する。
+ */
+function translateShape(
+	shape: ShapeData,
+	dx: number,
+	dy: number,
+	registry?: ShapeRegistry,
+): ShapeData {
+	const move = registry?.get(shape.type)?.move;
+	if (move) return { ...shape, ...move(shape, dx, dy) };
+	return { ...shape, x: shape.x + dx, y: shape.y + dy };
+}
+
 /** 新規 shape 群（新 id・親子の付け替え・初期 +20 オフセット）を生成。 */
-function cloneWithNewIds(shapes: ShapeData[]): { newShapes: ShapeData[]; newIds: string[] } {
+function cloneWithNewIds(
+	shapes: ShapeData[],
+	registry?: ShapeRegistry,
+): { newShapes: ShapeData[]; newIds: string[] } {
 	const idMap = new Map<string, string>();
 	const newIds: string[] = [];
 	for (const shape of shapes) {
@@ -51,10 +69,8 @@ function cloneWithNewIds(shapes: ShapeData[]): { newShapes: ShapeData[]; newIds:
 				? idMap.get(shape.parentId as string)
 				: undefined;
 		return {
-			...shape,
+			...translateShape(shape, PASTE_OFFSET, PASTE_OFFSET, registry),
 			id: newId,
-			x: shape.x + PASTE_OFFSET,
-			y: shape.y + PASTE_OFFSET,
 			...(parentId !== undefined ? { parentId } : {}),
 		} as ShapeData;
 	});
@@ -115,7 +131,7 @@ function placeAndCommit(
 				if (free.x === desired.x && free.y === desired.y) return;
 				const dx = free.x - desired.x;
 				const dy = free.y - desired.y;
-				placed = newShapes.map((s) => ({ ...s, x: s.x + dx, y: s.y + dy }));
+				placed = newShapes.map((s) => translateShape(s, dx, dy, shapeRegistry));
 			},
 		});
 	}
@@ -162,7 +178,7 @@ export async function pasteShapes(
 	if (!shapes) shapes = inMemoryClipboard;
 	if (!shapes || shapes.length === 0) return;
 
-	const { newShapes, newIds } = cloneWithNewIds(shapes);
+	const { newShapes, newIds } = cloneWithNewIds(shapes, shapeRegistry);
 	placeAndCommit(store, commands, events, newShapes, newIds, shapeRegistry);
 }
 
@@ -177,6 +193,6 @@ export function duplicateShapes(
 	const shapes = collectShapes(store);
 	if (shapes.length === 0) return;
 
-	const { newShapes, newIds } = cloneWithNewIds(shapes);
+	const { newShapes, newIds } = cloneWithNewIds(shapes, shapeRegistry);
 	placeAndCommit(store, commands, events, newShapes, newIds, shapeRegistry);
 }

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
@@ -6,6 +6,7 @@ import {
 	generateId,
 	getRotatedAABB,
 	type ShapeData,
+	type ShapeRegistry,
 	safeRotation,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
@@ -60,20 +61,29 @@ function cloneWithNewIds(shapes: ShapeData[]): { newShapes: ShapeData[]; newIds:
 	return { newShapes, newIds };
 }
 
-/** shape の回転を考慮した AABB（free-position プラグインの occupied 収集と揃える）。 */
-function shapeAABB(s: ShapeData): BoundingBox {
-	const box = { x: s.x, y: s.y, width: s.width, height: s.height };
+/**
+ * shape の footprint を回転考慮 AABB で返す。free-position プラグインの occupied 収集と
+ * 完全に揃えるため、registry があれば `ShapeDefinition.getBounds`（connector の矢印/ラベル等で
+ * 素の x/y/w/h より大きくなり得る）を用い、無ければ x/y/w/h にフォールバックする。
+ */
+function shapeAABB(s: ShapeData, registry?: ShapeRegistry): BoundingBox {
+	const bounds = registry?.get(s.type)?.getBounds(s) ?? {
+		x: s.x,
+		y: s.y,
+		width: s.width,
+		height: s.height,
+	};
 	const rotation = safeRotation(s.rotation);
-	return rotation ? getRotatedAABB(box, rotation) : box;
+	return rotation ? getRotatedAABB(bounds, rotation) : bounds;
 }
 
-function groupBounds(shapes: ShapeData[]): BoundingBox {
+function groupBounds(shapes: ShapeData[], registry?: ShapeRegistry): BoundingBox {
 	let minX = Number.POSITIVE_INFINITY;
 	let minY = Number.POSITIVE_INFINITY;
 	let maxX = Number.NEGATIVE_INFINITY;
 	let maxY = Number.NEGATIVE_INFINITY;
 	for (const s of shapes) {
-		const b = shapeAABB(s);
+		const b = shapeAABB(s, registry);
 		if (b.x < minX) minX = b.x;
 		if (b.y < minY) minY = b.y;
 		if (b.x + b.width > maxX) maxX = b.x + b.width;
@@ -93,10 +103,11 @@ function placeAndCommit(
 	events: EventBus | undefined,
 	newShapes: ShapeData[],
 	newIds: string[],
+	shapeRegistry?: ShapeRegistry,
 ): void {
 	let placed = newShapes;
 	if (events && newShapes.length > 0) {
-		const desired = groupBounds(newShapes);
+		const desired = groupBounds(newShapes, shapeRegistry);
 		// 同期コールバックで結果を受け、グループ全体を delta だけずらす。
 		events.emit("free-position:find", {
 			desired,
@@ -132,6 +143,7 @@ export async function pasteShapes(
 	store: BoardStore,
 	commands: CommandRegistry,
 	events?: EventBus,
+	shapeRegistry?: ShapeRegistry,
 ): Promise<void> {
 	if (isInputFocused()) return;
 
@@ -151,13 +163,14 @@ export async function pasteShapes(
 	if (!shapes || shapes.length === 0) return;
 
 	const { newShapes, newIds } = cloneWithNewIds(shapes);
-	placeAndCommit(store, commands, events, newShapes, newIds);
+	placeAndCommit(store, commands, events, newShapes, newIds, shapeRegistry);
 }
 
 export function duplicateShapes(
 	store: BoardStore,
 	commands: CommandRegistry,
 	events?: EventBus,
+	shapeRegistry?: ShapeRegistry,
 ): void {
 	if (isInputFocused()) return;
 
@@ -165,5 +178,5 @@ export function duplicateShapes(
 	if (shapes.length === 0) return;
 
 	const { newShapes, newIds } = cloneWithNewIds(shapes);
-	placeAndCommit(store, commands, events, newShapes, newIds);
+	placeAndCommit(store, commands, events, newShapes, newIds, shapeRegistry);
 }

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
@@ -4,7 +4,9 @@ import {
 	type CommandRegistry,
 	type EventBus,
 	generateId,
+	getRotatedAABB,
 	type ShapeData,
+	safeRotation,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 
@@ -58,16 +60,24 @@ function cloneWithNewIds(shapes: ShapeData[]): { newShapes: ShapeData[]; newIds:
 	return { newShapes, newIds };
 }
 
+/** shape の回転を考慮した AABB（free-position プラグインの occupied 収集と揃える）。 */
+function shapeAABB(s: ShapeData): BoundingBox {
+	const box = { x: s.x, y: s.y, width: s.width, height: s.height };
+	const rotation = safeRotation(s.rotation);
+	return rotation ? getRotatedAABB(box, rotation) : box;
+}
+
 function groupBounds(shapes: ShapeData[]): BoundingBox {
 	let minX = Number.POSITIVE_INFINITY;
 	let minY = Number.POSITIVE_INFINITY;
 	let maxX = Number.NEGATIVE_INFINITY;
 	let maxY = Number.NEGATIVE_INFINITY;
 	for (const s of shapes) {
-		if (s.x < minX) minX = s.x;
-		if (s.y < minY) minY = s.y;
-		if (s.x + s.width > maxX) maxX = s.x + s.width;
-		if (s.y + s.height > maxY) maxY = s.y + s.height;
+		const b = shapeAABB(s);
+		if (b.x < minX) minX = b.x;
+		if (b.y < minY) minY = b.y;
+		if (b.x + b.width > maxX) maxX = b.x + b.width;
+		if (b.y + b.height > maxY) maxY = b.y + b.height;
 	}
 	return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
 }

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/clipboard.ts
@@ -1,6 +1,8 @@
 import {
 	type BoardStore,
+	type BoundingBox,
 	type CommandRegistry,
+	type EventBus,
 	generateId,
 	type ShapeData,
 } from "@edv4h/usketch-shared";
@@ -30,6 +32,78 @@ function collectShapes(store: BoardStore): ShapeData[] {
 	return shapes;
 }
 
+/** 新規 shape 群（新 id・親子の付け替え・初期 +20 オフセット）を生成。 */
+function cloneWithNewIds(shapes: ShapeData[]): { newShapes: ShapeData[]; newIds: string[] } {
+	const idMap = new Map<string, string>();
+	const newIds: string[] = [];
+	for (const shape of shapes) {
+		const newId = generateId();
+		idMap.set(shape.id, newId);
+		newIds.push(newId);
+	}
+	const newShapes = shapes.map((shape) => {
+		const newId = idMap.get(shape.id) ?? shape.id;
+		const parentId =
+			shape.parentId && idMap.has(shape.parentId as string)
+				? idMap.get(shape.parentId as string)
+				: undefined;
+		return {
+			...shape,
+			id: newId,
+			x: shape.x + PASTE_OFFSET,
+			y: shape.y + PASTE_OFFSET,
+			...(parentId !== undefined ? { parentId } : {}),
+		} as ShapeData;
+	});
+	return { newShapes, newIds };
+}
+
+function groupBounds(shapes: ShapeData[]): BoundingBox {
+	let minX = Number.POSITIVE_INFINITY;
+	let minY = Number.POSITIVE_INFINITY;
+	let maxX = Number.NEGATIVE_INFINITY;
+	let maxY = Number.NEGATIVE_INFINITY;
+	for (const s of shapes) {
+		if (s.x < minX) minX = s.x;
+		if (s.y < minY) minY = s.y;
+		if (s.x + s.width > maxX) maxX = s.x + s.width;
+		if (s.y + s.height > maxY) maxY = s.y + s.height;
+	}
+	return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+}
+
+/**
+ * 新 shape 群を「被らない位置」へグループ単位でずらして確定する。
+ * free-position プラグインが居れば `free-position:find` で空き位置を取得（相対配置は維持）。
+ * 居なければ従来の `+20` オフセットのまま（graceful degradation）。
+ */
+function placeAndCommit(
+	store: BoardStore,
+	commands: CommandRegistry,
+	events: EventBus | undefined,
+	newShapes: ShapeData[],
+	newIds: string[],
+): void {
+	let placed = newShapes;
+	if (events && newShapes.length > 0) {
+		const desired = groupBounds(newShapes);
+		// 同期コールバックで結果を受け、グループ全体を delta だけずらす。
+		events.emit("free-position:find", {
+			desired,
+			onResult: (free: BoundingBox) => {
+				if (free.x === desired.x && free.y === desired.y) return;
+				const dx = free.x - desired.x;
+				const dy = free.y - desired.y;
+				placed = newShapes.map((s) => ({ ...s, x: s.x + dx, y: s.y + dy }));
+			},
+		});
+	}
+	for (const shape of placed) {
+		commands.execute(createAddShapeCommand(store, shape));
+	}
+	store.setSelection(newIds);
+}
+
 export async function copyShapes(store: BoardStore): Promise<void> {
 	if (isInputFocused()) return;
 	const shapes = collectShapes(store);
@@ -44,7 +118,11 @@ export async function copyShapes(store: BoardStore): Promise<void> {
 	}
 }
 
-export async function pasteShapes(store: BoardStore, commands: CommandRegistry): Promise<void> {
+export async function pasteShapes(
+	store: BoardStore,
+	commands: CommandRegistry,
+	events?: EventBus,
+): Promise<void> {
 	if (isInputFocused()) return;
 
 	let shapes: ShapeData[] | null = null;
@@ -59,73 +137,23 @@ export async function pasteShapes(store: BoardStore, commands: CommandRegistry):
 		// Clipboard API failed; fall through to in-memory
 	}
 
-	if (!shapes) {
-		shapes = inMemoryClipboard;
-	}
-
+	if (!shapes) shapes = inMemoryClipboard;
 	if (!shapes || shapes.length === 0) return;
 
-	const newIds: string[] = [];
-	const idMap = new Map<string, string>();
-
-	// Generate new IDs first
-	for (const shape of shapes) {
-		const newId = generateId();
-		idMap.set(shape.id, newId);
-		newIds.push(newId);
-	}
-
-	for (const shape of shapes) {
-		const newId = idMap.get(shape.id) ?? shape.id;
-		const parentId =
-			shape.parentId && idMap.has(shape.parentId as string)
-				? idMap.get(shape.parentId as string)
-				: undefined;
-
-		const newShape: ShapeData = {
-			...shape,
-			id: newId,
-			x: shape.x + PASTE_OFFSET,
-			y: shape.y + PASTE_OFFSET,
-			...(parentId !== undefined ? { parentId } : {}),
-		};
-		commands.execute(createAddShapeCommand(store, newShape));
-	}
-
-	store.setSelection(newIds);
+	const { newShapes, newIds } = cloneWithNewIds(shapes);
+	placeAndCommit(store, commands, events, newShapes, newIds);
 }
 
-export function duplicateShapes(store: BoardStore, commands: CommandRegistry): void {
+export function duplicateShapes(
+	store: BoardStore,
+	commands: CommandRegistry,
+	events?: EventBus,
+): void {
 	if (isInputFocused()) return;
 
 	const shapes = collectShapes(store);
 	if (shapes.length === 0) return;
 
-	const newIds: string[] = [];
-	const idMap = new Map<string, string>();
-
-	for (const shape of shapes) {
-		const newId = generateId();
-		idMap.set(shape.id, newId);
-		newIds.push(newId);
-	}
-
-	for (const shape of shapes) {
-		const newId = idMap.get(shape.id) ?? shape.id;
-		const parentId =
-			shape.parentId && idMap.has(shape.parentId as string)
-				? idMap.get(shape.parentId as string)
-				: undefined;
-
-		const newShape: ShapeData = {
-			...shape,
-			id: newId,
-			x: shape.x + PASTE_OFFSET,
-			y: shape.y + PASTE_OFFSET,
-			...(parentId !== undefined ? { parentId } : {}),
-		};
-		commands.execute(createAddShapeCommand(store, newShape));
-	}
-
-	store.setSelection(newIds);
+	const { newShapes, newIds } = cloneWithNewIds(shapes);
+	placeAndCommit(store, commands, events, newShapes, newIds);
 }

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/plugin.tsx
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/plugin.tsx
@@ -89,12 +89,12 @@ export function createKeyboardShortcutsPlugin(
 			);
 			cleanups.push(
 				shortcuts.register("Ctrl+V", () => {
-					void pasteShapes(store, commands);
+					void pasteShapes(store, commands, events);
 				}),
 			);
 			cleanups.push(
 				shortcuts.register("Ctrl+D", () => {
-					duplicateShapes(store, commands);
+					duplicateShapes(store, commands, events);
 				}),
 			);
 

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/plugin.tsx
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/plugin.tsx
@@ -25,7 +25,7 @@ export function createKeyboardShortcutsPlugin(
 			const cleanups: (() => void)[] = [];
 			let palette: CommandPaletteController | null = null;
 
-			const { store, shortcuts, events, commands } = ctx;
+			const { store, shortcuts, events, commands, shapes } = ctx;
 
 			// ── Side panel state tracking ──
 			let sidePanelOpen = false;
@@ -89,12 +89,12 @@ export function createKeyboardShortcutsPlugin(
 			);
 			cleanups.push(
 				shortcuts.register("Ctrl+V", () => {
-					void pasteShapes(store, commands, events);
+					void pasteShapes(store, commands, events, shapes);
 				}),
 			);
 			cleanups.push(
 				shortcuts.register("Ctrl+D", () => {
-					duplicateShapes(store, commands, events);
+					duplicateShapes(store, commands, events, shapes);
 				}),
 			);
 

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -4,6 +4,7 @@ import {
 	createConnectorTracker,
 	findShapeAtPoint as findShapeAtPointGeneric,
 	getAnchorPoint,
+	moveConnector,
 } from "@edv4h/usketch-connector-anchor";
 import type {
 	CanvasPointerEvent,
@@ -74,6 +75,7 @@ export function createConnectorPlugin(): UsketchPlugin {
 				getBounds: getBoundsConnector,
 				hitTest: hitTestConnector,
 				resize: (data) => ({ ...data }),
+				move: moveConnector,
 				createDefault: createDefaultConnector,
 				renderTarget: "svg",
 				resizable: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       '@edv4h/usketch-plugin-follow-me':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-follow-me
+      '@edv4h/usketch-plugin-free-position':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-free-position
       '@edv4h/usketch-plugin-keyboard-shortcuts':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-keyboard-shortcuts
@@ -1093,6 +1096,22 @@ importers:
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  plugins/usketch-plugin-free-position:
+    dependencies:
+      '@edv4h/usketch-shape-utils':
+        specifier: workspace:*
+        version: link:../../packages/usketch-shape-utils
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+    devDependencies:
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## 概要

Issue #581: **指定位置から最も近い、既存 shape と被らない位置を探す**機能。現状 paste/duplicate は固定 `+20px` オフセットで既存 shape と重なってしまうのを、最近傍の空き位置へ自動配置できるようにします。

3層構成（純ロジック / プラグイン / 既存配置への連携）で、いずれも疎結合・後方互換です。

## 変更

### `@edv4h/usketch-shape-utils`（純ユーティリティ）
- `findFreePosition({ desired, occupied, strategy, ... })` を追加。**2戦略を選択可能**:
  - `ring`（既定）: desired 中心から同心リングを外へ広げ、衝突しない**最近傍**を返す
  - `push`: 重なる相手から最小重なり軸方向へ押し出して分離
- `overlapsAny(box, occupied)` も公開。ストア非依存・テスト容易。

### `@edv4h/usketch-plugin-free-position`（新規）
- `free-position:find` イベント（snap の `snap:get-settings` と同じ同期コールバック方式）で問い合わせ。
- ボード上の shape を **回転考慮 AABB**（`getRotatedAABB`）で収集し、最近傍の空き位置を返す。
- `excludeIds`（自身除外）・リクエスト単位の `strategy` 上書き対応。UI なし。

### `@edv4h/usketch-plugin-keyboard-shortcuts`
- paste/duplicate が `free-position:find` を使い、複数 shape を**相対配置を保ったままグループ単位**で空き位置へ自動配置。
- free-position プラグイン未登録時は従来の `+20` オフセットに**フォールバック**（イベント契約のみの疎結合）。

### `apps/web`
- `createFreePositionPlugin()` を base plugins に登録。

> drop など他の配置経路も同じイベントを呼べば利用可能（README に明記）。`store.addShape` の monkey-patch は採用せず（描画中の scratch shape を動かさないため）配置経路に限定介入。

## テスト
- `findFreePosition`: ring/push、空き/被り/最小軸/上限 — 7件
- plugin: `free-position:find`（occupied 収集・回転後 AABB・excludeIds・戦略上書き）— 4件
- typecheck（shape-utils / free-position / keyboard-shortcuts / web）・Biome・build クリーン

## 動作確認
重なる位置で paste/duplicate（複製連打）→ 毎回最近傍の空きへずれ、複数選択は相対配置を維持。回転 shape 周辺でも回転後 AABB を避ける。

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)