### PR TITLE
🐛 fix(hud): Copilot レビュー指摘の追随修正 (#702 マージ後の残件)

### DIFF
--- a/.changeset/hud-copilot-review-hardening.md
+++ b/.changeset/hud-copilot-review-hardening.md
@@ -1,0 +1,9 @@
+---
+"@edv4h/usketch-plugin-debug-hud": patch
+"@edv4h/usketch-plugin-shape-connector": patch
+---
+
+Copilot レビュー指摘の堅牢性修正（#702 マージ後の追随分）:
+
+- **debug-hud / Control パネル**: Action 実行を `try/catch` + Promise `.catch` で内包し、`finally` で UI 再評価（`isActive`/`isEnabled`）を必ず実行（unhandled rejection 防止・実行後の状態反映を保証）。`Clear canvas` は本番でも HUD が出るため確認ダイアログを追加（0 件は no-op）。
+- **shape-connector**: `setConnectorAnchor` が両端接続時しか動かず、片端未接続の connector で HUD action が silent no-op だった問題を修正（anchor フィールドは常に更新、座標再計算は両端接続時のみ）。

--- a/plugins/usketch-plugin-debug-hud/src/panels/controls-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/controls-panel.tsx
@@ -197,9 +197,21 @@ function ActionRow({ action, onAfterRun }: { action: PluginAction; onAfterRun: (
 	// アクション実行後に必ず親を再レンダーさせ、isActive/isEnabled を再評価する。
 	// これがないと、store を変えずプラグインローカル状態だけ更新する toggle 系で
 	// インジケータが次の無関係な再レンダーまで stale になる。
+	// run は void | Promise<void>。同期例外・非同期 reject を握りつぶさずログし、
+	// finally で onAfterRun を必ず呼んで UI 反映を保証する。
 	const run = (a: Record<string, unknown>) => {
-		action.run(a);
-		onAfterRun();
+		try {
+			const result = action.run(a);
+			if (result && typeof (result as Promise<unknown>).then === "function") {
+				(result as Promise<unknown>).catch((err) =>
+					console.error(`Action "${action.id}" failed:`, err),
+				);
+			}
+		} catch (err) {
+			console.error(`Action "${action.id}" failed:`, err);
+		} finally {
+			onAfterRun();
+		}
 	};
 
 	if (!action.params || action.params.length === 0) {

--- a/plugins/usketch-plugin-debug-hud/src/panels/controls-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/controls-panel.tsx
@@ -399,6 +399,15 @@ function StyleControls({ store }: { store: BoardStore }) {
 
 	const clearCanvas = () => {
 		const ids = [...store.getShapes().keys()];
+		if (ids.length === 0) return;
+		// HUD が本番でも出るようになったため、誤爆防止に確認を挟む。
+		// deleteShape 直呼びは undo 履歴を通らない破壊的操作である点も明示する。
+		if (
+			typeof window !== "undefined" &&
+			!window.confirm(`Delete all ${ids.length} shape(s)? This cannot be undone.`)
+		) {
+			return;
+		}
 		for (const id of ids) store.deleteShape(id);
 	};
 

--- a/plugins/usketch-plugin-shape-connector/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-connector/src/plugin.tsx
@@ -325,16 +325,22 @@ export function createConnectorPlugin(options: ConnectorPluginOptions = {}): Usk
 					createBatchUpdateShapesCommand(ctx.store, [{ id, from, to: { [key]: value } }]),
 				);
 			};
-			// アンカー変更は端点座標を再計算する（両端が shape に接続している場合のみ）。
+			// アンカー変更。両端が shape に接続している場合のみ端点座標を再計算する。
+			// 片方でも未接続なら anchor フィールドだけ更新する（HUD の action は
+			// connector 選択中は常に有効なので、no-op にせず値は必ず反映させる）。
 			const setConnectorAnchor = (endpoint: "source" | "target", value: AnchorType) => {
 				const id = selectedConnectorId();
 				if (!id) return;
 				const c = ctx.store.getShape(id) as ConnectorShapeData | undefined;
-				if (!c || !c.sourceId || !c.targetId) return;
-				const sourceShape = ctx.store.getShape(c.sourceId);
-				const targetShape = ctx.store.getShape(c.targetId);
-				if (!sourceShape || !targetShape) return;
+				if (!c) return;
 				const key = endpoint === "source" ? "sourceAnchor" : "targetAnchor";
+				const sourceShape = c.sourceId ? ctx.store.getShape(c.sourceId) : undefined;
+				const targetShape = c.targetId ? ctx.store.getShape(c.targetId) : undefined;
+				if (!sourceShape || !targetShape) {
+					// 端点が両方 shape に接続していない → 座標再計算はせずフィールドのみ更新。
+					updateConnectorProp(key, value);
+					return;
+				}
 				const newSourceAnchor = endpoint === "source" ? value : (c.sourceAnchor ?? "auto");
 				const newTargetAnchor = endpoint === "target" ? value : (c.targetAnchor ?? "auto");
 				const targetCenter = {


### PR DESCRIPTION
## 背景

#702（Debug HUD 汎用コントロール面化）は自動マージされたが、Copilot レビュー対応の後半コミットがマージに乗らず main に未反映だった。本 PR でそれらを追随させる。

## 変更点（Copilot レビュー指摘の修正）

- **debug-hud / Control パネル**
  - Action の `run` を `try/catch` + Promise `.catch` で内包し、`finally` で UI 再評価（`isActive`/`isEnabled`）を必ず実行。同期例外・非同期 reject を握りつぶさずログし、unhandled rejection を防止。
  - `Clear canvas` に確認ダイアログを追加（本番でも HUD が出るため誤爆防止、0 件は no-op）。`store.deleteShape` 直呼びで undo 履歴を通らない破壊操作である点への対応。
- **shape-connector**
  - `setConnectorAnchor` が両端接続時しか動かず、片端未接続の connector で HUD action（`connector:source-anchor` / `connector:target-anchor`）が silent no-op になっていた問題を修正。anchor フィールドは常に更新し、端点座標の再計算は両端が shape に接続しているときのみ行う。

## 検証

- `pnpm --filter debug-hud --filter shape-connector build` 緑。
- `biome check` 緑。
- changeset 追加（debug-hud / shape-connector patch）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)