### PR TITLE
✨ feat(connector): アンカーハンドル表示タイミングをオプション化 (#675)

### DIFF
--- a/.changeset/connector-anchor-single-selection-675.md
+++ b/.changeset/connector-anchor-single-selection-675.md
@@ -1,5 +1,13 @@
 ---
-"@edv4h/usketch-plugin-shape-connector": patch
+"@edv4h/usketch-plugin-shape-connector": minor
 ---
 
-複数 shape 選択時に `AnchorHandleOverlay` が選択中の全 shape にアンカーハンドルを一斉表示して煩雑だった問題を修正（#675）。選択が **単一 shape のときのみ**選択由来のアンカーを表示するようにした（コネクタは通常 1 つの source から引くため）。個別 shape をホバーした際のアンカー表示は選択数に関係なく従来どおり機能する。
+複数 shape 選択時に `AnchorHandleOverlay` が選択中の全 shape にアンカーハンドルを一斉表示して煩雑だった問題を修正し、表示タイミングをオプション化した（#675）。
+
+- `createConnectorPlugin()` の `anchorHandles` オプションを `boolean | AnchorHandleMode` に拡張:
+  - `"single"`（**既定**）— 単一選択時のみ選択由来のアンカーを表示（コネクタは通常 1 つの source から引くため）。
+  - `"selection"` — 全選択 shape に表示（従来挙動）。
+  - `"hover"` — ホバー中の shape のみ。
+  - `true` = `"single"` / `false` = レイヤー無効（従来どおり）。
+- 個別 shape のホバー時アンカー表示はどのモードでも従来どおり機能する。
+- `AnchorHandleMode` 型を公開。

--- a/.changeset/connector-anchor-single-selection-675.md
+++ b/.changeset/connector-anchor-single-selection-675.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-shape-connector": patch
+---
+
+複数 shape 選択時に `AnchorHandleOverlay` が選択中の全 shape にアンカーハンドルを一斉表示して煩雑だった問題を修正（#675）。選択が **単一 shape のときのみ**選択由来のアンカーを表示するようにした（コネクタは通常 1 つの source から引くため）。個別 shape をホバーした際のアンカー表示は選択数に関係なく従来どおり機能する。

--- a/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
@@ -307,12 +307,22 @@ function findNonConnectorShape(ctx: PluginContext, point: Point): ShapeData | nu
 
 // ── Overlay Component ──
 
+/**
+ * When to surface selected-shape anchor handles. See
+ * `ConnectorPluginOptions.anchorHandles`. Defined here (rather than in
+ * `plugin.tsx`) so the overlay owns the enum it consumes and `plugin.tsx` can
+ * import it without a back-reference cycle.
+ */
+export type AnchorHandleMode = "hover" | "single" | "selection";
+
 interface AnchorHandleOverlayProps {
 	ctx: PluginContext;
 	viewport: Viewport;
+	/** Which shapes get anchor handles from the selection. Default `"single"`. */
+	mode?: AnchorHandleMode;
 }
 
-export function AnchorHandleOverlay({ ctx, viewport }: AnchorHandleOverlayProps) {
+export function AnchorHandleOverlay({ ctx, viewport, mode = "single" }: AnchorHandleOverlayProps) {
 	const hoverId = useSyncExternalStore(subscribeAnchorHover, getAnchorHover);
 	const drawing = useSyncExternalStore(subscribeAnchorDraw, getAnchorDraw);
 	const isDragging = useSyncExternalStore(subscribePointerDown, getPointerDown);
@@ -378,15 +388,18 @@ export function AnchorHandleOverlay({ ctx, viewport }: AnchorHandleOverlayProps)
 	// Hide anchor handles while dragging shapes
 	if (isDragging) return null;
 
-	// Not drawing: show anchor handles on the selected + hovered shape.
-	// Only surface the "start a connector here" affordance for a *single*
-	// selected shape — showing every selected shape's anchors on a multi-select
-	// is visually noisy and rarely useful (a connector starts from one source).
-	// Hovering an individual shape still reveals its anchors regardless of
-	// selection size (handled below).
+	// Not drawing: show anchor handles on the selected + hovered shape, per `mode`.
+	// - "selection": every selected shape
+	// - "single": only when exactly one shape is selected (default — a connector
+	//   starts from one source, so a multi-select showing every shape's anchors
+	//   is noise; #675)
+	// - "hover": nothing from the selection
+	// Hovering an individual shape still reveals its anchors in every mode
+	// (handled below).
 	const targets: { shape: ShapeData; isSelected: boolean }[] = [];
 
-	if (selection.size === 1) {
+	const showSelectionAnchors = mode === "selection" || (mode === "single" && selection.size === 1);
+	if (showSelectionAnchors) {
 		for (const id of selection) {
 			const s = shapes.get(id);
 			if (s && s.type !== "connector") {

--- a/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/anchor-handle-overlay.tsx
@@ -378,13 +378,20 @@ export function AnchorHandleOverlay({ ctx, viewport }: AnchorHandleOverlayProps)
 	// Hide anchor handles while dragging shapes
 	if (isDragging) return null;
 
-	// Not drawing: show anchor handles on selected + hovered shapes
+	// Not drawing: show anchor handles on the selected + hovered shape.
+	// Only surface the "start a connector here" affordance for a *single*
+	// selected shape — showing every selected shape's anchors on a multi-select
+	// is visually noisy and rarely useful (a connector starts from one source).
+	// Hovering an individual shape still reveals its anchors regardless of
+	// selection size (handled below).
 	const targets: { shape: ShapeData; isSelected: boolean }[] = [];
 
-	for (const id of selection) {
-		const s = shapes.get(id);
-		if (s && s.type !== "connector") {
-			targets.push({ shape: s, isSelected: true });
+	if (selection.size === 1) {
+		for (const id of selection) {
+			const s = shapes.get(id);
+			if (s && s.type !== "connector") {
+				targets.push({ shape: s, isSelected: true });
+			}
 		}
 	}
 

--- a/plugins/usketch-plugin-shape-connector/src/index.ts
+++ b/plugins/usketch-plugin-shape-connector/src/index.ts
@@ -1,4 +1,5 @@
 export {
+	type AnchorHandleMode,
 	CONNECTOR_LAYER_IDS,
 	type ConnectorPluginOptions,
 	createConnectorPlugin,

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -16,7 +16,11 @@ import type {
 } from "@edv4h/usketch-shared";
 import { generateId } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
-import { AnchorHandleOverlay, setupAnchorHandles } from "./anchor-handle-overlay.js";
+import {
+	type AnchorHandleMode,
+	AnchorHandleOverlay,
+	setupAnchorHandles,
+} from "./anchor-handle-overlay.js";
 import { ConnectorLabelEditor, handleConnectorClick, setEditingLabel } from "./connector-label.js";
 import { EndpointOverlay } from "./endpoint-overlay.js";
 import {
@@ -28,6 +32,7 @@ import {
 } from "./shapes/connector.js";
 import type { ConnectorShapeData } from "./types.js";
 
+export type { AnchorHandleMode } from "./anchor-handle-overlay.js";
 export type { ConnectorShapeData } from "./types.js";
 
 /**
@@ -62,11 +67,13 @@ export interface ConnectorPluginOptions {
 	/** Inline label editor. Default `true`. */
 	labelEditor?: boolean;
 	/**
-	 * Hover anchor handles + the anchor-drag drawing interaction. Default `true`.
-	 * The `connector-draw` tool still works when this is `false`; only the
-	 * hover-to-anchor affordance is removed.
+	 * Hover anchor handles + the anchor-drag drawing interaction.
+	 * - `true` (default) / an {@link AnchorHandleMode} string — enable the handles;
+	 *   a string picks *when* selected-shape anchors show (default mode `"single"`).
+	 * - `false` — disable entirely (no layer). The `connector-draw` tool still
+	 *   works; only the hover-to-anchor affordance is removed.
 	 */
-	anchorHandles?: boolean;
+	anchorHandles?: boolean | AnchorHandleMode;
 }
 
 function ConnectorIcon() {
@@ -103,6 +110,10 @@ function debugFields(shape: ShapeData): Record<string, unknown> {
 
 export function createConnectorPlugin(options: ConnectorPluginOptions = {}): UsketchPlugin {
 	const { endpoints = true, labelEditor = true, anchorHandles = true } = options;
+	const anchorHandlesEnabled = anchorHandles !== false;
+	// `true` maps to the default mode; a string is used verbatim.
+	const anchorHandlesMode: AnchorHandleMode =
+		typeof anchorHandles === "string" ? anchorHandles : "single";
 
 	return {
 		id: "usketch-plugin-shape-connector",
@@ -263,17 +274,19 @@ export function createConnectorPlugin(options: ConnectorPluginOptions = {}): Usk
 
 			// ── Anchor handle overlay (hover to show anchor points) ──
 
-			if (anchorHandles) {
+			if (anchorHandlesEnabled) {
 				ctx.layers.register({
 					id: CONNECTOR_LAYER_IDS.anchorHandles,
 					order: 79,
 					fixed: true,
-					render: (renderCtx) => <AnchorHandleOverlay ctx={ctx} viewport={renderCtx.viewport} />,
+					render: (renderCtx) => (
+						<AnchorHandleOverlay ctx={ctx} viewport={renderCtx.viewport} mode={anchorHandlesMode} />
+					),
 				});
 			}
 
 			// Anchor-drag drawing/hover behavior is tied to the anchor-handles UI.
-			const cleanupAnchorHandles = anchorHandles ? setupAnchorHandles(ctx) : undefined;
+			const cleanupAnchorHandles = anchorHandlesEnabled ? setupAnchorHandles(ctx) : undefined;
 
 			// Double-click detection for label editing
 			const unsubLabelClick = ctx.store.onMutation((event) => {
@@ -307,7 +320,7 @@ export function createConnectorPlugin(options: ConnectorPluginOptions = {}): Usk
 				cleanupAnchorHandles?.();
 				if (endpoints) ctx.layers.unregister(CONNECTOR_LAYER_IDS.endpoints);
 				if (labelEditor) ctx.layers.unregister(CONNECTOR_LAYER_IDS.labelEditor);
-				if (anchorHandles) ctx.layers.unregister(CONNECTOR_LAYER_IDS.anchorHandles);
+				if (anchorHandlesEnabled) ctx.layers.unregister(CONNECTOR_LAYER_IDS.anchorHandles);
 			};
 		},
 	};


### PR DESCRIPTION
## 概要

Closes #675

`connector-anchor-handles` レイヤー(`AnchorHandleOverlay`)は select ツール中に shape をホバー/選択するとアンカーハンドル(接続開始点)を表示する。しかし**複数 shape を選択すると選択中の全 shape に一斉表示され、視覚的に非常に煩雑**だった。

複数選択時の一斉表示を既定で抑止しつつ、**表示タイミングをオプションで選べる**ようにした(issue の提案1を既定に、提案2をオプションで両立)。

## 変更点

`createConnectorPlugin()` の `anchorHandles` オプションを `boolean | AnchorHandleMode` に拡張:

| 値 | 挙動 |
|---|---|
| `"single"`(**既定** / `true`) | 単一選択時のみ選択由来のアンカーを表示。コネクタは通常 1 つの source から引くため |
| `"selection"` | 全選択 shape に表示(従来挙動) |
| `"hover"` | ホバー中の shape のみ |
| `false` | レイヤー無効(従来どおり) |

- 個別 shape の**ホバー時**アンカー表示は、どのモードでも従来どおり機能。
- `AnchorHandleOverlay` に `mode` prop を追加し、プラグインがオプションから解決して渡す。
- `AnchorHandleMode` 型を公開 API として export。
- 描画中(drawing)/anchor-drag 作成の挙動は不変。

```ts
// 例: 従来どおり全選択で出したいホスト
createConnectorPlugin({ anchorHandles: "selection" });
// ホバー時のみ
createConnectorPlugin({ anchorHandles: "hover" });
```

## 検証

- `pnpm build`(web 含む)・`pnpm test`(148 タスク)緑
- 手動確認: 複数選択でアンカーが出ない(既定)/ 単一選択・ホバーで出る / `"selection"` 指定で全選択表示が戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)