### PR TITLE
✨ feat(container): container 機構のフラグ駆動化 + アタッチ/整列プラグイン + snap 除外 hook (#647)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
 		"@edv4h/usketch-plugin-ai-chat": "workspace:*",
 		"@edv4h/usketch-plugin-comments": "workspace:*",
 		"@edv4h/usketch-plugin-community-chat": "workspace:*",
+		"@edv4h/usketch-plugin-container": "workspace:*",
 		"@edv4h/usketch-plugin-side-panel": "workspace:*",
 		"@edv4h/usketch-plugin-ai-copilot": "workspace:*",
 		"@edv4h/usketch-plugin-ai-image": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -13,6 +13,7 @@ import { createAiVoicePlugin } from "@edv4h/usketch-plugin-ai-voice";
 import { createDotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
 import { createGridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
+import { createContainerPlugin } from "@edv4h/usketch-plugin-container";
 import { createDomainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
 import { createExportPlugin } from "@edv4h/usketch-plugin-export";
 import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
@@ -149,6 +150,7 @@ function createBasePlugins(): UsketchPlugin[] {
 		createDomainDesignPlugin(),
 		createSnapPlugin(),
 		createFreePositionPlugin(),
+		createContainerPlugin(),
 		createExportPlugin(),
 		createGpuRendererPlugin(),
 		createDomRendererPlugin(),

--- a/packages/shared/src/__tests__/container.test.ts
+++ b/packages/shared/src/__tests__/container.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { ShapeDefinition } from "../types/plugin.js";
+import type { ShapeData } from "../types/shape.js";
+import {
+	getContainerLayout,
+	hasSelectableChildren,
+	isContainerAutoAttach,
+	isShapeContainer,
+} from "../utils/container.js";
+
+const shape = (overrides: Partial<ShapeData> = {}): ShapeData =>
+	({
+		id: "s",
+		type: "x",
+		x: 0,
+		y: 0,
+		width: 10,
+		height: 10,
+		style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		...overrides,
+	}) as ShapeData;
+
+const def = (container?: ShapeDefinition["container"]): ShapeDefinition =>
+	({ container }) as ShapeDefinition;
+
+describe("isShapeContainer", () => {
+	it("is false when no container object", () => {
+		expect(isShapeContainer(def(undefined), shape())).toBe(false);
+		expect(isShapeContainer(undefined, shape())).toBe(false);
+	});
+
+	it("is true when container is present with no explicit enabled", () => {
+		expect(isShapeContainer(def({}), shape())).toBe(true);
+	});
+
+	it("honors a boolean enabled", () => {
+		expect(isShapeContainer(def({ enabled: false }), shape())).toBe(false);
+		expect(isShapeContainer(def({ enabled: true }), shape())).toBe(true);
+	});
+
+	it("honors a per-instance predicate enabled", () => {
+		const d = def({ enabled: (s) => s.meta?.component === "card" });
+		expect(isShapeContainer(d, shape({ meta: { component: "card" } }))).toBe(true);
+		expect(isShapeContainer(d, shape({ meta: { component: "button" } }))).toBe(false);
+	});
+});
+
+describe("hasSelectableChildren", () => {
+	it("is false for non-containers even if selectableChildren set", () => {
+		expect(hasSelectableChildren(def({ enabled: false, selectableChildren: true }), shape())).toBe(
+			false,
+		);
+	});
+
+	it("defaults to false (group behavior) when omitted", () => {
+		expect(hasSelectableChildren(def({}), shape())).toBe(false);
+	});
+
+	it("honors boolean and predicate forms", () => {
+		expect(hasSelectableChildren(def({ selectableChildren: true }), shape())).toBe(true);
+		const d = def({ selectableChildren: (s) => s.meta?.component === "card" });
+		expect(hasSelectableChildren(d, shape({ meta: { component: "card" } }))).toBe(true);
+		expect(hasSelectableChildren(d, shape({ meta: { component: "input" } }))).toBe(false);
+	});
+});
+
+describe("isContainerAutoAttach", () => {
+	it("is false by default and for non-containers", () => {
+		expect(isContainerAutoAttach(def({}), shape())).toBe(false);
+		expect(isContainerAutoAttach(def({ enabled: false, autoAttach: true }), shape())).toBe(false);
+	});
+
+	it("honors boolean and predicate forms", () => {
+		expect(isContainerAutoAttach(def({ autoAttach: true }), shape())).toBe(true);
+		const d = def({ autoAttach: (s) => s.meta?.component === "card" });
+		expect(isContainerAutoAttach(d, shape({ meta: { component: "card" } }))).toBe(true);
+		expect(isContainerAutoAttach(d, shape({ meta: { component: "x" } }))).toBe(false);
+	});
+});
+
+describe("getContainerLayout", () => {
+	it("returns the layout fn or undefined", () => {
+		const layout = () => [];
+		expect(getContainerLayout(def({ layout }))).toBe(layout);
+		expect(getContainerLayout(def({}))).toBeUndefined();
+		expect(getContainerLayout(undefined)).toBeUndefined();
+	});
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -56,6 +56,13 @@ export type { Theme } from "./types/theme.js";
 export { DEFAULT_THEME } from "./types/theme.js";
 // Color
 export { cssColorToRgba, cssColorToRgbaOrDefault } from "./utils/color.js";
+// Container
+export {
+	getContainerLayout,
+	hasSelectableChildren,
+	isContainerAutoAttach,
+	isShapeContainer,
+} from "./utils/container.js";
 export {
 	boundsToScreenRect,
 	getSelectionBounds,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -238,6 +238,52 @@ export interface ShapeDefinition {
 	 * decides it). Use {@link isShapeResizable} to evaluate it.
 	 */
 	resizable?: boolean | ((data: ShapeData) => boolean);
+	/**
+	 * Container behavior. When present, children (shapes referencing this shape
+	 * via `parentId`) follow the parent on move, are arranged by `layout`, and
+	 * are excluded from snapping while the parent is being dragged.
+	 *
+	 * Colocated with the definition like {@link resizable} / {@link move}, and
+	 * each sub-field accepts the same `boolean | (data) => boolean` predicate
+	 * form so a single shape type can vary per instance (e.g. a `wireframe`
+	 * type whose `meta.component === "card"` is a container). Evaluate via
+	 * {@link isShapeContainer} / {@link hasSelectableChildren} /
+	 * {@link getContainerLayout}. Omit for non-container shapes.
+	 */
+	container?: {
+		/**
+		 * Whether this instance acts as a container. Default: `true` (specifying
+		 * `container` at all opts in). Use a predicate for per-instance control.
+		 */
+		enabled?: boolean | ((data: ShapeData) => boolean);
+		/**
+		 * Whether children can be selected / resized individually. Default:
+		 * `false` (group behavior — clicking a child selects the whole container).
+		 * `true` gives frame/island behavior (clicking a child, or marquee over
+		 * it, selects the child itself). Only consulted when the shape is an
+		 * enabled container.
+		 */
+		selectableChildren?: boolean | ((data: ShapeData) => boolean);
+		/**
+		 * Whether a shape dropped/dragged fully inside this container is
+		 * automatically attached as its child (`parentId` set), and detached when
+		 * moved out. Default: `false` — containers like `group` (explicit) and
+		 * `island` (proximity-based) manage membership themselves, so only
+		 * containers that opt in (e.g. `frame`, or a custom card) auto-attach on
+		 * overlap. Evaluate via {@link isContainerAutoAttach}.
+		 */
+		autoAttach?: boolean | ((data: ShapeData) => boolean);
+		/**
+		 * Arrange the container's children (shapes referencing it via `parentId`).
+		 * Invoked by the container plugin on attach/detach, container move/resize,
+		 * and child add. Returns the patches to apply to each child. Omit for
+		 * free positioning (no auto-layout).
+		 */
+		layout?: (ctx: {
+			container: ShapeData;
+			children: ShapeData[];
+		}) => Array<{ id: string; patch: Partial<ShapeData> }>;
+	};
 	/** Shape-specific move logic (e.g. updating absolute point arrays). Default: update x/y only. */
 	move?: (data: ShapeData, dx: number, dy: number) => Partial<ShapeData>;
 	/** Fit shape data to new bounding box (for multi-resize). Default: apply newBounds as-is. */

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -239,9 +239,16 @@ export interface ShapeDefinition {
 	 */
 	resizable?: boolean | ((data: ShapeData) => boolean);
 	/**
-	 * Container behavior. When present, children (shapes referencing this shape
-	 * via `parentId`) follow the parent on move, are arranged by `layout`, and
-	 * are excluded from snapping while the parent is being dragged.
+	 * Container behavior for shapes with children (shapes referencing this shape
+	 * via `parentId`).
+	 *
+	 * Which behaviors are active depends on what's registered:
+	 * - **Selection resolution + move-follow** are native — `tool-helpers` /
+	 *   `tool-select` read these flags directly, no extra plugin needed.
+	 * - **`autoAttach` and `layout`** are driven by `@edv4h/usketch-plugin-container`;
+	 *   without it, declaring them has no effect.
+	 * - **Snap exclusion** of following children additionally requires
+	 *   `@edv4h/usketch-plugin-snap` (the container plugin configures it).
 	 *
 	 * Colocated with the definition like {@link resizable} / {@link move}, and
 	 * each sub-field accepts the same `boolean | (data) => boolean` predicate

--- a/packages/shared/src/utils/container.ts
+++ b/packages/shared/src/utils/container.ts
@@ -1,0 +1,51 @@
+import type { ShapeDefinition } from "../types/plugin.js";
+import type { ShapeData } from "../types/shape.js";
+
+/**
+ * Resolve whether a shape instance acts as a container, honoring the
+ * `boolean | (data) => boolean` predicate form of
+ * {@link ShapeDefinition.container.enabled}.
+ *
+ * - no `container` object   → `false` (not a container)
+ * - `enabled` undefined     → `true`  (specifying `container` opts in)
+ * - `boolean`               → that value
+ * - `(data) => boolean`     → evaluated against the shape instance
+ *
+ * Centralizes the rule so selection resolution, descendant follow, snap, and
+ * the containment attacher all agree on what counts as a container — replacing
+ * the old hardcoded `frame`/`island`/`group` type checks.
+ */
+export function isShapeContainer(def: ShapeDefinition | undefined, shape: ShapeData): boolean {
+	const c = def?.container;
+	if (!c) return false;
+	const e = c.enabled;
+	if (e === undefined) return true;
+	return typeof e === "function" ? e(shape) : e === true;
+}
+
+/**
+ * Resolve whether a container's children are individually selectable /
+ * resizable (frame/island behavior) versus selecting the whole container
+ * (group behavior). Always `false` for non-containers.
+ */
+export function hasSelectableChildren(def: ShapeDefinition | undefined, shape: ShapeData): boolean {
+	if (!isShapeContainer(def, shape)) return false;
+	const s = def?.container?.selectableChildren;
+	return typeof s === "function" ? s(shape) : s === true;
+}
+
+/**
+ * Resolve whether a container auto-attaches shapes dropped inside it as
+ * children (frame-style), versus managing membership itself (group/island).
+ * Always `false` for non-containers.
+ */
+export function isContainerAutoAttach(def: ShapeDefinition | undefined, shape: ShapeData): boolean {
+	if (!isShapeContainer(def, shape)) return false;
+	const a = def?.container?.autoAttach;
+	return typeof a === "function" ? a(shape) : a === true;
+}
+
+/** The container's child-layout function, or `undefined` if it uses free positioning. */
+export function getContainerLayout(def: ShapeDefinition | undefined) {
+	return def?.container?.layout;
+}

--- a/packages/store/src/__tests__/containment-attacher.test.ts
+++ b/packages/store/src/__tests__/containment-attacher.test.ts
@@ -1,0 +1,126 @@
+import type { CommandRegistry, EventBus, ShapeData } from "@edv4h/usketch-shared";
+import { describe, expect, it, vi } from "vitest";
+import { createBoardStore } from "../board-store.js";
+import { createContainmentAttacher } from "../containment-attacher.js";
+
+function makeShape(overrides: Partial<ShapeData> = {}): ShapeData {
+	return {
+		id: "s",
+		type: "rect",
+		x: 0,
+		y: 0,
+		width: 50,
+		height: 50,
+		style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		...overrides,
+	} as ShapeData;
+}
+
+/** Minimal command registry that just executes commands (no history needed here). */
+function makeCommands(): CommandRegistry {
+	return {
+		execute: (cmd: { execute(): void }) => cmd.execute(),
+		undo() {},
+		redo() {},
+		canUndo: () => false,
+		canRedo: () => false,
+		getHistorySize: () => 0,
+		getCursor: () => 0,
+	} as unknown as CommandRegistry;
+}
+
+/** Minimal synchronous event bus. */
+function makeEvents(): EventBus {
+	const listeners = new Map<string, Set<(p: unknown) => void>>();
+	return {
+		on(type: string, fn: (p: unknown) => void) {
+			const bucket = listeners.get(type) ?? new Set();
+			bucket.add(fn);
+			listeners.set(type, bucket);
+			return () => bucket.delete(fn);
+		},
+		emit(type: string, payload: unknown) {
+			for (const fn of listeners.get(type) ?? []) fn(payload);
+		},
+		pause() {},
+		resume() {},
+		isPaused: () => false,
+	} as unknown as EventBus;
+}
+
+const isFrame = (s: ShapeData) => s.type === "frame";
+
+describe("createContainmentAttacher", () => {
+	it("attaches a shape added inside an attach-target container", () => {
+		const store = createBoardStore();
+		const stop = createContainmentAttacher({
+			store,
+			commands: makeCommands(),
+			events: makeEvents(),
+			isAttachTarget: isFrame,
+		});
+
+		store.addShape(makeShape({ id: "frame", type: "frame", x: 0, y: 0, width: 400, height: 400 }));
+		store.addShape(makeShape({ id: "child", x: 20, y: 20, width: 50, height: 50 }));
+
+		expect(store.getShape("child")?.parentId).toBe("frame");
+		stop();
+	});
+
+	it("does not attach a shape added outside any container", () => {
+		const store = createBoardStore();
+		const stop = createContainmentAttacher({
+			store,
+			commands: makeCommands(),
+			events: makeEvents(),
+			isAttachTarget: isFrame,
+		});
+
+		store.addShape(makeShape({ id: "frame", type: "frame", x: 0, y: 0, width: 100, height: 100 }));
+		store.addShape(makeShape({ id: "child", x: 500, y: 500, width: 50, height: 50 }));
+
+		expect(store.getShape("child")?.parentId).toBeUndefined();
+		stop();
+	});
+
+	it("does not auto-attach attach-target containers themselves (frames stay top-level)", () => {
+		const store = createBoardStore();
+		const stop = createContainmentAttacher({
+			store,
+			commands: makeCommands(),
+			events: makeEvents(),
+			isAttachTarget: isFrame,
+		});
+
+		store.addShape(makeShape({ id: "big", type: "frame", x: 0, y: 0, width: 400, height: 400 }));
+		store.addShape(makeShape({ id: "small", type: "frame", x: 20, y: 20, width: 50, height: 50 }));
+
+		expect(store.getShape("small")?.parentId).toBeUndefined();
+		stop();
+	});
+
+	it("detaches on move-end when the shape leaves its container", () => {
+		vi.useFakeTimers();
+		const store = createBoardStore();
+		const events = makeEvents();
+		const stop = createContainmentAttacher({
+			store,
+			commands: makeCommands(),
+			events,
+			isAttachTarget: isFrame,
+		});
+
+		store.addShape(makeShape({ id: "frame", type: "frame", x: 0, y: 0, width: 200, height: 200 }));
+		store.addShape(makeShape({ id: "child", x: 20, y: 20, width: 50, height: 50 }));
+		expect(store.getShape("child")?.parentId).toBe("frame");
+
+		// Move the child out and signal move-end.
+		store.updateShape("child", { x: 500, y: 500 });
+		events.emit("shapes:move-end", { shapeIds: ["child"] });
+		vi.runAllTimers();
+
+		expect(store.getShape("child")?.parentId).toBeUndefined();
+		stop();
+		vi.useRealTimers();
+	});
+});

--- a/packages/store/src/collision-utils.ts
+++ b/packages/store/src/collision-utils.ts
@@ -110,7 +110,8 @@ export function createCollisionWatcher(options: CollisionWatcherOptions): () => 
 		if (watchTypes && !watchTypes.includes(shape.type)) return;
 
 		if (mode === "contain") {
-			// Check if this shape is now contained by a frame
+			// Check if this shape is now contained by a container (per the
+			// `isContainer` predicate — `type === "frame"` by default).
 			const containers = findContainers(store, payload.id, isContainer);
 			const smallestContainer = containers.reduce<ShapeData | null>((best, c) => {
 				if (!best) return c;

--- a/packages/store/src/collision-utils.ts
+++ b/packages/store/src/collision-utils.ts
@@ -86,11 +86,18 @@ export interface CollisionWatcherOptions {
 	watchTypes?: string[];
 	/** Collision detection mode */
 	mode: "intersect" | "contain";
+	/**
+	 * Predicate identifying container shapes for `mode: "contain"`. Defaults to
+	 * the legacy `type === "frame"` check; pass a registry-aware predicate to
+	 * treat any shape whose definition marks it as a container.
+	 */
+	isContainer?: (shape: ShapeData) => boolean;
 }
 
 /** Watch for shape changes and emit collision events */
 export function createCollisionWatcher(options: CollisionWatcherOptions): () => void {
 	const { store, events, watchTypes, mode } = options;
+	const isContainer = options.isContainer ?? ((s: ShapeData) => s.type === "frame");
 	const containmentMap = new Map<string, string>(); // childId -> containerId
 
 	const unsubscribe = store.onMutation((event) => {
@@ -104,7 +111,7 @@ export function createCollisionWatcher(options: CollisionWatcherOptions): () => 
 
 		if (mode === "contain") {
 			// Check if this shape is now contained by a frame
-			const containers = findContainers(store, payload.id, (s) => s.type === "frame");
+			const containers = findContainers(store, payload.id, isContainer);
 			const smallestContainer = containers.reduce<ShapeData | null>((best, c) => {
 				if (!best) return c;
 				return c.width * c.height < best.width * best.height ? c : best;

--- a/packages/store/src/containment-attacher.ts
+++ b/packages/store/src/containment-attacher.ts
@@ -64,13 +64,18 @@ export function createContainmentAttacher(opts: ContainmentAttacherOptions): () 
 		}
 	}
 
+	// Pending deferred reparents, so teardown can cancel any that haven't fired.
+	const pending = new Set<ReturnType<typeof setTimeout>>();
+
 	// On move-end (emitted by the select tool after a move command commits).
 	// Deferred so reparent runs after the current render/microtask cycle.
 	const offMoveEnd = events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
 		if (!data?.shapeIds) return;
-		setTimeout(() => {
+		const timer = setTimeout(() => {
+			pending.delete(timer);
 			for (const shapeId of data.shapeIds) autoReparent(shapeId);
 		}, 0);
+		pending.add(timer);
 	});
 
 	// On shape:added (e.g. drawing a shape inside a container).
@@ -83,5 +88,7 @@ export function createContainmentAttacher(opts: ContainmentAttacherOptions): () 
 	return () => {
 		offMoveEnd();
 		offAdded();
+		for (const timer of pending) clearTimeout(timer);
+		pending.clear();
 	};
 }

--- a/packages/store/src/containment-attacher.ts
+++ b/packages/store/src/containment-attacher.ts
@@ -1,0 +1,87 @@
+import type { BoardStore, CommandRegistry, EventBus, ShapeData } from "@edv4h/usketch-shared";
+import { containsAABB } from "./collision-utils.js";
+import { createReparentCommand } from "./commands.js";
+import { wouldCreateCycle } from "./hierarchy-utils.js";
+
+export interface ContainmentAttacherOptions {
+	store: BoardStore;
+	commands: CommandRegistry;
+	events: EventBus;
+	/**
+	 * Whether a shape can act as an auto-attach container (evaluated per
+	 * candidate). Typically registry-aware: `isContainerAutoAttach(def, shape)`.
+	 */
+	isAttachTarget: (shape: ShapeData) => boolean;
+	/**
+	 * Whether a shape is eligible to be auto-attached as a child. Default:
+	 * anything that isn't a connector and isn't itself an attach-target — so
+	 * attach-target containers (e.g. frames) stay top-level and don't nest, while
+	 * non-attach containers (island/group) and plain shapes may attach.
+	 */
+	canAttach?: (shape: ShapeData) => boolean;
+}
+
+const boundsOf = (s: ShapeData) => ({ x: s.x, y: s.y, width: s.width, height: s.height });
+
+/**
+ * Wire up automatic parent-child attachment by containment. When a shape is
+ * added or finishes a move, find the smallest attach-target container that
+ * fully contains it and set its `parentId` (or clear it when moved out).
+ *
+ * Generalizes the frame plugin's former bespoke `autoReparent` so any shape
+ * whose definition opts in via `container.autoAttach` participates. Reuses
+ * {@link containsAABB} and undo-able {@link createReparentCommand}.
+ *
+ * Returns a teardown function.
+ */
+export function createContainmentAttacher(opts: ContainmentAttacherOptions): () => void {
+	const { store, commands, events, isAttachTarget } = opts;
+	const canAttach =
+		opts.canAttach ?? ((s: ShapeData) => s.type !== "connector" && !isAttachTarget(s));
+
+	function autoReparent(shapeId: string) {
+		const shape = store.getShape(shapeId);
+		if (!shape || !canAttach(shape)) return;
+
+		const shapeBounds = boundsOf(shape);
+		// Find the smallest attach-target container that fully contains the shape.
+		let best: ShapeData | null = null;
+		for (const [id, candidate] of store.getShapes()) {
+			if (id === shapeId) continue;
+			if (!isAttachTarget(candidate)) continue;
+			// Never nest a shape into one of its own descendants.
+			if (wouldCreateCycle(store, shapeId, id)) continue;
+			if (!containsAABB(boundsOf(candidate), shapeBounds)) continue;
+			if (!best || candidate.width * candidate.height < best.width * best.height) {
+				best = candidate;
+			}
+		}
+
+		const currentParentId = shape.parentId as string | undefined;
+		const newParentId = best?.id;
+		if (currentParentId !== newParentId) {
+			commands.execute(createReparentCommand(store, [shapeId], newParentId ?? undefined));
+		}
+	}
+
+	// On move-end (emitted by the select tool after a move command commits).
+	// Deferred so reparent runs after the current render/microtask cycle.
+	const offMoveEnd = events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
+		if (!data?.shapeIds) return;
+		setTimeout(() => {
+			for (const shapeId of data.shapeIds) autoReparent(shapeId);
+		}, 0);
+	});
+
+	// On shape:added (e.g. drawing a shape inside a container).
+	const offAdded = store.onMutation((event) => {
+		if (event.type !== "shape:added") return;
+		const payload = event.payload as { id?: string } | undefined;
+		if (payload?.id) autoReparent(payload.id);
+	});
+
+	return () => {
+		offMoveEnd();
+		offAdded();
+	};
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -26,6 +26,10 @@ export {
 	createUpdateShapeCommand,
 } from "./commands.js";
 export {
+	type ContainmentAttacherOptions,
+	createContainmentAttacher,
+} from "./containment-attacher.js";
+export {
 	computeGroupBounds,
 	getAncestorChain,
 	getChildShapes,

--- a/packages/usketch-tool-helpers/src/__tests__/hover.test.ts
+++ b/packages/usketch-tool-helpers/src/__tests__/hover.test.ts
@@ -73,6 +73,79 @@ describe("findShapeAtPoint", () => {
 		);
 	});
 
+	it("resolves a frame child to the child itself (selectableChildren)", () => {
+		// frame/island are containers with selectableChildren → clicking a child
+		// selects the child directly, not the container.
+		const ctx = createTestToolContext();
+		ctx.store.addShape(
+			makeShape({ id: "frame", type: "frame", x: 0, y: 0, width: 200, height: 200 }),
+		);
+		ctx.store.addShape(
+			makeShape({ id: "child", x: 10, y: 10, width: 50, height: 50, parentId: "frame" }),
+		);
+		expect(findShapeAtPoint(ctx, { x: 20, y: 20 })).toBe("child");
+	});
+
+	it("resolves a group child to the group ancestor (no selectableChildren)", () => {
+		const ctx = createTestToolContext();
+		ctx.store.addShape(makeShape({ id: "g", type: "group", x: 0, y: 0, width: 200, height: 200 }));
+		ctx.store.addShape(
+			makeShape({ id: "child", x: 10, y: 10, width: 50, height: 50, parentId: "g" }),
+		);
+		expect(findShapeAtPoint(ctx, { x: 20, y: 20 })).toBe("g");
+	});
+
+	it("honors a per-instance selectableChildren predicate on a custom type", () => {
+		// A single "wireframe" type whose meta.component === "card" is a container
+		// with selectable children; other components are plain shapes.
+		const ctx = createTestToolContext();
+		ctx.shapes.register("wireframe", {
+			type: "wireframe",
+			minSize: { width: 1, height: 1 },
+			hitTest: (data: ShapeDefinition & ShapeData, point: { x: number; y: number }) =>
+				point.x >= (data as ShapeData).x &&
+				point.x <= (data as ShapeData).x + (data as ShapeData).width &&
+				point.y >= (data as ShapeData).y &&
+				point.y <= (data as ShapeData).y + (data as ShapeData).height,
+			getBounds: (data: ShapeData) => ({
+				x: data.x,
+				y: data.y,
+				width: data.width,
+				height: data.height,
+			}),
+			render: () => null,
+			container: {
+				enabled: (s: ShapeData) => s.meta?.component === "card",
+				selectableChildren: (s: ShapeData) => s.meta?.component === "card",
+			},
+		} as unknown as ShapeDefinition);
+
+		ctx.store.addShape(
+			makeShape({
+				id: "card",
+				type: "wireframe",
+				x: 0,
+				y: 0,
+				width: 200,
+				height: 200,
+				meta: { component: "card" },
+			}),
+		);
+		ctx.store.addShape(
+			makeShape({
+				id: "btn",
+				type: "wireframe",
+				x: 10,
+				y: 10,
+				width: 50,
+				height: 50,
+				parentId: "card",
+				meta: { component: "button" },
+			}),
+		);
+		expect(findShapeAtPoint(ctx, { x: 20, y: 20 })).toBe("btn");
+	});
+
 	it("applies excludeIds/filter to the resolved group ancestor, not just the hit child", () => {
 		// A group child hit resolves to its top-level group ancestor. Excluding or
 		// filtering out that ancestor must continue the walk to the shape below,

--- a/packages/usketch-tool-helpers/src/__tests__/test-helpers.ts
+++ b/packages/usketch-tool-helpers/src/__tests__/test-helpers.ts
@@ -146,17 +146,19 @@ function rectDefinition(): ShapeDefinition {
 
 function frameDefinition(): ShapeDefinition {
 	const def = rectDefinition();
-	return { ...def, type: "frame" } as ShapeDefinition;
+	// Matches the real frame plugin: container with individually-selectable children.
+	return { ...def, type: "frame", container: { selectableChildren: true } } as ShapeDefinition;
 }
 
 function groupDefinition(): ShapeDefinition {
 	const def = rectDefinition();
-	return { ...def, type: "group" } as ShapeDefinition;
+	// Container, but children select the whole group (selectableChildren omitted).
+	return { ...def, type: "group", container: {} } as ShapeDefinition;
 }
 
 function islandDefinition(): ShapeDefinition {
 	const def = rectDefinition();
-	return { ...def, type: "island" } as ShapeDefinition;
+	return { ...def, type: "island", container: { selectableChildren: true } } as ShapeDefinition;
 }
 
 export function createTestCommands(): CommandRegistry & { history: unknown[] } {

--- a/packages/usketch-tool-helpers/src/drag.ts
+++ b/packages/usketch-tool-helpers/src/drag.ts
@@ -27,16 +27,18 @@ export interface DragSessionOptions {
 	 * move only the top-level shapes.
 	 *
 	 * Which descendants follow is decided by `followChildrenOf`: by default
-	 * only containers (group/frame/island) propagate to their children, but a
-	 * custom predicate widens this to any parent the caller chooses. In other
+	 * only containers (shapes whose definition marks them as such) propagate to
+	 * their children, but a custom predicate widens this to any parent the
+	 * caller chooses. In other
 	 * words, "descendants" here means "children of every shape `followChildrenOf`
 	 * returns `true` for", not strictly container children.
 	 */
 	includeDescendants?: boolean;
 	/**
 	 * Predicate deciding whether a shape's children should follow it on move.
-	 * Defaults to the container check (group/frame/island). Pass a custom
-	 * predicate to also drag children of ordinary (non-container) parents —
+	 * Defaults to the container check (shapes whose definition marks them as a
+	 * container). Pass a custom predicate to also drag children of ordinary
+	 * (non-container) parents —
 	 * e.g. a sticker/reaction attached via `parentId` to an arbitrary shape.
 	 * Only consulted when `includeDescendants` is `true` (the default).
 	 */

--- a/packages/usketch-tool-helpers/src/hover.ts
+++ b/packages/usketch-tool-helpers/src/hover.ts
@@ -8,7 +8,7 @@ import type {
 	ToolContext,
 	Viewport,
 } from "@edv4h/usketch-shared";
-import { safeRotation } from "@edv4h/usketch-shared";
+import { hasSelectableChildren, safeRotation } from "@edv4h/usketch-shared";
 import { getTopLevelAncestor } from "@edv4h/usketch-store";
 import {
 	findHandleAtScreenPoint,
@@ -159,7 +159,6 @@ export function findShapeAtPoint(
 				: null;
 	const filter = options.filter;
 	const shapes = ctx.store.getShapes();
-	const CONTAINER_TYPES = new Set(["island", "frame"]);
 	const entries = [...shapes.entries()].reverse();
 
 	let containerHit: string | null = null;
@@ -177,7 +176,7 @@ export function findShapeAtPoint(
 
 		if (typeof data.parentId === "string") {
 			const parent = ctx.store.getShape(data.parentId);
-			if (parent?.type === "frame" || parent?.type === "island") {
+			if (parent && hasSelectableChildren(ctx.shapes.get(parent.type), parent)) {
 				return id;
 			}
 			// The resolved ancestor — not the hit child — is what we return, so it
@@ -191,7 +190,7 @@ export function findShapeAtPoint(
 			continue;
 		}
 
-		if (CONTAINER_TYPES.has(data.type)) {
+		if (hasSelectableChildren(def, data)) {
 			if (!containerHit) containerHit = id;
 			continue;
 		}

--- a/packages/usketch-tool-helpers/src/internal/descendants.ts
+++ b/packages/usketch-tool-helpers/src/internal/descendants.ts
@@ -1,17 +1,15 @@
 import type { ShapeData, ToolContext } from "@edv4h/usketch-shared";
+import { isShapeContainer } from "@edv4h/usketch-shared";
 import { getChildShapes } from "@edv4h/usketch-store";
-
-const CONTAINER_TYPES: ReadonlySet<string> = new Set(["group", "frame", "island"]);
-
-/** Default predicate: only containers (group/frame/island) follow with their children. */
-const isContainer = (shape: ShapeData): boolean => CONTAINER_TYPES.has(shape.type);
 
 export interface CollectDescendantsOptions {
 	/**
 	 * Decide whether a shape's children should be collected (and thus follow on
-	 * move). Defaults to the container check (group/frame/island). Pass a custom
-	 * predicate to also follow children of ordinary (non-container) parents —
-	 * e.g. "a sticker attached via parentId to any shape should move with it".
+	 * move). Defaults to the container check (any shape whose registered
+	 * definition marks it as a container — see {@link isShapeContainer}). Pass a
+	 * custom predicate to also follow children of ordinary (non-container)
+	 * parents — e.g. "a sticker attached via parentId to any shape should move
+	 * with it".
 	 */
 	followChildrenOf?: (shape: ShapeData) => boolean;
 }
@@ -32,7 +30,9 @@ export function collectSelectionWithDescendants(
 	rootIds: Iterable<string>,
 	options: CollectDescendantsOptions = {},
 ): Map<string, ShapeData> {
-	const follows = options.followChildrenOf ?? isContainer;
+	const follows =
+		options.followChildrenOf ??
+		((shape: ShapeData) => isShapeContainer(ctx.shapes.get(shape.type), shape));
 	const result = new Map<string, ShapeData>();
 	const queue: string[] = [];
 
@@ -66,7 +66,7 @@ export function collectSelectionWithDescendants(
 export function collectChildrenOnly(ctx: ToolContext, rootId: string): Map<string, ShapeData> {
 	const result = new Map<string, ShapeData>();
 	const root = ctx.store.getShape(rootId);
-	if (!root || !CONTAINER_TYPES.has(root.type)) return result;
+	if (!root || !isShapeContainer(ctx.shapes.get(root.type), root)) return result;
 
 	const queue: string[] = [rootId];
 	while (queue.length > 0) {
@@ -75,7 +75,7 @@ export function collectChildrenOnly(ctx: ToolContext, rootId: string): Map<strin
 		for (const child of getChildShapes(ctx.store, parentId)) {
 			if (result.has(child.id)) continue;
 			result.set(child.id, { ...child });
-			if (CONTAINER_TYPES.has(child.type)) queue.push(child.id);
+			if (isShapeContainer(ctx.shapes.get(child.type), child)) queue.push(child.id);
 		}
 	}
 	return result;

--- a/packages/usketch-tool-helpers/src/marquee.ts
+++ b/packages/usketch-tool-helpers/src/marquee.ts
@@ -1,4 +1,5 @@
 import type { BoundingBox, CanvasPointerEvent, Point, ToolContext } from "@edv4h/usketch-shared";
+import { hasSelectableChildren } from "@edv4h/usketch-shared";
 import { getTopLevelAncestor } from "@edv4h/usketch-store";
 import type { ToolSession } from "./types.js";
 
@@ -119,7 +120,7 @@ export function findShapesInRect(
 
 		if (typeof data.parentId === "string") {
 			const parent = ctx.store.getShape(data.parentId);
-			if (parent?.type === "frame") {
+			if (parent && hasSelectableChildren(ctx.shapes.get(parent.type), parent)) {
 				ids.add(id);
 			} else {
 				const ancestor = getTopLevelAncestor(ctx.store, id);

--- a/plugins/usketch-plugin-container/README.md
+++ b/plugins/usketch-plugin-container/README.md
@@ -1,0 +1,62 @@
+# @edv4h/usketch-plugin-container
+
+Runtime for **container shapes** — shapes whose `ShapeDefinition` declares a
+`container` object. It supplies the parentId-based container mechanics that a
+shape definition can't express on its own:
+
+- **Auto-attach** — a shape dropped fully inside a container that sets
+  `container.autoAttach` gets its `parentId` set (and cleared when moved out).
+- **Arrange** — a container's `container.layout` positions its children on
+  attach/detach, resize, and (non-drag) updates.
+- **Snap exclusion** — while a container is dragged, its children (which follow
+  natively) are excluded from snapping so they don't jitter. Requires
+  `@edv4h/usketch-plugin-snap`; a no-op if snap isn't installed.
+
+Selection resolution ("click a child, select the child") and move-follow
+("drag the parent, children follow") are handled **natively** by
+`tool-helpers`/`tool-select` from the same `container` flags — this plugin only
+adds the reactive pieces above.
+
+## Usage
+
+Register **after** the snap plugin so its `snap:configure` listener is ready:
+
+```ts
+import { createContainerPlugin } from "@edv4h/usketch-plugin-container";
+
+const plugins = [
+  // ...
+  createSnapPlugin(),
+  createContainerPlugin(),
+];
+```
+
+Declare a container on a shape definition (all fields accept a
+`boolean | (data) => boolean` predicate, so a single type can vary per
+instance):
+
+```ts
+import { stackLayout } from "@edv4h/usketch-plugin-container";
+
+ctx.shapes.register("wireframe", {
+  // ...render/hitTest/resize/createDefault...
+  container: {
+    enabled: (s) => s.meta?.component === "card", // only cards are containers
+    selectableChildren: true,                     // children selectable individually
+    autoAttach: true,                             // drop-inside attaches as child
+    layout: stackLayout({ padding: 16, gap: 8 }), // arrange children vertically
+  },
+});
+```
+
+Children are ordinary shapes referencing the container via native `parentId`.
+
+## Notes / limitations
+
+- **z-order / nesting**: children are positioned but not z-ordered by this
+  plugin — visual nesting relies on `zIndex`.
+- **Single `excludeTargets`**: `snap:configure` holds one `excludeTargets`
+  predicate; if multiple plugins set it, last write wins. Only this plugin is
+  expected to.
+- **Rotation**: children follow/arrange on move and resize; parent rotation is
+  not propagated to children.

--- a/plugins/usketch-plugin-container/package.json
+++ b/plugins/usketch-plugin-container/package.json
@@ -1,0 +1,45 @@
+{
+	"name": "@edv4h/usketch-plugin-container",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-container"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	},
+	"devDependencies": {
+		"typescript": "5.9.3",
+		"vitest": "3.2.4"
+	}
+}

--- a/plugins/usketch-plugin-container/src/__tests__/container.test.ts
+++ b/plugins/usketch-plugin-container/src/__tests__/container.test.ts
@@ -1,0 +1,152 @@
+import type { PluginContext, ShapeData, ShapeDefinition } from "@edv4h/usketch-shared";
+import { describe, expect, it, vi } from "vitest";
+import { setupArrange } from "../arrange.js";
+import { gridLayout, stackLayout } from "../layouts.js";
+import { setupSnapExclude } from "../snap-exclude.js";
+
+const shape = (o: Partial<ShapeData> = {}): ShapeData =>
+	({
+		id: "s",
+		type: "rect",
+		x: 0,
+		y: 0,
+		width: 40,
+		height: 20,
+		style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		...o,
+	}) as ShapeData;
+
+/** Minimal PluginContext covering only what these modules touch. */
+function makeCtx(defs: Record<string, ShapeDefinition["container"]>) {
+	const shapes = new Map<string, ShapeData>();
+	const selection = new Set<string>();
+	const mutationListeners = new Set<(e: { type: string; payload?: unknown }) => void>();
+	const eventListeners = new Map<string, Set<(p: unknown) => void>>();
+	const emitted: Array<{ type: string; payload: unknown }> = [];
+
+	function notifyMutation(type: string, id: string) {
+		for (const fn of mutationListeners) fn({ type, payload: { id } });
+	}
+
+	const ctx = {
+		store: {
+			getShapes: () => shapes,
+			getShape: (id: string) => shapes.get(id),
+			getSelection: () => selection,
+			addShape(s: ShapeData) {
+				shapes.set(s.id, s);
+				notifyMutation("shape:added", s.id);
+			},
+			updateShape(id: string, patch: Partial<ShapeData>) {
+				const cur = shapes.get(id);
+				if (!cur) return;
+				shapes.set(id, { ...cur, ...patch });
+				notifyMutation("shape:updated", id);
+			},
+			onMutation(fn: (e: { type: string; payload?: unknown }) => void) {
+				mutationListeners.add(fn);
+				return () => mutationListeners.delete(fn);
+			},
+		},
+		shapes: {
+			get: (type: string) => ({ container: defs[type] }) as ShapeDefinition,
+		},
+		events: {
+			emit(type: string, payload: unknown) {
+				emitted.push({ type, payload });
+				for (const fn of eventListeners.get(type) ?? []) fn(payload);
+			},
+			on(type: string, fn: (p: unknown) => void) {
+				const bucket = eventListeners.get(type) ?? new Set();
+				bucket.add(fn);
+				eventListeners.set(type, bucket);
+				return () => bucket.delete(fn);
+			},
+		},
+	} as unknown as PluginContext;
+
+	return { ctx, shapes, selection, emitted };
+}
+
+describe("layouts", () => {
+	it("stackLayout arranges children vertically with padding/gap", () => {
+		const container = shape({ id: "c", x: 100, y: 100, width: 240, height: 180 });
+		const children = [shape({ id: "a", height: 40 }), shape({ id: "b", height: 40 })];
+		const patches = stackLayout({ padding: 16, gap: 8 })({ container, children });
+		expect(patches).toEqual([
+			{ id: "a", patch: { x: 116, y: 116, width: 208 } },
+			{ id: "b", patch: { x: 116, y: 164, width: 208 } }, // 116 + 40 + 8
+		]);
+	});
+
+	it("gridLayout wraps children into columns", () => {
+		const container = shape({ id: "c", x: 0, y: 0, width: 220, height: 400 });
+		const children = [
+			shape({ id: "a", height: 30 }),
+			shape({ id: "b", height: 50 }),
+			shape({ id: "c2", height: 30 }),
+		];
+		const patches = gridLayout({ columns: 2, padding: 10, gap: 10 })({ container, children });
+		// inner width 200, cellWidth = (200 - 10) / 2 = 95
+		expect(patches[0]).toEqual({ id: "a", patch: { x: 10, y: 10, width: 95 } });
+		expect(patches[1]).toEqual({ id: "b", patch: { x: 115, y: 10, width: 95 } });
+		// third wraps to next row: rowY = 10 + max(30,50) + 10 = 70
+		expect(patches[2]).toEqual({ id: "c2", patch: { x: 10, y: 70, width: 95 } });
+	});
+});
+
+describe("setupSnapExclude", () => {
+	it("excludes a child whose container parent is selected, not otherwise", () => {
+		const { ctx, shapes, selection, emitted } = makeCtx({
+			frame: { selectableChildren: true },
+			rect: undefined,
+		});
+		shapes.set("frame", shape({ id: "frame", type: "frame", width: 200, height: 200 }));
+		shapes.set("child", shape({ id: "child", type: "rect", parentId: "frame" }));
+		shapes.set("loose", shape({ id: "loose", type: "rect" }));
+
+		const stop = setupSnapExclude(ctx);
+		const configure = emitted.find((e) => e.type === "snap:configure");
+		const exclude = (configure?.payload as { excludeTargets: (s: ShapeData) => boolean })
+			.excludeTargets;
+
+		// Parent not selected → child not excluded.
+		expect(exclude(shapes.get("child") as ShapeData)).toBe(false);
+		// Parent selected → child excluded.
+		selection.add("frame");
+		expect(exclude(shapes.get("child") as ShapeData)).toBe(true);
+		// Non-child never excluded.
+		expect(exclude(shapes.get("loose") as ShapeData)).toBe(false);
+
+		stop();
+		// Teardown clears the predicate.
+		const last = emitted[emitted.length - 1];
+		expect(last.type).toBe("snap:configure");
+		expect((last.payload as { excludeTargets?: unknown }).excludeTargets).toBeUndefined();
+	});
+});
+
+describe("setupArrange", () => {
+	it("lays out a container's children on pointer up and does not loop", () => {
+		vi.useFakeTimers();
+		const layout = vi.fn(stackLayout({ padding: 0, gap: 0, direction: "vertical" }));
+		const { ctx, shapes } = makeCtx({ frame: { selectableChildren: true, layout } });
+		shapes.set("frame", shape({ id: "frame", type: "frame", x: 0, y: 0, width: 100, height: 100 }));
+		shapes.set("a", shape({ id: "a", type: "rect", parentId: "frame", height: 20 }));
+		shapes.set("b", shape({ id: "b", type: "rect", parentId: "frame", height: 20 }));
+
+		const stop = setupArrange(ctx);
+		ctx.events.emit("canvas:pointerup", {});
+		vi.runAllTimers();
+
+		// Children stacked: a at y=0, b at y=20; both stretched to width 100.
+		expect(shapes.get("a")).toMatchObject({ x: 0, y: 0, width: 100 });
+		expect(shapes.get("b")).toMatchObject({ x: 0, y: 20, width: 100 });
+		// The layout's own updateShape calls must not re-trigger arrange (no loop):
+		// exactly one layout pass from the single pointerup.
+		expect(layout).toHaveBeenCalledTimes(1);
+
+		stop();
+		vi.useRealTimers();
+	});
+});

--- a/plugins/usketch-plugin-container/src/__tests__/container.test.ts
+++ b/plugins/usketch-plugin-container/src/__tests__/container.test.ts
@@ -79,6 +79,29 @@ describe("layouts", () => {
 		]);
 	});
 
+	it("stackLayout clamps width/height to >= 0 for tiny containers", () => {
+		const container = shape({ id: "c", x: 0, y: 0, width: 10, height: 10 });
+		const [v] = stackLayout({ padding: 16 })({ container, children: [shape({ id: "a" })] });
+		expect(v.patch.width).toBe(0); // 10 - 32 clamped to 0, not negative
+		const [h] = stackLayout({ padding: 16, direction: "horizontal" })({
+			container,
+			children: [shape({ id: "a" })],
+		});
+		expect(h.patch.height).toBe(0);
+	});
+
+	it("gridLayout guards columns <= 0 (no division by zero / negative widths)", () => {
+		const container = shape({ id: "c", x: 0, y: 0, width: 100, height: 100 });
+		const patches = gridLayout({ columns: 0, padding: 10, gap: 10 })({
+			container,
+			children: [shape({ id: "a" }), shape({ id: "b" })],
+		});
+		for (const p of patches) {
+			expect(Number.isFinite(p.patch.width)).toBe(true);
+			expect(p.patch.width as number).toBeGreaterThanOrEqual(0);
+		}
+	});
+
 	it("gridLayout wraps children into columns", () => {
 		const container = shape({ id: "c", x: 0, y: 0, width: 220, height: 400 });
 		const children = [
@@ -136,6 +159,10 @@ describe("setupArrange", () => {
 		shapes.set("b", shape({ id: "b", type: "rect", parentId: "frame", height: 20 }));
 
 		const stop = setupArrange(ctx);
+		// Simulate a drag that touches the container: pointer down, the container
+		// moves (recorded as dirty), then pointer up flushes the re-layout.
+		ctx.events.emit("canvas:pointerdown", {});
+		ctx.store.updateShape("frame", { x: 0 });
 		ctx.events.emit("canvas:pointerup", {});
 		vi.runAllTimers();
 

--- a/plugins/usketch-plugin-container/src/__tests__/container.test.ts
+++ b/plugins/usketch-plugin-container/src/__tests__/container.test.ts
@@ -141,6 +141,10 @@ describe("setupSnapExclude", () => {
 		// Non-child never excluded.
 		expect(exclude(shapes.get("loose") as ShapeData)).toBe(false);
 
+		// Deeply-nested descendant excluded when an ancestor container is selected.
+		shapes.set("grandchild", shape({ id: "grandchild", type: "rect", parentId: "child" }));
+		expect(exclude(shapes.get("grandchild") as ShapeData)).toBe(true);
+
 		stop();
 		// Teardown clears the predicate.
 		const last = emitted[emitted.length - 1];

--- a/plugins/usketch-plugin-container/src/arrange.ts
+++ b/plugins/usketch-plugin-container/src/arrange.ts
@@ -1,4 +1,4 @@
-import type { CanvasPointerEvent, PluginContext } from "@edv4h/usketch-shared";
+import type { CanvasPointerEvent, PluginContext, ShapeData } from "@edv4h/usketch-shared";
 import { getContainerLayout, isShapeContainer } from "@edv4h/usketch-shared";
 import { getChildShapes } from "@edv4h/usketch-store";
 
@@ -28,8 +28,11 @@ export function setupArrange(ctx: PluginContext): () => void {
 	// O(all shapes on the board).
 	const dirty = new Set<string>();
 
-	function hasLayout(type: string): boolean {
-		return getContainerLayout(ctx.shapes.get(type)) !== undefined;
+	// A shape is a layout container only if this *instance* is an enabled
+	// container (honoring per-instance `container.enabled`) and defines a layout.
+	function isLayoutContainer(shape: ShapeData): boolean {
+		const def = ctx.shapes.get(shape.type);
+		return isShapeContainer(def, shape) && getContainerLayout(def) !== undefined;
 	}
 
 	function layoutContainer(containerId: string): void {
@@ -56,10 +59,10 @@ export function setupArrange(ctx: PluginContext): () => void {
 	function markDirty(shapeId: string): void {
 		const shape = ctx.store.getShape(shapeId);
 		if (!shape) return;
-		if (hasLayout(shape.type)) dirty.add(shapeId);
+		if (isLayoutContainer(shape)) dirty.add(shapeId);
 		if (typeof shape.parentId === "string") {
 			const parent = ctx.store.getShape(shape.parentId);
-			if (parent && hasLayout(parent.type)) dirty.add(shape.parentId);
+			if (parent && isLayoutContainer(parent)) dirty.add(shape.parentId);
 		}
 	}
 

--- a/plugins/usketch-plugin-container/src/arrange.ts
+++ b/plugins/usketch-plugin-container/src/arrange.ts
@@ -98,6 +98,9 @@ export function setupArrange(ctx: PluginContext): () => void {
 		// after the containment attacher's own deferred reparent (also on pointer
 		// up); the attach's later `shape:updated` re-layouts the new parent too.
 		setTimeout(() => {
+			// If another drag started before this fired, defer again: laying out
+			// mid-drag would fight native descendant-follow. Keep `dirty` intact.
+			if (pointerDown) return;
 			const ids = [...dirty];
 			dirty.clear();
 			for (const containerId of ids) layoutContainer(containerId);

--- a/plugins/usketch-plugin-container/src/arrange.ts
+++ b/plugins/usketch-plugin-container/src/arrange.ts
@@ -20,6 +20,9 @@ export function setupArrange(ctx: PluginContext): () => void {
 	// Guard so the layout's own `updateShape` calls don't re-trigger arrange.
 	let applying = false;
 	let pointerDown = false;
+	// Handle for the deferred pointer-up flush, so it can be cancelled when a new
+	// drag starts or the plugin is torn down.
+	let flushTimer: ReturnType<typeof setTimeout> | null = null;
 	// Containers touched during the current pointer drag, re-laid out on pointer
 	// up. Scoped to what actually changed so pointer-up work is O(touched), not
 	// O(all shapes on the board).
@@ -91,13 +94,19 @@ export function setupArrange(ctx: PluginContext): () => void {
 
 	const offDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", () => {
 		pointerDown = true;
+		// Cancel a previous drag's pending flush so it can't run mid-drag.
+		if (flushTimer !== null) {
+			clearTimeout(flushTimer);
+			flushTimer = null;
+		}
 	});
 	const offUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", () => {
 		pointerDown = false;
 		// Re-layout the containers touched during the drag. Deferred so it runs
 		// after the containment attacher's own deferred reparent (also on pointer
 		// up); the attach's later `shape:updated` re-layouts the new parent too.
-		setTimeout(() => {
+		flushTimer = setTimeout(() => {
+			flushTimer = null;
 			// If another drag started before this fired, defer again: laying out
 			// mid-drag would fight native descendant-follow. Keep `dirty` intact.
 			if (pointerDown) return;
@@ -111,5 +120,6 @@ export function setupArrange(ctx: PluginContext): () => void {
 		offMutation();
 		offDown();
 		offUp();
+		if (flushTimer !== null) clearTimeout(flushTimer);
 	};
 }

--- a/plugins/usketch-plugin-container/src/arrange.ts
+++ b/plugins/usketch-plugin-container/src/arrange.ts
@@ -20,6 +20,14 @@ export function setupArrange(ctx: PluginContext): () => void {
 	// Guard so the layout's own `updateShape` calls don't re-trigger arrange.
 	let applying = false;
 	let pointerDown = false;
+	// Containers touched during the current pointer drag, re-laid out on pointer
+	// up. Scoped to what actually changed so pointer-up work is O(touched), not
+	// O(all shapes on the board).
+	const dirty = new Set<string>();
+
+	function hasLayout(type: string): boolean {
+		return getContainerLayout(ctx.shapes.get(type)) !== undefined;
+	}
 
 	function layoutContainer(containerId: string): void {
 		const container = ctx.store.getShape(containerId);
@@ -40,18 +48,32 @@ export function setupArrange(ctx: PluginContext): () => void {
 		}
 	}
 
-	function layoutAllContainers(): void {
-		for (const [id, shape] of ctx.store.getShapes()) {
-			if (getContainerLayout(ctx.shapes.get(shape.type))) layoutContainer(id);
+	// Record the layout-container(s) a change to `shapeId` could affect: the
+	// shape itself (container moved/resized) and its parent (child added/moved).
+	function markDirty(shapeId: string): void {
+		const shape = ctx.store.getShape(shapeId);
+		if (!shape) return;
+		if (hasLayout(shape.type)) dirty.add(shapeId);
+		if (typeof shape.parentId === "string") {
+			const parent = ctx.store.getShape(shape.parentId);
+			if (parent && hasLayout(parent.type)) dirty.add(shape.parentId);
 		}
 	}
 
 	const offMutation = ctx.store.onMutation((event) => {
-		if (applying || pointerDown) return; // ignore self-induced + mid-drag churn
+		if (applying) return; // ignore self-induced updates
 		const payload = event.payload as { id?: string } | undefined;
 		const id = payload?.id;
 		if (!id) return;
 
+		if (pointerDown) {
+			// Mid-drag: don't fight native follow — just remember what to re-arrange
+			// on pointer up.
+			if (event.type === "shape:updated" || event.type === "shape:added") markDirty(id);
+			return;
+		}
+
+		// Not dragging: apply immediately (programmatic / MCP / undo / deferred attach).
 		if (event.type === "shape:added") {
 			const parentId = ctx.store.getShape(id)?.parentId;
 			if (typeof parentId === "string") layoutContainer(parentId);
@@ -72,9 +94,14 @@ export function setupArrange(ctx: PluginContext): () => void {
 	});
 	const offUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", () => {
 		pointerDown = false;
-		// Re-layout after a drag/resize commits. Deferred so it runs after the
-		// containment attacher's own deferred reparent (also on pointer up).
-		setTimeout(() => layoutAllContainers(), 0);
+		// Re-layout the containers touched during the drag. Deferred so it runs
+		// after the containment attacher's own deferred reparent (also on pointer
+		// up); the attach's later `shape:updated` re-layouts the new parent too.
+		setTimeout(() => {
+			const ids = [...dirty];
+			dirty.clear();
+			for (const containerId of ids) layoutContainer(containerId);
+		}, 0);
 	});
 
 	return () => {

--- a/plugins/usketch-plugin-container/src/arrange.ts
+++ b/plugins/usketch-plugin-container/src/arrange.ts
@@ -1,0 +1,85 @@
+import type { CanvasPointerEvent, PluginContext } from "@edv4h/usketch-shared";
+import { getContainerLayout, isShapeContainer } from "@edv4h/usketch-shared";
+import { getChildShapes } from "@edv4h/usketch-store";
+
+/**
+ * Keep a container's children arranged per its `container.layout`.
+ *
+ * Layout runs after a container's children/geometry settle — on pointer up
+ * (covers drag-move, resize, and deferred auto-attach), on shape add, and on
+ * non-drag (programmatic / MCP) updates. It intentionally does NOT run on every
+ * intermediate `shape:updated` during a pointer drag: the select tool already
+ * moves children with the container (native descendant follow), so re-laying
+ * out mid-drag would fight that and cause jitter.
+ *
+ * Containers without a `layout` are ignored entirely (free positioning).
+ *
+ * Returns a teardown function.
+ */
+export function setupArrange(ctx: PluginContext): () => void {
+	// Guard so the layout's own `updateShape` calls don't re-trigger arrange.
+	let applying = false;
+	let pointerDown = false;
+
+	function layoutContainer(containerId: string): void {
+		const container = ctx.store.getShape(containerId);
+		if (!container) return;
+		const def = ctx.shapes.get(container.type);
+		if (!isShapeContainer(def, container)) return;
+		const layout = getContainerLayout(def);
+		if (!layout) return;
+		const children = getChildShapes(ctx.store, containerId);
+		if (children.length === 0) return;
+
+		const patches = layout({ container, children });
+		applying = true;
+		try {
+			for (const { id, patch } of patches) ctx.store.updateShape(id, patch);
+		} finally {
+			applying = false;
+		}
+	}
+
+	function layoutAllContainers(): void {
+		for (const [id, shape] of ctx.store.getShapes()) {
+			if (getContainerLayout(ctx.shapes.get(shape.type))) layoutContainer(id);
+		}
+	}
+
+	const offMutation = ctx.store.onMutation((event) => {
+		if (applying || pointerDown) return; // ignore self-induced + mid-drag churn
+		const payload = event.payload as { id?: string } | undefined;
+		const id = payload?.id;
+		if (!id) return;
+
+		if (event.type === "shape:added") {
+			const parentId = ctx.store.getShape(id)?.parentId;
+			if (typeof parentId === "string") layoutContainer(parentId);
+			return;
+		}
+		if (event.type === "shape:updated") {
+			const shape = ctx.store.getShape(id);
+			if (!shape) return;
+			// Container geometry changed → re-layout its children.
+			if (isShapeContainer(ctx.shapes.get(shape.type), shape)) layoutContainer(id);
+			// Child attached/edited under a container → re-layout that container.
+			if (typeof shape.parentId === "string") layoutContainer(shape.parentId);
+		}
+	});
+
+	const offDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", () => {
+		pointerDown = true;
+	});
+	const offUp = ctx.events.on<CanvasPointerEvent>("canvas:pointerup", () => {
+		pointerDown = false;
+		// Re-layout after a drag/resize commits. Deferred so it runs after the
+		// containment attacher's own deferred reparent (also on pointer up).
+		setTimeout(() => layoutAllContainers(), 0);
+	});
+
+	return () => {
+		offMutation();
+		offDown();
+		offUp();
+	};
+}

--- a/plugins/usketch-plugin-container/src/index.ts
+++ b/plugins/usketch-plugin-container/src/index.ts
@@ -1,0 +1,10 @@
+export { setupArrange } from "./arrange.js";
+export {
+	type ContainerLayout,
+	type GridLayoutOptions,
+	gridLayout,
+	type StackLayoutOptions,
+	stackLayout,
+} from "./layouts.js";
+export { createContainerPlugin } from "./plugin.js";
+export { setupSnapExclude } from "./snap-exclude.js";

--- a/plugins/usketch-plugin-container/src/layouts.ts
+++ b/plugins/usketch-plugin-container/src/layouts.ts
@@ -27,20 +27,23 @@ export function stackLayout(options: StackLayoutOptions = {}): ContainerLayout {
 	return ({ container, children }) => {
 		const patches: Array<{ id: string; patch: Partial<ShapeData> }> = [];
 		if (direction === "vertical") {
+			// Clamp so a container narrower than 2×padding never yields a negative width.
+			const width = Math.max(0, container.width - padding * 2);
 			let y = container.y + padding;
 			for (const child of children) {
 				patches.push({
 					id: child.id,
-					patch: { x: container.x + padding, y, width: container.width - padding * 2 },
+					patch: { x: container.x + padding, y, width },
 				});
 				y += child.height + gap;
 			}
 		} else {
+			const height = Math.max(0, container.height - padding * 2);
 			let x = container.x + padding;
 			for (const child of children) {
 				patches.push({
 					id: child.id,
-					patch: { x, y: container.y + padding, height: container.height - padding * 2 },
+					patch: { x, y: container.y + padding, height },
 				});
 				x += child.width + gap;
 			}
@@ -65,14 +68,16 @@ export interface GridLayoutOptions {
  */
 export function gridLayout(options: GridLayoutOptions = {}): ContainerLayout {
 	const { columns = 2, padding = 8, gap = 8 } = options;
+	// Guard against columns <= 0 (division by zero / Infinity) and negative cells.
+	const cols = Math.max(1, Math.floor(columns));
 	return ({ container, children }) => {
 		const patches: Array<{ id: string; patch: Partial<ShapeData> }> = [];
 		const innerWidth = container.width - padding * 2;
-		const cellWidth = (innerWidth - gap * (columns - 1)) / columns;
+		const cellWidth = Math.max(0, (innerWidth - gap * (cols - 1)) / cols);
 		let rowY = container.y + padding;
 		let rowHeight = 0;
 		children.forEach((child, i) => {
-			const col = i % columns;
+			const col = i % cols;
 			if (col === 0 && i > 0) {
 				rowY += rowHeight + gap;
 				rowHeight = 0;

--- a/plugins/usketch-plugin-container/src/layouts.ts
+++ b/plugins/usketch-plugin-container/src/layouts.ts
@@ -1,0 +1,92 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** The shape of a `ShapeDefinition.container.layout` function. */
+export type ContainerLayout = (ctx: {
+	container: ShapeData;
+	children: ShapeData[];
+}) => Array<{ id: string; patch: Partial<ShapeData> }>;
+
+export interface StackLayoutOptions {
+	/** Inner padding on all sides (world units). Default 8. */
+	padding?: number;
+	/** Gap between adjacent children. Default 8. */
+	gap?: number;
+	/** Stacking direction. Default "vertical". */
+	direction?: "vertical" | "horizontal";
+}
+
+/**
+ * A simple single-axis stack: children are laid out top-to-bottom (vertical)
+ * or left-to-right (horizontal), each stretched to the container's inner width
+ * (vertical) or height (horizontal). Reads the children in their given order.
+ *
+ * A container opts in by setting `container.layout: stackLayout({ gap: 8 })`.
+ */
+export function stackLayout(options: StackLayoutOptions = {}): ContainerLayout {
+	const { padding = 8, gap = 8, direction = "vertical" } = options;
+	return ({ container, children }) => {
+		const patches: Array<{ id: string; patch: Partial<ShapeData> }> = [];
+		if (direction === "vertical") {
+			let y = container.y + padding;
+			for (const child of children) {
+				patches.push({
+					id: child.id,
+					patch: { x: container.x + padding, y, width: container.width - padding * 2 },
+				});
+				y += child.height + gap;
+			}
+		} else {
+			let x = container.x + padding;
+			for (const child of children) {
+				patches.push({
+					id: child.id,
+					patch: { x, y: container.y + padding, height: container.height - padding * 2 },
+				});
+				x += child.width + gap;
+			}
+		}
+		return patches;
+	};
+}
+
+export interface GridLayoutOptions {
+	/** Number of columns. Default 2. */
+	columns?: number;
+	/** Inner padding on all sides. Default 8. */
+	padding?: number;
+	/** Gap between cells (both axes). Default 8. */
+	gap?: number;
+}
+
+/**
+ * A fixed-column grid: children flow left-to-right, wrapping every `columns`.
+ * Each cell is sized to an equal share of the container's inner width; the row
+ * height follows the tallest child in that row.
+ */
+export function gridLayout(options: GridLayoutOptions = {}): ContainerLayout {
+	const { columns = 2, padding = 8, gap = 8 } = options;
+	return ({ container, children }) => {
+		const patches: Array<{ id: string; patch: Partial<ShapeData> }> = [];
+		const innerWidth = container.width - padding * 2;
+		const cellWidth = (innerWidth - gap * (columns - 1)) / columns;
+		let rowY = container.y + padding;
+		let rowHeight = 0;
+		children.forEach((child, i) => {
+			const col = i % columns;
+			if (col === 0 && i > 0) {
+				rowY += rowHeight + gap;
+				rowHeight = 0;
+			}
+			patches.push({
+				id: child.id,
+				patch: {
+					x: container.x + padding + col * (cellWidth + gap),
+					y: rowY,
+					width: cellWidth,
+				},
+			});
+			rowHeight = Math.max(rowHeight, child.height);
+		});
+		return patches;
+	};
+}

--- a/plugins/usketch-plugin-container/src/plugin.ts
+++ b/plugins/usketch-plugin-container/src/plugin.ts
@@ -1,0 +1,47 @@
+import type { PluginContext, ShapeData, UsketchPlugin } from "@edv4h/usketch-shared";
+import { isContainerAutoAttach } from "@edv4h/usketch-shared";
+import { createContainmentAttacher } from "@edv4h/usketch-store";
+import { setupArrange } from "./arrange.js";
+import { setupSnapExclude } from "./snap-exclude.js";
+
+/**
+ * Runtime for shapes that declare `container` in their `ShapeDefinition`.
+ * Drives the parentId-based container mechanics that can't live in a shape
+ * definition alone:
+ *
+ * - **Auto-attach** — a shape dropped inside a container with
+ *   `container.autoAttach` gets `parentId` set (and cleared when moved out).
+ * - **Arrange** — a container's `container.layout` positions its children.
+ * - **Snap exclusion** — children following a dragged container are excluded
+ *   from snapping (requires `plugin-snap`; no-op without it).
+ *
+ * Selection resolution and move-follow are handled natively by tool-helpers via
+ * the same `container` flags, so this plugin only supplies the reactive pieces.
+ *
+ * Register it after `createSnapPlugin()` so the snap event bus is listening
+ * before this plugin emits `snap:configure`.
+ */
+export function createContainerPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-container",
+		name: "コンテナ",
+		setup(ctx: PluginContext) {
+			const isAttachTarget = (s: ShapeData) => isContainerAutoAttach(ctx.shapes.get(s.type), s);
+
+			const stopAttach = createContainmentAttacher({
+				store: ctx.store,
+				commands: ctx.commands,
+				events: ctx.events,
+				isAttachTarget,
+			});
+			const stopArrange = setupArrange(ctx);
+			const stopSnap = setupSnapExclude(ctx);
+
+			return () => {
+				stopAttach();
+				stopArrange();
+				stopSnap();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-container/src/snap-exclude.ts
+++ b/plugins/usketch-plugin-container/src/snap-exclude.ts
@@ -1,0 +1,31 @@
+import type { PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import { isShapeContainer } from "@edv4h/usketch-shared";
+
+/** Payload accepted by the snap plugin's `snap:configure` event (subset we set). */
+interface SnapConfigurePatch {
+	excludeTargets?: (shape: ShapeData) => boolean;
+}
+
+/**
+ * Configure `plugin-snap` to exclude a container's children from snapping while
+ * the container is being dragged. Such children follow the parent's motion, so
+ * snapping them individually (or letting the parent snap to them) causes
+ * jitter. Non-selected children and free (child-dragged-alone) cases are
+ * untouched, so a child dragged on its own still snaps normally.
+ *
+ * Returns a teardown that clears the exclusion.
+ */
+export function setupSnapExclude(ctx: PluginContext): () => void {
+	const excludeTargets = (shape: ShapeData): boolean => {
+		const parentId = shape.parentId;
+		if (typeof parentId !== "string" || !ctx.store.getSelection().has(parentId)) return false;
+		const parent = ctx.store.getShape(parentId);
+		return !!parent && isShapeContainer(ctx.shapes.get(parent.type), parent);
+	};
+
+	ctx.events.emit<SnapConfigurePatch>("snap:configure", { excludeTargets });
+
+	return () => {
+		ctx.events.emit<SnapConfigurePatch>("snap:configure", { excludeTargets: undefined });
+	};
+}

--- a/plugins/usketch-plugin-container/src/snap-exclude.ts
+++ b/plugins/usketch-plugin-container/src/snap-exclude.ts
@@ -21,7 +21,12 @@ interface SnapConfigurePatch {
  */
 export function setupSnapExclude(ctx: PluginContext): () => void {
 	const excludeTargets = (shape: ShapeData): boolean => {
+		// Fast paths before allocating the cycle-guard Set — this predicate runs
+		// for every candidate shape on every snap frame.
+		if (typeof shape.parentId !== "string") return false;
 		const selection = ctx.store.getSelection();
+		if (selection.size === 0) return false;
+
 		const visited = new Set<string>();
 		let current: ShapeData | undefined = shape;
 		while (current && typeof current.parentId === "string" && !visited.has(current.parentId)) {

--- a/plugins/usketch-plugin-container/src/snap-exclude.ts
+++ b/plugins/usketch-plugin-container/src/snap-exclude.ts
@@ -7,20 +7,34 @@ interface SnapConfigurePatch {
 }
 
 /**
- * Configure `plugin-snap` to exclude a container's children from snapping while
- * the container is being dragged. Such children follow the parent's motion, so
- * snapping them individually (or letting the parent snap to them) causes
- * jitter. Non-selected children and free (child-dragged-alone) cases are
- * untouched, so a child dragged on its own still snaps normally.
+ * Configure `plugin-snap` to exclude the descendants of a dragged container
+ * from snapping. Such descendants follow the container's motion, so snapping
+ * them individually (or letting the container snap to them) causes jitter.
+ *
+ * Walks the full `parentId` chain (cycle-guarded), not just the immediate
+ * parent, so deeply-nested descendants (e.g. a shape inside a group inside a
+ * dragged frame) are excluded too. Non-selected ancestors and free
+ * (child-dragged-alone) cases are untouched, so a child dragged on its own
+ * still snaps normally.
  *
  * Returns a teardown that clears the exclusion.
  */
 export function setupSnapExclude(ctx: PluginContext): () => void {
 	const excludeTargets = (shape: ShapeData): boolean => {
-		const parentId = shape.parentId;
-		if (typeof parentId !== "string" || !ctx.store.getSelection().has(parentId)) return false;
-		const parent = ctx.store.getShape(parentId);
-		return !!parent && isShapeContainer(ctx.shapes.get(parent.type), parent);
+		const selection = ctx.store.getSelection();
+		const visited = new Set<string>();
+		let current: ShapeData | undefined = shape;
+		while (current && typeof current.parentId === "string" && !visited.has(current.parentId)) {
+			visited.add(current.parentId);
+			const parent = ctx.store.getShape(current.parentId);
+			if (!parent) break;
+			// Excluded if any selected ancestor is a container being dragged.
+			if (selection.has(parent.id) && isShapeContainer(ctx.shapes.get(parent.type), parent)) {
+				return true;
+			}
+			current = parent;
+		}
+		return false;
 	};
 
 	ctx.events.emit<SnapConfigurePatch>("snap:configure", { excludeTargets });

--- a/plugins/usketch-plugin-container/tsconfig.json
+++ b/plugins/usketch-plugin-container/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"]
+}

--- a/plugins/usketch-plugin-shape-frame/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-frame/src/plugin.tsx
@@ -6,7 +6,7 @@ import type {
 	UsketchPlugin,
 } from "@edv4h/usketch-shared";
 import { generateId } from "@edv4h/usketch-shared";
-import { containsAABB, createAddShapeCommand, createReparentCommand } from "@edv4h/usketch-store";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
 import {
 	createDefaultFrame,
 	getBoundsFrame,
@@ -85,6 +85,9 @@ export function createFramePlugin(): UsketchPlugin {
 				renderTarget: "html",
 				minSize: { width: 50, height: 50 },
 				simplifiedComponent: SimplifiedFrame,
+				// Frames are containers whose children stay individually selectable
+				// and are auto-attached on overlap (handled by the container plugin).
+				container: { selectableChildren: true, autoAttach: true },
 			});
 
 			// Drawing tool state
@@ -142,83 +145,14 @@ export function createFramePlugin(): UsketchPlugin {
 			});
 
 			// ── Auto-parenting ──
+			//
+			// Attaching shapes to a containing frame (and detaching on exit) is now
+			// handled generically by `usketch-plugin-container` via the frame's
+			// `container.autoAttach` flag, so no frame-specific reparent logic lives
+			// here. Frame moves also drag children along via the select tool's
+			// container-aware descendant snapshotting.
 
-			// On move-end: reparent moved shapes (emitted by select tool after move command commits).
-			// Use setTimeout to defer reparent until after React finishes the current render cycle,
-			// since the emit happens inside a queueMicrotask from the select tool.
-			const unsubMoveEnd = ctx.events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
-				if (!data?.shapeIds) return;
-				setTimeout(() => {
-					for (const shapeId of data.shapeIds) {
-						autoReparent(shapeId);
-					}
-				}, 0);
-			});
-
-			// On shape:added (e.g. drawing inside a frame)
-			const unsubAdded = ctx.store.onMutation((event) => {
-				if (event.type !== "shape:added") return;
-				const payload = event.payload as { id: string } | undefined;
-				if (!payload?.id) return;
-				const shape = ctx.store.getShape(payload.id);
-				if (!shape || shape.type === "frame" || shape.type === "connector") return;
-				autoReparent(payload.id);
-			});
-
-			function autoReparent(shapeId: string) {
-				const shape = ctx.store.getShape(shapeId);
-				if (!shape || shape.type === "frame" || shape.type === "connector") return;
-
-				const shapeBounds = { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
-
-				// Find the smallest frame that fully contains this shape
-				let bestFrame: ShapeData | null = null;
-				for (const [id, candidate] of ctx.store.getShapes()) {
-					if (id === shapeId || candidate.type !== "frame") continue;
-					const frameBounds = {
-						x: candidate.x,
-						y: candidate.y,
-						width: candidate.width,
-						height: candidate.height,
-					};
-					if (containsAABB(frameBounds, shapeBounds)) {
-						if (
-							!bestFrame ||
-							candidate.width * candidate.height < bestFrame.width * bestFrame.height
-						) {
-							bestFrame = candidate;
-						}
-					}
-				}
-
-				const currentParentId = shape.parentId as string | undefined;
-				const newParentId = bestFrame?.id;
-
-				if (currentParentId !== newParentId) {
-					ctx.commands.execute(
-						createReparentCommand(ctx.store, [shapeId], newParentId ?? undefined),
-					);
-				}
-			}
-
-			// ── Frame move: move all children along with the frame ──
-			const unsubMove = ctx.store.onMutation((event) => {
-				if (event.type !== "shape:updated") return;
-				const payload = event.payload as { id: string } | undefined;
-				if (!payload?.id) return;
-
-				const shape = ctx.store.getShape(payload.id);
-				if (!shape || shape.type !== "frame") return;
-
-				// This is handled by the select tool which includes children in snapshots
-				// when moving a frame. No additional logic needed here.
-			});
-
-			return () => {
-				unsubMoveEnd();
-				unsubAdded();
-				unsubMove();
-			};
+			return () => {};
 		},
 	};
 }

--- a/plugins/usketch-plugin-shape-group/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-group/src/plugin.tsx
@@ -30,6 +30,9 @@ export function createGroupPlugin(): UsketchPlugin {
 				createDefault: createDefaultGroup,
 				minSize: { width: 1, height: 1 },
 				resizable: false,
+				// A group is a container, but clicking a child selects the whole
+				// group (selectableChildren omitted → group selection behavior).
+				container: {},
 			});
 
 			function groupSelected() {

--- a/plugins/usketch-plugin-shape-island/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-island/src/plugin.tsx
@@ -43,6 +43,8 @@ export function createIslandPlugin(): UsketchPlugin {
 				createDefault: createDefaultIsland,
 				renderTarget: "html",
 				minSize: { width: 100, height: 100 },
+				// Islands are containers whose children stay individually selectable.
+				container: { selectableChildren: true },
 			});
 
 			// ── Metaball background layer (renders below shapes) ──

--- a/plugins/usketch-plugin-snap/src/engine/types.ts
+++ b/plugins/usketch-plugin-snap/src/engine/types.ts
@@ -1,3 +1,5 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
 export type SnapEdge = "min" | "center" | "max";
 
 export interface SnapPoint {
@@ -56,4 +58,11 @@ export interface SnapSettings {
 	guideStyle: GuideStyle;
 	/** Alt(Option) キーの挙動（既定 `"suppress"`）。 */
 	altBehavior: AltBehavior;
+	/**
+	 * スナップ計算から完全に除外する述語。`true` を返すシェイプは
+	 * (a) 吸着先候補にならず、(b) それ自身が動いても吸着されない。
+	 * 例: container プラグインが「移動中の親コンテナに追従中の子」を除外する。
+	 * `snap:configure` 経由で設定し、`undefined` を渡せば解除。
+	 */
+	excludeTargets?: (shape: ShapeData) => boolean;
 }

--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -213,6 +213,15 @@ export function createSnapPlugin(options: SnapPluginOptions = {}): UsketchPlugin
 					return;
 				}
 
+				// Skip snap for shapes a consumer excluded from snapping entirely
+				// (e.g. a container's child following its dragged parent). Excluded
+				// shapes are neither snapped when moved nor used as snap targets.
+				if (settings.excludeTargets?.(shape)) {
+					originalUpdateShape(id, updates);
+					setState({ lines: [] });
+					return;
+				}
+
 				// Skip snap for child shapes whose parent is being dragged (in selection).
 				// Children follow their parent's snap offset; snapping them individually
 				// causes jitter because each child gets its own snap delta.
@@ -258,6 +267,7 @@ export function createSnapPlugin(options: SnapPluginOptions = {}): UsketchPlugin
 						ctx,
 						movingIds,
 						settings.viewportOnly ? ctx.store.getViewport() : null,
+						settings.excludeTargets,
 					);
 				frameCandidateBoxes = candidateBoxes;
 
@@ -481,6 +491,7 @@ function getCandidateBoxes(
 	ctx: PluginContext,
 	movingIds: ReadonlySet<string>,
 	viewport: Viewport | null,
+	excludeTargets?: (shape: ShapeData) => boolean,
 ): Map<string, BoundingBox> {
 	const visibleRect = viewport ? getVisibleWorldRect(viewport) : null;
 
@@ -504,6 +515,8 @@ function getCandidateBoxes(
 		if (movingIds.has(id)) continue;
 		// Connectors are never snap targets
 		if (shape.type === "connector") continue;
+		// Consumer-excluded shapes are never snap targets
+		if (excludeTargets?.(shape)) continue;
 		// Exclude children of moving shapes so a frame doesn't snap to its own children
 		const parentId = shape.parentId as string | undefined;
 		if (parentId && movingIds.has(parentId)) continue;

--- a/plugins/usketch-plugin-snap/src/plugin.tsx
+++ b/plugins/usketch-plugin-snap/src/plugin.tsx
@@ -216,9 +216,11 @@ export function createSnapPlugin(options: SnapPluginOptions = {}): UsketchPlugin
 				// Skip snap for shapes a consumer excluded from snapping entirely
 				// (e.g. a container's child following its dragged parent). Excluded
 				// shapes are neither snapped when moved nor used as snap targets.
+				// Leave the guide lines untouched: these child updates are interleaved
+				// with the dragged parent's snapped update, and clearing lines here
+				// would wipe the parent's snap feedback mid-drag.
 				if (settings.excludeTargets?.(shape)) {
 					originalUpdateShape(id, updates);
-					setState({ lines: [] });
 					return;
 				}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@edv4h/usketch-plugin-community-chat':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-community-chat
+      '@edv4h/usketch-plugin-container':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-container
       '@edv4h/usketch-plugin-domain-design':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-domain-design
@@ -962,6 +965,22 @@ importers:
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.6.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  plugins/usketch-plugin-container:
+    dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
+    devDependencies:
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## 概要

Closes #647

カスタム ShapePlugin で「独自コンテナ型シェイプ」(親を動かすと子が追従・整列するが、子は個別選択・リサイズ可能)を作れるようにする。従来 `frame`/`island`/`group` の **type 文字列にハードコード**されていたコンテナ挙動を、`parentId` を正としたまま **ShapeDefinition のフラグ駆動**に開放し、`plugin-snap` に除外 hook を追加。さらに parentId を見てアタッチ/整列する **container プラグイン**を新設した。

## 変更内容

### A. コアのフラグ駆動化 (`shared` / `tool-helpers`)
- `ShapeDefinition.container?: { enabled?, selectableChildren?, autoAttach?, layout? }` を追加。各値は既存 `resizable` と同じ `boolean | ((data) => boolean)` 述語形 → 「単一 type + discriminator」(例 `wireframe` の `meta.component === "card"` だけコンテナ)に対応。
- 評価ヘルパー `isShapeContainer` / `hasSelectableChildren` / `isContainerAutoAttach` / `getContainerLayout` を新設。
- `hover.ts` / `marquee.ts` / `descendants.ts` の型ハードコードを全廃しヘルパー経由に。frame/island の子は個別選択、group は従来どおり親ごと選択。

### B. snap 除外 hook (`plugin-snap`)
- `SnapSettings.excludeTargets` を追加(`snap:configure` 経由)。該当シェイプは吸着先候補からも被スナップからも除外 → 追従中の子のジッターを防止。

### C. アタッチの一本化 (`store`)
- frame プラグインの bespoke `autoReparent`(約90行)を撤去し、汎用 `createContainmentAttacher` に集約(重なりで parentId 付与/解除、循環ガード、undo 対応)。
- `createCollisionWatcher` に `isContainer` 述語オプションを追加。

### D. 新プラグイン `@edv4h/usketch-plugin-container`
- アタッチ + コンテナ内整列(`container.layout`、`stackLayout`/`gridLayout` 同梱)+ snap 除外を `onMutation`/イベントで駆動(コネクタの反応型パターン踏襲)。
- frame/island/group に `container` を付与(後方互換)。`apps/web` に snap の後で登録。

## プランからの補強点

1. **`container.autoAttach` フラグを追加** — 全 `isContainer` へ一律アタッチすると独自 membership を持つ island(近接)/group(明示)が退行するため、frame + オプトインの独自コンテナのみアタッチするようガード。既存挙動を維持。
2. **snap の parentId チェーン除外ヘルパーは省略** — container プラグインの `excludeTargets` が同機能を包含するため一本化。

## 検証

- ✅ 全77パッケージ build(web の Vite 本番ビルド含む)/ typecheck / biome(新規ファイル エラー0)
- ✅ 単体テスト計202件: shared 75 / store 63(実 board store に対する attach/detach/frame-非ネスト含む)/ tool-helpers 40 / container 4 / snap 20
- ✅ ローカルで frontend(Vite)+ backend(Wrangler)起動、疎通確認済み
- ⚠️ ライブブラウザ E2E はサンドボックスの Playwright ブラウザDL失敗により未実行(コード側の問題ではない)。ローカルで `playwright install` 後に `board.spec.ts` で確認可能。

## 後方互換 / 留意点

- frame/island/group の既存挙動は維持(frame の自動アタッチは container プラグイン経由に移行、標準構成で常時登録)。
- 回転追従はスコープ外。`snap:configure` の `excludeTargets` は単一(後勝ち)。子の視覚ネストは zIndex 管理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkRjATouummrVAYcjX7ptn
