### PR TITLE
📝 chore(changeset): add missing changeset for container mechanics (#647)

### DIFF
--- a/.changeset/container-shape-647.md
+++ b/.changeset/container-shape-647.md
@@ -1,0 +1,20 @@
+---
+"@edv4h/usketch-shared": minor
+"@edv4h/usketch-tool-helpers": minor
+"@edv4h/usketch-store": minor
+"@edv4h/usketch-plugin-snap": minor
+"@edv4h/usketch-plugin-container": minor
+"@edv4h/usketch-plugin-shape-frame": minor
+"@edv4h/usketch-plugin-shape-group": patch
+"@edv4h/usketch-plugin-shape-island": patch
+---
+
+コンテナ機構を type 文字列のハードコードからフラグ駆動に開放し、独自コンテナ型シェイプを可能にした（#647）。
+
+- `@edv4h/usketch-shared`: `ShapeDefinition.container?: { enabled?, selectableChildren?, autoAttach?, layout? }` を追加（各値は `resizable` 同様の `boolean | ((data) => boolean)` 述語形）。評価ヘルパー `isShapeContainer` / `hasSelectableChildren` / `isContainerAutoAttach` / `getContainerLayout` を追加。
+- `@edv4h/usketch-tool-helpers`: `findShapeAtPoint` / marquee / descendant collection の `frame`/`island`/`group` 型ハードコードを撤廃し、`container` フラグ駆動に。frame/island 相当の子は個別選択、group 相当は親ごと選択。
+- `@edv4h/usketch-store`: 汎用 `createContainmentAttacher`（重なりで parentId 付与/解除、循環ガード、undo 対応）を追加。`createCollisionWatcher` に `isContainer` 述語オプションを追加。
+- `@edv4h/usketch-plugin-snap`: `SnapSettings.excludeTargets`（`snap:configure` 経由）を追加。該当シェイプは吸着先候補からも被スナップからも除外。
+- `@edv4h/usketch-plugin-container`（新規）: `container` 定義を持つシェイプのアタッチ・整列（`container.layout`、`stackLayout`/`gridLayout` 同梱）・スナップ除外を `onMutation`/イベントで駆動。
+- `@edv4h/usketch-plugin-shape-frame`: `container: { selectableChildren: true, autoAttach: true }` を付与し、独自の `autoReparent` を撤去して container プラグインの共有アタッチャに一本化。
+- `@edv4h/usketch-plugin-shape-group` / `@edv4h/usketch-plugin-shape-island`: `container` を付与（後方互換。group は selectableChildren なし＝従来の親ごと選択、island は selectableChildren あり）。


### PR DESCRIPTION
## 概要

PR #648(container 機構のフラグ駆動化 + アタッチ/整列プラグイン + snap 除外 hook)が **changeset なしでマージ**されたため、対象パッケージのリリースに必要な changeset を追加します。**コード変更はありません**(changeset ファイル1件のみ)。

## バンプ内容

| bump | パッケージ |
|---|---|
| minor | `usketch-shared`, `usketch-tool-helpers`, `usketch-store`, `usketch-plugin-snap`, `usketch-plugin-container`(新規), `usketch-plugin-shape-frame` |
| patch | `usketch-plugin-shape-group`, `usketch-plugin-shape-island` |

`pnpm changeset status` で検証済み。

Refs #647, follow-up to #648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkRjATouummrVAYcjX7ptn