### PR TITLE
🐛 fix(ci): リリースのタグpush失敗（commit_refs）に耐性を持たせる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
 
       - name: Create Release PR or Publish to npm
         id: changesets
+        # `changeset publish` pushes each package's git tag with a separate
+        # `git push origin <tag>` call. On a large batch (80+ packages) these
+        # rapid consecutive pushes intermittently trip GitHub's
+        # "remote: fatal error in commit_refs", which fails the step with some
+        # tags/releases left uncreated even though npm publish fully succeeded.
+        # Tolerate the failure here and reconcile below in a single batched push.
+        continue-on-error: true
         uses: changesets/action@v1
         with:
           version: pnpm run version
@@ -59,3 +66,62 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Reconcile any tags that changeset publish created locally but failed to
+      # push. A single batched `git push --tags` (retried) replaces the ~80
+      # individual pushes and reliably lands the stragglers.
+      - name: Reconcile git tags
+        if: always()
+        run: |
+          n=0
+          until git push origin --tags; do
+            n=$((n + 1))
+            if [ "$n" -ge 5 ]; then
+              echo "::error::failed to push tags after $n attempts"
+              exit 1
+            fi
+            echo "tag push failed (attempt $n); retrying in $((n * 10))s..."
+            sleep $((n * 10))
+          done
+
+      # changesets/action creates one GitHub Release per published package, but
+      # aborts partway when the publish step errors on the tag push above. Ensure
+      # a release exists for every tag on the release commit.
+      - name: Reconcile GitHub Releases
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch --tags --force
+          for tag in $(git tag --points-at HEAD); do
+            if gh release view "$tag" >/dev/null 2>&1; then
+              continue
+            fi
+            echo "creating missing GitHub Release: $tag"
+            notes=""
+            pkg_dir=$(git ls-files '*/package.json' | while read -r f; do
+              name=$(node -p "require('./$f').name" 2>/dev/null || true)
+              if [ "$name@$(node -p "require('./$f').version" 2>/dev/null)" = "$tag" ]; then
+                dirname "$f"
+                break
+              fi
+            done)
+            if [ -n "$pkg_dir" ] && [ -f "$pkg_dir/CHANGELOG.md" ]; then
+              ver="${tag##*@}"
+              notes=$(awk -v v="## $ver" 'index($0,v)==1{f=1;next} /^## /{if(f)exit} f{print}' "$pkg_dir/CHANGELOG.md")
+            fi
+            [ -z "$notes" ] && notes="Automated release for $tag"
+            gh release create "$tag" --title "$tag" --notes "$notes" --verify-tag
+          done
+
+      # Only the tag push is tolerated above. If the changesets step failed for
+      # any other reason (e.g. npm publish actually failed), fail the job.
+      - name: Verify publish succeeded
+        if: ${{ always() && steps.changesets.outcome == 'failure' }}
+        run: |
+          if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
+            echo "npm publish succeeded; the changesets step failure was the transient tag push, now reconciled."
+          else
+            echo "::error::changesets step failed and no packages were published."
+            exit 1
+          fi


### PR DESCRIPTION
## 背景

Release ワークフロー run [#29567148596](https://github.com/EdV4H/usketch/actions/runs/29567148596/job/87842214490) が失敗。

`changeset publish` は npm 公開後、**パッケージごとに `git push origin <tag>` を個別実行**する。今回の 80+ パッケージ一括リリースでは、この約71回の高速連続 push が GitHub サーバ側の `remote: fatal error in commit_refs`（一時的エラー）を踏み、**4件のタグ push が拒否 → step が exit 1 → ジョブ失敗**となった。

### 被害の切り分け
- ✅ npm 公開: **全パッケージ成功**
- ✅ バージョン反映（main）: 反映済み
- ❌ git tag 4件 / GitHub Release 4件 が未作成
  - `@edv4h/usketch-plugin-tool-select@3.2.0`
  - `@edv4h/usketch-plugin-tool-pan@2.0.6`
  - `@edv4h/usketch-plugin-shape-markdown@0.1.0`
  - `@edv4h/usketch-plugin-viewport-nav@2.0.6`

> 欠損した4件のタグ/Releaseは、リリースコミット `fec43b3b` を指す形で**手動リカバリ済み**。本PRは再発防止のみ。

## 変更内容

`changeset publish` のタグ push（CLI内部の個別push）は無効化する手段がないため、失敗を許容したうえで**バッチ push で確実に回収**する構成にした。

1. **changesets step を `continue-on-error`** — 一時的なタグpush失敗でジョブを即死させない
2. **Reconcile git tags** — `git push origin --tags` を1回のバッチ + リトライ（最大5回）で実行し、取りこぼしたタグを回収（71回の個別pushを1回に集約するので commit_refs 自体もほぼ発生しなくなる）
3. **Reconcile GitHub Releases** — リリースコミットの全タグに対し、欠損している Release を CHANGELOG 由来のノートで補完
4. **Verify publish succeeded** — npm 公開が**実際に**失敗した場合（`published != true`）のみジョブを失敗させる。タグpushだけの一時失敗は成功扱い

## テスト

- YAML 構文検証済み（`yaml.safe_load` パス）
- 通常リリース（タグpush成功時）では Reconcile ステップは no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)