### PR TITLE
✨ feat(connector): 内蔵 UI レイヤーをホストから opt-out 可能に (#665)

### DIFF
--- a/.changeset/connector-optional-ui-665.md
+++ b/.changeset/connector-optional-ui-665.md
@@ -4,9 +4,9 @@
 
 コネクタの内蔵 UI をホストの裁量に分離した（#665）。
 
-- **パラメータ Toolbar（`ConnectorPropertyBar`）をプラグインの構成要素から完全に削除。** shape 定義が特定の設定 UI を規定すべきでないため、`createConnectorPlugin()` はもう property Toolbar を `layers.register` しない。代わりに `ConnectorPropertyBar` コンポーネントを export したので、必要なホストは自前の layer として描画する（`useApp()` で store を読む props 不要の自己完結コンポーネント）。
+- **パラメータ Toolbar（`ConnectorPropertyBar`）をパッケージから完全に撤去。** shape 定義が特定の設定 UI を規定すべきでないため、`createConnectorPlugin()` は property Toolbar を `layers.register` せず、コンポーネント自体もこのパッケージに含めない（UI はホスト管轄）。代わりにコネクタのデータ型 `ConnectorShapeData` / `ArrowHead` / `PathType` を公開し、ホストが自前 UI を組めるようにした。
 - 残りの UI レイヤーは `createConnectorPlugin(options?)` の per-layer フラグ `ConnectorPluginOptions` で出し分け可能に（`endpoints` / `labelEditor` / `anchorHandles`、いずれも既定 `true`）。`anchorHandles: false` でも `connector-draw` ツールでの作成は可能。
 - 安定 API として登録レイヤーの id 定数 `CONNECTOR_LAYER_IDS`（endpoints / labelEditor / anchorHandles）を公開。
 - shape 定義・作成ツール・位置追従・カスケード削除（コア挙動）は常に有効。
 
-**破壊的変更に近い注意点**: これまで `createConnectorPlugin()` だけで表示されていた property Toolbar は表示されなくなる。従来の見た目を保つには、`ConnectorPropertyBar` を自前 layer として登録すること（apps/web は `createConnectorPropertyBarPlugin()` で対応済み）。
+**破壊的変更の注意点**: これまで `createConnectorPlugin()` だけで表示されていた property Toolbar は表示されなくなり、`ConnectorPropertyBar` コンポーネントの export も無くなる。従来の見た目が必要なホストは、公開されたデータ型を使って自前の property bar を実装する（apps/web は `src/plugins/connector-property-bar.tsx` に実装を持ち、`createConnectorPropertyBarPlugin()` で layer 登録する形で対応済み）。

--- a/.changeset/connector-optional-ui-665.md
+++ b/.changeset/connector-optional-ui-665.md
@@ -1,0 +1,14 @@
+---
+"@edv4h/usketch-plugin-shape-connector": minor
+---
+
+コネクタの内蔵 UI レイヤーをホストから opt-out できるようにした（#665）。`createConnectorPlugin(options?)` に per-layer フラグ `ConnectorPluginOptions` を追加し、shape 定義・作成ツール・位置追従/カスケード削除（コア挙動）は常に有効なまま、UI レイヤーだけを無効化できる。内部 layer id への依存や `layers.unregister` の手動呼び出しが不要になる。
+
+```ts
+// 独自の property UI を持つホストは内蔵ツールバーを抑止できる
+createConnectorPlugin({ propertyBar: false });
+```
+
+- 追加オプション（いずれも既定 `true`）: `propertyBar`（線種/矢じりのパラメータ Toolbar）/ `endpoints`（端点ハンドル）/ `labelEditor`（ラベル編集）/ `anchorHandles`（hover アンカー表示 + anchor-drag 作成）。`anchorHandles: false` でも `connector-draw` ツールでの作成は可能。
+- 安定 API として layer id 定数 `CONNECTOR_LAYER_IDS` を公開（命令的に `layers.unregister` したいホスト向け）。
+- 既定ではすべて登録され、従来と完全に後方互換。

--- a/.changeset/connector-optional-ui-665.md
+++ b/.changeset/connector-optional-ui-665.md
@@ -2,13 +2,11 @@
 "@edv4h/usketch-plugin-shape-connector": minor
 ---
 
-コネクタの内蔵 UI レイヤーをホストから opt-out できるようにした（#665）。`createConnectorPlugin(options?)` に per-layer フラグ `ConnectorPluginOptions` を追加し、shape 定義・作成ツール・位置追従/カスケード削除（コア挙動）は常に有効なまま、UI レイヤーだけを無効化できる。内部 layer id への依存や `layers.unregister` の手動呼び出しが不要になる。
+コネクタの内蔵 UI をホストの裁量に分離した（#665）。
 
-```ts
-// 独自の property UI を持つホストは内蔵ツールバーを抑止できる
-createConnectorPlugin({ propertyBar: false });
-```
+- **パラメータ Toolbar（`ConnectorPropertyBar`）をプラグインの構成要素から完全に削除。** shape 定義が特定の設定 UI を規定すべきでないため、`createConnectorPlugin()` はもう property Toolbar を `layers.register` しない。代わりに `ConnectorPropertyBar` コンポーネントを export したので、必要なホストは自前の layer として描画する（`useApp()` で store を読む props 不要の自己完結コンポーネント）。
+- 残りの UI レイヤーは `createConnectorPlugin(options?)` の per-layer フラグ `ConnectorPluginOptions` で出し分け可能に（`endpoints` / `labelEditor` / `anchorHandles`、いずれも既定 `true`）。`anchorHandles: false` でも `connector-draw` ツールでの作成は可能。
+- 安定 API として登録レイヤーの id 定数 `CONNECTOR_LAYER_IDS`（endpoints / labelEditor / anchorHandles）を公開。
+- shape 定義・作成ツール・位置追従・カスケード削除（コア挙動）は常に有効。
 
-- 追加オプション（いずれも既定 `true`）: `propertyBar`（線種/矢じりのパラメータ Toolbar）/ `endpoints`（端点ハンドル）/ `labelEditor`（ラベル編集）/ `anchorHandles`（hover アンカー表示 + anchor-drag 作成）。`anchorHandles: false` でも `connector-draw` ツールでの作成は可能。
-- 安定 API として layer id 定数 `CONNECTOR_LAYER_IDS` を公開（命令的に `layers.unregister` したいホスト向け）。
-- 既定ではすべて登録され、従来と完全に後方互換。
+**破壊的変更に近い注意点**: これまで `createConnectorPlugin()` だけで表示されていた property Toolbar は表示されなくなる。従来の見た目を保つには、`ConnectorPropertyBar` を自前 layer として登録すること（apps/web は `createConnectorPropertyBarPlugin()` で対応済み）。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"@edv4h/usketch-canvas-engine": "workspace:*",
+		"@edv4h/usketch-connector-anchor": "workspace:*",
 		"@edv4h/usketch-core": "workspace:*",
 		"@edv4h/usketch-dom-renderer": "workspace:*",
 		"@edv4h/usketch-gpu-renderer": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -79,6 +79,7 @@ import { localBoards } from "./lib/local-boards.js";
 import { computePresentStage, type StageRect } from "./lib/present-stage.js";
 import { useAuth } from "./lib/use-auth.js";
 import { useKeyboardShortcuts } from "./lib/use-keyboard-shortcuts.js";
+import { createConnectorPropertyBarPlugin } from "./plugins/connector-property-bar-plugin.js";
 
 type PresentationMode = "off" | "edit" | "present";
 
@@ -140,6 +141,7 @@ function createBasePlugins(): UsketchPlugin[] {
 		createGroupPlugin(),
 		createFramePlugin(),
 		createConnectorPlugin(),
+		createConnectorPropertyBarPlugin(),
 		createFreedrawPlugin(),
 		createTextPlugin(),
 		createStickyPlugin(),

--- a/apps/web/src/plugins/connector-property-bar-plugin.tsx
+++ b/apps/web/src/plugins/connector-property-bar-plugin.tsx
@@ -1,0 +1,29 @@
+import { ConnectorPropertyBar } from "@edv4h/usketch-plugin-shape-connector";
+import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+
+/**
+ * App-owned layer for the connector parameter Toolbar.
+ *
+ * `@edv4h/usketch-plugin-shape-connector` intentionally no longer registers this
+ * UI (the shape definition shouldn't dictate a settings Toolbar — see #665); it
+ * only exports the `ConnectorPropertyBar` component. This app opts into the
+ * default bar by registering it as its own layer, keeping the previous UX. A
+ * host with a custom connector UI would simply omit this plugin.
+ */
+export function createConnectorPropertyBarPlugin(): UsketchPlugin {
+	return {
+		id: "app-connector-property-bar",
+		name: "コネクタ プロパティバー",
+		setup(ctx: PluginContext) {
+			ctx.layers.register({
+				id: "connector-properties",
+				order: 82,
+				fixed: true,
+				render: () => <ConnectorPropertyBar />,
+			});
+			return () => {
+				ctx.layers.unregister("connector-properties");
+			};
+		},
+	};
+}

--- a/apps/web/src/plugins/connector-property-bar-plugin.tsx
+++ b/apps/web/src/plugins/connector-property-bar-plugin.tsx
@@ -1,14 +1,15 @@
-import { ConnectorPropertyBar } from "@edv4h/usketch-plugin-shape-connector";
 import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import { ConnectorPropertyBar } from "./connector-property-bar.js";
 
 /**
  * App-owned layer for the connector parameter Toolbar.
  *
- * `@edv4h/usketch-plugin-shape-connector` intentionally no longer registers this
- * UI (the shape definition shouldn't dictate a settings Toolbar — see #665); it
- * only exports the `ConnectorPropertyBar` component. This app opts into the
- * default bar by registering it as its own layer, keeping the previous UX. A
- * host with a custom connector UI would simply omit this plugin.
+ * `@edv4h/usketch-plugin-shape-connector` intentionally does not ship this UI
+ * (the shape definition shouldn't dictate a settings Toolbar — see #665). The
+ * `ConnectorPropertyBar` component lives here in the app, built from the
+ * connector data types the package exports. This app opts into the default bar
+ * by registering it as its own layer, keeping the previous UX. A host with a
+ * custom connector UI would simply omit this plugin.
  */
 export function createConnectorPropertyBarPlugin(): UsketchPlugin {
 	return {

--- a/apps/web/src/plugins/connector-property-bar.tsx
+++ b/apps/web/src/plugins/connector-property-bar.tsx
@@ -1,10 +1,13 @@
 import { ShapeAnchorOverlay, useApp, useStoreSubscribe } from "@edv4h/usketch-canvas-engine";
 import { type AnchorType, getAnchorPoint } from "@edv4h/usketch-connector-anchor";
+import type {
+	ArrowHead,
+	ConnectorShapeData,
+	PathType,
+} from "@edv4h/usketch-plugin-shape-connector";
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { createBatchUpdateShapesCommand } from "@edv4h/usketch-store";
 import { useCallback } from "react";
-import type { ArrowHead, PathType } from "./shapes/connector.js";
-import type { ConnectorShapeData } from "./types.js";
 
 // ── Arrow Icons ──
 

--- a/plugins/usketch-plugin-shape-connector/src/index.ts
+++ b/plugins/usketch-plugin-shape-connector/src/index.ts
@@ -1,1 +1,5 @@
-export { createConnectorPlugin } from "./plugin.js";
+export {
+	CONNECTOR_LAYER_IDS,
+	type ConnectorPluginOptions,
+	createConnectorPlugin,
+} from "./plugin.js";

--- a/plugins/usketch-plugin-shape-connector/src/index.ts
+++ b/plugins/usketch-plugin-shape-connector/src/index.ts
@@ -1,3 +1,7 @@
+// The parameter Toolbar is not registered by the plugin — export the component
+// so a host can render it as its own layer (see apps/web). Self-contained: reads
+// selection/store via `useApp()`, takes no props.
+export { ConnectorPropertyBar } from "./connector-property-bar.js";
 export {
 	CONNECTOR_LAYER_IDS,
 	type ConnectorPluginOptions,

--- a/plugins/usketch-plugin-shape-connector/src/index.ts
+++ b/plugins/usketch-plugin-shape-connector/src/index.ts
@@ -1,9 +1,10 @@
-// The parameter Toolbar is not registered by the plugin — export the component
-// so a host can render it as its own layer (see apps/web). Self-contained: reads
-// selection/store via `useApp()`, takes no props.
-export { ConnectorPropertyBar } from "./connector-property-bar.js";
 export {
 	CONNECTOR_LAYER_IDS,
 	type ConnectorPluginOptions,
 	createConnectorPlugin,
 } from "./plugin.js";
+// Connector data-model types — the shape's public contract. The parameter
+// Toolbar UI is intentionally not part of this package (see #665); a host that
+// builds its own connector settings UI imports these to read/write the shape.
+export type { ArrowHead, PathType } from "./shapes/connector.js";
+export type { ConnectorShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -18,7 +18,6 @@ import { generateId } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { AnchorHandleOverlay, setupAnchorHandles } from "./anchor-handle-overlay.js";
 import { ConnectorLabelEditor, handleConnectorClick, setEditingLabel } from "./connector-label.js";
-import { ConnectorPropertyBar } from "./connector-property-bar.js";
 import { EndpointOverlay } from "./endpoint-overlay.js";
 import {
 	createDefaultConnector,
@@ -36,9 +35,13 @@ export type { ConnectorShapeData } from "./types.js";
  * disables a layer imperatively (`instance.layers.unregister(...)`) doesn't have
  * to hardcode the internal strings. Prefer {@link ConnectorPluginOptions} to
  * opt out at construction time.
+ *
+ * Note: the parameter Toolbar (`ConnectorPropertyBar`) is intentionally **not**
+ * part of this plugin — the shape definition should not dictate a specific
+ * settings UI. Hosts that want it register the exported `ConnectorPropertyBar`
+ * component as their own layer (see the component's docs / apps/web).
  */
 export const CONNECTOR_LAYER_IDS = {
-	propertyBar: "connector-properties",
 	endpoints: "connector-endpoints",
 	labelEditor: "connector-label-editor",
 	anchorHandles: "connector-anchor-handles",
@@ -46,16 +49,14 @@ export const CONNECTOR_LAYER_IDS = {
 
 /**
  * Opt out of the connector plugin's built-in UI layers when the host provides
- * its own (e.g. a custom ActionRing / property panel). Each flag defaults to
- * `true`; set `false` to skip registering that layer. The shape, drawing tool,
- * position tracking, and cascade-delete (the core behavior) are always active.
+ * its own. Each flag defaults to `true`; set `false` to skip registering that
+ * layer. The shape, drawing tool, position tracking, and cascade-delete (the
+ * core behavior) are always active.
+ *
+ * The parameter Toolbar is not listed here because it is no longer owned by this
+ * plugin at all — render `ConnectorPropertyBar` from the host instead.
  */
 export interface ConnectorPluginOptions {
-	/**
-	 * The built-in parameter Toolbar (line style / arrowheads). Set `false` when
-	 * the host renders its own connector settings UI to avoid a duplicate/conflicting bar.
-	 */
-	propertyBar?: boolean;
 	/** Endpoint drag handles (used to re-anchor a connector's ends). Default `true`. */
 	endpoints?: boolean;
 	/** Inline label editor. Default `true`. */
@@ -101,12 +102,7 @@ function debugFields(shape: ShapeData): Record<string, unknown> {
 }
 
 export function createConnectorPlugin(options: ConnectorPluginOptions = {}): UsketchPlugin {
-	const {
-		propertyBar = true,
-		endpoints = true,
-		labelEditor = true,
-		anchorHandles = true,
-	} = options;
+	const { endpoints = true, labelEditor = true, anchorHandles = true } = options;
 
 	return {
 		id: "usketch-plugin-shape-connector",
@@ -238,18 +234,10 @@ export function createConnectorPlugin(options: ConnectorPluginOptions = {}): Usk
 				},
 			});
 
-			// ── Connector property bar (Phase 4) ──
 			// UI layers are opt-out (see ConnectorPluginOptions) so a host with its
 			// own toolbar/UI can suppress them without depending on internal layer ids.
-
-			if (propertyBar) {
-				ctx.layers.register({
-					id: CONNECTOR_LAYER_IDS.propertyBar,
-					order: 82,
-					fixed: true,
-					render: () => <ConnectorPropertyBar />,
-				});
-			}
+			// The parameter Toolbar is deliberately absent — hosts render
+			// `ConnectorPropertyBar` themselves (see apps/web).
 
 			// ── Endpoint overlay (Phase 5) ──
 
@@ -317,7 +305,6 @@ export function createConnectorPlugin(options: ConnectorPluginOptions = {}): Usk
 				unsubLabelClick();
 				unsubPointerForLabel();
 				cleanupAnchorHandles?.();
-				if (propertyBar) ctx.layers.unregister(CONNECTOR_LAYER_IDS.propertyBar);
 				if (endpoints) ctx.layers.unregister(CONNECTOR_LAYER_IDS.endpoints);
 				if (labelEditor) ctx.layers.unregister(CONNECTOR_LAYER_IDS.labelEditor);
 				if (anchorHandles) ctx.layers.unregister(CONNECTOR_LAYER_IDS.anchorHandles);

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -31,6 +31,43 @@ import type { ConnectorShapeData } from "./types.js";
 
 export type { ConnectorShapeData } from "./types.js";
 
+/**
+ * Stable ids of the UI layers this plugin registers. Exported so a host that
+ * disables a layer imperatively (`instance.layers.unregister(...)`) doesn't have
+ * to hardcode the internal strings. Prefer {@link ConnectorPluginOptions} to
+ * opt out at construction time.
+ */
+export const CONNECTOR_LAYER_IDS = {
+	propertyBar: "connector-properties",
+	endpoints: "connector-endpoints",
+	labelEditor: "connector-label-editor",
+	anchorHandles: "connector-anchor-handles",
+} as const;
+
+/**
+ * Opt out of the connector plugin's built-in UI layers when the host provides
+ * its own (e.g. a custom ActionRing / property panel). Each flag defaults to
+ * `true`; set `false` to skip registering that layer. The shape, drawing tool,
+ * position tracking, and cascade-delete (the core behavior) are always active.
+ */
+export interface ConnectorPluginOptions {
+	/**
+	 * The built-in parameter Toolbar (line style / arrowheads). Set `false` when
+	 * the host renders its own connector settings UI to avoid a duplicate/conflicting bar.
+	 */
+	propertyBar?: boolean;
+	/** Endpoint drag handles (used to re-anchor a connector's ends). Default `true`. */
+	endpoints?: boolean;
+	/** Inline label editor. Default `true`. */
+	labelEditor?: boolean;
+	/**
+	 * Hover anchor handles + the anchor-drag drawing interaction. Default `true`.
+	 * The `connector-draw` tool still works when this is `false`; only the
+	 * hover-to-anchor affordance is removed.
+	 */
+	anchorHandles?: boolean;
+}
+
 function ConnectorIcon() {
 	return (
 		<svg width="20" height="20" viewBox="0 0 20 20">
@@ -63,7 +100,14 @@ function debugFields(shape: ShapeData): Record<string, unknown> {
 	};
 }
 
-export function createConnectorPlugin(): UsketchPlugin {
+export function createConnectorPlugin(options: ConnectorPluginOptions = {}): UsketchPlugin {
+	const {
+		propertyBar = true,
+		endpoints = true,
+		labelEditor = true,
+		anchorHandles = true,
+	} = options;
+
 	return {
 		id: "usketch-plugin-shape-connector",
 		name: "コネクタ",
@@ -195,42 +239,53 @@ export function createConnectorPlugin(): UsketchPlugin {
 			});
 
 			// ── Connector property bar (Phase 4) ──
+			// UI layers are opt-out (see ConnectorPluginOptions) so a host with its
+			// own toolbar/UI can suppress them without depending on internal layer ids.
 
-			ctx.layers.register({
-				id: "connector-properties",
-				order: 82,
-				fixed: true,
-				render: () => <ConnectorPropertyBar />,
-			});
+			if (propertyBar) {
+				ctx.layers.register({
+					id: CONNECTOR_LAYER_IDS.propertyBar,
+					order: 82,
+					fixed: true,
+					render: () => <ConnectorPropertyBar />,
+				});
+			}
 
 			// ── Endpoint overlay (Phase 5) ──
 
-			ctx.layers.register({
-				id: "connector-endpoints",
-				order: 81,
-				fixed: true,
-				render: (renderCtx) => <EndpointOverlay ctx={ctx} viewport={renderCtx.viewport} />,
-			});
+			if (endpoints) {
+				ctx.layers.register({
+					id: CONNECTOR_LAYER_IDS.endpoints,
+					order: 81,
+					fixed: true,
+					render: (renderCtx) => <EndpointOverlay ctx={ctx} viewport={renderCtx.viewport} />,
+				});
+			}
 
 			// ── Label editor overlay (Phase 6) ──
 
-			ctx.layers.register({
-				id: "connector-label-editor",
-				order: 83,
-				fixed: true,
-				render: (renderCtx) => <ConnectorLabelEditor ctx={ctx} viewport={renderCtx.viewport} />,
-			});
+			if (labelEditor) {
+				ctx.layers.register({
+					id: CONNECTOR_LAYER_IDS.labelEditor,
+					order: 83,
+					fixed: true,
+					render: (renderCtx) => <ConnectorLabelEditor ctx={ctx} viewport={renderCtx.viewport} />,
+				});
+			}
 
 			// ── Anchor handle overlay (hover to show anchor points) ──
 
-			ctx.layers.register({
-				id: "connector-anchor-handles",
-				order: 79,
-				fixed: true,
-				render: (renderCtx) => <AnchorHandleOverlay ctx={ctx} viewport={renderCtx.viewport} />,
-			});
+			if (anchorHandles) {
+				ctx.layers.register({
+					id: CONNECTOR_LAYER_IDS.anchorHandles,
+					order: 79,
+					fixed: true,
+					render: (renderCtx) => <AnchorHandleOverlay ctx={ctx} viewport={renderCtx.viewport} />,
+				});
+			}
 
-			const cleanupAnchorHandles = setupAnchorHandles(ctx);
+			// Anchor-drag drawing/hover behavior is tied to the anchor-handles UI.
+			const cleanupAnchorHandles = anchorHandles ? setupAnchorHandles(ctx) : undefined;
 
 			// Double-click detection for label editing
 			const unsubLabelClick = ctx.store.onMutation((event) => {
@@ -261,11 +316,11 @@ export function createConnectorPlugin(): UsketchPlugin {
 				stopCascade();
 				unsubLabelClick();
 				unsubPointerForLabel();
-				cleanupAnchorHandles();
-				ctx.layers.unregister("connector-properties");
-				ctx.layers.unregister("connector-endpoints");
-				ctx.layers.unregister("connector-label-editor");
-				ctx.layers.unregister("connector-anchor-handles");
+				cleanupAnchorHandles?.();
+				if (propertyBar) ctx.layers.unregister(CONNECTOR_LAYER_IDS.propertyBar);
+				if (endpoints) ctx.layers.unregister(CONNECTOR_LAYER_IDS.endpoints);
+				if (labelEditor) ctx.layers.unregister(CONNECTOR_LAYER_IDS.labelEditor);
+				if (anchorHandles) ctx.layers.unregister(CONNECTOR_LAYER_IDS.anchorHandles);
 			};
 		},
 	};

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -36,10 +36,10 @@ export type { ConnectorShapeData } from "./types.js";
  * to hardcode the internal strings. Prefer {@link ConnectorPluginOptions} to
  * opt out at construction time.
  *
- * Note: the parameter Toolbar (`ConnectorPropertyBar`) is intentionally **not**
- * part of this plugin — the shape definition should not dictate a specific
- * settings UI. Hosts that want it register the exported `ConnectorPropertyBar`
- * component as their own layer (see the component's docs / apps/web).
+ * Note: the parameter Toolbar is intentionally **not** part of this package —
+ * the shape definition should not dictate a specific settings UI. The host owns
+ * that UI entirely (apps/web ships its own connector property bar). This package
+ * only exports the connector data types the host needs to build one.
  */
 export const CONNECTOR_LAYER_IDS = {
 	endpoints: "connector-endpoints",
@@ -53,8 +53,8 @@ export const CONNECTOR_LAYER_IDS = {
  * layer. The shape, drawing tool, position tracking, and cascade-delete (the
  * core behavior) are always active.
  *
- * The parameter Toolbar is not listed here because it is no longer owned by this
- * plugin at all — render `ConnectorPropertyBar` from the host instead.
+ * The parameter Toolbar is not listed here because it is not owned by this
+ * package at all — the host renders its own (see apps/web).
  */
 export interface ConnectorPluginOptions {
 	/** Endpoint drag handles (used to re-anchor a connector's ends). Default `true`. */
@@ -236,8 +236,8 @@ export function createConnectorPlugin(options: ConnectorPluginOptions = {}): Usk
 
 			// UI layers are opt-out (see ConnectorPluginOptions) so a host with its
 			// own toolbar/UI can suppress them without depending on internal layer ids.
-			// The parameter Toolbar is deliberately absent — hosts render
-			// `ConnectorPropertyBar` themselves (see apps/web).
+			// The parameter Toolbar is deliberately absent — the host owns that UI
+			// entirely (see apps/web).
 
 			// ── Endpoint overlay (Phase 5) ──
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@edv4h/usketch-canvas-engine':
         specifier: workspace:*
         version: link:../../packages/canvas-engine
+      '@edv4h/usketch-connector-anchor':
+        specifier: workspace:*
+        version: link:../../packages/usketch-connector-anchor
       '@edv4h/usketch-core':
         specifier: workspace:*
         version: link:../../packages/core


### PR DESCRIPTION
## 概要

Closes #665

`createConnectorPlugin()` は shape 定義・作成ツールに加え、UI レイヤー(property Toolbar / 端点ハンドル / ラベル編集 / hover アンカー)まで内蔵で `ctx.layers.register` していた。独自 UI を持つホストではこれらが不要・二重表示・レイアウト競合になる。

本 PR では **パラメータ Toolbar をパッケージから完全に撤去してホスト管轄に一本化**し、残りの UI はフラグで出し分けられるようにする。

## 変更点

### 1. パラメータ Toolbar をパッケージから撤去(コア/UI 完全分離)
- `createConnectorPlugin()` は `ConnectorPropertyBar`(線種/矢じり設定 UI)を `layers.register` しない。
- **`ConnectorPropertyBar` コンポーネント自体をパッケージから削除**し、`apps/web/src/plugins/connector-property-bar.tsx` へ移設。パッケージは UI を一切持たない。
- 代わりにコネクタの**データ型 `ConnectorShapeData` / `ArrowHead` / `PathType` を公開**し、ホストが自前 UI を組めるようにした。
- apps/web は移設したコンポーネントを `createConnectorPropertyBarPlugin()`(app ローカル)で layer 登録し、従来の Toolbar 表示を維持。

### 2. 残りの UI レイヤーは per-layer フラグで出し分け
`createConnectorPlugin(options?: ConnectorPluginOptions)`(いずれも既定 `true`):

| フラグ | 対象 | 備考 |
|---|---|---|
| `endpoints` | 端点ドラッグハンドル | |
| `labelEditor` | インラインラベル編集 | |
| `anchorHandles` | hover アンカー + anchor-drag 作成 | `false` でも `connector-draw` ツールでの作成は可能 |

### 3. 安定 API
- 登録レイヤーの id 定数 **`CONNECTOR_LAYER_IDS`**(endpoints / labelEditor / anchorHandles)を公開。
- `index.ts` から `ConnectorPluginOptions` / `CONNECTOR_LAYER_IDS` / データ型を re-export。

shape 定義・作成ツール・位置追従(tracker)・カスケード削除の**コア挙動は常に有効**。

## 破壊的変更の注意点
- `createConnectorPlugin()` だけでは property Toolbar が表示されなくなる。
- `ConnectorPropertyBar` の **export が無くなる**。従来の UI が必要なホストは、公開データ型を使って自前の property bar を実装する(apps/web の実装が参考)。

## 設計判断
当初は opt-out フラグ案 → レビューで「property bar をプラグインの要素から外す」→ さらに「コンポーネント自体も app へ移設」と段階的に踏み込み、issue の第2案「コア挙動と UI を分離」を最も強い形で実現。shape の定義・挙動(パッケージ)と、特定の UI 表現(ホスト)を完全分離した。過剰なパッケージ分割は避け、UI はアプリ内、データ型はパッケージ公開という構成。

## 検証
- `pnpm build`(web 含む)・`pnpm test`(148 タスク)緑
- apps/web は移設コンポーネント + `createConnectorPropertyBarPlugin()` で Toolbar 表示を維持 = ユーザー体験は不変
- パッケージからの `ConnectorPropertyBar` import / 削除 option / 内部 layer id への dangling 参照なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)