### PR TITLE
🐛 fix(connector): 曲線の制御点ドラッグを離す前からライブ反映

### DIFF
--- a/.changeset/connector-curve-live-drag.md
+++ b/.changeset/connector-curve-live-drag.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-shape-connector": patch
+---
+
+コネクタの曲線(curve)の制御点をドラッグ調整する際、曲がり具合がドラッグ中は変化せず離した瞬間に反映されて分かりにくかった問題を修正。制御点ハンドルの `onMove` で `controlPoint` を store にライブ更新するようにし、曲線とハンドルがポインタに追従するようにした。undo 用の履歴は従来どおり `onUp` で1コマンドだけコミット(before=ドラッグ開始時の元値 / after=最終位置)。

--- a/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/endpoint-overlay.tsx
@@ -282,6 +282,15 @@ function EndpointHandle({
 						currentPoint: wp,
 						targetShapeId: null,
 					});
+					// Live-update the curve so the bend (and the handle, which reads the
+					// shape's controlPoint) follows the pointer during the drag instead of
+					// only snapping into place on release. The single undoable command is
+					// still committed once in onUp (before = original captured at
+					// pointerdown, after = final position).
+					ctx.store.updateShape(connectorId, {
+						controlPoint: wp,
+						controlPointAuto: false,
+					} as Partial<ConnectorShapeData>);
 					return;
 				}
 


### PR DESCRIPTION
## 概要

コネクタの曲線(`pathType: "curve"`)の制御点をドラッグして曲がり具合を調整するとき、**ドラッグ中は曲線もハンドルも動かず、ポインタを離した瞬間に反映**されるため分かりにくかった。ドラッグに追従してライブ反映するよう修正。

## 原因

`endpoint-overlay.tsx` の制御点ドラッグ処理:
- `onMove` の `controlPoint` 分岐は `setEndpointDrag(...)`(ハンドル表示用の一時状態)を更新するだけで、connector shape の `controlPoint` は更新しない。
- 実際の曲線(shape の render)と制御点ハンドル位置(shape の `controlPoint` から算出)は shape を見るため、`onUp` でコミットするまで動かない。
- さらに `DragPreview` は source/target のみ対応で `controlPoint` には `null` を返すため、ドラッグ中のプレビューも無い。

## 修正

`onMove` の `controlPoint` 分岐で `ctx.store.updateShape(connectorId, { controlPoint: wp, controlPointAuto: false })` を呼び、曲線とハンドルがポインタに追従するようにした。

- undo 用の履歴は従来どおり `onUp` で **1コマンドだけ**コミット。`before` はドラッグ開始時(pointerdown の closure)に捕捉した元値、`after` は最終位置。`createBatchUpdateShapesCommand` は `from`/`to` を明示値で保持するため、ライブ更新後に execute しても undo は元の曲がり具合(または auto)へ正しく戻る。
- source/target 端点ドラッグや connector 作成ツールの `onPointerMove` と同じ「ドラッグ中はライブ更新、離したら1コマンド」パターンに揃えた。

## 検証

- `pnpm build`(web 含む)・`pnpm test`(148 タスク)緑
- 手動確認: curve コネクタを選択 → 制御点ハンドルをドラッグ → **ドラッグ中に曲線が追従**、離すと確定、Undo で元の曲がり具合へ復帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)