### PR TITLE
✨ feat(timter): timer shape の見た目カスタマイズ口（renderShape）+ timer kind 公開register API

### DIFF
--- a/plugins/usketch-plugin-timter/README.md
+++ b/plugins/usketch-plugin-timter/README.md
@@ -1,0 +1,122 @@
+# @edv4h/usketch-plugin-timter
+
+Shared timers as **canvas shapes** (single source of truth). A `timer` shape is
+placeable/movable and syncs through the normal shapes map; timing runs against a
+shared `ServerClock` so every user agrees on "now". The plugin also surfaces
+every timer in the Debug HUD's Controls dock (group "Timter").
+
+The domain model (`timer-model`) is pure, framework-free, and time-source
+agnostic — every function takes an explicit `serverNow`.
+
+## Install
+
+```ts
+import { createTimterPlugin } from "@edv4h/usketch-plugin-timter";
+
+const timter = createTimterPlugin({
+  serverClock, // your shared ServerClock
+  userId,      // optional, attribution (reserved)
+});
+```
+
+## Customizing the shape's look — `renderShape`
+
+By default the timer renders with a built-in visual. To match your own design
+(hand-drawn theme, design tokens, custom controls), pass a `renderShape`
+render-prop. It receives the shape, its live `TimerCore`, a fresh `serverNow`
+(recomputed on every self-tick while running), and the timer `actions`. The
+plugin owns the tick and the store writes — your renderer only draws and calls
+actions.
+
+```tsx
+import {
+  createTimterPlugin,
+  displayMs,
+  formatDuration,
+  isDone,
+} from "@edv4h/usketch-plugin-timter";
+
+createTimterPlugin({
+  serverClock,
+  renderShape: ({ shape, core, serverNow, actions }) => (
+    <div className="my-timer" data-done={isDone(core, serverNow)}>
+      <span className="my-timer__time">
+        {formatDuration(displayMs(core, serverNow))}
+      </span>
+      <button type="button" onClick={actions.toggle}>
+        {shape.running ? "pause" : "start"}
+      </button>
+      <button type="button" onClick={actions.reset}>reset</button>
+    </div>
+  ),
+});
+```
+
+`actions`:
+
+| action | effect |
+| --- | --- |
+| `toggle()` | start if paused, pause if running |
+| `reset()` | back to the configured, stopped state |
+| `switchType()` | advance to the next registered kind (paused only) |
+| `adjust(deltaMs)` | change the configured duration by `deltaMs` (duration-based kinds, paused only) |
+
+> Buttons should call `e.stopPropagation()` on `onPointerDown` so the click
+> doesn't start a canvas drag — see `defaultRenderTimerShape` for the pattern.
+
+### Extend, don't replace
+
+`defaultRenderTimerShape` is exported, so you can wrap the built-in visual
+instead of rewriting it:
+
+```tsx
+import { defaultRenderTimerShape } from "@edv4h/usketch-plugin-timter";
+
+createTimterPlugin({
+  serverClock,
+  renderShape: (ctx) => (
+    <div className="my-frame">{defaultRenderTimerShape(ctx)}</div>
+  ),
+});
+```
+
+## Adding a timer type — `registerTimerKind`
+
+`countdown` and `stopwatch` are built in. Register your own kind (e.g.
+`pomodoro`) once at startup; the model transitions, the shape renderer, and the
+Controls dock all treat it like a built-in. `switchType()` cycles through every
+registered kind.
+
+```ts
+import { registerTimerKind, TIMER_KINDS } from "@edv4h/usketch-plugin-timter";
+
+registerTimerKind("pomodoro", {
+  ...TIMER_KINDS.countdown, // reuse countdown transitions
+  icon: "🍅",
+  // always a 25-minute work block
+  initial: () => ({ anchorAt: null, accumMs: 25 * 60_000, durationMs: 25 * 60_000 }),
+});
+```
+
+A `TimerKind` defines pure transitions over `TimerCore`:
+
+```ts
+interface TimerKind {
+  icon?: string; // glyph used by the built-in renderer / Controls dock
+  displayMs(c, serverNow): number;
+  isDone(c, serverNow): boolean;
+  onStart(c, serverNow): Pick<TimerCore, "anchorAt" | "accumMs">;
+  onPause(c, serverNow): Pick<TimerCore, "anchorAt" | "accumMs">;
+  initial(durationMs): Pick<TimerCore, "anchorAt" | "accumMs" | "durationMs">;
+}
+```
+
+## Model exports
+
+`start` · `pause` · `reset` · `initialCore` · `displayMs` · `isDone` ·
+`formatDuration` · `getTimerKind` · `timerTypes` · `registerTimerKind` ·
+`TIMER_KINDS` — plus types `TimerCore` · `TimerType` · `TimerKind`.
+
+Shape exports: `TIMER_SHAPE_TYPE` · `TimerShapeData` · `defaultRenderTimerShape`
+· `makeTimerShape` · `dispatchTimerShapeAction` — plus types
+`TimerShapeRenderer` · `TimerRenderContext` · `TimerShapeActions`.

--- a/plugins/usketch-plugin-timter/src/__tests__/timer-model.test.ts
+++ b/plugins/usketch-plugin-timter/src/__tests__/timer-model.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
 	displayMs,
 	formatDuration,
+	getTimerKind,
 	initialCore,
 	isDone,
 	pause,
+	registerTimerKind,
 	reset,
 	start,
+	TIMER_KINDS,
+	timerTypes,
 } from "../timer-model.js";
 
 const T0 = 1_000_000; // arbitrary server epoch base
@@ -83,5 +87,30 @@ describe("formatDuration", () => {
 		expect(formatDuration(65_000)).toBe("1:05");
 		expect(formatDuration(3_661_000)).toBe("1:01:01");
 		expect(formatDuration(-5000)).toBe("0:00");
+	});
+});
+
+describe("registerTimerKind (host extension)", () => {
+	it("registers a custom kind that flows through the model transitions", () => {
+		// A 25-minute pomodoro that behaves like a countdown but always starts at 25m.
+		registerTimerKind("pomodoro", {
+			...TIMER_KINDS.countdown,
+			icon: "🍅",
+			initial: () => ({ anchorAt: null, accumMs: 25 * 60_000, durationMs: 25 * 60_000 }),
+		});
+
+		const e = initialCore("pomodoro", 5 * 60_000); // requested 5m is ignored by the kind
+		expect(e.type).toBe("pomodoro");
+		expect(displayMs(e, T0)).toBe(25 * 60_000);
+
+		const running = start(e, T0);
+		expect(displayMs(running, T0 + 60_000)).toBe(24 * 60_000);
+		expect(isDone(running, T0 + 26 * 60_000)).toBe(true);
+	});
+
+	it("exposes the kind via getTimerKind / timerTypes and throws for unknown types", () => {
+		expect(getTimerKind("pomodoro").icon).toBe("🍅");
+		expect(timerTypes()).toEqual(expect.arrayContaining(["countdown", "stopwatch", "pomodoro"]));
+		expect(() => getTimerKind("nope")).toThrow(/unknown timer type/);
 	});
 });

--- a/plugins/usketch-plugin-timter/src/__tests__/timer-model.test.ts
+++ b/plugins/usketch-plugin-timter/src/__tests__/timer-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
 	displayMs,
 	formatDuration,
@@ -8,6 +8,7 @@ import {
 	pause,
 	registerTimerKind,
 	reset,
+	resolveTimerKind,
 	start,
 	TIMER_KINDS,
 	timerTypes,
@@ -91,14 +92,21 @@ describe("formatDuration", () => {
 });
 
 describe("registerTimerKind (host extension)", () => {
-	it("registers a custom kind that flows through the model transitions", () => {
+	// Register in setup and restore in teardown so tests are order-independent and
+	// the global registry doesn't leak "pomodoro" into other test files.
+	beforeAll(() => {
 		// A 25-minute pomodoro that behaves like a countdown but always starts at 25m.
 		registerTimerKind("pomodoro", {
 			...TIMER_KINDS.countdown,
 			icon: "🍅",
 			initial: () => ({ anchorAt: null, accumMs: 25 * 60_000, durationMs: 25 * 60_000 }),
 		});
+	});
+	afterAll(() => {
+		delete TIMER_KINDS.pomodoro;
+	});
 
+	it("registers a custom kind that flows through the model transitions", () => {
 		const e = initialCore("pomodoro", 5 * 60_000); // requested 5m is ignored by the kind
 		expect(e.type).toBe("pomodoro");
 		expect(displayMs(e, T0)).toBe(25 * 60_000);
@@ -112,5 +120,18 @@ describe("registerTimerKind (host extension)", () => {
 		expect(getTimerKind("pomodoro").icon).toBe("🍅");
 		expect(timerTypes()).toEqual(expect.arrayContaining(["countdown", "stopwatch", "pomodoro"]));
 		expect(() => getTimerKind("nope")).toThrow(/unknown timer type/);
+	});
+});
+
+describe("resolveTimerKind (render-safe fallback)", () => {
+	it("returns the registered kind, and an inert fallback for unknown types", () => {
+		expect(resolveTimerKind("countdown")).toBe(TIMER_KINDS.countdown);
+
+		// Unknown type must never throw during render — it degrades to a frozen,
+		// never-done display of the stored accumMs.
+		const stale = { type: "ghost", running: true, anchorAt: T0, accumMs: 42_000, durationMs: 0 };
+		expect(() => resolveTimerKind("ghost")).not.toThrow();
+		expect(displayMs(stale, T0 + 10_000)).toBe(42_000);
+		expect(isDone(stale, T0 + 10_000)).toBe(false);
 	});
 });

--- a/plugins/usketch-plugin-timter/src/index.ts
+++ b/plugins/usketch-plugin-timter/src/index.ts
@@ -2,12 +2,26 @@ export { createTimterPlugin, type TimterPluginOptions } from "./plugin.js";
 export {
 	displayMs,
 	formatDuration,
+	getTimerKind,
 	initialCore,
 	isDone,
 	pause,
+	registerTimerKind,
 	reset,
 	start,
+	TIMER_KINDS,
 	type TimerCore,
+	type TimerKind,
 	type TimerType,
+	timerTypes,
 } from "./timer-model.js";
-export { TIMER_SHAPE_TYPE, type TimerShapeData } from "./timer-shape.js";
+export {
+	defaultRenderTimerShape,
+	dispatchTimerShapeAction,
+	makeTimerShape,
+	TIMER_SHAPE_TYPE,
+	type TimerRenderContext,
+	type TimerShapeActions,
+	type TimerShapeData,
+	type TimerShapeRenderer,
+} from "./timer-shape.js";

--- a/plugins/usketch-plugin-timter/src/index.ts
+++ b/plugins/usketch-plugin-timter/src/index.ts
@@ -8,6 +8,7 @@ export {
 	pause,
 	registerTimerKind,
 	reset,
+	resolveTimerKind,
 	start,
 	TIMER_KINDS,
 	type TimerCore,

--- a/plugins/usketch-plugin-timter/src/plugin.ts
+++ b/plugins/usketch-plugin-timter/src/plugin.ts
@@ -6,7 +6,7 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import type { ServerClock } from "@edv4h/usketch-sync";
-import { displayMs, formatDuration, isDone, type TimerType } from "./timer-model.js";
+import { displayMs, formatDuration, getTimerKind, isDone, type TimerType } from "./timer-model.js";
 import {
 	coreOf,
 	dispatchTimerShapeAction,
@@ -14,6 +14,7 @@ import {
 	registerTimerShape,
 	TIMER_SHAPE_TYPE,
 	type TimerShapeData,
+	type TimerShapeRenderer,
 } from "./timer-shape.js";
 
 export interface TimterPluginOptions {
@@ -21,6 +22,14 @@ export interface TimterPluginOptions {
 	serverClock: ServerClock;
 	/** Attribution for created-by (reserved). Defaults to "local". */
 	userId?: string;
+	/**
+	 * Replace the built-in timer-shape visual with a host renderer (theme /
+	 * hand-drawn look / design tokens). Receives the shape, its live
+	 * {@link TimerCore}, a fresh `serverNow`, and toggle/reset/switchType/adjust
+	 * actions. Omit to use the built-in renderer (`defaultRenderTimerShape`),
+	 * which you can also import and wrap.
+	 */
+	renderShape?: TimerShapeRenderer;
 }
 
 /**
@@ -40,7 +49,12 @@ export function createTimterPlugin(options: TimterPluginOptions): UsketchPlugin 
 			const now = () => options.serverClock.now();
 
 			// ── Timer shape (placeable, movable) — the source of truth ──
-			const disposeShape = registerTimerShape(ctx, options.serverClock, options.userId ?? "local");
+			const disposeShape = registerTimerShape(
+				ctx,
+				options.serverClock,
+				options.userId ?? "local",
+				options.renderShape,
+			);
 
 			const listTimers = (): TimerShapeData[] =>
 				[...ctx.store.getShapes().values()]
@@ -109,8 +123,8 @@ export function createTimterPlugin(options: TimterPluginOptions): UsketchPlugin 
 
 				timers.forEach((s, idx) => {
 					const n = idx + 1;
-					const icon = s.timerType === "countdown" ? "⏳" : "⏱";
-					const done = s.timerType === "countdown" && isDone(coreOf(s), serverNow);
+					const icon = getTimerKind(s.timerType).icon ?? "⏱";
+					const done = isDone(coreOf(s), serverNow);
 					const time = formatDuration(displayMs(coreOf(s), serverNow));
 					perTimerOffs.push(
 						ctx.actions.register({

--- a/plugins/usketch-plugin-timter/src/plugin.ts
+++ b/plugins/usketch-plugin-timter/src/plugin.ts
@@ -6,7 +6,13 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import type { ServerClock } from "@edv4h/usketch-sync";
-import { displayMs, formatDuration, getTimerKind, isDone, type TimerType } from "./timer-model.js";
+import {
+	displayMs,
+	formatDuration,
+	isDone,
+	resolveTimerKind,
+	type TimerType,
+} from "./timer-model.js";
 import {
 	coreOf,
 	dispatchTimerShapeAction,
@@ -123,7 +129,7 @@ export function createTimterPlugin(options: TimterPluginOptions): UsketchPlugin 
 
 				timers.forEach((s, idx) => {
 					const n = idx + 1;
-					const icon = getTimerKind(s.timerType).icon ?? "⏱";
+					const icon = resolveTimerKind(s.timerType).icon ?? "⏱";
 					const done = isDone(coreOf(s), serverNow);
 					const time = formatDuration(displayMs(coreOf(s), serverNow));
 					perTimerOffs.push(

--- a/plugins/usketch-plugin-timter/src/timer-model.ts
+++ b/plugins/usketch-plugin-timter/src/timer-model.ts
@@ -89,12 +89,43 @@ export function registerTimerKind(type: string, kind: TimerKind): void {
 	TIMER_KINDS[type] = kind;
 }
 
-/** The registered kind for `type`. Throws if the kind was never registered. */
+/**
+ * The registered kind for `type`. **Throws** if the kind was never registered —
+ * the strict getter, for callers that control the type and want to fail loudly
+ * on a typo. Rendering / display of *synced* shape data (whose `timerType` is
+ * untrusted — stale documents, remote updates for a kind this client never
+ * registered) must use {@link resolveTimerKind} instead so a bad value can't
+ * crash the render tree.
+ */
 export function getTimerKind(type: TimerType): TimerKind {
 	const kind = TIMER_KINDS[type];
 	if (!kind)
 		throw new Error(`[timter] unknown timer type "${type}" (register it with registerTimerKind)`);
 	return kind;
+}
+
+/**
+ * A safe, inert kind used for unregistered types: shows the stored `accumMs`
+ * frozen, never "done", and treats start/pause as no-ops. Keeps a malformed or
+ * unknown `timerType` from throwing mid-render.
+ */
+const FALLBACK_KIND: TimerKind = {
+	icon: "⏱",
+	displayMs: (c) => c.accumMs,
+	isDone: () => false,
+	onStart: (c) => ({ anchorAt: c.anchorAt, accumMs: c.accumMs }),
+	onPause: (c) => ({ anchorAt: c.anchorAt, accumMs: c.accumMs }),
+	initial: (d) => ({ anchorAt: null, accumMs: d, durationMs: d }),
+};
+
+/**
+ * Like {@link getTimerKind} but **never throws** — returns {@link FALLBACK_KIND}
+ * for an unregistered type. Use everywhere a timer's kind is resolved from
+ * synced/untrusted shape data (render, LOD, Controls rebuild, transitions) so an
+ * unknown kind degrades to an inert display instead of crashing the canvas.
+ */
+export function resolveTimerKind(type: TimerType): TimerKind {
+	return TIMER_KINDS[type] ?? FALLBACK_KIND;
 }
 
 /** All registered timer-type ids, in registration order. */
@@ -104,27 +135,27 @@ export function timerTypes(): TimerType[] {
 
 /** Fresh, stopped core for a type + configured duration. */
 export function initialCore(type: TimerType, durationMs: number): TimerCore {
-	return { type, running: false, ...getTimerKind(type).initial(durationMs) };
+	return { type, running: false, ...resolveTimerKind(type).initial(durationMs) };
 }
 
 export function displayMs(c: TimerCore, serverNow: number): number {
-	return getTimerKind(c.type).displayMs(c, serverNow);
+	return resolveTimerKind(c.type).displayMs(c, serverNow);
 }
 
 export function isDone(c: TimerCore, serverNow: number): boolean {
-	return getTimerKind(c.type).isDone(c, serverNow);
+	return resolveTimerKind(c.type).isDone(c, serverNow);
 }
 
 /** Start or resume. Returns the same core (no-op) if already running. */
 export function start(c: TimerCore, serverNow: number): TimerCore {
 	if (c.running) return c;
-	return { ...c, ...getTimerKind(c.type).onStart(c, serverNow), running: true };
+	return { ...c, ...resolveTimerKind(c.type).onStart(c, serverNow), running: true };
 }
 
 /** Pause, snapshotting remaining/elapsed. No-op if already paused. */
 export function pause(c: TimerCore, serverNow: number): TimerCore {
 	if (!c.running) return c;
-	return { ...c, ...getTimerKind(c.type).onPause(c, serverNow), running: false };
+	return { ...c, ...resolveTimerKind(c.type).onPause(c, serverNow), running: false };
 }
 
 /** Return to the stopped, initial state for the configured duration. */

--- a/plugins/usketch-plugin-timter/src/timer-model.ts
+++ b/plugins/usketch-plugin-timter/src/timer-model.ts
@@ -105,9 +105,10 @@ export function getTimerKind(type: TimerType): TimerKind {
 }
 
 /**
- * A safe, inert kind used for unregistered types: shows the stored `accumMs`
- * frozen, never "done", and treats start/pause as no-ops. Keeps a malformed or
- * unknown `timerType` from throwing mid-render.
+ * A safe, inert kind used for unregistered types: the displayed time stays frozen
+ * at the stored `accumMs` and it is never "done" (start/pause still flip the
+ * `running` flag but leave `anchorAt`/`accumMs` untouched, so the reading doesn't
+ * move). Keeps a malformed or unknown `timerType` from throwing mid-render.
  */
 const FALLBACK_KIND: TimerKind = {
 	icon: "⏱",

--- a/plugins/usketch-plugin-timter/src/timer-model.ts
+++ b/plugins/usketch-plugin-timter/src/timer-model.ts
@@ -3,12 +3,21 @@
  * function takes an explicit `serverNow` so the same logic runs against the
  * shared server clock). The core timing state ({@link TimerCore}) is deliberately
  * envelope-free so it can be embedded both in the collaborative `timters` map
- * (as {@link TimerEntry}) and in a canvas timer shape. New timer types are added
- * by extending {@link TimerType} + one {@link TIMER_KINDS} entry; the transitions
- * stay type-agnostic.
+ * (as {@link TimerEntry}) and in a canvas timer shape.
+ *
+ * New timer types are added by registering one {@link TimerKind} via
+ * {@link registerTimerKind} (hosts can add e.g. a `pomodoro` kind); the
+ * transitions ({@link start} / {@link pause} / {@link reset}) stay type-agnostic
+ * and dispatch through the kind registry. `"countdown"` and `"stopwatch"` are
+ * built in.
  */
 
-export type TimerType = "countdown" | "stopwatch";
+/**
+ * A timer kind's id. The two built-ins are named for autocomplete; the
+ * `(string & {})` arm keeps any host-registered kind assignable while still
+ * suggesting the built-ins. Register new ids with {@link registerTimerKind}.
+ */
+export type TimerType = "countdown" | "stopwatch" | (string & {});
 
 /** The minimal timing state shared by every timer representation. */
 export interface TimerCore {
@@ -22,7 +31,15 @@ export interface TimerCore {
 	durationMs: number;
 }
 
-interface TimerKind {
+/**
+ * The behavior of one timer kind. Register a custom kind (e.g. `pomodoro`) with
+ * {@link registerTimerKind}; the model's transitions and the shape renderer then
+ * treat it like a built-in. All methods are pure — timing flows through the
+ * explicit `serverNow`, never `Date.now()`.
+ */
+export interface TimerKind {
+	/** Optional glyph used by the built-in shape renderer / Controls dock. */
+	icon?: string;
 	displayMs(c: TimerCore, serverNow: number): number;
 	isDone(c: TimerCore, serverNow: number): boolean;
 	onStart(c: TimerCore, serverNow: number): Pick<TimerCore, "anchorAt" | "accumMs">;
@@ -30,8 +47,15 @@ interface TimerKind {
 	initial(durationMs: number): Pick<TimerCore, "anchorAt" | "accumMs" | "durationMs">;
 }
 
-export const TIMER_KINDS: Record<TimerType, TimerKind> = {
+/**
+ * The kind registry. Built-ins are seeded here; hosts extend it via
+ * {@link registerTimerKind}. Read via {@link getTimerKind} / {@link timerTypes}
+ * (this record is the live registry — treat it as read-only and mutate only
+ * through `registerTimerKind`).
+ */
+export const TIMER_KINDS: Record<string, TimerKind> = {
 	countdown: {
+		icon: "⏳",
 		displayMs: (c, now) => (c.running ? Math.max(0, (c.anchorAt ?? now) - now) : c.accumMs),
 		isDone: (c, now) => (c.running ? (c.anchorAt ?? now) - now <= 0 : c.accumMs <= 0),
 		onStart: (c, now) => ({ anchorAt: now + c.accumMs, accumMs: c.accumMs }),
@@ -39,6 +63,7 @@ export const TIMER_KINDS: Record<TimerType, TimerKind> = {
 		initial: (d) => ({ anchorAt: null, accumMs: d, durationMs: d }),
 	},
 	stopwatch: {
+		icon: "⏱",
 		displayMs: (c, now) => (c.running ? now - (c.anchorAt ?? now) + c.accumMs : c.accumMs),
 		isDone: () => false,
 		onStart: (c, now) => ({ anchorAt: now, accumMs: c.accumMs }),
@@ -47,29 +72,59 @@ export const TIMER_KINDS: Record<TimerType, TimerKind> = {
 	},
 };
 
+/**
+ * Register (or replace) a timer kind so custom types behave like the built-ins.
+ * Call once at startup, before any timer of that type is created. Example:
+ *
+ * ```ts
+ * registerTimerKind("pomodoro", {
+ *   // 25-min work block — behaves like a countdown
+ *   ...TIMER_KINDS.countdown,
+ *   icon: "🍅",
+ *   initial: () => ({ anchorAt: null, accumMs: 25 * 60_000, durationMs: 25 * 60_000 }),
+ * });
+ * ```
+ */
+export function registerTimerKind(type: string, kind: TimerKind): void {
+	TIMER_KINDS[type] = kind;
+}
+
+/** The registered kind for `type`. Throws if the kind was never registered. */
+export function getTimerKind(type: TimerType): TimerKind {
+	const kind = TIMER_KINDS[type];
+	if (!kind)
+		throw new Error(`[timter] unknown timer type "${type}" (register it with registerTimerKind)`);
+	return kind;
+}
+
+/** All registered timer-type ids, in registration order. */
+export function timerTypes(): TimerType[] {
+	return Object.keys(TIMER_KINDS);
+}
+
 /** Fresh, stopped core for a type + configured duration. */
 export function initialCore(type: TimerType, durationMs: number): TimerCore {
-	return { type, running: false, ...TIMER_KINDS[type].initial(durationMs) };
+	return { type, running: false, ...getTimerKind(type).initial(durationMs) };
 }
 
 export function displayMs(c: TimerCore, serverNow: number): number {
-	return TIMER_KINDS[c.type].displayMs(c, serverNow);
+	return getTimerKind(c.type).displayMs(c, serverNow);
 }
 
 export function isDone(c: TimerCore, serverNow: number): boolean {
-	return TIMER_KINDS[c.type].isDone(c, serverNow);
+	return getTimerKind(c.type).isDone(c, serverNow);
 }
 
 /** Start or resume. Returns the same core (no-op) if already running. */
 export function start(c: TimerCore, serverNow: number): TimerCore {
 	if (c.running) return c;
-	return { ...c, ...TIMER_KINDS[c.type].onStart(c, serverNow), running: true };
+	return { ...c, ...getTimerKind(c.type).onStart(c, serverNow), running: true };
 }
 
 /** Pause, snapshotting remaining/elapsed. No-op if already paused. */
 export function pause(c: TimerCore, serverNow: number): TimerCore {
 	if (!c.running) return c;
-	return { ...c, ...TIMER_KINDS[c.type].onPause(c, serverNow), running: false };
+	return { ...c, ...getTimerKind(c.type).onPause(c, serverNow), running: false };
 }
 
 /** Return to the stopped, initial state for the configured duration. */

--- a/plugins/usketch-plugin-timter/src/timer-shape.tsx
+++ b/plugins/usketch-plugin-timter/src/timer-shape.tsx
@@ -10,10 +10,11 @@ import {
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import type { ServerClock } from "@edv4h/usketch-sync";
-import { useEffect, useReducer } from "react";
+import { type ReactElement, useEffect, useReducer } from "react";
 import {
 	displayMs,
 	formatDuration,
+	getTimerKind,
 	initialCore,
 	isDone,
 	pause,
@@ -21,6 +22,7 @@ import {
 	start,
 	type TimerCore,
 	type TimerType,
+	timerTypes,
 } from "./timer-model.js";
 
 export const TIMER_SHAPE_TYPE = "timer";
@@ -39,6 +41,7 @@ export interface TimerShapeData extends ShapeData {
 
 export type ShapeAction =
 	| { id: string; action: "toggle" | "reset" | "switch-type" }
+	/** `value` is a delta in **milliseconds** applied to the configured duration. */
 	| { id: string; action: "adjust"; value: number };
 
 export const coreOf = (s: TimerShapeData): TimerCore => ({
@@ -64,7 +67,42 @@ function emit(detail: ShapeAction) {
 /** Dispatch a timer-shape action (toggle/reset/…) — used by the Controls actions too. */
 export const dispatchTimerShapeAction = emit;
 
-// ── View ──
+// ── Render customization (host escape hatch) ──
+
+/**
+ * Live, one-minute-step actions handed to a timer-shape renderer. Each dispatches
+ * the same event the built-in buttons use, so a custom renderer stays in sync with
+ * the Controls dock and never touches the store directly.
+ */
+export interface TimerShapeActions {
+	/** Start if paused, pause if running. */
+	toggle(): void;
+	/** Return to the configured, stopped state. */
+	reset(): void;
+	/** Advance to the next registered timer kind (only while paused). */
+	switchType(): void;
+	/** Change the configured duration by `deltaMs` (duration-based kinds, while paused). */
+	adjust(deltaMs: number): void;
+}
+
+/**
+ * Everything a timer-shape renderer needs. `core` / `serverNow` are recomputed on
+ * every self-tick while running, so a renderer can read `displayMs(core, serverNow)`
+ * / `isDone(core, serverNow)` straight from the model without its own clock.
+ */
+export interface TimerRenderContext {
+	shape: TimerShapeData;
+	core: TimerCore;
+	serverNow: number;
+	actions: TimerShapeActions;
+}
+
+/**
+ * Replaces the built-in timer-shape visual. Supplied via
+ * `TimterPluginOptions.renderShape`; when omitted the plugin uses
+ * {@link defaultRenderTimerShape}. Wrap the default to extend rather than replace.
+ */
+export type TimerShapeRenderer = (ctx: TimerRenderContext) => ReactElement;
 
 const btn: React.CSSProperties = {
 	border: "1px solid #d1d5db",
@@ -77,28 +115,19 @@ const btn: React.CSSProperties = {
 	padding: "4px 8px",
 };
 
-function TimerShapeView({
+const stopEvent = (e: React.SyntheticEvent) => e.stopPropagation();
+
+/** The built-in timer-shape renderer. Exported so hosts can wrap/extend it. */
+export function defaultRenderTimerShape({
 	shape,
-	serverClock,
-}: {
-	shape: TimerShapeData;
-	serverClock: ServerClock;
-}) {
-	const [, force] = useReducer((n: number) => n + 1, 0);
+	core,
+	serverNow,
+	actions,
+}: TimerRenderContext): ReactElement {
 	const running = shape.running;
-
-	// Self-tick while running so the display counts without writing to the store.
-	useEffect(() => {
-		if (!running) return;
-		const id = setInterval(force, 250);
-		return () => clearInterval(id);
-	}, [running]);
-
-	const core = coreOf(shape);
-	const serverNow = serverClock.now();
-	const done = shape.timerType === "countdown" && isDone(core, serverNow);
-	const icon = shape.timerType === "countdown" ? "⏳" : "⏱";
-	const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+	const done = isDone(core, serverNow);
+	const icon = getTimerKind(shape.timerType).icon ?? "⏱";
+	const durationBased = core.durationMs > 0;
 
 	return (
 		<div
@@ -125,10 +154,10 @@ function TimerShapeView({
 						type="button"
 						title="種別を切替"
 						style={btn}
-						onPointerDown={stop}
+						onPointerDown={stopEvent}
 						onClick={(e) => {
-							stop(e);
-							emit({ id: shape.id, action: "switch-type" });
+							stopEvent(e);
+							actions.switchType();
 						}}
 					>
 						{icon}
@@ -147,16 +176,16 @@ function TimerShapeView({
 				</span>
 			</div>
 
-			{!running && shape.timerType === "countdown" && (
+			{!running && durationBased && (
 				<div style={{ display: "flex", alignItems: "center", gap: 6 }}>
 					<button
 						type="button"
 						title="−1分"
 						style={btn}
-						onPointerDown={stop}
+						onPointerDown={stopEvent}
 						onClick={(e) => {
-							stop(e);
-							emit({ id: shape.id, action: "adjust", value: -1 });
+							stopEvent(e);
+							actions.adjust(-60_000);
 						}}
 					>
 						−
@@ -165,10 +194,10 @@ function TimerShapeView({
 						type="button"
 						title="+1分"
 						style={btn}
-						onPointerDown={stop}
+						onPointerDown={stopEvent}
 						onClick={(e) => {
-							stop(e);
-							emit({ id: shape.id, action: "adjust", value: 1 });
+							stopEvent(e);
+							actions.adjust(60_000);
 						}}
 					>
 						＋
@@ -181,10 +210,10 @@ function TimerShapeView({
 					type="button"
 					title={running ? "一時停止" : "開始"}
 					style={btn}
-					onPointerDown={stop}
+					onPointerDown={stopEvent}
 					onClick={(e) => {
-						stop(e);
-						emit({ id: shape.id, action: "toggle" });
+						stopEvent(e);
+						actions.toggle();
 					}}
 				>
 					{running ? "⏸" : "▶"}
@@ -193,10 +222,10 @@ function TimerShapeView({
 					type="button"
 					title="リセット"
 					style={btn}
-					onPointerDown={stop}
+					onPointerDown={stopEvent}
 					onClick={(e) => {
-						stop(e);
-						emit({ id: shape.id, action: "reset" });
+						stopEvent(e);
+						actions.reset();
 					}}
 				>
 					↺
@@ -204,6 +233,46 @@ function TimerShapeView({
 			</div>
 		</div>
 	);
+}
+
+// ── View ──
+
+/**
+ * Host wrapper around a timer-shape renderer. Owns the self-tick (so the display
+ * counts down without writing to the store), recomputes `core`/`serverNow` each
+ * render, and builds the {@link TimerShapeActions} that emit the shared action
+ * event. Delegates the actual visual to `render` (a host `renderShape` or the
+ * built-in {@link defaultRenderTimerShape}).
+ */
+function TimerShapeView({
+	shape,
+	serverClock,
+	render,
+}: {
+	shape: TimerShapeData;
+	serverClock: ServerClock;
+	render: TimerShapeRenderer;
+}) {
+	const [, force] = useReducer((n: number) => n + 1, 0);
+	const running = shape.running;
+
+	// Self-tick while running so the display counts without writing to the store.
+	useEffect(() => {
+		if (!running) return;
+		const id = setInterval(force, 250);
+		return () => clearInterval(id);
+	}, [running]);
+
+	const core = coreOf(shape);
+	const serverNow = serverClock.now();
+	const actions: TimerShapeActions = {
+		toggle: () => emit({ id: shape.id, action: "toggle" }),
+		reset: () => emit({ id: shape.id, action: "reset" }),
+		switchType: () => emit({ id: shape.id, action: "switch-type" }),
+		adjust: (deltaMs) => emit({ id: shape.id, action: "adjust", value: deltaMs }),
+	};
+
+	return render({ shape, core, serverNow, actions });
 }
 
 function SimplifiedTimer({ shape }: { shape: ShapeData }) {
@@ -233,7 +302,7 @@ function SimplifiedTimer({ shape }: { shape: ShapeData }) {
 				transformOrigin: "center center",
 			}}
 		>
-			{s.timerType === "countdown" ? "⏳" : "⏱"} {formatDuration(s.accumMs)}
+			{getTimerKind(s.timerType).icon ?? "⏱"} {formatDuration(s.accumMs)}
 		</div>
 	);
 }
@@ -321,8 +390,9 @@ export function makeTimerShape(params: {
 	serverNow: number;
 }): TimerShapeData {
 	const base = createDefault({ id: params.id, x: params.x, y: params.y });
-	const dur =
-		params.timerType === "countdown" ? (params.durationMs ?? DEFAULT_MINUTES * 60_000) : 0;
+	// The kind's `initial` decides how (or whether) the duration is used —
+	// non-duration kinds like stopwatch ignore it.
+	const dur = params.durationMs ?? DEFAULT_MINUTES * 60_000;
 	const core = start(initialCore(params.timerType, dur), params.serverNow);
 	return { ...base, ...corePatch(core) };
 }
@@ -340,17 +410,25 @@ function TimerToolIcon() {
 /**
  * Register the timer shape, its draw tool, and the button-action listener.
  * `serverClock` is closed over by the renderer so every client computes the
- * remaining/elapsed time against the shared server clock.
+ * remaining/elapsed time against the shared server clock. `renderShape`
+ * overrides the built-in visual (defaults to {@link defaultRenderTimerShape}).
  */
 export function registerTimerShape(
 	ctx: PluginContext,
 	serverClock: ServerClock,
 	_userId: string,
+	renderShape: TimerShapeRenderer = defaultRenderTimerShape,
 ): () => void {
 	const now = () => serverClock.now();
 
 	ctx.shapes.register(TIMER_SHAPE_TYPE, {
-		render: (shape) => <TimerShapeView shape={shape as TimerShapeData} serverClock={serverClock} />,
+		render: (shape) => (
+			<TimerShapeView
+				shape={shape as TimerShapeData}
+				serverClock={serverClock}
+				render={renderShape}
+			/>
+		),
 		getBounds,
 		hitTest,
 		resize,
@@ -378,14 +456,19 @@ export function registerTimerShape(
 				break;
 			case "switch-type": {
 				if (core.running) return;
-				const nextType: TimerType = core.type === "countdown" ? "stopwatch" : "countdown";
-				const dur = nextType === "countdown" ? core.durationMs || DEFAULT_MINUTES * 60_000 : 0;
-				next = initialCore(nextType, dur);
+				// Cycle through every registered kind (built-ins + host-registered).
+				const types = timerTypes();
+				const idx = types.indexOf(core.type);
+				const nextType = types[(idx + 1) % types.length] ?? core.type;
+				// Carry a sensible duration forward; non-duration kinds (e.g. stopwatch)
+				// ignore it via their own `initial`.
+				next = initialCore(nextType, core.durationMs || DEFAULT_MINUTES * 60_000);
 				break;
 			}
 			case "adjust": {
-				if (core.running || core.type !== "countdown") return;
-				next = initialCore("countdown", Math.max(60_000, core.durationMs + detail.value * 60_000));
+				// `value` is a millisecond delta; only duration-based kinds respond.
+				if (core.running || core.durationMs <= 0) return;
+				next = initialCore(core.type, Math.max(60_000, core.durationMs + detail.value));
 				break;
 			}
 			default:

--- a/plugins/usketch-plugin-timter/src/timer-shape.tsx
+++ b/plugins/usketch-plugin-timter/src/timer-shape.tsx
@@ -14,11 +14,11 @@ import { type ReactElement, useEffect, useReducer } from "react";
 import {
 	displayMs,
 	formatDuration,
-	getTimerKind,
 	initialCore,
 	isDone,
 	pause,
 	reset,
+	resolveTimerKind,
 	start,
 	type TimerCore,
 	type TimerType,
@@ -126,7 +126,7 @@ export function defaultRenderTimerShape({
 }: TimerRenderContext): ReactElement {
 	const running = shape.running;
 	const done = isDone(core, serverNow);
-	const icon = getTimerKind(shape.timerType).icon ?? "⏱";
+	const icon = resolveTimerKind(shape.timerType).icon ?? "⏱";
 	const durationBased = core.durationMs > 0;
 
 	return (
@@ -302,7 +302,7 @@ function SimplifiedTimer({ shape }: { shape: ShapeData }) {
 				transformOrigin: "center center",
 			}}
 		>
-			{getTimerKind(s.timerType).icon ?? "⏱"} {formatDuration(s.accumMs)}
+			{resolveTimerKind(s.timerType).icon ?? "⏱"} {formatDuration(s.accumMs)}
 		</div>
 	);
 }

--- a/plugins/usketch-plugin-timter/src/timer-shape.tsx
+++ b/plugins/usketch-plugin-timter/src/timer-shape.tsx
@@ -70,9 +70,9 @@ export const dispatchTimerShapeAction = emit;
 // ── Render customization (host escape hatch) ──
 
 /**
- * Live, one-minute-step actions handed to a timer-shape renderer. Each dispatches
- * the same event the built-in buttons use, so a custom renderer stays in sync with
- * the Controls dock and never touches the store directly.
+ * Live actions handed to a timer-shape renderer. Each dispatches the same event
+ * the built-in buttons use, so a custom renderer stays in sync with the Controls
+ * dock and never touches the store directly.
  */
 export interface TimerShapeActions {
 	/** Start if paused, pause if running. */
@@ -459,6 +459,9 @@ export function registerTimerShape(
 				// Cycle through every registered kind (built-ins + host-registered).
 				const types = timerTypes();
 				const idx = types.indexOf(core.type);
+				// Unknown/removed kind: don't silently switch to the first kind — leave
+				// the shape untouched (the model treats unregistered types as an error).
+				if (idx < 0) return;
 				const nextType = types[(idx + 1) % types.length] ?? core.type;
 				// Carry a sensible duration forward; non-duration kinds (e.g. stopwatch)
 				// ignore it via their own `initial`.


### PR DESCRIPTION
Closes #754

## 背景
プロダクト（社内共同編集ホワイトボード）に `@edv4h/usketch-plugin-timter` を組み込むにあたり、timer shape の見た目を自社デザイン（手描き風テーマ・独自トークン）へ寄せる必要があった。従来 `TimterPluginOptions` は `{ serverClock, userId? }` のみで、レンダラ差し替えの口が無かった。

## 変更点

### 案A — `renderShape` render-prop（見た目の完全差し替え）
- `TimterPluginOptions.renderShape?: TimerShapeRenderer` を追加
- 内蔵 `TimerShapeView` を **host wrapper** 化：self-tick（running中250ms）と `serverNow` 算出を内蔵が担当し、`{ shape, core, serverNow, actions }` を注入。host は見た目だけ書けばよい
- `actions: { toggle, reset, switchType, adjust(deltaMs) }` — issue 通り `adjust` は **ms ベース**
- `defaultRenderTimerShape` を分離・export（内蔵レンダラをラップして拡張可能）
- 内蔵ボタンを直 emit から `ctx.actions` 経由に統一、`done` 判定を `isDone(core, serverNow)` に一般化

```tsx
createTimterPlugin({
  serverClock,
  renderShape: ({ shape, core, serverNow, actions }) => (
    <div className="my-timer" data-done={isDone(core, serverNow)}>
      <span>{formatDuration(displayMs(core, serverNow))}</span>
      <button onClick={actions.toggle}>{shape.running ? "pause" : "start"}</button>
    </div>
  ),
});
```

### nice-to-have — `registerTimerKind` 公開（timer type 拡張点）
- `registerTimerKind` / `getTimerKind` / `timerTypes` を公開
- `TimerType` を `"countdown" | "stopwatch" | (string & {})` に緩め、`TIMER_KINDS` を registry 化、`TimerKind` に `icon?` を追加
- `switch-type` は登録済み全 kind をサイクル、未登録 type は明示エラー

```ts
registerTimerKind("pomodoro", {
  ...TIMER_KINDS.countdown,
  icon: "🍅",
  initial: () => ({ anchorAt: null, accumMs: 25 * 60_000, durationMs: 25 * 60_000 }),
});
```

> tool icon の差し替えは今回スコープ外（別途対応可）。

## 後方互換
オプション追加のみ・既存の `{ serverClock, userId }` 呼び出しは無変更で動作。`apps/web` は変更不要。

## 検証
- ✅ typecheck / build（plugin 単体 + apps/web 含む 72 パッケージ）
- ✅ test 11 passed（pomodoro kind テスト追加）
- ✅ biome clean
- 📄 README.md 新規作成（renderShape / registerTimerKind の使用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)