### PR TITLE
✨ feat(portal): 画面固定ウィジェットプラグイン（個人＋共有トグル） — closes #709

### DIFF
--- a/.changeset/plugin-portal.md
+++ b/.changeset/plugin-portal.md
@@ -1,0 +1,8 @@
+---
+"@edv4h/usketch-plugin-portal": minor
+---
+
+ポータルプラグイン `usketch-plugin-portal` を追加（issue #709）。任意のシェイプを**画面の固定位置にピン留め**して、pan/zoom に関係なく常時表示できる（picture-in-picture）。既存シェイプの描画定義（`ctx.shapes.get(type).render`）をそのまま再利用するため、タイマー等の**インタラクティブなシェイプはポータル上でもボタン操作が効く**。
+
+- **既定は個人ビュー**（位置/サイズを localStorage に per-user 保存）、パネルの🔒/👥トグルで**全員共有**（共有 `Y.Doc` の `portals` マップ＝既存 DO で同期・永続、サーバ改修不要）に昇格できる。
+- Debug HUD の Controls（group "Portal"）から「選択をポータル」「自分のポータルを全解除」。各パネルはドラッグ移動/リサイズ/共有トグル/クローズ可能。対象シェイプが消えるとポータルも消える。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
 		"@edv4h/usketch-plugin-presentation": "workspace:*",
 		"@edv4h/usketch-plugin-reactions": "workspace:*",
 		"@edv4h/usketch-plugin-spatial-chat": "workspace:*",
+		"@edv4h/usketch-plugin-portal": "workspace:*",
 		"@edv4h/usketch-plugin-spotlight": "workspace:*",
 		"@edv4h/usketch-plugin-timter": "workspace:*",
 		"@edv4h/usketch-plugin-voting": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -20,6 +20,7 @@ import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
 import { createFreePositionPlugin } from "@edv4h/usketch-plugin-free-position";
 import { createLaserPlugin } from "@edv4h/usketch-plugin-laser";
 import { createMarkdownToShapePlugin } from "@edv4h/usketch-plugin-markdown-to-shape";
+import { createPortalPlugin } from "@edv4h/usketch-plugin-portal";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
 import { createPresenceEnhancedPlugin } from "@edv4h/usketch-plugin-presence-enhanced";
 import { createPresentationPlugin } from "@edv4h/usketch-plugin-presentation";
@@ -373,6 +374,16 @@ export function App() {
 		extraPlugins.push(
 			createTimterPlugin({
 				serverClock,
+				userId: userIdRef.current ?? getDevUser()?.id ?? "local",
+			}),
+		);
+
+		// Portal: 任意のシェイプを画面固定でピン。既定は個人（localStorage）、共有トグルで
+		// doc の `portals` マップに載せて全員へ。ローカル/Cloud 共通。
+		extraPlugins.push(
+			createPortalPlugin({
+				doc: syncHandle.doc,
+				boardId,
 				userId: userIdRef.current ?? getDevUser()?.id ?? "local",
 			}),
 		);

--- a/plugins/usketch-plugin-portal/package.json
+++ b/plugins/usketch-plugin-portal/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@edv4h/usketch-plugin-portal",
+	"version": "0.0.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shared": "workspace:*",
+		"yjs": "^13.6.0"
+	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.17",
+		"typescript": "7.0.2",
+		"vitest": "4.1.10"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-portal"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-portal/src/__tests__/portal-store.test.ts
+++ b/plugins/usketch-plugin-portal/src/__tests__/portal-store.test.ts
@@ -86,7 +86,7 @@ describe("createPortalStore", () => {
 });
 
 describe("defaultPortalBox", () => {
-	it("fits bounds into the max box preserving aspect, never upscaling", () => {
+	it("fits bounds into the max box preserving aspect (fit downscales only)", () => {
 		const wide = defaultPortalBox({ width: 800, height: 400 }, 0, 1000);
 		// 800×400 scaled to fit 260×200 → k=0.325 → 260×130 + header
 		expect(wide.w).toBe(260);

--- a/plugins/usketch-plugin-portal/src/__tests__/portal-store.test.ts
+++ b/plugins/usketch-plugin-portal/src/__tests__/portal-store.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import * as Y from "yjs";
+import { createPortalStore, defaultPortalBox } from "../portal-store.js";
+
+function memStorage() {
+	const m = new Map<string, string>();
+	return {
+		store: {
+			getItem: (k: string) => m.get(k) ?? null,
+			setItem: (k: string, v: string) => void m.set(k, v),
+		},
+		raw: m,
+	};
+}
+
+const box = { x: 10, y: 20, w: 200, h: 150 };
+
+describe("createPortalStore", () => {
+	it("adds/removes private portals and persists to storage", () => {
+		const { store: storage, raw } = memStorage();
+		const doc = new Y.Doc();
+		const s = createPortalStore({ doc, userId: "u1", boardId: "b1", storage });
+
+		const e = s.add("shape-1", box);
+		expect(s.getAll()).toHaveLength(1);
+		expect(s.getAll()[0]).toMatchObject({ shared: false, entry: { shapeId: "shape-1", x: 10 } });
+		// persisted under the per-user key
+		expect(raw.get("usketch:portals:b1:u1")).toContain("shape-1");
+
+		s.remove(e.id);
+		expect(s.getAll()).toHaveLength(0);
+	});
+
+	it("reloads private portals from storage", () => {
+		const { store: storage } = memStorage();
+		const doc = new Y.Doc();
+		createPortalStore({ doc, userId: "u1", storage }).add("shape-x", box);
+		// A fresh store over the same storage sees the persisted portal.
+		const s2 = createPortalStore({ doc: new Y.Doc(), userId: "u1", storage });
+		expect(s2.getAll().map((it) => it.entry.shapeId)).toEqual(["shape-x"]);
+	});
+
+	it("update mutates position/size", () => {
+		const s = createPortalStore({ doc: new Y.Doc(), userId: "u", storage: memStorage().store });
+		const e = s.add("s", box);
+		s.update(e.id, { x: 99, w: 300 });
+		expect(s.getAll()[0].entry).toMatchObject({ x: 99, w: 300, y: 20 });
+	});
+
+	it("setShared moves an entry between private and the shared Y.Map (keeping id)", () => {
+		const doc = new Y.Doc();
+		const s = createPortalStore({ doc, userId: "u", boardId: "b", storage: memStorage().store });
+		const e = s.add("s", box);
+		expect(doc.getMap("portals").size).toBe(0);
+
+		s.setShared(e.id, true);
+		expect(doc.getMap("portals").has(e.id)).toBe(true);
+		expect(s.getAll()).toHaveLength(1);
+		expect(s.getAll()[0].shared).toBe(true);
+
+		s.setShared(e.id, false);
+		expect(doc.getMap("portals").has(e.id)).toBe(false);
+		expect(s.getAll()[0].shared).toBe(false);
+	});
+
+	it("reflects remote shared portals via observe", () => {
+		const doc = new Y.Doc();
+		const s = createPortalStore({ doc, userId: "u", storage: memStorage().store });
+		let notified = 0;
+		s.subscribe(() => notified++);
+		// Simulate a remote client writing into the shared map.
+		doc.getMap("portals").set("p1", { id: "p1", shapeId: "s9", x: 0, y: 0, w: 100, h: 100 });
+		expect(notified).toBeGreaterThan(0);
+		expect(s.getAll().find((it) => it.entry.id === "p1")?.shared).toBe(true);
+	});
+
+	it("clearPrivate removes only private portals", () => {
+		const doc = new Y.Doc();
+		const s = createPortalStore({ doc, userId: "u", storage: memStorage().store });
+		const a = s.add("a", box);
+		s.add("b", box);
+		s.setShared(a.id, true); // a → shared
+		s.clearPrivate();
+		expect(s.getAll().map((it) => it.entry.shapeId)).toEqual(["a"]); // only the shared one remains
+	});
+});
+
+describe("defaultPortalBox", () => {
+	it("fits bounds into the max box preserving aspect, never upscaling", () => {
+		const wide = defaultPortalBox({ width: 800, height: 400 }, 0, 1000);
+		// 800×400 scaled to fit 260×200 → k=0.325 → 260×130 + header
+		expect(wide.w).toBe(260);
+		expect(wide.h).toBe(130 + 30);
+	});
+
+	it("cascades from the top-right by index", () => {
+		const a = defaultPortalBox({ width: 100, height: 100 }, 0, 1000);
+		const b = defaultPortalBox({ width: 100, height: 100 }, 1, 1000);
+		expect(b.x).toBeLessThan(a.x);
+		expect(b.y).toBeGreaterThan(a.y);
+	});
+});

--- a/plugins/usketch-plugin-portal/src/index.ts
+++ b/plugins/usketch-plugin-portal/src/index.ts
@@ -1,0 +1,8 @@
+export { createPortalPlugin, type PortalPluginOptions } from "./plugin.js";
+export {
+	createPortalStore,
+	defaultPortalBox,
+	type PortalEntry,
+	type PortalItem,
+	type PortalStore,
+} from "./portal-store.js";

--- a/plugins/usketch-plugin-portal/src/plugin.tsx
+++ b/plugins/usketch-plugin-portal/src/plugin.tsx
@@ -1,0 +1,90 @@
+import type { BoundingBox, PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import type * as Y from "yjs";
+import { PortalLayer } from "./portal-layer.js";
+import { createPortalStore, defaultPortalBox } from "./portal-store.js";
+
+export interface PortalPluginOptions {
+	/** Shared Yjs doc — shared portals live in its `portals` map. */
+	doc: Y.Doc;
+	/** For the per-user localStorage key. */
+	boardId?: string;
+	/** For the per-user localStorage key. Defaults to "local". */
+	userId?: string;
+}
+
+const LAYER_ID = "portal";
+
+/**
+ * "Portal" — pin any shape to a fixed on-screen panel that stays visible through
+ * pan/zoom (picture-in-picture). Portals are per-user by default (localStorage)
+ * and can be toggled to shared (a `portals` Y.Map, synced to everyone). The panel
+ * re-renders the shape via its registered definition, so interactive shapes (e.g.
+ * the timer) remain operable inside the portal.
+ */
+export function createPortalPlugin(options: PortalPluginOptions): UsketchPlugin {
+	return {
+		id: "usketch-plugin-portal",
+		name: "ポータル",
+
+		setup(ctx: PluginContext) {
+			const store = createPortalStore({
+				doc: options.doc,
+				userId: options.userId ?? "local",
+				boardId: options.boardId,
+			});
+
+			ctx.layers.register({
+				id: LAYER_ID,
+				order: 150,
+				fixed: true,
+				render: () => <PortalLayer portalStore={store} store={ctx.store} shapes={ctx.shapes} />,
+			});
+			ctx.events.emit("layers:changed", {});
+
+			const boundsOf = (shapeId: string): BoundingBox | null => {
+				const shape = ctx.store.getShape(shapeId);
+				if (!shape) return null;
+				const def = ctx.shapes.get(shape.type);
+				return def
+					? def.getBounds(shape)
+					: { x: shape.x, y: shape.y, width: shape.width, height: shape.height };
+			};
+
+			const offActions = [
+				ctx.actions.register({
+					id: "portal:pin-selected",
+					label: "📌 選択をポータル",
+					group: "Portal",
+					order: 0,
+					isEnabled: () => ctx.store.getSelection().size >= 1,
+					run: () => {
+						const already = new Set(store.getAll().map((it) => it.entry.shapeId));
+						let i = 0;
+						for (const id of ctx.store.getSelection()) {
+							if (already.has(id)) continue;
+							const bounds = boundsOf(id);
+							if (!bounds) continue;
+							store.add(id, defaultPortalBox(bounds, i));
+							i++;
+						}
+					},
+				}),
+				ctx.actions.register({
+					id: "portal:clear-mine",
+					label: "✕ 自分のポータルを全解除",
+					group: "Portal",
+					order: 1,
+					isEnabled: () => store.getAll().some((it) => !it.shared),
+					run: () => store.clearPrivate(),
+				}),
+			];
+
+			return () => {
+				for (const off of offActions) off();
+				ctx.layers.unregister(LAYER_ID);
+				ctx.events.emit("layers:changed", {});
+				store.destroy();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-portal/src/portal-layer.tsx
+++ b/plugins/usketch-plugin-portal/src/portal-layer.tsx
@@ -116,8 +116,11 @@ function PortalPanel({
 		const ow = entry.w;
 		const oh = entry.h;
 		trackPointer((ev) => {
-			const w = clamp(ow + ev.clientX - sx, 140, window.innerWidth - entry.x);
-			const h = clamp(oh + ev.clientY - sy, 100, window.innerHeight - entry.y);
+			// Guard max ≥ min: near the right/bottom edge the available space can be
+			// smaller than the min, in which case clamp(min, max<min) would return min
+			// and push the panel off-screen.
+			const w = clamp(ow + ev.clientX - sx, 140, Math.max(140, window.innerWidth - entry.x));
+			const h = clamp(oh + ev.clientY - sy, 100, Math.max(100, window.innerHeight - entry.y));
 			onUpdate(entry.id, { w, h });
 		});
 	};
@@ -173,6 +176,7 @@ function PortalPanel({
 				<button
 					type="button"
 					title={shared ? "全員に共有中（クリックで個人に戻す）" : "個人（クリックで全員に共有）"}
+					onPointerDown={(e) => e.stopPropagation()}
 					onClick={() => onToggleShared(entry.id, !shared)}
 					style={headerBtn}
 				>
@@ -181,6 +185,7 @@ function PortalPanel({
 				<button
 					type="button"
 					title="閉じる"
+					onPointerDown={(e) => e.stopPropagation()}
 					onClick={() => onRemove(entry.id)}
 					style={{ ...headerBtn, color: "#9ca3af" }}
 				>

--- a/plugins/usketch-plugin-portal/src/portal-layer.tsx
+++ b/plugins/usketch-plugin-portal/src/portal-layer.tsx
@@ -13,6 +13,24 @@ const stopCanvas = {
 
 const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
 
+/**
+ * Track a pointer drag on `window` until it ends. Cleans up on pointerup AND on
+ * pointercancel / window blur, so an interrupted gesture (OS gesture, lost
+ * capture, focus loss) never leaves listeners stuck updating the panel.
+ */
+function trackPointer(onMove: (ev: PointerEvent) => void): void {
+	const end = () => {
+		window.removeEventListener("pointermove", onMove);
+		window.removeEventListener("pointerup", end);
+		window.removeEventListener("pointercancel", end);
+		window.removeEventListener("blur", end);
+	};
+	window.addEventListener("pointermove", onMove);
+	window.addEventListener("pointerup", end);
+	window.addEventListener("pointercancel", end);
+	window.addEventListener("blur", end);
+}
+
 function ShapeContent({
 	def,
 	shape,
@@ -83,17 +101,11 @@ function PortalPanel({
 		const sy = e.clientY;
 		const ox = entry.x;
 		const oy = entry.y;
-		const move = (ev: PointerEvent) => {
+		trackPointer((ev) => {
 			const x = clamp(ox + ev.clientX - sx, 0, window.innerWidth - entry.w);
 			const y = clamp(oy + ev.clientY - sy, 0, window.innerHeight - entry.h);
 			onUpdate(entry.id, { x, y });
-		};
-		const up = () => {
-			window.removeEventListener("pointermove", move);
-			window.removeEventListener("pointerup", up);
-		};
-		window.addEventListener("pointermove", move);
-		window.addEventListener("pointerup", up);
+		});
 	};
 
 	const startResize = (e: React.PointerEvent) => {
@@ -103,17 +115,11 @@ function PortalPanel({
 		const sy = e.clientY;
 		const ow = entry.w;
 		const oh = entry.h;
-		const move = (ev: PointerEvent) => {
+		trackPointer((ev) => {
 			const w = clamp(ow + ev.clientX - sx, 140, window.innerWidth - entry.x);
 			const h = clamp(oh + ev.clientY - sy, 100, window.innerHeight - entry.y);
 			onUpdate(entry.id, { w, h });
-		};
-		const up = () => {
-			window.removeEventListener("pointermove", move);
-			window.removeEventListener("pointerup", up);
-		};
-		window.addEventListener("pointermove", move);
-		window.addEventListener("pointerup", up);
+		});
 	};
 
 	return (

--- a/plugins/usketch-plugin-portal/src/portal-layer.tsx
+++ b/plugins/usketch-plugin-portal/src/portal-layer.tsx
@@ -1,0 +1,256 @@
+import type { BoardStore, BoundingBox, ShapeData, ShapeRegistry } from "@edv4h/usketch-shared";
+import { useEffect, useReducer, useSyncExternalStore } from "react";
+import { PORTAL_HEADER_H, type PortalEntry, type PortalStore } from "./portal-store.js";
+
+// Keep panel pointer/click/wheel from reaching the canvas (which would pan/select).
+// Children (e.g. a timer shape's buttons) still receive their events at the target
+// first, so they keep working; this only stops bubbling up to the canvas.
+const stopCanvas = {
+	onPointerDown: (e: React.PointerEvent) => e.stopPropagation(),
+	onWheel: (e: React.WheelEvent) => e.stopPropagation(),
+	onContextMenu: (e: React.MouseEvent) => e.stopPropagation(),
+} as const;
+
+const clamp = (v: number, min: number, max: number) => Math.max(min, Math.min(max, v));
+
+function ShapeContent({
+	def,
+	shape,
+	bodyW,
+	bodyH,
+}: {
+	def: ReturnType<ShapeRegistry["get"]>;
+	shape: ShapeData;
+	bodyW: number;
+	bodyH: number;
+}) {
+	if (!def) return null;
+	const b: BoundingBox = def.getBounds(shape);
+	if (def.renderTarget === "html") {
+		const k = Math.min(bodyW / Math.max(1, b.width), bodyH / Math.max(1, b.height));
+		return (
+			<div style={{ width: bodyW, height: bodyH, overflow: "hidden", position: "relative" }}>
+				<div
+					style={{
+						width: b.width,
+						height: b.height,
+						transform: `scale(${k})`,
+						transformOrigin: "top left",
+					}}
+				>
+					{def.render(shape)}
+				</div>
+			</div>
+		);
+	}
+	// SVG (default): viewBox does the world→box fit for us.
+	return (
+		<svg
+			width={bodyW}
+			height={bodyH}
+			viewBox={`${b.x} ${b.y} ${b.width} ${b.height}`}
+			preserveAspectRatio="xMidYMid meet"
+			aria-label="portal shape"
+		>
+			{def.render(shape)}
+		</svg>
+	);
+}
+
+function PortalPanel({
+	entry,
+	shared,
+	shape,
+	def,
+	onUpdate,
+	onRemove,
+	onToggleShared,
+}: {
+	entry: PortalEntry;
+	shared: boolean;
+	shape: ShapeData;
+	def: ReturnType<ShapeRegistry["get"]>;
+	onUpdate: (id: string, patch: Partial<Pick<PortalEntry, "x" | "y" | "w" | "h">>) => void;
+	onRemove: (id: string) => void;
+	onToggleShared: (id: string, shared: boolean) => void;
+}) {
+	const bodyH = Math.max(0, entry.h - PORTAL_HEADER_H);
+
+	const startDrag = (e: React.PointerEvent) => {
+		e.stopPropagation();
+		e.preventDefault();
+		const sx = e.clientX;
+		const sy = e.clientY;
+		const ox = entry.x;
+		const oy = entry.y;
+		const move = (ev: PointerEvent) => {
+			const x = clamp(ox + ev.clientX - sx, 0, window.innerWidth - entry.w);
+			const y = clamp(oy + ev.clientY - sy, 0, window.innerHeight - entry.h);
+			onUpdate(entry.id, { x, y });
+		};
+		const up = () => {
+			window.removeEventListener("pointermove", move);
+			window.removeEventListener("pointerup", up);
+		};
+		window.addEventListener("pointermove", move);
+		window.addEventListener("pointerup", up);
+	};
+
+	const startResize = (e: React.PointerEvent) => {
+		e.stopPropagation();
+		e.preventDefault();
+		const sx = e.clientX;
+		const sy = e.clientY;
+		const ow = entry.w;
+		const oh = entry.h;
+		const move = (ev: PointerEvent) => {
+			const w = clamp(ow + ev.clientX - sx, 140, window.innerWidth - entry.x);
+			const h = clamp(oh + ev.clientY - sy, 100, window.innerHeight - entry.y);
+			onUpdate(entry.id, { w, h });
+		};
+		const up = () => {
+			window.removeEventListener("pointermove", move);
+			window.removeEventListener("pointerup", up);
+		};
+		window.addEventListener("pointermove", move);
+		window.addEventListener("pointerup", up);
+	};
+
+	return (
+		<div
+			{...stopCanvas}
+			style={{
+				position: "fixed",
+				left: entry.x,
+				top: entry.y,
+				width: entry.w,
+				height: entry.h,
+				display: "flex",
+				flexDirection: "column",
+				background: "#fff",
+				border: "1px solid #d1d5db",
+				borderRadius: 8,
+				boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
+				overflow: "hidden",
+				pointerEvents: "auto",
+				fontFamily: "system-ui, sans-serif",
+			}}
+		>
+			<div
+				onPointerDown={startDrag}
+				style={{
+					height: PORTAL_HEADER_H,
+					flex: "0 0 auto",
+					display: "flex",
+					alignItems: "center",
+					gap: 4,
+					padding: "0 6px",
+					background: "#f3f4f6",
+					borderBottom: "1px solid #e5e7eb",
+					cursor: "move",
+					userSelect: "none",
+				}}
+			>
+				<span
+					style={{
+						flex: 1,
+						fontSize: 11,
+						fontWeight: 600,
+						color: "#374151",
+						whiteSpace: "nowrap",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+					}}
+				>
+					{(shape as { label?: string }).label || shape.type}
+				</span>
+				<button
+					type="button"
+					title={shared ? "全員に共有中（クリックで個人に戻す）" : "個人（クリックで全員に共有）"}
+					onClick={() => onToggleShared(entry.id, !shared)}
+					style={headerBtn}
+				>
+					{shared ? "👥" : "🔒"}
+				</button>
+				<button
+					type="button"
+					title="閉じる"
+					onClick={() => onRemove(entry.id)}
+					style={{ ...headerBtn, color: "#9ca3af" }}
+				>
+					✕
+				</button>
+			</div>
+
+			<div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+				<ShapeContent def={def} shape={shape} bodyW={entry.w} bodyH={bodyH} />
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: resize grip */}
+				<div
+					onPointerDown={startResize}
+					style={{
+						position: "absolute",
+						right: 0,
+						bottom: 0,
+						width: 14,
+						height: 14,
+						cursor: "nwse-resize",
+						background:
+							"linear-gradient(135deg, transparent 50%, rgba(0,0,0,0.25) 50%, rgba(0,0,0,0.25) 60%, transparent 60%)",
+					}}
+				/>
+			</div>
+		</div>
+	);
+}
+
+const headerBtn: React.CSSProperties = {
+	border: "none",
+	background: "transparent",
+	cursor: "pointer",
+	fontSize: 13,
+	lineHeight: 1,
+	padding: 2,
+};
+
+export function PortalLayer({
+	portalStore,
+	store,
+	shapes,
+}: {
+	portalStore: PortalStore;
+	store: BoardStore;
+	shapes: ShapeRegistry;
+}) {
+	const items = useSyncExternalStore(portalStore.subscribe, portalStore.getAll);
+	// Re-render on any store mutation so pinned shapes reflect edits.
+	const [, tick] = useReducer((n: number) => n + 1, 0);
+	useEffect(() => store.subscribe(tick), [store]);
+
+	// Drop portals whose target shape no longer exists.
+	useEffect(() => {
+		for (const { entry } of items) {
+			if (!store.getShape(entry.shapeId)) portalStore.remove(entry.id);
+		}
+	}, [items, store, portalStore]);
+
+	return (
+		<>
+			{items.map(({ entry, shared }) => {
+				const shape = store.getShape(entry.shapeId);
+				if (!shape) return null;
+				return (
+					<PortalPanel
+						key={entry.id}
+						entry={entry}
+						shared={shared}
+						shape={shape}
+						def={shapes.get(shape.type)}
+						onUpdate={portalStore.update}
+						onRemove={portalStore.remove}
+						onToggleShared={portalStore.setShared}
+					/>
+				);
+			})}
+		</>
+	);
+}

--- a/plugins/usketch-plugin-portal/src/portal-store.ts
+++ b/plugins/usketch-plugin-portal/src/portal-store.ts
@@ -1,0 +1,217 @@
+import { generateId } from "@edv4h/usketch-shared";
+import type * as Y from "yjs";
+
+/** A pinned widget: which shape, and where/how big on screen (screen px). */
+export interface PortalEntry {
+	id: string;
+	shapeId: string;
+	x: number;
+	y: number;
+	w: number;
+	h: number;
+}
+
+/** A portal plus whether it lives in the shared (everyone) or private (me) backend. */
+export interface PortalItem {
+	entry: PortalEntry;
+	shared: boolean;
+}
+
+export interface PortalBox {
+	x: number;
+	y: number;
+	w: number;
+	h: number;
+}
+
+export interface PortalStore {
+	/** All portals (private + shared), stable reference until the next change. */
+	getAll(): PortalItem[];
+	/** Pin a shape (private by default). Returns the created entry. */
+	add(shapeId: string, box: PortalBox, shared?: boolean): PortalEntry;
+	/** Move/resize a portal (screen px). */
+	update(id: string, patch: Partial<PortalBox>): void;
+	remove(id: string): void;
+	/** Move a portal between the private and shared backends (keeps its id). */
+	setShared(id: string, shared: boolean): void;
+	/** Remove all of this user's private portals. */
+	clearPrivate(): void;
+	subscribe(cb: () => void): () => void;
+	destroy(): void;
+}
+
+type MinimalStorage = Pick<Storage, "getItem" | "setItem">;
+
+function storageKey(boardId: string | undefined, userId: string): string {
+	return `usketch:portals:${boardId ?? "local"}:${userId}`;
+}
+
+/** localStorage may be unavailable (SSR / node tests / privacy mode) → in-memory fallback. */
+function safeStorage(): MinimalStorage | null {
+	try {
+		if (typeof localStorage === "undefined") return null;
+		return localStorage;
+	} catch {
+		return null;
+	}
+}
+
+export interface CreatePortalStoreOptions {
+	/** Shared Yjs doc — shared portals live in its `portals` map. */
+	doc: Y.Doc;
+	userId: string;
+	boardId?: string;
+	/** Injectable storage (tests). Defaults to `localStorage` when available. */
+	storage?: MinimalStorage | null;
+}
+
+/** Portal panel header height (px) — shared with the layer for body sizing. */
+export const PORTAL_HEADER_H = 30;
+const MAX_W = 260;
+const MAX_H = 200;
+const MIN_W = 140;
+const MIN_H = 100;
+
+/**
+ * Default panel box for a freshly pinned shape: fit its bounds into MAX_W×MAX_H
+ * preserving aspect (never upscaling), add header height, and cascade from the
+ * top-right corner by `index` so multiple pins don't stack exactly.
+ */
+export function defaultPortalBox(
+	bounds: { width: number; height: number },
+	index: number,
+	viewportWidth = typeof window !== "undefined" ? window.innerWidth : 1200,
+): PortalBox {
+	const k = Math.min(MAX_W / Math.max(1, bounds.width), MAX_H / Math.max(1, bounds.height), 1);
+	const w = Math.max(MIN_W, Math.round(bounds.width * k));
+	const h = Math.max(MIN_H, Math.round(bounds.height * k)) + PORTAL_HEADER_H;
+	const margin = 16;
+	const step = 28;
+	const x = Math.max(margin, viewportWidth - w - margin - index * step);
+	const y = margin + index * step;
+	return { x, y, w, h };
+}
+
+export function createPortalStore(options: CreatePortalStoreOptions): PortalStore {
+	const { doc, userId, boardId } = options;
+	const storage = options.storage !== undefined ? options.storage : safeStorage();
+	const key = storageKey(boardId, userId);
+	const sharedMap = doc.getMap<PortalEntry>("portals");
+	const listeners = new Set<() => void>();
+
+	let priv: PortalEntry[] = loadPrivate();
+
+	function loadPrivate(): PortalEntry[] {
+		if (!storage) return [];
+		try {
+			const raw = storage.getItem(key);
+			const parsed = raw ? JSON.parse(raw) : null;
+			return Array.isArray(parsed) ? (parsed as PortalEntry[]) : [];
+		} catch {
+			return [];
+		}
+	}
+
+	function persistPrivate() {
+		if (!storage) return;
+		try {
+			storage.setItem(key, JSON.stringify(priv));
+		} catch {
+			// quota / disabled — keep in-memory copy only
+		}
+	}
+
+	function computeSnapshot(): PortalItem[] {
+		const shared: PortalItem[] = [];
+		sharedMap.forEach((entry) => {
+			if (entry) shared.push({ entry, shared: true });
+		});
+		const mine: PortalItem[] = priv.map((entry) => ({ entry, shared: false }));
+		return [...mine, ...shared].sort((a, b) => a.entry.id.localeCompare(b.entry.id));
+	}
+
+	let snapshot = computeSnapshot();
+
+	function refresh() {
+		snapshot = computeSnapshot();
+		for (const cb of listeners) cb();
+	}
+
+	const observer = () => refresh();
+	sharedMap.observe(observer);
+
+	const findPrivate = (id: string) => priv.find((e) => e.id === id);
+
+	return {
+		getAll: () => snapshot,
+
+		add(shapeId, box, shared = false) {
+			const entry: PortalEntry = { id: generateId(), shapeId, ...box };
+			if (shared) {
+				sharedMap.set(entry.id, entry); // observe → refresh
+			} else {
+				priv = [...priv, entry];
+				persistPrivate();
+				refresh();
+			}
+			return entry;
+		},
+
+		update(id, patch) {
+			const p = findPrivate(id);
+			if (p) {
+				priv = priv.map((e) => (e.id === id ? { ...e, ...patch } : e));
+				persistPrivate();
+				refresh();
+				return;
+			}
+			const s = sharedMap.get(id);
+			if (s) sharedMap.set(id, { ...s, ...patch }); // observe → refresh
+		},
+
+		remove(id) {
+			if (findPrivate(id)) {
+				priv = priv.filter((e) => e.id !== id);
+				persistPrivate();
+				refresh();
+				return;
+			}
+			if (sharedMap.has(id)) sharedMap.delete(id);
+		},
+
+		setShared(id, shared) {
+			if (shared) {
+				const p = findPrivate(id);
+				if (!p) return;
+				priv = priv.filter((e) => e.id !== id);
+				persistPrivate();
+				sharedMap.set(id, p); // observe → refresh (also covers the private removal)
+				refresh();
+			} else {
+				const s = sharedMap.get(id);
+				if (!s) return;
+				sharedMap.delete(id);
+				priv = [...priv, s];
+				persistPrivate();
+				refresh();
+			}
+		},
+
+		clearPrivate() {
+			if (priv.length === 0) return;
+			priv = [];
+			persistPrivate();
+			refresh();
+		},
+
+		subscribe(cb) {
+			listeners.add(cb);
+			return () => listeners.delete(cb);
+		},
+
+		destroy() {
+			sharedMap.unobserve(observer);
+			listeners.clear();
+		},
+	};
+}

--- a/plugins/usketch-plugin-portal/src/portal-store.ts
+++ b/plugins/usketch-plugin-portal/src/portal-store.ts
@@ -74,8 +74,10 @@ const MIN_H = 100;
 
 /**
  * Default panel box for a freshly pinned shape: fit its bounds into MAX_W×MAX_H
- * preserving aspect (never upscaling), add header height, and cascade from the
- * top-right corner by `index` so multiple pins don't stack exactly.
+ * preserving aspect — the fit itself only downscales (`k ≤ 1`) — then apply a
+ * MIN_W/MIN_H floor (which may enlarge the panel for very small shapes; the
+ * renderer scales content to fill). Header height is added and the box cascades
+ * from the top-right corner by `index` so multiple pins don't stack exactly.
  */
 export function defaultPortalBox(
 	bounds: { width: number; height: number },
@@ -180,20 +182,22 @@ export function createPortalStore(options: CreatePortalStoreOptions): PortalStor
 		},
 
 		setShared(id, shared) {
+			// In both directions we mutate the *other* backend first (silently), then
+			// touch the Y.Map last so its observer fires exactly one refresh over an
+			// already-consistent state — no double-notify, no transient frame where
+			// the portal is missing or duplicated.
 			if (shared) {
 				const p = findPrivate(id);
 				if (!p) return;
 				priv = priv.filter((e) => e.id !== id);
 				persistPrivate();
-				sharedMap.set(id, p); // observe → refresh (also covers the private removal)
-				refresh();
+				sharedMap.set(id, p); // observer → single refresh
 			} else {
 				const s = sharedMap.get(id);
 				if (!s) return;
-				sharedMap.delete(id);
 				priv = [...priv, s];
 				persistPrivate();
-				refresh();
+				sharedMap.delete(id); // observer → single refresh
 			}
 		},
 

--- a/plugins/usketch-plugin-portal/tsconfig.json
+++ b/plugins/usketch-plugin-portal/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
       '@edv4h/usketch-plugin-markdown-to-shape':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-markdown-to-shape
+      '@edv4h/usketch-plugin-portal':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-portal
       '@edv4h/usketch-plugin-presence-cursor':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-presence-cursor
@@ -1230,6 +1233,28 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
     devDependencies:
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  plugins/usketch-plugin-portal:
+    dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+      yjs:
+        specifier: ^13.6.0
+        version: 13.6.31
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
       typescript:
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
Closes #709

## 概要
**任意のシェイプを画面の固定位置にピン留め**して、pan/zoom に関係なく常時表示できる Portal プラグイン（picture-in-picture）。タイマー表示を隅に固定し続ける、といった用途。

## 設計のポイント
- **既存シェイプの描画を再利用**: `ctx.shapes.get(type).render(shape)` をそのまま固定オーバーレイの箱に描画（SVG は `viewBox`、HTML は `transform:scale` でフィット）。→ 汎用（timer/sticky/counter/image…何でもピン可能）、かつ**タイマー等のボタンは window イベント方式なのでポータル上でも操作が効く**。
- **個人＋共有トグル**（ユーザー選択）: 既定は個人（位置/サイズを **localStorage** に per-user 保存、`hand-store` の privacy パターン踏襲）。パネルの 🔒/👥 で**全員共有**（共有 `Y.Doc` の `portals` マップ＝既存 Durable Object が汎用リレー＆永続、**サーバ改修なし**）に昇格。
- **固定レイヤー**（`ctx.layers.register({ fixed:true, order:150 })`）でスクリーン座標描画。canvas への伝播を止めつつ子（シェイプ内ボタン）のクリックは通す。対象シェイプが消えるとポータルも自動除去。

## 操作
- Controls（group "Portal"）: 「📌 選択をポータル」（選択1つ以上で有効）/「✕ 自分のポータルを全解除」。
- 各パネル: ヘッダでドラッグ移動、右下ハンドルでリサイズ、🔒/👥 共有トグル、✕ クローズ。

## 変更
- 新規 `plugins/usketch-plugin-portal/`（`portal-store` facade＋`defaultPortalBox` / `portal-layer` / `plugin`）。
- `apps/web`: `createPortalPlugin({ doc, boardId, userId })` を配線（local/cloud 共通）。

## 検証
- build（web 含む）緑、**typecheck 157 tasks 緑**、lint 0 error。
- ユニット `portal-store` 8（add/remove/update・localStorage 永続/再読込・`setShared` の private↔shared 移動・observe 反映・clearPrivate、`defaultPortalBox` アスペクトフィット/カスケード）。
- 手動: タイマーシェイプを選択→ポータル→ pan/zoom で固定、ポータル上でタイマー操作、ドラッグ/リサイズ→リロード復元、共有トグルで別タブに出現、対象削除で消滅。

## 非スコープ / 既知の制約
- 非スコープ: 他人のビューポート/画面ミラー（follow/presence 系の別機能）、専用の動画シェイプ（動画シェイプができればポータルは汎用で対応）。
- 共有ポータルは screen px 保存でクライアント毎にクランプ（ウィンドウ幅差で位置は近似）、移動/閉じは誰でも可（LWW）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)