### PR TITLE
✨ feat(shape): Markdown shape プラグイン (#666)

### DIFF
--- a/.changeset/shape-markdown-plugin.md
+++ b/.changeset/shape-markdown-plugin.md
@@ -10,5 +10,5 @@
 - **Mermaid 図**対応（```mermaid```）。mermaid は動的 import で code-split し、`securityLevel: "strict"` で描画。不正構文は生コード＋エラーにフォールバック。
 - 編集は raw Markdown を textarea で直接編集。**編集開始は明示操作**（Control HUD の `Markdown ▸ ✎ Edit source` action。markdown 選択中のみ有効）。blur/Esc/外側クリック/選択解除で確定、undo 対応、空なら削除。表示は内容に応じて高さ自動フィット。
 - **コンテンツ操作は選択中のみ**：未選択時は非操作（クリック/ドラッグで shape 選択/移動）、選択中はリンククリック可＋**Alt+ドラッグでテキスト選択**（プレーンなドラッグは移動のまま）。ダブルクリックで編集に吸われる問題を解消。
-- **テキストのペースト/ドロップ**で markdown shape を自動生成（external-content handler、`order:0`）。内部シェイプコピー(`usketch/shapes` JSON)は横取りしない。編集中の textarea へのペーストはネイティブ動作。
+- **ペースト/ドロップ**で markdown shape を自動生成（external-content handler）。表データ（Excel/スプレッドシートの HTML table・TSV/CSV）は **GFM 表**に変換する専用ハンドラ（`order:10`）、それ以外のテキストは catch-all（`order:0`）。=「具体 match が勝ち／無ければ Markdown」という order ベースのルーティング。内部シェイプコピー(`usketch/shapes` JSON)は横取りしない。編集中の textarea へのペーストはネイティブ動作。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、debug fields 対応。

--- a/.changeset/shape-markdown-plugin.md
+++ b/.changeset/shape-markdown-plugin.md
@@ -9,6 +9,6 @@
 - **シンタックスハイライト**（rehype-highlight、github 風テーマを内蔵注入、ライト/ダーク追従）。
 - **Mermaid 図**対応（```mermaid```）。mermaid は動的 import で code-split し、`securityLevel: "strict"` で描画。不正構文は生コード＋エラーにフォールバック。
 - 編集は raw Markdown を textarea で直接編集。**編集開始は明示操作**（Control HUD の `Markdown ▸ ✎ Edit source` action。markdown 選択中のみ有効）。blur/Esc/外側クリック/選択解除で確定、undo 対応、空なら削除。表示は内容に応じて高さ自動フィット。
-- **コンテンツ操作は選択中のみ**：未選択時は非操作（クリックで shape 選択/移動）、選択中はリンク/テキスト選択が可能（`pointerEvents` を選択状態で切替）。ダブルクリックで編集に吸われる問題を解消。
+- **コンテンツ操作は選択中のみ**：未選択時は非操作（クリック/ドラッグで shape 選択/移動）、選択中はリンククリック可＋**Alt+ドラッグでテキスト選択**（プレーンなドラッグは移動のまま）。ダブルクリックで編集に吸われる問題を解消。
 - **テキストのペースト/ドロップ**で markdown shape を自動生成（external-content handler、`order:0`）。内部シェイプコピー(`usketch/shapes` JSON)は横取りしない。編集中の textarea へのペーストはネイティブ動作。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、debug fields 対応。

--- a/.changeset/shape-markdown-plugin.md
+++ b/.changeset/shape-markdown-plugin.md
@@ -9,4 +9,5 @@
 - **シンタックスハイライト**（rehype-highlight、github 風テーマを内蔵注入、ライト/ダーク追従）。
 - **Mermaid 図**対応（```mermaid```）。mermaid は動的 import で code-split し、`securityLevel: "strict"` で描画。不正構文は生コード＋エラーにフォールバック。
 - 編集は raw Markdown を textarea で直接編集（ダブルクリックで編集、blur/Esc/外側クリック/選択解除で確定、undo 対応、空なら削除）。表示は内容に応じて高さ自動フィット。
+- **テキストのペースト/ドロップ**で markdown shape を自動生成（external-content handler、`order:0`）。内部シェイプコピー(`usketch/shapes` JSON)は横取りしない。編集中の textarea へのペーストはネイティブ動作。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、debug fields 対応。

--- a/.changeset/shape-markdown-plugin.md
+++ b/.changeset/shape-markdown-plugin.md
@@ -1,0 +1,12 @@
+---
+"@edv4h/usketch-plugin-shape-markdown": minor
+---
+
+新規: Markdown shape プラグイン `usketch-plugin-shape-markdown`（#666）。
+
+- 新 shape 型 `markdown`（`ShapeData<{ source, isEditing }>` の meta 方式、`renderTarget: "html"`）。
+- 表示は **react-markdown + remark-gfm**（GFM: 見出し / 装飾 / リスト / リンク / 表 / コードブロック / タスクリスト / 引用）。`dangerouslySetInnerHTML` を使わず raw HTML は既定 off なので XSS 安全。
+- **シンタックスハイライト**（rehype-highlight、github 風テーマを内蔵注入、ライト/ダーク追従）。
+- **Mermaid 図**対応（```mermaid```）。mermaid は動的 import で code-split し、`securityLevel: "strict"` で描画。不正構文は生コード＋エラーにフォールバック。
+- 編集は raw Markdown を textarea で直接編集（ダブルクリックで編集、blur/Esc/外側クリック/選択解除で確定、undo 対応、空なら削除）。表示は内容に応じて高さ自動フィット。
+- ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、debug fields 対応。

--- a/.changeset/shape-markdown-plugin.md
+++ b/.changeset/shape-markdown-plugin.md
@@ -8,6 +8,7 @@
 - 表示は **react-markdown + remark-gfm**（GFM: 見出し / 装飾 / リスト / リンク / 表 / コードブロック / タスクリスト / 引用）。`dangerouslySetInnerHTML` を使わず raw HTML は既定 off なので XSS 安全。
 - **シンタックスハイライト**（rehype-highlight、github 風テーマを内蔵注入、ライト/ダーク追従）。
 - **Mermaid 図**対応（```mermaid```）。mermaid は動的 import で code-split し、`securityLevel: "strict"` で描画。不正構文は生コード＋エラーにフォールバック。
-- 編集は raw Markdown を textarea で直接編集（ダブルクリックで編集、blur/Esc/外側クリック/選択解除で確定、undo 対応、空なら削除）。表示は内容に応じて高さ自動フィット。
+- 編集は raw Markdown を textarea で直接編集。**編集開始は明示操作**（Control HUD の `Markdown ▸ ✎ Edit source` action。markdown 選択中のみ有効）。blur/Esc/外側クリック/選択解除で確定、undo 対応、空なら削除。表示は内容に応じて高さ自動フィット。
+- **コンテンツ操作は選択中のみ**：未選択時は非操作（クリックで shape 選択/移動）、選択中はリンク/テキスト選択が可能（`pointerEvents` を選択状態で切替）。ダブルクリックで編集に吸われる問題を解消。
 - **テキストのペースト/ドロップ**で markdown shape を自動生成（external-content handler、`order:0`）。内部シェイプコピー(`usketch/shapes` JSON)は横取りしない。編集中の textarea へのペーストはネイティブ動作。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、debug fields 対応。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,6 +61,7 @@
 		"@edv4h/usketch-plugin-shape-frame": "workspace:*",
 		"@edv4h/usketch-plugin-shape-group": "workspace:*",
 		"@edv4h/usketch-plugin-shape-freedraw": "workspace:*",
+		"@edv4h/usketch-plugin-shape-markdown": "workspace:*",
 		"@edv4h/usketch-plugin-shape-sticky": "workspace:*",
 		"@edv4h/usketch-plugin-shape-text": "workspace:*",
 		"@edv4h/usketch-plugin-shape-wireframe": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -30,6 +30,7 @@ import { createFramePlugin } from "@edv4h/usketch-plugin-shape-frame";
 import { createFreedrawPlugin } from "@edv4h/usketch-plugin-shape-freedraw";
 import { createGroupPlugin } from "@edv4h/usketch-plugin-shape-group";
 import { createImageShapePlugin } from "@edv4h/usketch-plugin-shape-image";
+import { createMarkdownPlugin } from "@edv4h/usketch-plugin-shape-markdown";
 import { createOpenUIShapePlugin } from "@edv4h/usketch-plugin-shape-openui";
 import { createStickyPlugin } from "@edv4h/usketch-plugin-shape-sticky";
 import { createTextPlugin } from "@edv4h/usketch-plugin-shape-text";
@@ -141,6 +142,7 @@ function createBasePlugins(cardHand: CardHandWiring): UsketchPlugin[] {
 		createConnectorPlugin(),
 		createFreedrawPlugin(),
 		createTextPlugin(),
+		createMarkdownPlugin(),
 		createStickyPlugin(),
 		createCardPlugin({
 			cardTypes: EXAMPLE_CARD_TYPES,

--- a/plugins/usketch-plugin-shape-markdown/README.md
+++ b/plugins/usketch-plugin-shape-markdown/README.md
@@ -11,7 +11,11 @@ Markdown を整形表示する uSketch の shape プラグイン。付箋 / テ�
 - **Mermaid**: ` ```mermaid ` ブロックを図として描画。`mermaid` は**動的 import で code-split**（図を含むボードを開いたときだけロード）。`securityLevel: "strict"` で描画し、不正構文は生コード＋エラー文言にフォールバック。
 - **編集（明示操作）**: shape を選択し、Control HUD の `Markdown ▸ ✎ Edit source`（バッククォート `` ` `` で HUD を開く）で raw Markdown 編集モードに入る。blur / Esc / 外側クリック / 選択解除で確定。undo 対応。空にすると shape は削除。ダブルクリックには**バインドしない**（コンテンツ操作を邪魔しないため）。
 - **コンテンツ操作（選択中のみ）**: リンククリックは常に可。**テキスト選択は Alt+ドラッグ**（プレーンなドラッグは shape の移動、Alt を押しながらドラッグでテキスト選択）。未選択時は非操作で、クリック/ドラッグは shape の選択/移動になる。
-- **ペースト / ドロップ**: キャンバスにテキストをペースト（Cmd/Ctrl+V）またはドロップすると markdown shape を自動生成（external-content handler、`order:0` なので host が上書き可）。内部シェイプコピー（`usketch/shapes` JSON）は横取りしない。編集中の textarea へのペーストはブラウザ標準動作。
+- **ペースト / ドロップ**: キャンバスにペースト（Cmd/Ctrl+V）またはドロップで markdown shape を自動生成（external-content handler）。
+  - **表データ**（Excel / Google スプレッドシートの HTML table、TSV/CSV）→ **GFM 表**に変換（`order:10`）。
+  - それ以外のテキスト → そのまま Markdown（catch-all `order:0`、host が上書き可）。
+  - ＝「具体 match が勝ち／無ければ Markdown」という order ベースのルーティング（専用ルータープラグイン不要。canvas-engine の `externalContent` レジストリがルーターを担う）。
+  - 内部シェイプコピー（`usketch/shapes` JSON）は横取りしない。編集中の textarea へのペーストはブラウザ標準動作。
 - **高さ自動フィット**: 表示は描画内容に追従（Mermaid の非同期描画にも `ResizeObserver` で追従）。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、Debug HUD の debug fields 対応。
 

--- a/plugins/usketch-plugin-shape-markdown/README.md
+++ b/plugins/usketch-plugin-shape-markdown/README.md
@@ -10,6 +10,7 @@ Markdown を整形表示する uSketch の shape プラグイン。付箋 / テ�
 - **シンタックスハイライト**: `rehype-highlight`（github 風テーマを内蔵注入、ライト/ダーク追従）。
 - **Mermaid**: ` ```mermaid ` ブロックを図として描画。`mermaid` は**動的 import で code-split**（図を含むボードを開いたときだけロード）。`securityLevel: "strict"` で描画し、不正構文は生コード＋エラー文言にフォールバック。
 - **編集**: ダブルクリックで raw Markdown を `textarea` で直接編集。blur / Esc / 外側クリック / 選択解除で確定。undo 対応。空にすると shape は削除。
+- **ペースト / ドロップ**: キャンバスにテキストをペースト（Cmd/Ctrl+V）またはドロップすると markdown shape を自動生成（external-content handler、`order:0` なので host が上書き可）。内部シェイプコピー（`usketch/shapes` JSON）は横取りしない。編集中の textarea へのペーストはブラウザ標準動作。
 - **高さ自動フィット**: 表示は描画内容に追従（Mermaid の非同期描画にも `ResizeObserver` で追従）。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、Debug HUD の debug fields 対応。
 

--- a/plugins/usketch-plugin-shape-markdown/README.md
+++ b/plugins/usketch-plugin-shape-markdown/README.md
@@ -9,7 +9,8 @@ Markdown を整形表示する uSketch の shape プラグイン。付箋 / テ�
 - **XSS 安全**: `dangerouslySetInnerHTML` を使わず、raw HTML は既定で無効。悪意ある `<script>` 等はレンダリングされない。
 - **シンタックスハイライト**: `rehype-highlight`（github 風テーマを内蔵注入、ライト/ダーク追従）。
 - **Mermaid**: ` ```mermaid ` ブロックを図として描画。`mermaid` は**動的 import で code-split**（図を含むボードを開いたときだけロード）。`securityLevel: "strict"` で描画し、不正構文は生コード＋エラー文言にフォールバック。
-- **編集**: ダブルクリックで raw Markdown を `textarea` で直接編集。blur / Esc / 外側クリック / 選択解除で確定。undo 対応。空にすると shape は削除。
+- **編集（明示操作）**: shape を選択し、Control HUD の `Markdown ▸ ✎ Edit source`（バッククォート `` ` `` で HUD を開く）で raw Markdown 編集モードに入る。blur / Esc / 外側クリック / 選択解除で確定。undo 対応。空にすると shape は削除。ダブルクリックには**バインドしない**（コンテンツ操作を邪魔しないため）。
+- **コンテンツ操作**: リンク / テキスト選択は **shape 選択中のみ**有効（未選択時は非操作で、クリックすると shape の選択/移動になる）。
 - **ペースト / ドロップ**: キャンバスにテキストをペースト（Cmd/Ctrl+V）またはドロップすると markdown shape を自動生成（external-content handler、`order:0` なので host が上書き可）。内部シェイプコピー（`usketch/shapes` JSON）は横取りしない。編集中の textarea へのペーストはブラウザ標準動作。
 - **高さ自動フィット**: 表示は描画内容に追従（Mermaid の非同期描画にも `ResizeObserver` で追従）。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、Debug HUD の debug fields 対応。

--- a/plugins/usketch-plugin-shape-markdown/README.md
+++ b/plugins/usketch-plugin-shape-markdown/README.md
@@ -1,0 +1,33 @@
+# @edv4h/usketch-plugin-shape-markdown
+
+Markdown を整形表示する uSketch の shape プラグイン。付箋 / テキストと同じ HTML 描画 shape として、GFM 記法・シンタックスハイライト・Mermaid 図をキャンバス上でレンダリングする。
+
+## 特徴
+
+- **shape 型** `markdown`（`ShapeData<{ source: string; isEditing: boolean }>` の `meta` 方式、`renderTarget: "html"`）。
+- **GFM レンダリング**: 見出し / 太字・斜体 / リスト / リンク / 表 / コードブロック / タスクリスト（チェックボックス）/ 引用。`react-markdown + remark-gfm`。
+- **XSS 安全**: `dangerouslySetInnerHTML` を使わず、raw HTML は既定で無効。悪意ある `<script>` 等はレンダリングされない。
+- **シンタックスハイライト**: `rehype-highlight`（github 風テーマを内蔵注入、ライト/ダーク追従）。
+- **Mermaid**: ` ```mermaid ` ブロックを図として描画。`mermaid` は**動的 import で code-split**（図を含むボードを開いたときだけロード）。`securityLevel: "strict"` で描画し、不正構文は生コード＋エラー文言にフォールバック。
+- **編集**: ダブルクリックで raw Markdown を `textarea` で直接編集。blur / Esc / 外側クリック / 選択解除で確定。undo 対応。空にすると shape は削除。
+- **高さ自動フィット**: 表示は描画内容に追従（Mermaid の非同期描画にも `ResizeObserver` で追従）。
+- ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、Debug HUD の debug fields 対応。
+
+## 非対応（今後）
+
+- KaTeX 数式。
+- ボード全体の Markdown インポート / エクスポート。
+
+## 使い方
+
+```ts
+import { createApp } from "@edv4h/usketch-core";
+import { createMarkdownPlugin } from "@edv4h/usketch-plugin-shape-markdown";
+
+const app = await createApp({
+  store,
+  plugins: [createMarkdownPlugin()],
+});
+```
+
+ツールバー / ショートカット `m` で配置 → ダブルクリックで Markdown を編集 → フォーカスを外すと整形表示に切り替わる。

--- a/plugins/usketch-plugin-shape-markdown/README.md
+++ b/plugins/usketch-plugin-shape-markdown/README.md
@@ -10,7 +10,7 @@ Markdown を整形表示する uSketch の shape プラグイン。付箋 / テ�
 - **シンタックスハイライト**: `rehype-highlight`（github 風テーマを内蔵注入、ライト/ダーク追従）。
 - **Mermaid**: ` ```mermaid ` ブロックを図として描画。`mermaid` は**動的 import で code-split**（図を含むボードを開いたときだけロード）。`securityLevel: "strict"` で描画し、不正構文は生コード＋エラー文言にフォールバック。
 - **編集（明示操作）**: shape を選択し、Control HUD の `Markdown ▸ ✎ Edit source`（バッククォート `` ` `` で HUD を開く）で raw Markdown 編集モードに入る。blur / Esc / 外側クリック / 選択解除で確定。undo 対応。空にすると shape は削除。ダブルクリックには**バインドしない**（コンテンツ操作を邪魔しないため）。
-- **コンテンツ操作（選択中のみ）**: リンククリックは常に可。**テキスト選択は Alt+ドラッグ**（プレーンなドラッグは shape の移動、Alt を押しながらドラッグでテキスト選択）。未選択時は非操作で、クリック/ドラッグは shape の選択/移動になる。
+- **コンテンツ操作（選択中のみ）**: shape 選択中はリンククリック可＋**テキスト選択は Alt+ドラッグ**（プレーンなドラッグは shape の移動、Alt を押しながらドラッグでテキスト選択）。**未選択時はコンテンツ非操作**（リンクも押せない）で、クリック/ドラッグは shape の選択/移動になる。
 - **ペースト / ドロップ**: キャンバスにペースト（Cmd/Ctrl+V）またはドロップで markdown shape を自動生成（external-content handler）。
   - **表データ**（Excel / Google スプレッドシートの HTML table、TSV/CSV）→ **GFM 表**に変換（`order:10`）。
   - それ以外のテキスト → そのまま Markdown（catch-all `order:0`、host が上書き可）。
@@ -36,4 +36,4 @@ const app = await createApp({
 });
 ```
 
-ツールバー / ショートカット `m` で配置 → ダブルクリックで Markdown を編集 → フォーカスを外すと整形表示に切り替わる。
+ツールバー / ショートカット `m` で配置（配置直後は編集モード）→ 確定後に再編集するときは shape を選択し、Control HUD（`` ` `` で開く）の `Markdown ▸ ✎ Edit source` を実行 → フォーカスを外す / Esc で整形表示に切り替わる。

--- a/plugins/usketch-plugin-shape-markdown/README.md
+++ b/plugins/usketch-plugin-shape-markdown/README.md
@@ -10,7 +10,7 @@ Markdown を整形表示する uSketch の shape プラグイン。付箋 / テ�
 - **シンタックスハイライト**: `rehype-highlight`（github 風テーマを内蔵注入、ライト/ダーク追従）。
 - **Mermaid**: ` ```mermaid ` ブロックを図として描画。`mermaid` は**動的 import で code-split**（図を含むボードを開いたときだけロード）。`securityLevel: "strict"` で描画し、不正構文は生コード＋エラー文言にフォールバック。
 - **編集（明示操作）**: shape を選択し、Control HUD の `Markdown ▸ ✎ Edit source`（バッククォート `` ` `` で HUD を開く）で raw Markdown 編集モードに入る。blur / Esc / 外側クリック / 選択解除で確定。undo 対応。空にすると shape は削除。ダブルクリックには**バインドしない**（コンテンツ操作を邪魔しないため）。
-- **コンテンツ操作**: リンク / テキスト選択は **shape 選択中のみ**有効（未選択時は非操作で、クリックすると shape の選択/移動になる）。
+- **コンテンツ操作（選択中のみ）**: リンククリックは常に可。**テキスト選択は Alt+ドラッグ**（プレーンなドラッグは shape の移動、Alt を押しながらドラッグでテキスト選択）。未選択時は非操作で、クリック/ドラッグは shape の選択/移動になる。
 - **ペースト / ドロップ**: キャンバスにテキストをペースト（Cmd/Ctrl+V）またはドロップすると markdown shape を自動生成（external-content handler、`order:0` なので host が上書き可）。内部シェイプコピー（`usketch/shapes` JSON）は横取りしない。編集中の textarea へのペーストはブラウザ標準動作。
 - **高さ自動フィット**: 表示は描画内容に追従（Mermaid の非同期描画にも `ResizeObserver` で追従）。
 - ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、Debug HUD の debug fields 対応。

--- a/plugins/usketch-plugin-shape-markdown/package.json
+++ b/plugins/usketch-plugin-shape-markdown/package.json
@@ -18,7 +18,6 @@
 		"clean": "rm -rf dist"
 	},
 	"dependencies": {
-		"@edv4h/usketch-core": "workspace:*",
 		"@edv4h/usketch-shared": "workspace:*",
 		"@edv4h/usketch-store": "workspace:*",
 		"@zag-js/core": "^1.37.0",

--- a/plugins/usketch-plugin-shape-markdown/package.json
+++ b/plugins/usketch-plugin-shape-markdown/package.json
@@ -1,0 +1,56 @@
+{
+	"name": "@edv4h/usketch-plugin-shape-markdown",
+	"version": "0.0.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-core": "workspace:*",
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*",
+		"@zag-js/core": "^1.37.0",
+		"@zag-js/vanilla": "^1.37.0",
+		"mermaid": "^11.4.0",
+		"react-markdown": "^9.0.1",
+		"rehype-highlight": "^7.0.1",
+		"remark-gfm": "^4.0.0"
+	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.17",
+		"typescript": "5.9.3",
+		"vitest": "3.2.7"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-markdown"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
@@ -132,6 +132,35 @@ describe("markdown editing machine", () => {
 		expect(readMarkdownMeta(shape).source).toBe("# existing");
 	});
 
+	it("preserves extra meta keys through an edit (no silent data loss)", async () => {
+		const { ctx, store } = makeCtx();
+		const shape: MarkdownShapeData = {
+			id: "mx",
+			type: MARKDOWN_TYPE,
+			x: 0,
+			y: 0,
+			width: 320,
+			height: 120,
+			style: { ...DEFAULT_STYLE },
+			meta: { source: "a", isEditing: false, custom: "keep-me" },
+		};
+		store.addShape(shape);
+		store.setSelection(["mx"]);
+		service = createMarkdownEditingService(ctx);
+
+		service.send({ type: "BEGIN_EDIT", shapeId: "mx" });
+		await tick();
+		service.send({ type: "EDIT_INPUT", id: "mx", source: "b", scrollHeight: 80 });
+		await tick();
+		service.send({ type: "EDIT_ESCAPE", id: "mx" });
+		await tick();
+
+		const meta = (store.getShape("mx") as ShapeData).meta as Record<string, unknown>;
+		expect(meta.custom).toBe("keep-me");
+		expect(meta.source).toBe("b");
+		expect(meta.isEditing).toBe(false);
+	});
+
 	it("EDIT_ESCAPE with empty source deletes the shape", async () => {
 		const { ctx, store } = makeCtx();
 		addMarkdown(store, "m3");

--- a/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
@@ -1,7 +1,14 @@
-import type { Command, PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import type {
+	Command,
+	ExternalContentHandlerCtx,
+	ExternalContentText,
+	PluginContext,
+	ShapeData,
+} from "@edv4h/usketch-shared";
 import { DEFAULT_STYLE } from "@edv4h/usketch-shared";
 import { createBoardStore } from "@edv4h/usketch-store";
 import { afterEach, describe, expect, it } from "vitest";
+import { createMarkdownTextHandler } from "../external-content-handler.js";
 import { createMarkdownEditingService } from "../markdown-editing-machine.js";
 import { MARKDOWN_TYPE, type MarkdownShapeData, readMarkdownMeta } from "../types.js";
 
@@ -121,5 +128,55 @@ describe("markdown editing machine", () => {
 		await tick();
 
 		expect(store.getShape("m3")).toBeUndefined();
+	});
+});
+
+// ── Paste / drop text → markdown shape ──
+
+function textContent(text: string): ExternalContentText {
+	return { kind: "text", via: "paste", text, html: null };
+}
+
+describe("markdown text external-content handler", () => {
+	const handler = createMarkdownTextHandler();
+	const ctx = {} as ExternalContentHandlerCtx;
+
+	it("matches non-empty text", () => {
+		expect(handler.match(textContent("# hello"), ctx)).toBe(true);
+	});
+
+	it("ignores empty/whitespace-only text", () => {
+		expect(handler.match(textContent("   "), ctx)).toBe(false);
+	});
+
+	it("does not hijack the internal shape-clipboard JSON", () => {
+		const internal = JSON.stringify({ format: "usketch/shapes", shapes: [] });
+		expect(handler.match(textContent(internal), ctx)).toBe(false);
+		// ...but unrelated JSON is still treated as markdown text.
+		expect(handler.match(textContent('{"foo":1}'), ctx)).toBe(true);
+	});
+
+	it("creates a selected markdown shape carrying the pasted text (undoable)", () => {
+		const store = createBoardStore();
+		const history: Command[] = [];
+		const hctx = {
+			store,
+			commands: {
+				execute: (c: Command) => {
+					c.execute();
+					history.push(c);
+				},
+			},
+		} as unknown as ExternalContentHandlerCtx;
+
+		handler.handle(textContent("# Pasted\n\n- a\n- b"), hctx);
+
+		const shapes = [...store.getShapes().values()];
+		expect(shapes).toHaveLength(1);
+		const shape = shapes[0] as ShapeData;
+		expect(shape.type).toBe(MARKDOWN_TYPE);
+		expect(readMarkdownMeta(shape).source).toBe("# Pasted\n\n- a\n- b");
+		expect(store.getSelection().has(shape.id)).toBe(true);
+		expect(history).toHaveLength(1);
 	});
 });

--- a/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
@@ -1,0 +1,125 @@
+import type { Command, PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import { DEFAULT_STYLE } from "@edv4h/usketch-shared";
+import { createBoardStore } from "@edv4h/usketch-store";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMarkdownEditingService } from "../markdown-editing-machine.js";
+import { MARKDOWN_TYPE, type MarkdownShapeData, readMarkdownMeta } from "../types.js";
+
+// ── readMarkdownMeta (pure) ──
+
+describe("readMarkdownMeta", () => {
+	it("returns safe defaults when meta is missing", () => {
+		const shape = { meta: undefined } as unknown as ShapeData;
+		expect(readMarkdownMeta(shape)).toEqual({ source: "", isEditing: false });
+	});
+
+	it("reads source and isEditing from meta", () => {
+		const shape = { meta: { source: "# Hi", isEditing: true } } as unknown as ShapeData;
+		expect(readMarkdownMeta(shape)).toEqual({ source: "# Hi", isEditing: true });
+	});
+
+	it("coerces wrong types to defaults (defensive against foreign shapes)", () => {
+		const shape = { meta: { source: 123, isEditing: "yes" } } as unknown as ShapeData;
+		expect(readMarkdownMeta(shape)).toEqual({ source: "", isEditing: false });
+	});
+});
+
+// ── Editing machine flow (real store + minimal command registry) ──
+
+function makeCtx() {
+	const store = createBoardStore();
+	const history: Command[] = [];
+	const commands = {
+		execute: (c: Command) => {
+			c.execute();
+			history.push(c);
+		},
+		undo: () => history.pop()?.undo(),
+		redo: () => {},
+		canUndo: () => history.length > 0,
+		canRedo: () => false,
+		getHistorySize: () => history.length,
+		getCursor: () => history.length - 1,
+	};
+	const ctx = { store, commands } as unknown as PluginContext;
+	return { ctx, store, history };
+}
+
+function addMarkdown(store: ReturnType<typeof createBoardStore>, id: string, source = ""): void {
+	const shape: MarkdownShapeData = {
+		id,
+		type: MARKDOWN_TYPE,
+		x: 0,
+		y: 0,
+		width: 320,
+		height: 120,
+		style: { ...DEFAULT_STYLE },
+		meta: { source, isEditing: false },
+	};
+	store.addShape(shape);
+}
+
+describe("markdown editing machine", () => {
+	let service: ReturnType<typeof createMarkdownEditingService> | null = null;
+	// The machine processes internally-queued events (e.g. the entry action's
+	// ENTER_EDIT) on a microtask, so flush between sends before asserting.
+	const tick = () => new Promise((r) => setTimeout(r, 0));
+	afterEach(() => {
+		service?.stop();
+		service = null;
+	});
+
+	it("CREATE_SHAPE → EDIT_INPUT updates meta.source (merged, not replaced) and height", async () => {
+		const { ctx, store } = makeCtx();
+		addMarkdown(store, "m1");
+		store.setSelection(["m1"]);
+		service = createMarkdownEditingService(ctx);
+
+		service.send({ type: "CREATE_SHAPE", shapeId: "m1" });
+		await tick();
+		expect(readMarkdownMeta(store.getShape("m1") as ShapeData).isEditing).toBe(true);
+
+		service.send({ type: "EDIT_INPUT", id: "m1", source: "# Title", scrollHeight: 200 });
+		await tick();
+		const shape = store.getShape("m1") as ShapeData;
+		expect(readMarkdownMeta(shape).source).toBe("# Title");
+		// isEditing must survive the source merge (meta is merged, not overwritten).
+		expect(readMarkdownMeta(shape).isEditing).toBe(true);
+		expect(shape.height).toBe(200);
+	});
+
+	it("EDIT_ESCAPE with non-empty source exits edit and records an undoable change", async () => {
+		const { ctx, store, history } = makeCtx();
+		addMarkdown(store, "m2");
+		store.setSelection(["m2"]);
+		service = createMarkdownEditingService(ctx);
+
+		service.send({ type: "CREATE_SHAPE", shapeId: "m2" });
+		await tick();
+		service.send({ type: "EDIT_INPUT", id: "m2", source: "hello", scrollHeight: 100 });
+		await tick();
+		service.send({ type: "EDIT_ESCAPE", id: "m2" });
+		await tick();
+
+		const shape = store.getShape("m2") as ShapeData;
+		expect(readMarkdownMeta(shape).isEditing).toBe(false);
+		expect(readMarkdownMeta(shape).source).toBe("hello");
+		expect(history.length).toBe(1);
+	});
+
+	it("EDIT_ESCAPE with empty source deletes the shape", async () => {
+		const { ctx, store } = makeCtx();
+		addMarkdown(store, "m3");
+		store.setSelection(["m3"]);
+		service = createMarkdownEditingService(ctx);
+
+		service.send({ type: "CREATE_SHAPE", shapeId: "m3" });
+		await tick();
+		service.send({ type: "EDIT_INPUT", id: "m3", source: "   ", scrollHeight: 60 });
+		await tick();
+		service.send({ type: "EDIT_ESCAPE", id: "m3" });
+		await tick();
+
+		expect(store.getShape("m3")).toBeUndefined();
+	});
+});

--- a/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
@@ -114,6 +114,20 @@ describe("markdown editing machine", () => {
 		expect(history.length).toBe(1);
 	});
 
+	it("BEGIN_EDIT enters edit mode for an existing shape (explicit edit trigger)", async () => {
+		const { ctx, store } = makeCtx();
+		addMarkdown(store, "me", "# existing");
+		store.setSelection(["me"]);
+		service = createMarkdownEditingService(ctx);
+
+		service.send({ type: "BEGIN_EDIT", shapeId: "me" });
+		await tick();
+
+		const shape = store.getShape("me") as ShapeData;
+		expect(readMarkdownMeta(shape).isEditing).toBe(true);
+		expect(readMarkdownMeta(shape).source).toBe("# existing");
+	});
+
 	it("EDIT_ESCAPE with empty source deletes the shape", async () => {
 		const { ctx, store } = makeCtx();
 		addMarkdown(store, "m3");

--- a/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/__tests__/markdown.test.ts
@@ -8,8 +8,12 @@ import type {
 import { DEFAULT_STYLE } from "@edv4h/usketch-shared";
 import { createBoardStore } from "@edv4h/usketch-store";
 import { afterEach, describe, expect, it } from "vitest";
-import { createMarkdownTextHandler } from "../external-content-handler.js";
+import {
+	createMarkdownTableHandler,
+	createMarkdownTextHandler,
+} from "../external-content-handler.js";
 import { createMarkdownEditingService } from "../markdown-editing-machine.js";
+import { parseDelimited, toMarkdownTable } from "../table-paste.js";
 import { MARKDOWN_TYPE, type MarkdownShapeData, readMarkdownMeta } from "../types.js";
 
 // ── readMarkdownMeta (pure) ──
@@ -192,5 +196,70 @@ describe("markdown text external-content handler", () => {
 		expect(readMarkdownMeta(shape).source).toBe("# Pasted\n\n- a\n- b");
 		expect(store.getSelection().has(shape.id)).toBe(true);
 		expect(history).toHaveLength(1);
+	});
+});
+
+// ── Tabular paste → markdown table ──
+
+describe("table-paste parsing", () => {
+	it("parses TSV into a grid", () => {
+		expect(parseDelimited("a\tb\n1\t2")).toEqual([
+			["a", "b"],
+			["1", "2"],
+		]);
+	});
+
+	it("parses consistent CSV into a grid", () => {
+		expect(parseDelimited("x,y,z\n1,2,3")).toEqual([
+			["x", "y", "z"],
+			["1", "2", "3"],
+		]);
+	});
+
+	it("rejects non-tabular text (prose / single column / ragged)", () => {
+		expect(parseDelimited("just a sentence, with a comma")).toBeNull(); // 1 line
+		expect(parseDelimited("hello\nworld")).toBeNull(); // no delimiter
+		expect(parseDelimited("a\tb\n1")).toBeNull(); // ragged column count
+	});
+
+	it("renders a GFM table (escaping pipes)", () => {
+		expect(
+			toMarkdownTable([
+				["h1", "h2"],
+				["a|b", "c"],
+			]),
+		).toBe("| h1 | h2 |\n| --- | --- |\n| a\\|b | c |");
+	});
+});
+
+describe("markdown table external-content handler", () => {
+	const table = createMarkdownTableHandler();
+	const ctx = {} as ExternalContentHandlerCtx;
+
+	it("matches TSV text and HTML tables, ignores prose", () => {
+		expect(table.match(textContent("a\tb\n1\t2"), ctx)).toBe(true);
+		expect(
+			table.match(
+				{ kind: "text", via: "paste", text: "", html: "<table><tr><td>x</td></tr></table>" },
+				ctx,
+			),
+		).toBe(true);
+		expect(table.match(textContent("just some prose here"), ctx)).toBe(false);
+	});
+
+	it("has higher order than the plain-text catch-all", () => {
+		expect((table.order ?? 0) > (createMarkdownTextHandler().order ?? 0)).toBe(true);
+	});
+
+	it("creates a markdown shape whose source is a GFM table", () => {
+		const store = createBoardStore();
+		const hctx = {
+			store,
+			commands: { execute: (c: Command) => c.execute() },
+		} as unknown as ExternalContentHandlerCtx;
+
+		table.handle(textContent("name\tqty\napple\t3"), hctx);
+		const shape = [...store.getShapes().values()][0] as ShapeData;
+		expect(readMarkdownMeta(shape).source).toBe("| name | qty |\n| --- | --- |\n| apple | 3 |");
 	});
 });

--- a/plugins/usketch-plugin-shape-markdown/src/constants.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/constants.ts
@@ -1,0 +1,11 @@
+/** Default size for a freshly placed markdown shape. */
+export const MARKDOWN_DEFAULT_SIZE = { width: 320, height: 120 };
+
+/** Minimum resizable size. Height auto-fits content, so this is mostly a floor. */
+export const MARKDOWN_MIN_SIZE = { width: 140, height: 48 };
+
+/** Keyboard shortcut for the markdown draw tool. */
+export const MARKDOWN_SHORTCUT = "m";
+
+/** Placeholder shown in the editor while the source is empty. */
+export const MARKDOWN_PLACEHOLDER = "# Markdown\n\n- **GFM** 対応\n- ```mermaid``` 図も可";

--- a/plugins/usketch-plugin-shape-markdown/src/external-content-handler.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/external-content-handler.ts
@@ -6,6 +6,7 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { MARKDOWN_DEFAULT_SIZE } from "./constants.js";
+import { htmlHasTable, parseDelimited, parseHtmlTable, toMarkdownTable } from "./table-paste.js";
 import { MARKDOWN_TYPE, type MarkdownShapeData } from "./types.js";
 
 /** Internal shape copy/paste marker (from usketch-plugin-keyboard-shortcuts). */
@@ -16,6 +17,24 @@ function viewportCenterToWorld(ctx: ExternalContentHandlerCtx): { x: number; y: 
 	const screenW = typeof window !== "undefined" ? window.innerWidth : 0;
 	const screenH = typeof window !== "undefined" ? window.innerHeight : 0;
 	return { x: (screenW / 2 - vp.x) / vp.zoom, y: (screenH / 2 - vp.y) / vp.zoom };
+}
+
+/** Create a markdown shape centered on the viewport and select it (undoable). */
+function placeMarkdownShape(ctx: ExternalContentHandlerCtx, source: string): void {
+	const center = viewportCenterToWorld(ctx);
+	const id = generateId();
+	const shape: MarkdownShapeData = {
+		id,
+		type: MARKDOWN_TYPE,
+		x: Math.round(center.x - MARKDOWN_DEFAULT_SIZE.width / 2),
+		y: Math.round(center.y - MARKDOWN_DEFAULT_SIZE.height / 2),
+		width: MARKDOWN_DEFAULT_SIZE.width,
+		height: MARKDOWN_DEFAULT_SIZE.height,
+		style: { ...DEFAULT_STYLE, fill: "transparent", strokeWidth: 0 },
+		meta: { source, isEditing: false },
+	};
+	ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
+	ctx.store.setSelection([id]);
 }
 
 /** True when the text is the internal shape-clipboard JSON (don't hijack it). */
@@ -49,22 +68,33 @@ export function createMarkdownTextHandler(): ExternalContentHandler<"text"> {
 			return !isInternalShapesClipboard(text);
 		},
 		handle: (content, ctx) => {
-			const center = viewportCenterToWorld(ctx);
-			const id = generateId();
-			const shape: MarkdownShapeData = {
-				id,
-				type: MARKDOWN_TYPE,
-				x: Math.round(center.x - MARKDOWN_DEFAULT_SIZE.width / 2),
-				y: Math.round(center.y - MARKDOWN_DEFAULT_SIZE.height / 2),
-				width: MARKDOWN_DEFAULT_SIZE.width,
-				height: MARKDOWN_DEFAULT_SIZE.height,
-				style: { ...DEFAULT_STYLE, fill: "transparent", strokeWidth: 0 },
-				// Preserve the original text verbatim (rendered as GFM on view;
-				// plain text renders as-is). Height auto-fits after render.
-				meta: { source: content.text, isEditing: false },
-			};
-			ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
-			ctx.store.setSelection([id]);
+			// Preserve the original text verbatim (rendered as GFM on view; plain
+			// text renders as-is). Height auto-fits after render.
+			placeMarkdownShape(ctx, content.text);
+		},
+	};
+}
+
+/**
+ * Table paste: a spreadsheet selection (Excel / Google Sheets / web `<table>`)
+ * or delimited TSV/CSV text becomes a GFM markdown table shape. Registered at a
+ * higher `order` than the plain-text catch-all so tabular pastes win; anything
+ * non-tabular falls through to {@link createMarkdownTextHandler}.
+ */
+export function createMarkdownTableHandler(): ExternalContentHandler<"text"> {
+	return {
+		id: "usketch-plugin-shape-markdown:table",
+		kind: "text",
+		order: 10,
+		match: (content) => {
+			if (content.text && isInternalShapesClipboard(content.text.trim())) return false;
+			return htmlHasTable(content.html) || parseDelimited(content.text) !== null;
+		},
+		handle: (content, ctx) => {
+			// Prefer the rich HTML table (handles multi-word cells) over delimited text.
+			const rows = parseHtmlTable(content.html) ?? parseDelimited(content.text);
+			if (!rows) return;
+			placeMarkdownShape(ctx, toMarkdownTable(rows));
 		},
 	};
 }

--- a/plugins/usketch-plugin-shape-markdown/src/external-content-handler.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/external-content-handler.ts
@@ -1,0 +1,70 @@
+import {
+	DEFAULT_STYLE,
+	type ExternalContentHandler,
+	type ExternalContentHandlerCtx,
+	generateId,
+} from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { MARKDOWN_DEFAULT_SIZE } from "./constants.js";
+import { MARKDOWN_TYPE, type MarkdownShapeData } from "./types.js";
+
+/** Internal shape copy/paste marker (from usketch-plugin-keyboard-shortcuts). */
+const INTERNAL_SHAPES_FORMAT = "usketch/shapes";
+
+function viewportCenterToWorld(ctx: ExternalContentHandlerCtx): { x: number; y: number } {
+	const vp = ctx.store.getViewport();
+	const screenW = typeof window !== "undefined" ? window.innerWidth : 0;
+	const screenH = typeof window !== "undefined" ? window.innerHeight : 0;
+	return { x: (screenW / 2 - vp.x) / vp.zoom, y: (screenH / 2 - vp.y) / vp.zoom };
+}
+
+/** True when the text is the internal shape-clipboard JSON (don't hijack it). */
+function isInternalShapesClipboard(text: string): boolean {
+	if (!text.startsWith("{")) return false;
+	try {
+		const parsed = JSON.parse(text) as { format?: unknown };
+		return (
+			typeof parsed === "object" && parsed !== null && parsed.format === INTERNAL_SHAPES_FORMAT
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * External-content handler: paste or drop of plain text creates a markdown
+ * shape from the text. Registered at `order: 0` so a host/third-party handler
+ * can override. Skips the internal shape-clipboard JSON so Cmd+V of copied
+ * shapes still pastes shapes (both the keyboard shortcut and the document
+ * `paste` event fire on Cmd+V).
+ */
+export function createMarkdownTextHandler(): ExternalContentHandler<"text"> {
+	return {
+		id: "usketch-plugin-shape-markdown:text",
+		kind: "text",
+		order: 0,
+		match: (content) => {
+			const text = content.text?.trim();
+			if (!text) return false;
+			return !isInternalShapesClipboard(text);
+		},
+		handle: (content, ctx) => {
+			const center = viewportCenterToWorld(ctx);
+			const id = generateId();
+			const shape: MarkdownShapeData = {
+				id,
+				type: MARKDOWN_TYPE,
+				x: Math.round(center.x - MARKDOWN_DEFAULT_SIZE.width / 2),
+				y: Math.round(center.y - MARKDOWN_DEFAULT_SIZE.height / 2),
+				width: MARKDOWN_DEFAULT_SIZE.width,
+				height: MARKDOWN_DEFAULT_SIZE.height,
+				style: { ...DEFAULT_STYLE, fill: "transparent", strokeWidth: 0 },
+				// Preserve the original text verbatim (rendered as GFM on view;
+				// plain text renders as-is). Height auto-fits after render.
+				meta: { source: content.text, isEditing: false },
+			};
+			ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
+			ctx.store.setSelection([id]);
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-markdown/src/index.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/index.ts
@@ -1,0 +1,3 @@
+export { MARKDOWN_DEFAULT_SIZE, MARKDOWN_MIN_SIZE, MARKDOWN_SHORTCUT } from "./constants.js";
+export { createMarkdownPlugin } from "./plugin.js";
+export { MARKDOWN_TYPE, type MarkdownMeta, type MarkdownShapeData } from "./types.js";

--- a/plugins/usketch-plugin-shape-markdown/src/markdown-editing-machine.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/markdown-editing-machine.ts
@@ -25,7 +25,7 @@ type MarkdownEvent =
 interface MarkdownMachineSchema extends MachineSchema {
 	context: {
 		editingShapeId: string | null;
-		sourceSnapshot: string | null;
+		metaSnapshot: Record<string, unknown> | null;
 		heightSnapshot: number | null;
 	};
 	refs: {
@@ -48,9 +48,18 @@ interface MarkdownMachineSchema extends MachineSchema {
 	computed: Record<string, never>;
 }
 
-/** Merge a partial meta patch onto the shape's current markdown meta. */
-function metaPatch(shape: ShapeData, patch: Partial<MarkdownMeta>): { meta: MarkdownMeta } {
-	return { meta: { ...readMarkdownMeta(shape), ...patch } };
+/**
+ * Merge a partial patch onto the shape's current meta. Spreads the **raw**
+ * existing meta (not the normalized {source,isEditing}) so any extra keys —
+ * present now or added later by other tooling — are preserved through edits.
+ * `store.updateShape` replaces `meta` wholesale, so we must carry it forward.
+ */
+function metaPatch(
+	shape: ShapeData,
+	patch: Partial<MarkdownMeta>,
+): { meta: Record<string, unknown> } {
+	const existing = (shape.meta ?? {}) as Record<string, unknown>;
+	return { meta: { ...existing, ...patch } };
 }
 
 // ── Machine Definition ──
@@ -61,7 +70,7 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 	context({ bindable }) {
 		return {
 			editingShapeId: bindable<string | null>(() => ({ defaultValue: null })),
-			sourceSnapshot: bindable<string | null>(() => ({ defaultValue: null })),
+			metaSnapshot: bindable<Record<string, unknown> | null>(() => ({ defaultValue: null })),
 			heightSnapshot: bindable<number | null>(() => ({ defaultValue: null })),
 		};
 	},
@@ -133,7 +142,7 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 				const shape = pluginCtx.store.getShape(id);
 				if (!shape || shape.type !== MARKDOWN_TYPE) return;
 
-				context.set("sourceSnapshot", readMarkdownMeta(shape).source);
+				context.set("metaSnapshot", { ...((shape.meta ?? {}) as Record<string, unknown>) });
 				context.set("heightSnapshot", shape.height);
 				pluginCtx.store.updateShape(id, metaPatch(shape, { isEditing: true }));
 			},
@@ -150,7 +159,8 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 			exitEdit({ context, refs }) {
 				const id = context.get("editingShapeId");
 				if (!id) return;
-				const prevSource = context.get("sourceSnapshot");
+				const prevMeta = context.get("metaSnapshot") ?? {};
+				const prevSource = readMarkdownMeta({ meta: prevMeta } as unknown as ShapeData).source;
 				const prevHeight = context.get("heightSnapshot");
 				const pluginCtx = refs.get("pluginCtx");
 
@@ -163,7 +173,7 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 				const shape = pluginCtx.store.getShape(id);
 				if (!shape) {
 					context.set("editingShapeId", null);
-					context.set("sourceSnapshot", null);
+					context.set("metaSnapshot", null);
 					context.set("heightSnapshot", null);
 					return;
 				}
@@ -177,16 +187,20 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 				if (currentSource.trim() === "") {
 					pluginCtx.commands.execute(createDeleteShapeCommand(pluginCtx.store, id));
 				} else if (currentSource !== prevSource) {
+					// Preserve any extra meta keys on both sides of the undo step.
 					pluginCtx.commands.execute(
 						createUpdateShapeCommand(
 							pluginCtx.store,
 							id,
 							{
-								meta: { source: prevSource ?? "", isEditing: false },
+								meta: { ...prevMeta, isEditing: false },
 								height: prevHeight ?? currentShape.height,
 							},
 							{
-								meta: { source: currentSource, isEditing: false },
+								meta: {
+									...((currentShape.meta ?? {}) as Record<string, unknown>),
+									isEditing: false,
+								},
 								height: currentShape.height,
 							},
 						),
@@ -194,7 +208,7 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 				}
 
 				context.set("editingShapeId", null);
-				context.set("sourceSnapshot", null);
+				context.set("metaSnapshot", null);
 				context.set("heightSnapshot", null);
 			},
 
@@ -232,7 +246,7 @@ export function createMarkdownEditingService(pluginCtx: PluginContext) {
 		get context() {
 			return {
 				editingShapeId: machine.context.get("editingShapeId"),
-				sourceSnapshot: machine.context.get("sourceSnapshot"),
+				metaSnapshot: machine.context.get("metaSnapshot"),
 				heightSnapshot: machine.context.get("heightSnapshot"),
 			};
 		},

--- a/plugins/usketch-plugin-shape-markdown/src/markdown-editing-machine.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/markdown-editing-machine.ts
@@ -5,12 +5,14 @@ import { VanillaMachine } from "@zag-js/vanilla";
 import { MARKDOWN_TYPE, type MarkdownMeta, readMarkdownMeta } from "./types.js";
 
 // ── Event Types ──
+// Editing is entered only by explicit intent: CREATE_SHAPE (tool placement) or
+// BEGIN_EDIT (Control HUD "Edit source" action). There is no double-click path
+// so rendered content clicks are free for the shape's own interactions.
 
 type MarkdownEvent =
-	| { type: "POINTER_DOWN"; shapeId: string | null }
 	| { type: "CREATE_SHAPE"; shapeId: string }
+	| { type: "BEGIN_EDIT"; shapeId: string }
 	| { type: "ENTER_EDIT" }
-	| { type: "CLICK_TIMEOUT" }
 	| { type: "SETTLE_TIMEOUT" }
 	| { type: "EDIT_INPUT"; id: string; source: string; scrollHeight: number }
 	| { type: "EDIT_BLUR"; id: string }
@@ -25,20 +27,15 @@ interface MarkdownMachineSchema extends MachineSchema {
 		editingShapeId: string | null;
 		sourceSnapshot: string | null;
 		heightSnapshot: number | null;
-		clickedShapeId: string | null;
 	};
 	refs: {
-		clickTimer: ReturnType<typeof setTimeout> | null;
 		settleTimer: ReturnType<typeof setTimeout> | null;
 		pluginCtx: PluginContext;
 	};
-	state: "idle" | "clicked" | "creating" | "editing" | "editing.settling" | "editing.active";
+	state: "idle" | "creating" | "editing" | "editing.settling" | "editing.active";
 	event: MarkdownEvent;
-	guard: "hasShape" | "isSameShape" | "isEditingTarget";
+	guard: "isEditingTarget";
 	action:
-		| "setClicked"
-		| "startClickTimer"
-		| "clearClicked"
 		| "setEditing"
 		| "enterEdit"
 		| "exitEdit"
@@ -66,13 +63,11 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 			editingShapeId: bindable<string | null>(() => ({ defaultValue: null })),
 			sourceSnapshot: bindable<string | null>(() => ({ defaultValue: null })),
 			heightSnapshot: bindable<number | null>(() => ({ defaultValue: null })),
-			clickedShapeId: bindable<string | null>(() => ({ defaultValue: null })),
 		};
 	},
 
 	refs() {
 		return {
-			clickTimer: null as ReturnType<typeof setTimeout> | null,
 			settleTimer: null as ReturnType<typeof setTimeout> | null,
 			pluginCtx: null as unknown as PluginContext,
 		};
@@ -81,26 +76,8 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 	states: {
 		idle: {
 			on: {
-				POINTER_DOWN: [
-					{ guard: "hasShape", target: "clicked", actions: ["setClicked", "startClickTimer"] },
-				],
 				CREATE_SHAPE: { target: "creating", actions: ["setEditing"] },
-			},
-		},
-
-		clicked: {
-			on: {
-				POINTER_DOWN: [
-					{ guard: "isSameShape", target: "editing", actions: ["setEditing", "enterEdit"] },
-					{
-						guard: "hasShape",
-						target: "clicked",
-						actions: ["setClicked", "startClickTimer"],
-						reenter: true,
-					},
-					{ target: "idle", actions: ["clearClicked"] },
-				],
-				CLICK_TIMEOUT: { target: "idle", actions: ["clearClicked"] },
+				BEGIN_EDIT: { target: "creating", actions: ["setEditing"] },
 			},
 		},
 
@@ -139,42 +116,12 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 
 	implementations: {
 		guards: {
-			hasShape({ event }) {
-				return event.shapeId != null;
-			},
-			isSameShape({ context, event }) {
-				return event.shapeId != null && event.shapeId === context.get("clickedShapeId");
-			},
 			isEditingTarget({ context, event }) {
 				return event.id === context.get("editingShapeId");
 			},
 		},
 
 		actions: {
-			setClicked({ context, event, refs }) {
-				const prev = refs.get("clickTimer");
-				if (prev != null) clearTimeout(prev);
-				context.set("clickedShapeId", event.shapeId);
-			},
-
-			startClickTimer({ refs, send }) {
-				const prev = refs.get("clickTimer");
-				if (prev != null) clearTimeout(prev);
-				const timer = setTimeout(() => {
-					send({ type: "CLICK_TIMEOUT" });
-				}, 300);
-				refs.set("clickTimer", timer);
-			},
-
-			clearClicked({ context, refs }) {
-				context.set("clickedShapeId", null);
-				const timer = refs.get("clickTimer");
-				if (timer != null) {
-					clearTimeout(timer);
-					refs.set("clickTimer", null);
-				}
-			},
-
 			setEditing({ context, event }) {
 				context.set("editingShapeId", event.shapeId);
 			},
@@ -188,12 +135,6 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 
 				context.set("sourceSnapshot", readMarkdownMeta(shape).source);
 				context.set("heightSnapshot", shape.height);
-				context.set("clickedShapeId", null);
-				const clickTimer = refs.get("clickTimer");
-				if (clickTimer != null) {
-					clearTimeout(clickTimer);
-					refs.set("clickTimer", null);
-				}
 				pluginCtx.store.updateShape(id, metaPatch(shape, { isEditing: true }));
 			},
 
@@ -227,7 +168,7 @@ const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
 					return;
 				}
 
-				// Leave edit mode first so the from/to snapshots below capture the
+				// Leave edit mode first so the from/to snapshots capture the
 				// non-editing meta (isEditing:false) on both sides of the undo step.
 				pluginCtx.store.updateShape(id, metaPatch(shape, { isEditing: false }));
 				const currentShape = pluginCtx.store.getShape(id) ?? shape;
@@ -293,7 +234,6 @@ export function createMarkdownEditingService(pluginCtx: PluginContext) {
 				editingShapeId: machine.context.get("editingShapeId"),
 				sourceSnapshot: machine.context.get("sourceSnapshot"),
 				heightSnapshot: machine.context.get("heightSnapshot"),
-				clickedShapeId: machine.context.get("clickedShapeId"),
 			};
 		},
 		matches: (...values: string[]) => {
@@ -301,8 +241,6 @@ export function createMarkdownEditingService(pluginCtx: PluginContext) {
 			return values.some((v) => state === v || state.startsWith(`${v}.`));
 		},
 		stop() {
-			const clickTimer = machine.refs.get("clickTimer");
-			if (clickTimer != null) clearTimeout(clickTimer);
 			const settleTimer = machine.refs.get("settleTimer");
 			if (settleTimer != null) clearTimeout(settleTimer);
 			machine.stop();

--- a/plugins/usketch-plugin-shape-markdown/src/markdown-editing-machine.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/markdown-editing-machine.ts
@@ -1,0 +1,311 @@
+import type { PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import { createDeleteShapeCommand, createUpdateShapeCommand } from "@edv4h/usketch-store";
+import { createMachine, type MachineSchema } from "@zag-js/core";
+import { VanillaMachine } from "@zag-js/vanilla";
+import { MARKDOWN_TYPE, type MarkdownMeta, readMarkdownMeta } from "./types.js";
+
+// ── Event Types ──
+
+type MarkdownEvent =
+	| { type: "POINTER_DOWN"; shapeId: string | null }
+	| { type: "CREATE_SHAPE"; shapeId: string }
+	| { type: "ENTER_EDIT" }
+	| { type: "CLICK_TIMEOUT" }
+	| { type: "SETTLE_TIMEOUT" }
+	| { type: "EDIT_INPUT"; id: string; source: string; scrollHeight: number }
+	| { type: "EDIT_BLUR"; id: string }
+	| { type: "EDIT_ESCAPE"; id: string }
+	| { type: "OUTSIDE_CLICK" }
+	| { type: "DESELECTED" };
+
+// ── Machine Schema ──
+
+interface MarkdownMachineSchema extends MachineSchema {
+	context: {
+		editingShapeId: string | null;
+		sourceSnapshot: string | null;
+		heightSnapshot: number | null;
+		clickedShapeId: string | null;
+	};
+	refs: {
+		clickTimer: ReturnType<typeof setTimeout> | null;
+		settleTimer: ReturnType<typeof setTimeout> | null;
+		pluginCtx: PluginContext;
+	};
+	state: "idle" | "clicked" | "creating" | "editing" | "editing.settling" | "editing.active";
+	event: MarkdownEvent;
+	guard: "hasShape" | "isSameShape" | "isEditingTarget";
+	action:
+		| "setClicked"
+		| "startClickTimer"
+		| "clearClicked"
+		| "setEditing"
+		| "enterEdit"
+		| "exitEdit"
+		| "updateSource"
+		| "sendEnterEdit"
+		| "startSettleTimer";
+	effect: never;
+	tag: never;
+	props: { id: string };
+	computed: Record<string, never>;
+}
+
+/** Merge a partial meta patch onto the shape's current markdown meta. */
+function metaPatch(shape: ShapeData, patch: Partial<MarkdownMeta>): { meta: MarkdownMeta } {
+	return { meta: { ...readMarkdownMeta(shape), ...patch } };
+}
+
+// ── Machine Definition ──
+
+const markdownEditingMachine = createMachine<MarkdownMachineSchema>({
+	initialState: () => "idle",
+
+	context({ bindable }) {
+		return {
+			editingShapeId: bindable<string | null>(() => ({ defaultValue: null })),
+			sourceSnapshot: bindable<string | null>(() => ({ defaultValue: null })),
+			heightSnapshot: bindable<number | null>(() => ({ defaultValue: null })),
+			clickedShapeId: bindable<string | null>(() => ({ defaultValue: null })),
+		};
+	},
+
+	refs() {
+		return {
+			clickTimer: null as ReturnType<typeof setTimeout> | null,
+			settleTimer: null as ReturnType<typeof setTimeout> | null,
+			pluginCtx: null as unknown as PluginContext,
+		};
+	},
+
+	states: {
+		idle: {
+			on: {
+				POINTER_DOWN: [
+					{ guard: "hasShape", target: "clicked", actions: ["setClicked", "startClickTimer"] },
+				],
+				CREATE_SHAPE: { target: "creating", actions: ["setEditing"] },
+			},
+		},
+
+		clicked: {
+			on: {
+				POINTER_DOWN: [
+					{ guard: "isSameShape", target: "editing", actions: ["setEditing", "enterEdit"] },
+					{
+						guard: "hasShape",
+						target: "clicked",
+						actions: ["setClicked", "startClickTimer"],
+						reenter: true,
+					},
+					{ target: "idle", actions: ["clearClicked"] },
+				],
+				CLICK_TIMEOUT: { target: "idle", actions: ["clearClicked"] },
+			},
+		},
+
+		creating: {
+			entry: ["sendEnterEdit"],
+			on: {
+				ENTER_EDIT: { target: "editing", actions: ["enterEdit"] },
+			},
+		},
+
+		editing: {
+			initial: "settling",
+			states: {
+				settling: {
+					entry: ["startSettleTimer"],
+					on: {
+						EDIT_INPUT: { guard: "isEditingTarget", actions: ["updateSource"] },
+						EDIT_ESCAPE: { guard: "isEditingTarget", target: "idle", actions: ["exitEdit"] },
+						DESELECTED: { target: "idle", actions: ["exitEdit"] },
+						SETTLE_TIMEOUT: { target: "active" },
+						// EDIT_BLUR and OUTSIDE_CLICK are ignored while settling
+					},
+				},
+				active: {
+					on: {
+						EDIT_INPUT: { guard: "isEditingTarget", actions: ["updateSource"] },
+						EDIT_BLUR: { guard: "isEditingTarget", target: "idle", actions: ["exitEdit"] },
+						OUTSIDE_CLICK: { target: "idle", actions: ["exitEdit"] },
+						EDIT_ESCAPE: { guard: "isEditingTarget", target: "idle", actions: ["exitEdit"] },
+						DESELECTED: { target: "idle", actions: ["exitEdit"] },
+					},
+				},
+			},
+		},
+	},
+
+	implementations: {
+		guards: {
+			hasShape({ event }) {
+				return event.shapeId != null;
+			},
+			isSameShape({ context, event }) {
+				return event.shapeId != null && event.shapeId === context.get("clickedShapeId");
+			},
+			isEditingTarget({ context, event }) {
+				return event.id === context.get("editingShapeId");
+			},
+		},
+
+		actions: {
+			setClicked({ context, event, refs }) {
+				const prev = refs.get("clickTimer");
+				if (prev != null) clearTimeout(prev);
+				context.set("clickedShapeId", event.shapeId);
+			},
+
+			startClickTimer({ refs, send }) {
+				const prev = refs.get("clickTimer");
+				if (prev != null) clearTimeout(prev);
+				const timer = setTimeout(() => {
+					send({ type: "CLICK_TIMEOUT" });
+				}, 300);
+				refs.set("clickTimer", timer);
+			},
+
+			clearClicked({ context, refs }) {
+				context.set("clickedShapeId", null);
+				const timer = refs.get("clickTimer");
+				if (timer != null) {
+					clearTimeout(timer);
+					refs.set("clickTimer", null);
+				}
+			},
+
+			setEditing({ context, event }) {
+				context.set("editingShapeId", event.shapeId);
+			},
+
+			enterEdit({ context, refs }) {
+				const id = context.get("editingShapeId");
+				if (!id) return;
+				const pluginCtx = refs.get("pluginCtx");
+				const shape = pluginCtx.store.getShape(id);
+				if (!shape || shape.type !== MARKDOWN_TYPE) return;
+
+				context.set("sourceSnapshot", readMarkdownMeta(shape).source);
+				context.set("heightSnapshot", shape.height);
+				context.set("clickedShapeId", null);
+				const clickTimer = refs.get("clickTimer");
+				if (clickTimer != null) {
+					clearTimeout(clickTimer);
+					refs.set("clickTimer", null);
+				}
+				pluginCtx.store.updateShape(id, metaPatch(shape, { isEditing: true }));
+			},
+
+			startSettleTimer({ refs, send }) {
+				const prev = refs.get("settleTimer");
+				if (prev != null) clearTimeout(prev);
+				const timer = setTimeout(() => {
+					send({ type: "SETTLE_TIMEOUT" });
+				}, 200);
+				refs.set("settleTimer", timer);
+			},
+
+			exitEdit({ context, refs }) {
+				const id = context.get("editingShapeId");
+				if (!id) return;
+				const prevSource = context.get("sourceSnapshot");
+				const prevHeight = context.get("heightSnapshot");
+				const pluginCtx = refs.get("pluginCtx");
+
+				const settleTimer = refs.get("settleTimer");
+				if (settleTimer != null) {
+					clearTimeout(settleTimer);
+					refs.set("settleTimer", null);
+				}
+
+				const shape = pluginCtx.store.getShape(id);
+				if (!shape) {
+					context.set("editingShapeId", null);
+					context.set("sourceSnapshot", null);
+					context.set("heightSnapshot", null);
+					return;
+				}
+
+				// Leave edit mode first so the from/to snapshots below capture the
+				// non-editing meta (isEditing:false) on both sides of the undo step.
+				pluginCtx.store.updateShape(id, metaPatch(shape, { isEditing: false }));
+				const currentShape = pluginCtx.store.getShape(id) ?? shape;
+				const currentSource = readMarkdownMeta(currentShape).source;
+
+				if (currentSource.trim() === "") {
+					pluginCtx.commands.execute(createDeleteShapeCommand(pluginCtx.store, id));
+				} else if (currentSource !== prevSource) {
+					pluginCtx.commands.execute(
+						createUpdateShapeCommand(
+							pluginCtx.store,
+							id,
+							{
+								meta: { source: prevSource ?? "", isEditing: false },
+								height: prevHeight ?? currentShape.height,
+							},
+							{
+								meta: { source: currentSource, isEditing: false },
+								height: currentShape.height,
+							},
+						),
+					);
+				}
+
+				context.set("editingShapeId", null);
+				context.set("sourceSnapshot", null);
+				context.set("heightSnapshot", null);
+			},
+
+			updateSource({ refs, event }) {
+				const id = event.id;
+				if (!id) return;
+				const pluginCtx = refs.get("pluginCtx");
+				const shape = pluginCtx.store.getShape(id);
+				if (!shape) return;
+				const newHeight = Math.max(48, event.scrollHeight);
+				pluginCtx.store.updateShape(id, {
+					...metaPatch(shape, { source: event.source }),
+					height: newHeight,
+				});
+			},
+
+			sendEnterEdit({ send }) {
+				send({ type: "ENTER_EDIT" });
+			},
+		},
+	},
+});
+
+// ── Service Factory ──
+
+export type { MarkdownEvent };
+
+export function createMarkdownEditingService(pluginCtx: PluginContext) {
+	const machine = new VanillaMachine(markdownEditingMachine);
+	machine.refs.set("pluginCtx", pluginCtx);
+	machine.start();
+
+	return {
+		send: machine.send,
+		get context() {
+			return {
+				editingShapeId: machine.context.get("editingShapeId"),
+				sourceSnapshot: machine.context.get("sourceSnapshot"),
+				heightSnapshot: machine.context.get("heightSnapshot"),
+				clickedShapeId: machine.context.get("clickedShapeId"),
+			};
+		},
+		matches: (...values: string[]) => {
+			const state = machine.state.get();
+			return values.some((v) => state === v || state.startsWith(`${v}.`));
+		},
+		stop() {
+			const clickTimer = machine.refs.get("clickTimer");
+			if (clickTimer != null) clearTimeout(clickTimer);
+			const settleTimer = machine.refs.get("settleTimer");
+			if (settleTimer != null) clearTimeout(settleTimer);
+			machine.stop();
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
@@ -13,7 +13,10 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { MARKDOWN_DEFAULT_SIZE, MARKDOWN_MIN_SIZE, MARKDOWN_SHORTCUT } from "./constants.js";
-import { createMarkdownTextHandler } from "./external-content-handler.js";
+import {
+	createMarkdownTableHandler,
+	createMarkdownTextHandler,
+} from "./external-content-handler.js";
 import { createMarkdownEditingService } from "./markdown-editing-machine.js";
 import {
 	MD_BLUR_EVENT,
@@ -181,7 +184,10 @@ export function createMarkdownPlugin(): UsketchPlugin {
 			};
 			window.addEventListener("pointerdown", onWindowPointerDown, true);
 
-			// ── Paste / drop of plain text → markdown shape ──
+			// ── Paste / drop → markdown shape ──
+			// Table handler (order 10) wins for tabular content; plain text falls
+			// through to the catch-all (order 0).
+			const offTableHandler = ctx.externalContent.register(createMarkdownTableHandler());
 			const offExternal = ctx.externalContent.register(createMarkdownTextHandler());
 
 			// The currently-selected single markdown shape, or null. Used by the
@@ -259,6 +265,7 @@ export function createMarkdownPlugin(): UsketchPlugin {
 				window.removeEventListener(MD_MEASURE_EVENT, onMeasure);
 				window.removeEventListener("pointerdown", onWindowPointerDown, true);
 				offEditAction();
+				offTableHandler();
 				offExternal();
 				unsubscribe();
 			};

--- a/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
@@ -1,0 +1,249 @@
+import {
+	type BoundingBox,
+	type CanvasPointerEvent,
+	DEFAULT_STYLE,
+	generateId,
+	type PluginContext,
+	type Point,
+	type ResizeHandle,
+	type ShapeData,
+	type ToolContext,
+	type UsketchPlugin,
+	withRotation,
+} from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { MARKDOWN_DEFAULT_SIZE, MARKDOWN_MIN_SIZE, MARKDOWN_SHORTCUT } from "./constants.js";
+import { createMarkdownEditingService } from "./markdown-editing-machine.js";
+import {
+	MD_BLUR_EVENT,
+	MD_ESCAPE_EVENT,
+	MD_INPUT_EVENT,
+	MD_MEASURE_EVENT,
+	renderMarkdown,
+	SimplifiedMarkdown,
+} from "./render.js";
+import { MARKDOWN_TYPE, type MarkdownShapeData, readMarkdownMeta } from "./types.js";
+
+// ── Shape definition helpers ──
+
+function getBounds(data: ShapeData): BoundingBox {
+	return { x: data.x, y: data.y, width: data.width, height: data.height };
+}
+
+function hitTest(data: ShapeData, point: Point): boolean {
+	return (
+		point.x >= data.x &&
+		point.x <= data.x + data.width &&
+		point.y >= data.y &&
+		point.y <= data.y + data.height
+	);
+}
+
+function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
+	let { x, y, width, height } = data;
+	switch (handle) {
+		case "se":
+			width += delta.x;
+			height += delta.y;
+			break;
+		case "nw":
+			x += delta.x;
+			y += delta.y;
+			width -= delta.x;
+			height -= delta.y;
+			break;
+		case "ne":
+			y += delta.y;
+			width += delta.x;
+			height -= delta.y;
+			break;
+		case "sw":
+			x += delta.x;
+			width -= delta.x;
+			height += delta.y;
+			break;
+		case "e":
+			width += delta.x;
+			break;
+		case "w":
+			x += delta.x;
+			width -= delta.x;
+			break;
+		case "n":
+			y += delta.y;
+			height -= delta.y;
+			break;
+		case "s":
+			height += delta.y;
+			break;
+	}
+	return {
+		...data,
+		x,
+		y,
+		width: Math.max(MARKDOWN_MIN_SIZE.width, width),
+		height: Math.max(MARKDOWN_MIN_SIZE.height, height),
+	};
+}
+
+function createDefault(params: { id: string; x: number; y: number }): MarkdownShapeData {
+	return {
+		id: params.id,
+		type: MARKDOWN_TYPE,
+		x: params.x,
+		y: params.y,
+		width: MARKDOWN_DEFAULT_SIZE.width,
+		height: MARKDOWN_DEFAULT_SIZE.height,
+		style: { ...DEFAULT_STYLE, fill: "transparent", strokeWidth: 0 },
+		meta: { source: "", isEditing: false },
+	};
+}
+
+function serializeForAi(shape: ShapeData): Record<string, unknown> {
+	return { source: readMarkdownMeta(shape).source };
+}
+
+function debugFields(shape: ShapeData): Record<string, unknown> {
+	const { source, isEditing } = readMarkdownMeta(shape);
+	return {
+		source: source.length > 40 ? `${source.slice(0, 40)}…` : source,
+		isEditing,
+	};
+}
+
+function MarkdownIcon() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+			<text
+				x="10"
+				y="14"
+				textAnchor="middle"
+				fontSize="11"
+				fontWeight="bold"
+				fill="currentColor"
+				fontFamily="ui-monospace, monospace"
+			>
+				M↓
+			</text>
+		</svg>
+	);
+}
+
+// ── Plugin ──
+
+export function createMarkdownPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-markdown",
+		name: "Markdown",
+
+		setup(ctx: PluginContext) {
+			const service = createMarkdownEditingService(ctx);
+			const { send, matches, stop: stopMachine } = service;
+
+			// ── Editor CustomEvent listeners (dispatched from render.tsx) ──
+			const onInput = (e: Event) => {
+				const { id, source, scrollHeight } = (e as CustomEvent).detail;
+				send({ type: "EDIT_INPUT", id, source, scrollHeight });
+			};
+			const onBlur = (e: Event) => {
+				const { id } = (e as CustomEvent).detail;
+				requestAnimationFrame(() => send({ type: "EDIT_BLUR", id }));
+			};
+			const onEscape = (e: Event) => {
+				const { id } = (e as CustomEvent).detail;
+				send({ type: "EDIT_ESCAPE", id });
+			};
+			// Auto-fit shape height to rendered content (view mode only). Applied
+			// directly (not via a command) so it never pollutes undo history.
+			const onMeasure = (e: Event) => {
+				const { id, height } = (e as CustomEvent).detail as { id: string; height: number };
+				const shape = ctx.store.getShape(id);
+				if (!shape || shape.type !== MARKDOWN_TYPE) return;
+				if (readMarkdownMeta(shape).isEditing) return;
+				if (height > 0 && Math.abs(shape.height - height) > 1) {
+					ctx.store.updateShape(id, { height });
+				}
+			};
+
+			window.addEventListener(MD_INPUT_EVENT, onInput);
+			window.addEventListener(MD_BLUR_EVENT, onBlur);
+			window.addEventListener(MD_ESCAPE_EVENT, onEscape);
+			window.addEventListener(MD_MEASURE_EVENT, onMeasure);
+
+			// ── Outside-click exits edit mode ──
+			const onWindowPointerDown = (e: PointerEvent) => {
+				if (!matches("editing")) return;
+				const target = e.target instanceof Element ? e.target : (e.target as Node)?.parentElement;
+				if (target?.closest("[data-usketch-md-editor]")) return;
+				send({ type: "OUTSIDE_CLICK" });
+			};
+			window.addEventListener("pointerdown", onWindowPointerDown, true);
+
+			// ── Double-click detection via canvas pointerdown ──
+			const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+				const shapes = ctx.store.getShapes();
+				let hitShapeId: string | null = null;
+				for (const [id, shape] of shapes) {
+					if (shape.type === MARKDOWN_TYPE && hitTest(shape, event.worldPoint)) {
+						hitShapeId = id;
+					}
+				}
+				send({ type: "POINTER_DOWN", shapeId: hitShapeId });
+			});
+
+			// ── Exit edit when the editing shape gets deselected ──
+			const unsubscribe = ctx.store.subscribe(() => {
+				const editingShapeId = service.context.editingShapeId;
+				if (!editingShapeId) return;
+				if (!ctx.store.getSelection().has(editingShapeId)) {
+					send({ type: "DESELECTED" });
+				}
+			});
+
+			// ── Shape registration ──
+			ctx.shapes.register(MARKDOWN_TYPE, {
+				render: renderMarkdown,
+				getBounds,
+				hitTest: withRotation(hitTest),
+				resize,
+				createDefault,
+				renderTarget: "html",
+				minSize: MARKDOWN_MIN_SIZE,
+				simplifiedComponent: SimplifiedMarkdown,
+				serializeForAi,
+				debugFields,
+			});
+
+			// ── Draw tool ──
+			ctx.tools.register("markdown-draw", {
+				icon: MarkdownIcon,
+				cursor: "text",
+				shortcut: MARKDOWN_SHORTCUT,
+				order: 26,
+				onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					const id = generateId();
+					const defaults = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+					const shape = { ...defaults, y: defaults.y - defaults.height / 2 };
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
+					toolCtx.store.setSelection([id]);
+					toolCtx.store.resetToDefaultTool();
+					send({ type: "CREATE_SHAPE", shapeId: id });
+				},
+				onPointerMove() {},
+				onPointerUp() {},
+			});
+
+			// ── Teardown ──
+			return () => {
+				stopMachine();
+				window.removeEventListener(MD_INPUT_EVENT, onInput);
+				window.removeEventListener(MD_BLUR_EVENT, onBlur);
+				window.removeEventListener(MD_ESCAPE_EVENT, onEscape);
+				window.removeEventListener(MD_MEASURE_EVENT, onMeasure);
+				window.removeEventListener("pointerdown", onWindowPointerDown, true);
+				offPointerDown();
+				unsubscribe();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
@@ -13,6 +13,7 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { MARKDOWN_DEFAULT_SIZE, MARKDOWN_MIN_SIZE, MARKDOWN_SHORTCUT } from "./constants.js";
+import { createMarkdownTextHandler } from "./external-content-handler.js";
 import { createMarkdownEditingService } from "./markdown-editing-machine.js";
 import {
 	MD_BLUR_EVENT,
@@ -191,6 +192,9 @@ export function createMarkdownPlugin(): UsketchPlugin {
 				send({ type: "POINTER_DOWN", shapeId: hitShapeId });
 			});
 
+			// ── Paste / drop of plain text → markdown shape ──
+			const offExternal = ctx.externalContent.register(createMarkdownTextHandler());
+
 			// ── Exit edit when the editing shape gets deselected ──
 			const unsubscribe = ctx.store.subscribe(() => {
 				const editingShapeId = service.context.editingShapeId;
@@ -242,6 +246,7 @@ export function createMarkdownPlugin(): UsketchPlugin {
 				window.removeEventListener(MD_MEASURE_EVENT, onMeasure);
 				window.removeEventListener("pointerdown", onWindowPointerDown, true);
 				offPointerDown();
+				offExternal();
 				unsubscribe();
 			};
 		},

--- a/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/plugin.tsx
@@ -23,6 +23,7 @@ import {
 	renderMarkdown,
 	SimplifiedMarkdown,
 } from "./render.js";
+import { markdownSelection } from "./selection-store.js";
 import { MARKDOWN_TYPE, type MarkdownShapeData, readMarkdownMeta } from "./types.js";
 
 // ── Shape definition helpers ──
@@ -180,26 +181,38 @@ export function createMarkdownPlugin(): UsketchPlugin {
 			};
 			window.addEventListener("pointerdown", onWindowPointerDown, true);
 
-			// ── Double-click detection via canvas pointerdown ──
-			const offPointerDown = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
-				const shapes = ctx.store.getShapes();
-				let hitShapeId: string | null = null;
-				for (const [id, shape] of shapes) {
-					if (shape.type === MARKDOWN_TYPE && hitTest(shape, event.worldPoint)) {
-						hitShapeId = id;
-					}
-				}
-				send({ type: "POINTER_DOWN", shapeId: hitShapeId });
-			});
-
 			// ── Paste / drop of plain text → markdown shape ──
 			const offExternal = ctx.externalContent.register(createMarkdownTextHandler());
 
-			// ── Exit edit when the editing shape gets deselected ──
+			// The currently-selected single markdown shape, or null. Used by the
+			// "Edit source" action's isEnabled/run.
+			const selectedMarkdownId = (): string | null => {
+				const sel = ctx.store.getSelection();
+				if (sel.size !== 1) return null;
+				const id = [...sel][0] as string;
+				return ctx.store.getShape(id)?.type === MARKDOWN_TYPE ? id : null;
+			};
+
+			// ── Explicit edit trigger: Control HUD "Edit source" action ──
+			// (Editing is intentionally NOT bound to double-click, so rendered
+			// content interactions stay free.)
+			const offEditAction = ctx.actions.register({
+				id: "markdown:edit",
+				label: "✎ Edit source",
+				group: "Markdown",
+				isEnabled: () => selectedMarkdownId() !== null,
+				run: () => {
+					const id = selectedMarkdownId();
+					if (id) send({ type: "BEGIN_EDIT", shapeId: id });
+				},
+			});
+
+			// ── Track selection (drives content interactivity) + exit edit on deselect ──
+			markdownSelection.set(ctx.store.getSelection());
 			const unsubscribe = ctx.store.subscribe(() => {
+				markdownSelection.set(ctx.store.getSelection());
 				const editingShapeId = service.context.editingShapeId;
-				if (!editingShapeId) return;
-				if (!ctx.store.getSelection().has(editingShapeId)) {
+				if (editingShapeId && !ctx.store.getSelection().has(editingShapeId)) {
 					send({ type: "DESELECTED" });
 				}
 			});
@@ -245,7 +258,7 @@ export function createMarkdownPlugin(): UsketchPlugin {
 				window.removeEventListener(MD_ESCAPE_EVENT, onEscape);
 				window.removeEventListener(MD_MEASURE_EVENT, onMeasure);
 				window.removeEventListener("pointerdown", onWindowPointerDown, true);
-				offPointerDown();
+				offEditAction();
 				offExternal();
 				unsubscribe();
 			};

--- a/plugins/usketch-plugin-shape-markdown/src/render.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/render.tsx
@@ -133,6 +133,10 @@ function MarkdownView({ shape }: { shape: ShapeData }) {
 		<div
 			className="usketch-md"
 			ref={ref}
+			// While selected, keep pointerdown from reaching the canvas select tool
+			// so a drag does native text selection (and link clicks work) instead of
+			// moving/marquee-ing the shape. Unselected shapes stay pass-through.
+			onPointerDown={selected ? (e) => e.stopPropagation() : undefined}
 			style={{
 				width: "100%",
 				boxSizing: "border-box",
@@ -147,7 +151,7 @@ function MarkdownView({ shape }: { shape: ShapeData }) {
 			}}
 		>
 			{source.trim() === "" ? (
-				<span className="usketch-md-empty">（空の Markdown — ダブルクリックで編集）</span>
+				<span className="usketch-md-empty">（空の Markdown — HUD の Edit source で編集）</span>
 			) : (
 				<Markdown
 					remarkPlugins={[remarkGfm]}

--- a/plugins/usketch-plugin-shape-markdown/src/render.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/render.tsx
@@ -1,8 +1,9 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import Markdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
+import { markdownSelection } from "./selection-store.js";
 import { readMarkdownMeta } from "./types.js";
 
 // ── Custom events (plugin.tsx listens on window) ──
@@ -87,11 +88,25 @@ const mdComponents: Components = {
 		// rehype-highlight has already injected token <span>s into children.
 		return <code className={className}>{children}</code>;
 	},
+	// Links open in a new tab; never let a markdown link navigate the whole app.
+	a({ href, children }) {
+		return (
+			<a href={href} target="_blank" rel="noopener noreferrer">
+				{children}
+			</a>
+		);
+	},
 };
 
 function MarkdownView({ shape }: { shape: ShapeData }) {
 	const { source } = readMarkdownMeta(shape);
 	const ref = useRef<HTMLDivElement>(null);
+	// Content is interactive (links, text selection) only while the shape is
+	// selected; unselected shapes stay non-interactive so a click/drag on the
+	// canvas selects & moves the shape.
+	const selected = useSyncExternalStore(markdownSelection.subscribe, () =>
+		markdownSelection.has(shape.id),
+	);
 
 	useEffect(() => {
 		ensureStyles();
@@ -123,8 +138,10 @@ function MarkdownView({ shape }: { shape: ShapeData }) {
 				boxSizing: "border-box",
 				padding: 8,
 				overflow: "hidden",
-				pointerEvents: "none",
-				userSelect: "none",
+				// Selected → interactive content (links clickable, text selectable).
+				// Unselected → transparent to pointers so the canvas handles select/move.
+				pointerEvents: selected ? "auto" : "none",
+				userSelect: selected ? "text" : "none",
 				color: shape.style.stroke,
 				background: shape.style.fill === "transparent" ? "transparent" : shape.style.fill,
 			}}

--- a/plugins/usketch-plugin-shape-markdown/src/render.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/render.tsx
@@ -54,10 +54,14 @@ function MermaidBlock({ code }: { code: string }) {
 				});
 				const id = `usketch-mermaid-${Math.random().toString(36).slice(2)}`;
 				const { svg } = await mermaid.render(id, code);
-				if (!cancelled && ref.current) {
-					ref.current.innerHTML = svg;
-					setError(null);
-				}
+				if (cancelled || !ref.current) return;
+				// Parse the SVG string and adopt the <svg> node rather than assigning
+				// `innerHTML` — avoids a string-HTML sink (CSP / Trusted Types friendly).
+				const parsed = new DOMParser().parseFromString(svg, "image/svg+xml");
+				const svgEl = parsed.querySelector("svg");
+				if (!svgEl) throw new Error("Mermaid produced no <svg>");
+				ref.current.replaceChildren(document.importNode(svgEl, true));
+				setError(null);
 			} catch (e) {
 				if (!cancelled) setError(e instanceof Error ? e.message : "Mermaid render error");
 			}
@@ -133,10 +137,11 @@ function MarkdownView({ shape }: { shape: ShapeData }) {
 		<div
 			className="usketch-md"
 			ref={ref}
-			// When selected: Alt+drag selects text (stop propagation so the canvas
-			// doesn't move the shape); a plain drag moves the shape (bubbles to the
-			// select tool). Links are clickable either way. Unselected shapes stay
-			// pass-through so the canvas handles select/move.
+			// When selected: links are clickable and Alt+drag selects text (stop
+			// propagation so the canvas doesn't move the shape); a plain drag moves
+			// the shape (bubbles to the select tool). When unselected the content is
+			// pass-through (pointerEvents:none) so the canvas handles select/move —
+			// i.e. links are only clickable while the shape is selected.
 			onPointerDown={
 				selected
 					? (e) => {

--- a/plugins/usketch-plugin-shape-markdown/src/render.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/render.tsx
@@ -167,7 +167,10 @@ function MarkdownView({ shape }: { shape: ShapeData }) {
 			) : (
 				<Markdown
 					remarkPlugins={[remarkGfm]}
-					rehypePlugins={[rehypeHighlight]}
+					// ignoreMissing: unsupported languages (incl. our ```mermaid``` blocks,
+					// which highlight.js doesn't know) fall back to plain code instead of
+					// throwing and breaking the whole render.
+					rehypePlugins={[[rehypeHighlight, { ignoreMissing: true }]]}
 					components={mdComponents}
 				>
 					{source}

--- a/plugins/usketch-plugin-shape-markdown/src/render.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/render.tsx
@@ -133,19 +133,31 @@ function MarkdownView({ shape }: { shape: ShapeData }) {
 		<div
 			className="usketch-md"
 			ref={ref}
-			// While selected, keep pointerdown from reaching the canvas select tool
-			// so a drag does native text selection (and link clicks work) instead of
-			// moving/marquee-ing the shape. Unselected shapes stay pass-through.
-			onPointerDown={selected ? (e) => e.stopPropagation() : undefined}
+			// When selected: Alt+drag selects text (stop propagation so the canvas
+			// doesn't move the shape); a plain drag moves the shape (bubbles to the
+			// select tool). Links are clickable either way. Unselected shapes stay
+			// pass-through so the canvas handles select/move.
+			onPointerDown={
+				selected
+					? (e) => {
+							if (e.altKey) {
+								e.currentTarget.style.userSelect = "text";
+								e.stopPropagation();
+							} else {
+								e.currentTarget.style.userSelect = "none";
+							}
+						}
+					: undefined
+			}
 			style={{
 				width: "100%",
 				boxSizing: "border-box",
 				padding: 8,
 				overflow: "hidden",
-				// Selected → interactive content (links clickable, text selectable).
+				// Selected → interactive content (links clickable, Alt+drag text select).
 				// Unselected → transparent to pointers so the canvas handles select/move.
 				pointerEvents: selected ? "auto" : "none",
-				userSelect: selected ? "text" : "none",
+				userSelect: "none",
 				color: shape.style.stroke,
 				background: shape.style.fill === "transparent" ? "transparent" : shape.style.fill,
 			}}

--- a/plugins/usketch-plugin-shape-markdown/src/render.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/render.tsx
@@ -1,0 +1,306 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { useEffect, useRef, useState } from "react";
+import Markdown, { type Components } from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
+import remarkGfm from "remark-gfm";
+import { readMarkdownMeta } from "./types.js";
+
+// ── Custom events (plugin.tsx listens on window) ──
+export const MD_INPUT_EVENT = "usketch:markdown-input";
+export const MD_BLUR_EVENT = "usketch:markdown-blur";
+export const MD_ESCAPE_EVENT = "usketch:markdown-escape";
+export const MD_MEASURE_EVENT = "usketch:markdown-measure";
+
+const STYLE_ID = "usketch-markdown-styles";
+
+/** Inject scoped markdown + highlight.js theme CSS once per document. */
+function ensureStyles(): void {
+	if (typeof document === "undefined") return;
+	if (document.getElementById(STYLE_ID)) return;
+	const el = document.createElement("style");
+	el.id = STYLE_ID;
+	el.textContent = MARKDOWN_CSS;
+	document.head.appendChild(el);
+}
+
+function isDarkTheme(): boolean {
+	if (typeof document === "undefined") return false;
+	const attr = document.documentElement.getAttribute("data-theme");
+	if (attr === "dark") return true;
+	if (attr === "light") return false;
+	return (
+		typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches
+	);
+}
+
+// ── Mermaid block (dynamic import; renders SVG into a ref container) ──
+
+function MermaidBlock({ code }: { code: string }) {
+	const ref = useRef<HTMLDivElement>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		(async () => {
+			try {
+				// Dynamic import keeps the (large) mermaid bundle out of the main chunk.
+				const mermaid = (await import("mermaid")).default;
+				mermaid.initialize({
+					startOnLoad: false,
+					// strict: mermaid sanitizes labels, disables inline HTML & click handlers.
+					securityLevel: "strict",
+					theme: isDarkTheme() ? "dark" : "default",
+				});
+				const id = `usketch-mermaid-${Math.random().toString(36).slice(2)}`;
+				const { svg } = await mermaid.render(id, code);
+				if (!cancelled && ref.current) {
+					ref.current.innerHTML = svg;
+					setError(null);
+				}
+			} catch (e) {
+				if (!cancelled) setError(e instanceof Error ? e.message : "Mermaid render error");
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [code]);
+
+	if (error) {
+		return (
+			<pre className="usketch-md-mermaid-error" title={error}>
+				{`⚠ mermaid: ${error}\n\n${code}`}
+			</pre>
+		);
+	}
+	return <div ref={ref} className="usketch-md-mermaid" role="img" aria-label="mermaid diagram" />;
+}
+
+// ── Rendered (view) mode ──
+
+const mdComponents: Components = {
+	code({ className, children }) {
+		const lang = /language-(\w+)/.exec(className ?? "")?.[1];
+		if (lang === "mermaid") {
+			return <MermaidBlock code={String(children).replace(/\n$/, "")} />;
+		}
+		// rehype-highlight has already injected token <span>s into children.
+		return <code className={className}>{children}</code>;
+	},
+};
+
+function MarkdownView({ shape }: { shape: ShapeData }) {
+	const { source } = readMarkdownMeta(shape);
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		ensureStyles();
+	}, []);
+
+	// Auto-fit the shape height to the rendered content (GFM tables, mermaid
+	// diagrams etc. are usually taller than the raw source). Mermaid renders
+	// asynchronously, so a ResizeObserver catches the late height change.
+	useEffect(() => {
+		const el = ref.current;
+		if (!el || typeof ResizeObserver === "undefined") return;
+		const ro = new ResizeObserver(() => {
+			window.dispatchEvent(
+				new CustomEvent(MD_MEASURE_EVENT, {
+					detail: { id: shape.id, height: el.scrollHeight },
+				}),
+			);
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [shape.id]);
+
+	return (
+		<div
+			className="usketch-md"
+			ref={ref}
+			style={{
+				width: "100%",
+				boxSizing: "border-box",
+				padding: 8,
+				overflow: "hidden",
+				pointerEvents: "none",
+				userSelect: "none",
+				color: shape.style.stroke,
+				background: shape.style.fill === "transparent" ? "transparent" : shape.style.fill,
+			}}
+		>
+			{source.trim() === "" ? (
+				<span className="usketch-md-empty">（空の Markdown — ダブルクリックで編集）</span>
+			) : (
+				<Markdown
+					remarkPlugins={[remarkGfm]}
+					rehypePlugins={[rehypeHighlight]}
+					components={mdComponents}
+				>
+					{source}
+				</Markdown>
+			)}
+		</div>
+	);
+}
+
+// ── Editor (raw markdown) mode ──
+
+function MarkdownEditor({ shape }: { shape: ShapeData }) {
+	const { source } = readMarkdownMeta(shape);
+	const ref = useRef<HTMLTextAreaElement>(null);
+
+	// Focus + place cursor at end once when entering edit mode. The textarea's
+	// own value is uncontrolled after mount so the caret isn't reset on input.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: init once per mount (textarea is uncontrolled afterwards)
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+		el.value = source;
+		autoGrow(el);
+		requestAnimationFrame(() => {
+			el.focus();
+			el.setSelectionRange(el.value.length, el.value.length);
+		});
+	}, []);
+
+	const emitInput = (el: HTMLTextAreaElement) => {
+		autoGrow(el);
+		window.dispatchEvent(
+			new CustomEvent(MD_INPUT_EVENT, {
+				detail: { id: shape.id, source: el.value, scrollHeight: el.scrollHeight },
+			}),
+		);
+	};
+
+	return (
+		<textarea
+			ref={ref}
+			data-usketch-md-editor="1"
+			defaultValue={source}
+			spellCheck={false}
+			onInput={(e) => {
+				if ((e.nativeEvent as InputEvent).isComposing) return;
+				emitInput(e.currentTarget);
+			}}
+			onCompositionEnd={(e) => emitInput(e.currentTarget)}
+			onKeyDown={(e) => {
+				e.stopPropagation();
+				if (e.key === "Escape" && !e.nativeEvent.isComposing) {
+					window.dispatchEvent(new CustomEvent(MD_ESCAPE_EVENT, { detail: { id: shape.id } }));
+				}
+			}}
+			onBlur={() => {
+				window.dispatchEvent(new CustomEvent(MD_BLUR_EVENT, { detail: { id: shape.id } }));
+			}}
+			onPointerDown={(e) => e.stopPropagation()}
+			style={{
+				width: "100%",
+				height: "100%",
+				boxSizing: "border-box",
+				padding: 8,
+				border: "none",
+				outline: "none",
+				resize: "none",
+				background: "var(--bg-input, #1e1e1e)",
+				color: "var(--fg-primary, #eee)",
+				fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+				fontSize: 13,
+				lineHeight: 1.5,
+				cursor: "text",
+				pointerEvents: "auto",
+				userSelect: "auto",
+			}}
+		/>
+	);
+}
+
+function autoGrow(el: HTMLTextAreaElement): void {
+	el.style.height = "auto";
+	el.style.height = `${el.scrollHeight}px`;
+}
+
+// ── Entry point + LOD ──
+
+export function renderMarkdown(shape: ShapeData) {
+	return readMarkdownMeta(shape).isEditing ? (
+		<MarkdownEditor shape={shape} />
+	) : (
+		<MarkdownView shape={shape} />
+	);
+}
+
+/** LOD: first non-empty line, stripped of common markdown markers. */
+export function SimplifiedMarkdown({ shape }: { shape: ShapeData }) {
+	const { source } = readMarkdownMeta(shape);
+	const firstLine =
+		source
+			.split("\n")
+			.map((l) => l.trim())
+			.find((l) => l.length > 0) ?? "";
+	const plain = firstLine.replace(/^#{1,6}\s+/, "").replace(/[*_`>#-]/g, "");
+	return (
+		<div
+			style={{
+				position: "absolute",
+				left: shape.x,
+				top: shape.y,
+				width: shape.width,
+				height: shape.height,
+				padding: 8,
+				boxSizing: "border-box",
+				fontFamily: "system-ui, sans-serif",
+				fontSize: 14,
+				fontWeight: 600,
+				color: shape.style.stroke || "#222",
+				overflow: "hidden",
+				whiteSpace: "nowrap",
+				textOverflow: "ellipsis",
+				pointerEvents: "none",
+			}}
+		>
+			{plain || "Markdown"}
+		</div>
+	);
+}
+
+// ── Scoped CSS (markdown layout + compact highlight.js github theme) ──
+
+const MARKDOWN_CSS = `
+.usketch-md { font-family: system-ui, -apple-system, sans-serif; font-size: 13px; line-height: 1.55; word-break: break-word; }
+.usketch-md > :first-child { margin-top: 0; }
+.usketch-md > :last-child { margin-bottom: 0; }
+.usketch-md h1, .usketch-md h2, .usketch-md h3 { margin: 0.4em 0 0.3em; line-height: 1.25; font-weight: 700; }
+.usketch-md h1 { font-size: 1.6em; } .usketch-md h2 { font-size: 1.35em; } .usketch-md h3 { font-size: 1.15em; }
+.usketch-md p { margin: 0.4em 0; }
+.usketch-md ul, .usketch-md ol { margin: 0.3em 0; padding-left: 1.4em; }
+.usketch-md li { margin: 0.1em 0; }
+.usketch-md a { color: #2563eb; text-decoration: underline; }
+.usketch-md blockquote { margin: 0.4em 0; padding: 0 0.8em; border-left: 3px solid currentColor; opacity: 0.75; }
+.usketch-md table { border-collapse: collapse; margin: 0.4em 0; font-size: 0.95em; }
+.usketch-md th, .usketch-md td { border: 1px solid rgba(128,128,128,0.4); padding: 3px 8px; }
+.usketch-md th { background: rgba(128,128,128,0.15); font-weight: 600; }
+.usketch-md code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.9em; background: rgba(128,128,128,0.15); padding: 1px 4px; border-radius: 3px; }
+.usketch-md pre { margin: 0.4em 0; padding: 8px 10px; border-radius: 6px; overflow-x: auto; background: #f6f8fa; }
+.usketch-md pre code { background: none; padding: 0; }
+.usketch-md input[type="checkbox"] { margin-right: 6px; }
+.usketch-md-empty { opacity: 0.5; font-style: italic; }
+.usketch-md-mermaid { display: flex; justify-content: center; margin: 0.4em 0; }
+.usketch-md-mermaid svg { max-width: 100%; height: auto; }
+.usketch-md-mermaid-error { color: #dc2626; font-size: 0.85em; white-space: pre-wrap; }
+/* highlight.js (github light) */
+.usketch-md .hljs { color: #24292e; }
+.usketch-md .hljs-comment, .usketch-md .hljs-quote { color: #6a737d; }
+.usketch-md .hljs-keyword, .usketch-md .hljs-selector-tag, .usketch-md .hljs-literal, .usketch-md .hljs-type { color: #d73a49; }
+.usketch-md .hljs-string, .usketch-md .hljs-attr, .usketch-md .hljs-regexp, .usketch-md .hljs-addition { color: #032f62; }
+.usketch-md .hljs-number, .usketch-md .hljs-built_in, .usketch-md .hljs-symbol, .usketch-md .hljs-title { color: #005cc5; }
+.usketch-md .hljs-name, .usketch-md .hljs-section, .usketch-md .hljs-attribute { color: #22863a; }
+.usketch-md .hljs-variable, .usketch-md .hljs-template-variable, .usketch-md .hljs-deletion { color: #b31d28; }
+:root[data-theme="dark"] .usketch-md pre { background: #161b22; }
+:root[data-theme="dark"] .usketch-md .hljs { color: #c9d1d9; }
+:root[data-theme="dark"] .usketch-md .hljs-comment, :root[data-theme="dark"] .usketch-md .hljs-quote { color: #8b949e; }
+:root[data-theme="dark"] .usketch-md .hljs-keyword, :root[data-theme="dark"] .usketch-md .hljs-literal, :root[data-theme="dark"] .usketch-md .hljs-type { color: #ff7b72; }
+:root[data-theme="dark"] .usketch-md .hljs-string, :root[data-theme="dark"] .usketch-md .hljs-attr { color: #a5d6ff; }
+:root[data-theme="dark"] .usketch-md .hljs-number, :root[data-theme="dark"] .usketch-md .hljs-built_in, :root[data-theme="dark"] .usketch-md .hljs-title { color: #79c0ff; }
+:root[data-theme="dark"] .usketch-md .hljs-name, :root[data-theme="dark"] .usketch-md .hljs-section { color: #7ee787; }
+`;

--- a/plugins/usketch-plugin-shape-markdown/src/render.tsx
+++ b/plugins/usketch-plugin-shape-markdown/src/render.tsx
@@ -154,6 +154,10 @@ function MarkdownView({ shape }: { shape: ShapeData }) {
 						}
 					: undefined
 			}
+			// Reset the imperative userSelect after an Alt+drag so it doesn't linger
+			// into the next (plain) drag before a re-render clears it.
+			onPointerUp={selected ? (e) => (e.currentTarget.style.userSelect = "none") : undefined}
+			onPointerCancel={selected ? (e) => (e.currentTarget.style.userSelect = "none") : undefined}
 			style={{
 				width: "100%",
 				boxSizing: "border-box",

--- a/plugins/usketch-plugin-shape-markdown/src/selection-store.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/selection-store.ts
@@ -1,0 +1,33 @@
+/**
+ * Tiny observable of "which markdown shapes are currently selected", shared
+ * between the plugin (writer, from `store.subscribe`) and the view renderer
+ * (reader, via `useSyncExternalStore`).
+ *
+ * The view uses this to make rendered content interactive (links / checkboxes)
+ * only while the shape is selected — unselected shapes stay `pointerEvents:none`
+ * so a click selects/moves the shape on the canvas.
+ */
+let selectedIds: ReadonlySet<string> = new Set();
+const listeners = new Set<() => void>();
+
+export const markdownSelection = {
+	/** Replace the selected-id set and notify subscribers (no-op if unchanged). */
+	set(ids: ReadonlySet<string>): void {
+		if (sameSet(ids, selectedIds)) return;
+		selectedIds = new Set(ids);
+		for (const l of listeners) l();
+	},
+	has(id: string): boolean {
+		return selectedIds.has(id);
+	},
+	subscribe(listener: () => void): () => void {
+		listeners.add(listener);
+		return () => listeners.delete(listener);
+	},
+};
+
+function sameSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+	if (a.size !== b.size) return false;
+	for (const v of a) if (!b.has(v)) return false;
+	return true;
+}

--- a/plugins/usketch-plugin-shape-markdown/src/table-paste.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/table-paste.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure helpers to detect tabular clipboard content (HTML `<table>` from
+ * Excel/Google Sheets/web, or delimited TSV/CSV text) and turn it into a GFM
+ * markdown table string. Used by the table external-content handler so a paste
+ * of a spreadsheet selection becomes a rendered markdown table shape.
+ */
+
+/** Cheap check for `match`: does the HTML payload contain a table element? */
+export function htmlHasTable(html: string | null | undefined): boolean {
+	return !!html && /<table[\s>]/i.test(html);
+}
+
+/**
+ * Parse an HTML `<table>` (e.g. Excel / Google Sheets rich clipboard) into a
+ * grid of cell strings. Browser-only (uses DOMParser); returns null otherwise.
+ */
+export function parseHtmlTable(html: string | null | undefined): string[][] | null {
+	if (!html || typeof DOMParser === "undefined") return null;
+	const doc = new DOMParser().parseFromString(html, "text/html");
+	const table = doc.querySelector("table");
+	if (!table) return null;
+	const rows: string[][] = [];
+	for (const tr of Array.from(table.querySelectorAll("tr"))) {
+		const cells = Array.from(tr.querySelectorAll("th,td")).map((c) =>
+			(c.textContent ?? "").trim().replace(/\s+/g, " "),
+		);
+		if (cells.length > 0) rows.push(cells);
+	}
+	return rows.length > 0 ? rows : null;
+}
+
+/**
+ * Parse delimited plain text (TSV preferred, else CSV) into a grid. Conservative
+ * to avoid turning prose into a table: requires ≥2 non-empty lines, ≥2 columns,
+ * the delimiter present on *every* line, and a consistent column count.
+ * (No CSV quote handling — a pragmatic v1 for spreadsheet copies.)
+ */
+export function parseDelimited(text: string | null | undefined): string[][] | null {
+	if (!text) return null;
+	const lines = text.replace(/\r\n?/g, "\n").split("\n");
+	while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+	if (lines.length < 2) return null;
+	if (lines.some((l) => l.trim() === "")) return null;
+
+	const delim = lines.every((l) => l.includes("\t"))
+		? "\t"
+		: lines.every((l) => l.includes(","))
+			? ","
+			: null;
+	if (!delim) return null;
+
+	const rows = lines.map((l) => l.split(delim).map((c) => c.trim()));
+	const cols = rows[0].length;
+	if (cols < 2) return null;
+	if (!rows.every((r) => r.length === cols)) return null;
+	return rows;
+}
+
+/** Render a grid as a GFM table. First row is the header. */
+export function toMarkdownTable(rows: string[][]): string {
+	const cols = Math.max(...rows.map((r) => r.length));
+	const escapeCell = (s: string) => s.replace(/\|/g, "\\|").replace(/\n/g, " ");
+	const pad = (r: string[]) => Array.from({ length: cols }, (_, i) => escapeCell(r[i] ?? ""));
+	const line = (cells: string[]) => `| ${cells.join(" | ")} |`;
+	const header = pad(rows[0]);
+	const sep = header.map(() => "---");
+	const body = rows.slice(1).map(pad);
+	return [line(header), line(sep), ...body.map(line)].join("\n");
+}

--- a/plugins/usketch-plugin-shape-markdown/src/types.ts
+++ b/plugins/usketch-plugin-shape-markdown/src/types.ts
@@ -1,0 +1,30 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Shape type id for the markdown shape. */
+export const MARKDOWN_TYPE = "markdown";
+
+/**
+ * Markdown shape metadata. Shape-specific data lives under `meta` (per the
+ * project convention: prefer `ShapeData<TMeta>` over `extends ShapeData`).
+ *
+ * - `source` — raw Markdown source (edited directly, rendered to GFM on view).
+ * - `isEditing` — transient edit-mode flag the renderer switches on.
+ */
+export interface MarkdownMeta {
+	source: string;
+	isEditing: boolean;
+	// Index signature keeps MarkdownMeta assignable to the store's default
+	// `Record<string, unknown>` meta so store/command calls type-check.
+	[key: string]: unknown;
+}
+
+export type MarkdownShapeData = ShapeData<MarkdownMeta>;
+
+/** Read `meta` with safe defaults (meta is optional / loosely typed on ShapeData). */
+export function readMarkdownMeta(shape: ShapeData): MarkdownMeta {
+	const meta = shape.meta as Partial<MarkdownMeta> | undefined;
+	return {
+		source: typeof meta?.source === "string" ? meta.source : "",
+		isEditing: meta?.isEditing === true,
+	};
+}

--- a/plugins/usketch-plugin-shape-markdown/tsconfig.json
+++ b/plugins/usketch-plugin-shape-markdown/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@edv4h/usketch-plugin-shape-island':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-island
+      '@edv4h/usketch-plugin-shape-markdown':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-shape-markdown
       '@edv4h/usketch-plugin-shape-openui':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-openui
@@ -1688,6 +1691,49 @@ importers:
         specifier: 3.2.7
         version: 3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(tsx@4.21.0)(yaml@2.8.3)
 
+  plugins/usketch-plugin-shape-markdown:
+    dependencies:
+      '@edv4h/usketch-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@zag-js/core':
+        specifier: ^1.37.0
+        version: 1.42.0
+      '@zag-js/vanilla':
+        specifier: ^1.37.0
+        version: 1.42.0
+      mermaid:
+        specifier: ^11.4.0
+        version: 11.16.0
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      react-markdown:
+        specifier: ^9.0.1
+        version: 9.1.0(@types/react@19.2.17)(react@19.2.7)
+      rehype-highlight:
+        specifier: ^7.0.1
+        version: 7.0.2
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 3.2.7
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(tsx@4.21.0)(yaml@2.8.3)
+
   plugins/usketch-plugin-shape-openui:
     dependencies:
       '@edv4h/usketch-shared':
@@ -2130,6 +2176,9 @@ importers:
 
 packages:
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
     hasBin: true
@@ -2423,6 +2472,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
@@ -2481,6 +2533,9 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -3191,6 +3246,12 @@ packages:
       hono: '>=4.11.2'
       zod: ^3.25.0 || ^4.0.0
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -3656,6 +3717,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -4154,6 +4218,99 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -4168,6 +4325,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -4204,6 +4364,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -4222,6 +4385,9 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -4639,6 +4805,14 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
 
@@ -4675,6 +4849,12 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -4727,6 +4907,165 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -4757,6 +5096,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -4810,6 +5152,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -4970,6 +5315,9 @@ packages:
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.49.0:
+    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -5205,6 +5553,9 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -5259,12 +5610,19 @@ packages:
     resolution: {integrity: sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==}
     engines: {node: '>=6'}
 
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
+
   hono@4.12.30:
     resolution: {integrity: sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -5279,6 +5637,10 @@ packages:
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -5300,6 +5662,13 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -5421,6 +5790,13 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
@@ -5432,6 +5808,12 @@ packages:
   kysely@0.29.3:
     resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
     engines: {node: '>=22.0.0'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lib0@0.2.117:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
@@ -5445,6 +5827,9 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
@@ -5453,6 +5838,9 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -5473,6 +5861,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -5549,6 +5942,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -5850,6 +6246,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -5909,6 +6308,12 @@ packages:
     resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -5977,6 +6382,12 @@ packages:
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
+      react: 19.2.7
+
+  react-markdown@9.1.0:
+    resolution: {integrity: sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==}
+    peerDependencies:
+      '@types/react': '>=18'
       react: 19.2.7
 
   react-refresh@0.17.0:
@@ -6065,6 +6476,9 @@ packages:
   rehype-autolink-headings@7.1.0:
     resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
 
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
@@ -6139,6 +6553,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -6146,6 +6563,9 @@ packages:
 
   rou3@0.7.12:
     resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -6157,6 +6577,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -6333,6 +6756,9 @@ packages:
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
@@ -6392,6 +6818,10 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -6588,6 +7018,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -7040,6 +7474,11 @@ packages:
 
 snapshots:
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.7.0
+      tinyexec: 1.2.4
+
   '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@astrojs/language-server': 2.16.11(prettier@3.8.3)(typescript@5.9.3)
@@ -7387,6 +7826,8 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.4':
     optional: true
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@capsizecss/unpack@4.0.1':
     dependencies:
       fontkitten: 1.0.3
@@ -7533,6 +7974,8 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@chevrotain/types@11.1.2': {}
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -7923,6 +8366,14 @@ snapshots:
       hono: 4.12.30
       zod: 4.3.6
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -8270,6 +8721,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
@@ -8702,6 +9157,123 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -8715,6 +9287,8 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -8754,6 +9328,9 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -8771,6 +9348,11 @@ snapshots:
       '@types/node': 25.9.5
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.9.5)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -9282,6 +9864,10 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   common-ancestor-path@1.0.1: {}
 
   content-disposition@1.1.0: {}
@@ -9304,6 +9890,14 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -9357,6 +9951,192 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.21: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -9377,6 +10157,10 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   depd@2.0.0: {}
 
@@ -9419,6 +10203,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -9483,6 +10271,8 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.49.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -9848,6 +10638,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  hachure-fill@0.5.2: {}
+
   has-symbols@1.1.0: {}
 
   hasown@2.0.4:
@@ -9865,7 +10657,7 @@ snapshots:
 
   hast-util-from-parse5@8.0.3:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       devlop: 1.1.0
       hastscript: 9.0.1
@@ -9884,7 +10676,7 @@ snapshots:
 
   hast-util-parse-selector@4.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   hast-util-raw@9.1.0:
     dependencies:
@@ -9906,7 +10698,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       estree-util-attach-comments: 3.0.0
@@ -9959,7 +10751,7 @@ snapshots:
 
   hast-util-to-parse5@8.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       property-information: 7.1.0
@@ -9984,7 +10776,7 @@ snapshots:
 
   hastscript@9.0.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       comma-separated-tokens: 2.0.3
       hast-util-parse-selector: 4.0.0
       property-information: 7.1.0
@@ -9992,9 +10784,13 @@ snapshots:
 
   hex-rgb@4.3.0: {}
 
+  highlight.js@11.11.1: {}
+
   hono@4.12.30: {}
 
   html-escaper@3.0.3: {}
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -10009,6 +10805,10 @@ snapshots:
       toidentifier: 1.0.1
 
   human-id@4.1.3: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -10025,6 +10825,10 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.2.0: {}
 
@@ -10110,11 +10914,21 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
   kysely@0.29.3: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lib0@0.2.117:
     dependencies:
@@ -10129,11 +10943,19 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash-es@4.18.1: {}
+
   lodash.startcase@4.4.0: {}
 
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@11.5.2: {}
 
@@ -10154,6 +10976,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -10247,7 +11071,7 @@ snapshots:
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -10258,7 +11082,7 @@ snapshots:
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
@@ -10285,7 +11109,7 @@ snapshots:
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -10338,6 +11162,30 @@ snapshots:
   merge-descriptors@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -10779,6 +11627,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -10814,6 +11664,13 @@ snapshots:
       playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-value-parser@4.2.0: {}
 
@@ -10872,6 +11729,24 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-markdown@9.1.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.17
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -10970,6 +11845,14 @@ snapshots:
       hast-util-is-element: 3.0.0
       unified: 11.0.5
       unist-util-visit: 5.1.0
+
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
 
   rehype-parse@9.0.1:
     dependencies:
@@ -11099,6 +11982,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
@@ -11132,6 +12017,13 @@ snapshots:
 
   rou3@0.7.12: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -11147,6 +12039,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
 
@@ -11396,6 +12290,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.4.0: {}
+
   supports-color@10.2.2: {}
 
   svgo@4.0.1:
@@ -11443,6 +12339,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-dedent@2.3.0: {}
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
@@ -11598,6 +12496,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  uuid@14.0.1: {}
 
   vary@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1693,9 +1693,6 @@ importers:
 
   plugins/usketch-plugin-shape-markdown:
     dependencies:
-      '@edv4h/usketch-core':
-        specifier: workspace:*
-        version: link:../../packages/core
       '@edv4h/usketch-shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
Closes #666

## 概要

Markdown を整形表示する shape プラグイン `usketch-plugin-shape-markdown` を新設。付箋 / テキストと同じ HTML 描画 shape として、GFM 記法・シンタックスハイライト・Mermaid 図をキャンバス上でレンダリングする。

## 方針（issue の確認事項の結論）

1. Markdown 整形表示 **shape**（ボード全体の import/export は非スコープ）。
2. 編集は **raw Markdown 直接編集**（text/sticky の編集 UX に倣う）。
3. **react-markdown + remark-gfm**（+ rehype-highlight）。`dangerouslySetInnerHTML` 不使用・raw HTML 既定 off で **XSS 安全**。
4. **GFM コア + シンタックスハイライト + Mermaid**（KaTeX は非対応）。

## 変更点

- 新 shape 型 `markdown`：`ShapeData<{ source, isEditing }>` の **meta 方式**（プロジェクト規約に準拠）、`renderTarget: "html"`。
- 表示：react-markdown + remark-gfm（見出し / 装飾 / リスト / リンク / 表 / コードブロック / タスクリスト / 引用）。
- シンタックスハイライト：rehype-highlight（github 風テーマを内蔵注入、light/dark 追従）。
- **Mermaid**：` ```mermaid ` を図として描画。`mermaid` は**動的 import で code-split**（図を含むボードを開いたときだけロード）、`securityLevel: "strict"`、不正構文は生コード＋エラーにフォールバック。
- 編集：raw Markdown を `textarea` で直接編集（ダブルクリック編集 / blur・Esc・外側クリック・選択解除で確定 / undo / 空で削除）。表示は `ResizeObserver` で高さ自動フィット。
- ツール `markdown-draw`（ショートカット `m`）、LOD 簡易表示、AI serialize、Debug HUD の debug fields。
- apps/web の base plugins に登録。

## テスト / 検証

- unit：編集 machine フロー（create→input→escape、meta マージ、undo、空で削除）+ `readMarkdownMeta`（型防御）。全 6 passed。
- `pnpm build`（plugin + web）・`typecheck`・`biome` 緑。web ビルドで mermaid が別チャンクに code-split されることを確認。
- changeset（minor）+ README 追加。

## 非スコープ / 今後

- KaTeX 数式、ボード全体の Markdown import/export。

🤖 Generated with [Claude Code](https://claude.com/claude-code)