### PR TITLE
✨ feat(embed): iframe 埋め込みシェイプ（YouTube 再生同期つき）

### DIFF
--- a/.changeset/portal-chrome.md
+++ b/.changeset/portal-chrome.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-portal": minor
+---
+
+ポータルパネルの chrome（ヘッダ/枠）を差し替え可能に。`createPortalPlugin({ components: { Chrome } })` に独自コンポーネントを渡せる（`PortalChromeProps`: entry/shared/title/toggleShared/remove/dragHandleProps/resizeHandleProps/children）。ドラッグ移動・リサイズ・シェイプ内容は、custom Chrome が `dragHandleProps`/`resizeHandleProps` を配線し `children` を描画すれば保持される。`DefaultPortalChrome`/`PortalChrome` を export。

--- a/.changeset/shape-embed.md
+++ b/.changeset/shape-embed.md
@@ -8,3 +8,5 @@
 - **select-vs-interact**: 通常は選択/移動/リサイズ可（iframe は `pointerEvents:none`）、ダブルクリック or ▶ で操作モード、✕/選択解除で戻る。
 - **URL 貼り付け/ドロップ**で埋め込みを生成（`kind:"url"` 外部コンテンツハンドラ、order 0）。
 - **YouTube 再生同期（watch party）**: 再生/一時停止/シークを全ユーザーで同期。位置は共有 doc の `playback` に保持し、`@edv4h/usketch-sync` の server clock 基準でドリフト補正して追従（YouTube IFrame API を postMessage で制御、SDK 不要）。制御は既定「全員操作可（LWW）」、ヘッダの 🔒 でプレゼンターロック（1人主導）に切替可能。
+
+コンポーネント差し替え: `createEmbedShapePlugin({ components: { Chrome } })` でシェイプの chrome（ヘッダ/枠）を独自コンポーネントに置換可能（`EmbedChromeProps` を受け取り、機能コアの iframe/player は `children` を描画すれば保持）。`DefaultEmbedChrome`/`EmbedChrome` を export。

--- a/.changeset/shape-embed.md
+++ b/.changeset/shape-embed.md
@@ -1,0 +1,10 @@
+---
+"@edv4h/usketch-plugin-shape-embed": minor
+---
+
+埋め込みプラグイン `usketch-plugin-shape-embed` を追加。外部Webコンテンツを **iframe でキャンバスに埋め込む `embed` シェイプ**（tldraw の embed 機構に着想）。
+
+- **プロバイダ許可リスト**（YouTube / Vimeo / Figma / Google Maps / CodeSandbox）＋任意 http(s) の汎用フォールバック。既知プロバイダは共有URL→埋め込みURLへ変換し必要最小の iframe `sandbox`/`allow`、未知URLは strict sandbox（`allow-same-origin` 無し）。`createEmbedShapePlugin({ embeds })` で定義を追加/上書き可能。
+- **select-vs-interact**: 通常は選択/移動/リサイズ可（iframe は `pointerEvents:none`）、ダブルクリック or ▶ で操作モード、✕/選択解除で戻る。
+- **URL 貼り付け/ドロップ**で埋め込みを生成（`kind:"url"` 外部コンテンツハンドラ、order 0）。
+- **YouTube 再生同期（watch party）**: 再生/一時停止/シークを全ユーザーで同期。位置は共有 doc の `playback` に保持し、`@edv4h/usketch-sync` の server clock 基準でドリフト補正して追従（YouTube IFrame API を postMessage で制御、SDK 不要）。制御は既定「全員操作可（LWW）」、ヘッダの 🔒 でプレゼンターロック（1人主導）に切替可能。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -63,6 +63,7 @@
 		"@edv4h/usketch-plugin-shape-basic": "workspace:*",
 		"@edv4h/usketch-plugin-shape-card": "workspace:*",
 		"@edv4h/usketch-plugin-shape-connector": "workspace:*",
+		"@edv4h/usketch-plugin-shape-embed": "workspace:*",
 		"@edv4h/usketch-plugin-shape-frame": "workspace:*",
 		"@edv4h/usketch-plugin-shape-group": "workspace:*",
 		"@edv4h/usketch-plugin-shape-freedraw": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -414,9 +414,8 @@ export function App() {
 		// 全ユーザーで同期（server clock 基準）。URL 貼り付け/ドロップでも生成。
 		extraPlugins.push(
 			createEmbedShapePlugin({
-				apiUrl: isCloudBoard
-					? (import.meta.env.VITE_API_URL ?? "http://localhost:8787")
-					: undefined,
+				// Reuse the board-level clock (shared with Timter) instead of a 2nd poller.
+				serverClock,
 				boardId,
 				userId: userIdRef.current ?? getDevUser()?.id ?? "local",
 			}),

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -29,6 +29,7 @@ import { createBasicShapePlugin } from "@edv4h/usketch-plugin-shape-basic";
 import { createCardPlugin, EXAMPLE_CARD_TYPES } from "@edv4h/usketch-plugin-shape-card";
 import { createConnectorPlugin } from "@edv4h/usketch-plugin-shape-connector";
 import { createCounterPlugin } from "@edv4h/usketch-plugin-shape-counter";
+import { createEmbedShapePlugin } from "@edv4h/usketch-plugin-shape-embed";
 import { createFramePlugin } from "@edv4h/usketch-plugin-shape-frame";
 import { createFreedrawPlugin } from "@edv4h/usketch-plugin-shape-freedraw";
 import { createGroupPlugin } from "@edv4h/usketch-plugin-shape-group";
@@ -408,6 +409,18 @@ export function App() {
 		// Asset store: content-addressed な asset を doc の `assets` マップで共有。
 		// 画像等の重い blob を一度だけ保持し shape は assetId 参照（複製で再利用）。
 		extraPlugins.push(createAssetStorePlugin({ doc: syncHandle.doc }));
+
+		// Embed: 外部Web を iframe 埋め込み（`embed` シェイプ）。YouTube は再生位置を
+		// 全ユーザーで同期（server clock 基準）。URL 貼り付け/ドロップでも生成。
+		extraPlugins.push(
+			createEmbedShapePlugin({
+				apiUrl: isCloudBoard
+					? (import.meta.env.VITE_API_URL ?? "http://localhost:8787")
+					: undefined,
+				boardId,
+				userId: userIdRef.current ?? getDevUser()?.id ?? "local",
+			}),
+		);
 
 		// プレゼンテーション: ローカル/Cloud 共通で常にロードし、`?present=1` が付いた時だけ UI を出す。
 		// ルート切替せず URL クエリで切替える設計なので、アプリ再生成は起きない。

--- a/plugins/usketch-plugin-portal/src/index.ts
+++ b/plugins/usketch-plugin-portal/src/index.ts
@@ -1,5 +1,10 @@
 export { createPortalPlugin, type PortalPluginOptions } from "./plugin.js";
 export {
+	DefaultPortalChrome,
+	type PortalChrome,
+	type PortalChromeProps,
+} from "./portal-layer.js";
+export {
 	createPortalStore,
 	defaultPortalBox,
 	type PortalEntry,

--- a/plugins/usketch-plugin-portal/src/plugin.tsx
+++ b/plugins/usketch-plugin-portal/src/plugin.tsx
@@ -1,6 +1,6 @@
 import type { BoundingBox, PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
 import type * as Y from "yjs";
-import { PortalLayer } from "./portal-layer.js";
+import { type PortalChrome, PortalLayer } from "./portal-layer.js";
 import { createPortalStore, defaultPortalBox } from "./portal-store.js";
 
 export interface PortalPluginOptions {
@@ -10,6 +10,10 @@ export interface PortalPluginOptions {
 	boardId?: string;
 	/** For the per-user localStorage key. Defaults to "local". */
 	userId?: string;
+	/** Swap the panel chrome (header/frame). Drag/resize/content are retained as
+	 * long as the custom Chrome wires `dragHandleProps`/`resizeHandleProps` and
+	 * renders its `children`. */
+	components?: { Chrome?: PortalChrome };
 }
 
 const LAYER_ID = "portal";
@@ -37,7 +41,14 @@ export function createPortalPlugin(options: PortalPluginOptions): UsketchPlugin 
 				id: LAYER_ID,
 				order: 150,
 				fixed: true,
-				render: () => <PortalLayer portalStore={store} store={ctx.store} shapes={ctx.shapes} />,
+				render: () => (
+					<PortalLayer
+						portalStore={store}
+						store={ctx.store}
+						shapes={ctx.shapes}
+						Chrome={options.components?.Chrome}
+					/>
+				),
 			});
 			ctx.events.emit("layers:changed", {});
 

--- a/plugins/usketch-plugin-portal/src/portal-layer.tsx
+++ b/plugins/usketch-plugin-portal/src/portal-layer.tsx
@@ -75,6 +75,120 @@ function ShapeContent({
 	);
 }
 
+export interface PortalChromeProps {
+	entry: PortalEntry;
+	shared: boolean;
+	title: string;
+	toggleShared: () => void;
+	remove: () => void;
+	/** Spread onto the drag handle (header). */
+	dragHandleProps: { onPointerDown: (e: React.PointerEvent) => void };
+	/** Spread onto the resize grip. */
+	resizeHandleProps: { onPointerDown: (e: React.PointerEvent) => void };
+	/** Plugin-owned body (the re-rendered shape). Must be rendered. */
+	children: React.ReactNode;
+}
+export type PortalChrome = (props: PortalChromeProps) => React.ReactElement;
+
+const headerBtn: React.CSSProperties = {
+	border: "none",
+	background: "transparent",
+	cursor: "pointer",
+	fontSize: 13,
+	lineHeight: 1,
+	padding: 2,
+};
+
+/** Default portal panel chrome (overridable via the plugin's `components.Chrome`). */
+export function DefaultPortalChrome(p: PortalChromeProps) {
+	return (
+		<div
+			{...stopCanvas}
+			style={{
+				position: "fixed",
+				left: p.entry.x,
+				top: p.entry.y,
+				width: p.entry.w,
+				height: p.entry.h,
+				display: "flex",
+				flexDirection: "column",
+				background: "#fff",
+				border: "1px solid #d1d5db",
+				borderRadius: 8,
+				boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
+				overflow: "hidden",
+				pointerEvents: "auto",
+				fontFamily: "system-ui, sans-serif",
+			}}
+		>
+			<div
+				onPointerDown={p.dragHandleProps.onPointerDown}
+				style={{
+					height: PORTAL_HEADER_H,
+					flex: "0 0 auto",
+					display: "flex",
+					alignItems: "center",
+					gap: 4,
+					padding: "0 6px",
+					background: "#f3f4f6",
+					borderBottom: "1px solid #e5e7eb",
+					cursor: "move",
+					userSelect: "none",
+				}}
+			>
+				<span
+					style={{
+						flex: 1,
+						fontSize: 11,
+						fontWeight: 600,
+						color: "#374151",
+						whiteSpace: "nowrap",
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+					}}
+				>
+					{p.title}
+				</span>
+				<button
+					type="button"
+					title={p.shared ? "全員に共有中（クリックで個人に戻す）" : "個人（クリックで全員に共有）"}
+					onPointerDown={(e) => e.stopPropagation()}
+					onClick={p.toggleShared}
+					style={headerBtn}
+				>
+					{p.shared ? "👥" : "🔒"}
+				</button>
+				<button
+					type="button"
+					title="閉じる"
+					onPointerDown={(e) => e.stopPropagation()}
+					onClick={p.remove}
+					style={{ ...headerBtn, color: "#9ca3af" }}
+				>
+					✕
+				</button>
+			</div>
+			<div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+				{p.children}
+				{/* biome-ignore lint/a11y/noStaticElementInteractions: resize grip */}
+				<div
+					onPointerDown={p.resizeHandleProps.onPointerDown}
+					style={{
+						position: "absolute",
+						right: 0,
+						bottom: 0,
+						width: 14,
+						height: 14,
+						cursor: "nwse-resize",
+						background:
+							"linear-gradient(135deg, transparent 50%, rgba(0,0,0,0.25) 50%, rgba(0,0,0,0.25) 60%, transparent 60%)",
+					}}
+				/>
+			</div>
+		</div>
+	);
+}
+
 function PortalPanel({
 	entry,
 	shared,
@@ -83,6 +197,7 @@ function PortalPanel({
 	onUpdate,
 	onRemove,
 	onToggleShared,
+	Chrome,
 }: {
 	entry: PortalEntry;
 	shared: boolean;
@@ -91,6 +206,7 @@ function PortalPanel({
 	onUpdate: (id: string, patch: Partial<Pick<PortalEntry, "x" | "y" | "w" | "h">>) => void;
 	onRemove: (id: string) => void;
 	onToggleShared: (id: string, shared: boolean) => void;
+	Chrome: PortalChrome;
 }) {
 	const bodyH = Math.max(0, entry.h - PORTAL_HEADER_H);
 
@@ -116,9 +232,6 @@ function PortalPanel({
 		const ow = entry.w;
 		const oh = entry.h;
 		trackPointer((ev) => {
-			// Guard max ≥ min: near the right/bottom edge the available space can be
-			// smaller than the min, in which case clamp(min, max<min) would return min
-			// and push the panel off-screen.
 			const w = clamp(ow + ev.clientX - sx, 140, Math.max(140, window.innerWidth - entry.x));
 			const h = clamp(oh + ev.clientY - sy, 100, Math.max(100, window.innerHeight - entry.y));
 			onUpdate(entry.id, { w, h });
@@ -126,111 +239,30 @@ function PortalPanel({
 	};
 
 	return (
-		<div
-			{...stopCanvas}
-			style={{
-				position: "fixed",
-				left: entry.x,
-				top: entry.y,
-				width: entry.w,
-				height: entry.h,
-				display: "flex",
-				flexDirection: "column",
-				background: "#fff",
-				border: "1px solid #d1d5db",
-				borderRadius: 8,
-				boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
-				overflow: "hidden",
-				pointerEvents: "auto",
-				fontFamily: "system-ui, sans-serif",
-			}}
+		<Chrome
+			entry={entry}
+			shared={shared}
+			title={(shape as { label?: string }).label || shape.type}
+			toggleShared={() => onToggleShared(entry.id, !shared)}
+			remove={() => onRemove(entry.id)}
+			dragHandleProps={{ onPointerDown: startDrag }}
+			resizeHandleProps={{ onPointerDown: startResize }}
 		>
-			<div
-				onPointerDown={startDrag}
-				style={{
-					height: PORTAL_HEADER_H,
-					flex: "0 0 auto",
-					display: "flex",
-					alignItems: "center",
-					gap: 4,
-					padding: "0 6px",
-					background: "#f3f4f6",
-					borderBottom: "1px solid #e5e7eb",
-					cursor: "move",
-					userSelect: "none",
-				}}
-			>
-				<span
-					style={{
-						flex: 1,
-						fontSize: 11,
-						fontWeight: 600,
-						color: "#374151",
-						whiteSpace: "nowrap",
-						overflow: "hidden",
-						textOverflow: "ellipsis",
-					}}
-				>
-					{(shape as { label?: string }).label || shape.type}
-				</span>
-				<button
-					type="button"
-					title={shared ? "全員に共有中（クリックで個人に戻す）" : "個人（クリックで全員に共有）"}
-					onPointerDown={(e) => e.stopPropagation()}
-					onClick={() => onToggleShared(entry.id, !shared)}
-					style={headerBtn}
-				>
-					{shared ? "👥" : "🔒"}
-				</button>
-				<button
-					type="button"
-					title="閉じる"
-					onPointerDown={(e) => e.stopPropagation()}
-					onClick={() => onRemove(entry.id)}
-					style={{ ...headerBtn, color: "#9ca3af" }}
-				>
-					✕
-				</button>
-			</div>
-
-			<div style={{ flex: 1, minHeight: 0, position: "relative" }}>
-				<ShapeContent def={def} shape={shape} bodyW={entry.w} bodyH={bodyH} />
-				{/* biome-ignore lint/a11y/noStaticElementInteractions: resize grip */}
-				<div
-					onPointerDown={startResize}
-					style={{
-						position: "absolute",
-						right: 0,
-						bottom: 0,
-						width: 14,
-						height: 14,
-						cursor: "nwse-resize",
-						background:
-							"linear-gradient(135deg, transparent 50%, rgba(0,0,0,0.25) 50%, rgba(0,0,0,0.25) 60%, transparent 60%)",
-					}}
-				/>
-			</div>
-		</div>
+			<ShapeContent def={def} shape={shape} bodyW={entry.w} bodyH={bodyH} />
+		</Chrome>
 	);
 }
-
-const headerBtn: React.CSSProperties = {
-	border: "none",
-	background: "transparent",
-	cursor: "pointer",
-	fontSize: 13,
-	lineHeight: 1,
-	padding: 2,
-};
 
 export function PortalLayer({
 	portalStore,
 	store,
 	shapes,
+	Chrome = DefaultPortalChrome,
 }: {
 	portalStore: PortalStore;
 	store: BoardStore;
 	shapes: ShapeRegistry;
+	Chrome?: PortalChrome;
 }) {
 	const items = useSyncExternalStore(portalStore.subscribe, portalStore.getAll);
 	// Re-render on any store mutation so pinned shapes reflect edits.
@@ -259,6 +291,7 @@ export function PortalLayer({
 						onUpdate={portalStore.update}
 						onRemove={portalStore.remove}
 						onToggleShared={portalStore.setShared}
+						Chrome={Chrome}
 					/>
 				);
 			})}

--- a/plugins/usketch-plugin-shape-embed/package.json
+++ b/plugins/usketch-plugin-shape-embed/package.json
@@ -1,0 +1,50 @@
+{
+	"name": "@edv4h/usketch-plugin-shape-embed",
+	"version": "0.0.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*",
+		"@edv4h/usketch-sync": "workspace:*"
+	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.17",
+		"typescript": "7.0.2",
+		"vitest": "4.1.10"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-shape-embed"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-shape-embed/src/__tests__/embed-defs.test.ts
+++ b/plugins/usketch-plugin-shape-embed/src/__tests__/embed-defs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { GENERIC_DEF, resolveEmbed, YOUTUBE_DEF } from "../embed-defs.js";
+
+describe("resolveEmbed — YouTube", () => {
+	it("converts watch / youtu.be / shorts / embed URLs to a nocookie embed", () => {
+		for (const url of [
+			"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+			"https://youtu.be/dQw4w9WgXcQ",
+			"https://www.youtube.com/shorts/dQw4w9WgXcQ",
+			"https://www.youtube.com/embed/dQw4w9WgXcQ",
+		]) {
+			const r = resolveEmbed(url);
+			expect(r?.def.id).toBe("youtube");
+			expect(r?.embedUrl).toContain("/embed/dQw4w9WgXcQ");
+			expect(r?.embedUrl).toContain("enablejsapi=1"); // required for sync
+		}
+	});
+
+	it("YouTube is marked syncable and keeps allow-same-origin", () => {
+		expect(YOUTUBE_DEF.syncable).toBe(true);
+		expect(YOUTUBE_DEF.sandbox).toContain("allow-same-origin");
+	});
+});
+
+describe("resolveEmbed — providers", () => {
+	it("matches figma / vimeo / google maps by hostname", () => {
+		expect(resolveEmbed("https://www.figma.com/design/abc/My")?.def.id).toBe("figma");
+		expect(resolveEmbed("https://vimeo.com/123456789")?.def.id).toBe("vimeo");
+		expect(resolveEmbed("https://maps.google.com/maps?q=tokyo")?.def.id).toBe("google-maps");
+	});
+});
+
+describe("resolveEmbed — generic fallback & guards", () => {
+	it("falls back to GENERIC with a strict sandbox (no allow-same-origin)", () => {
+		const r = resolveEmbed("https://example.com/some/page");
+		expect(r?.def.id).toBe("generic");
+		expect(r?.embedUrl).toBe("https://example.com/some/page");
+		expect(GENERIC_DEF.sandbox).not.toContain("allow-same-origin");
+	});
+
+	it("rejects non-http(s) and unparseable input", () => {
+		expect(resolveEmbed("javascript:alert(1)")).toBeNull();
+		expect(resolveEmbed("data:text/html,<h1>x</h1>")).toBeNull();
+		expect(resolveEmbed("not a url")).toBeNull();
+		expect(resolveEmbed("")).toBeNull();
+	});
+
+	it("custom defs (passed first) override defaults", () => {
+		const custom = {
+			id: "my-yt",
+			title: "Custom",
+			hostnames: ["youtube.com"],
+			toEmbedUrl: () => "https://custom/embed",
+			sandbox: "allow-scripts",
+		};
+		const r = resolveEmbed("https://www.youtube.com/watch?v=x", [custom, YOUTUBE_DEF]);
+		expect(r?.def.id).toBe("my-yt");
+	});
+});

--- a/plugins/usketch-plugin-shape-embed/src/__tests__/playback.test.ts
+++ b/plugins/usketch-plugin-shape-embed/src/__tests__/playback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { needsCorrection, playbackFrom, projectTime } from "../playback.js";
+import type { PlaybackState } from "../types.js";
+
+const T0 = 1_000_000;
+const playing: PlaybackState = { playing: true, time: 10, at: T0, updatedBy: "u" };
+const paused: PlaybackState = { playing: false, time: 10, at: T0, updatedBy: "u" };
+
+describe("projectTime", () => {
+	it("advances while playing by elapsed wall time", () => {
+		expect(projectTime(playing, T0)).toBe(10);
+		expect(projectTime(playing, T0 + 5000)).toBe(15); // +5s
+	});
+	it("is frozen while paused", () => {
+		expect(projectTime(paused, T0 + 5000)).toBe(10);
+	});
+	it("clamps negative to 0", () => {
+		expect(projectTime({ ...playing, time: 1 }, T0 - 5000)).toBe(0);
+	});
+});
+
+describe("needsCorrection", () => {
+	it("true on play/pause mismatch", () => {
+		expect(needsCorrection(playing, T0, { playing: false, time: 10 })).toBe(true);
+	});
+	it("true when position drift exceeds the threshold", () => {
+		expect(needsCorrection(playing, T0 + 5000, { playing: true, time: 12 })).toBe(true); // expected 15, local 12
+	});
+	it("false within the threshold", () => {
+		expect(needsCorrection(playing, T0 + 5000, { playing: true, time: 14.8 })).toBe(false); // expected 15
+	});
+});
+
+describe("playbackFrom", () => {
+	it("captures the local player state + server time + user", () => {
+		expect(playbackFrom({ playing: true, time: 42 }, T0, "alice")).toEqual({
+			playing: true,
+			time: 42,
+			at: T0,
+			updatedBy: "alice",
+		});
+	});
+});

--- a/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
+++ b/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
@@ -1,0 +1,151 @@
+/**
+ * Embed provider allow-list (modeled on tldraw's EMBED_DEFINITIONS). Each entry
+ * maps a set of hostnames to an embeddable URL + the iframe sandbox/permissions
+ * that provider needs. Unknown URLs fall back to {@link GENERIC_DEF} with a
+ * strict sandbox. Add providers by passing extra definitions to the plugin.
+ */
+
+export interface EmbedDefinition {
+	id: string;
+	title: string;
+	/** Hostnames (without www.) this definition matches. */
+	hostnames: string[];
+	/** Convert a shareable URL to an embeddable one, or undefined if not embeddable. */
+	toEmbedUrl(url: URL): string | undefined;
+	/** Preferred width/height ratio for a freshly created embed. */
+	aspect?: number;
+	/** iframe `sandbox` tokens. */
+	sandbox: string;
+	/** iframe `allow` (feature policy), e.g. for fullscreen / autoplay. */
+	allow?: string;
+	/** True if this provider has a synced player (see players/). */
+	syncable?: boolean;
+}
+
+const stripWww = (host: string) => host.replace(/^www\./, "");
+
+/** Extract a YouTube video id from watch/short/embed/youtu.be URLs. */
+function youtubeId(u: URL): string | undefined {
+	const host = stripWww(u.hostname);
+	if (host === "youtu.be") return u.pathname.slice(1) || undefined;
+	if (u.pathname.startsWith("/watch")) return u.searchParams.get("v") ?? undefined;
+	const m = /^\/(embed|shorts|live)\/([^/?#]+)/.exec(u.pathname);
+	return m ? m[2] : undefined;
+}
+
+export const YOUTUBE_DEF: EmbedDefinition = {
+	id: "youtube",
+	title: "YouTube",
+	hostnames: ["youtube.com", "youtu.be", "youtube-nocookie.com"],
+	aspect: 16 / 9,
+	// enablejsapi=1 is required for the postMessage player control (watch-party sync).
+	toEmbedUrl: (u) => {
+		const id = youtubeId(u);
+		return id ? `https://www.youtube-nocookie.com/embed/${id}?enablejsapi=1&rel=0` : undefined;
+	},
+	sandbox: "allow-scripts allow-same-origin allow-popups allow-presentation",
+	allow: "autoplay; encrypted-media; picture-in-picture; fullscreen",
+	syncable: true,
+};
+
+export const VIMEO_DEF: EmbedDefinition = {
+	id: "vimeo",
+	title: "Vimeo",
+	hostnames: ["vimeo.com", "player.vimeo.com"],
+	aspect: 16 / 9,
+	toEmbedUrl: (u) => {
+		const id = /(\d+)/.exec(u.pathname)?.[1];
+		return id ? `https://player.vimeo.com/video/${id}` : undefined;
+	},
+	sandbox: "allow-scripts allow-same-origin allow-popups",
+	allow: "autoplay; fullscreen; picture-in-picture",
+};
+
+export const FIGMA_DEF: EmbedDefinition = {
+	id: "figma",
+	title: "Figma",
+	hostnames: ["figma.com"],
+	aspect: 4 / 3,
+	toEmbedUrl: (u) =>
+		/\/(file|design|board|proto)\//.test(u.pathname)
+			? `https://www.figma.com/embed?embed_host=usketch&url=${encodeURIComponent(u.href)}`
+			: undefined,
+	sandbox: "allow-scripts allow-same-origin allow-popups allow-forms",
+	allow: "fullscreen",
+};
+
+export const GOOGLE_MAPS_DEF: EmbedDefinition = {
+	id: "google-maps",
+	title: "Google Maps",
+	hostnames: ["google.com", "maps.google.com"],
+	aspect: 4 / 3,
+	toEmbedUrl: (u) =>
+		u.pathname.startsWith("/maps")
+			? `https://maps.google.com/maps?output=embed&q=${encodeURIComponent(u.href)}`
+			: undefined,
+	sandbox: "allow-scripts allow-same-origin allow-popups",
+	allow: "fullscreen",
+};
+
+export const CODESANDBOX_DEF: EmbedDefinition = {
+	id: "codesandbox",
+	title: "CodeSandbox",
+	hostnames: ["codesandbox.io"],
+	aspect: 4 / 3,
+	toEmbedUrl: (u) =>
+		u.pathname.startsWith("/s/") || u.pathname.startsWith("/p/")
+			? `https://codesandbox.io/embed/${u.pathname.replace(/^\/(s|p)\//, "")}`
+			: `https://codesandbox.io/embed${u.pathname}`,
+	sandbox: "allow-scripts allow-same-origin allow-popups allow-forms",
+	allow: "fullscreen",
+};
+
+/** Fallback for any http(s) URL: embed as-is with a STRICT sandbox (no allow-same-origin). */
+export const GENERIC_DEF: EmbedDefinition = {
+	id: "generic",
+	title: "Web page",
+	hostnames: [],
+	aspect: 4 / 3,
+	toEmbedUrl: (u) => (u.protocol === "http:" || u.protocol === "https:" ? u.href : undefined),
+	sandbox: "allow-scripts allow-popups allow-forms",
+};
+
+export const DEFAULT_EMBED_DEFS: EmbedDefinition[] = [
+	YOUTUBE_DEF,
+	VIMEO_DEF,
+	FIGMA_DEF,
+	GOOGLE_MAPS_DEF,
+	CODESANDBOX_DEF,
+];
+
+export interface ResolvedEmbed {
+	def: EmbedDefinition;
+	embedUrl: string;
+}
+
+/**
+ * Resolve a raw URL to an embeddable URL + its definition. Tries the provider
+ * allow-list (hostname match), then the generic fallback. Returns null for
+ * non-http(s) / unparseable input.
+ */
+export function resolveEmbed(
+	rawUrl: string,
+	defs: EmbedDefinition[] = DEFAULT_EMBED_DEFS,
+): ResolvedEmbed | null {
+	let u: URL;
+	try {
+		u = new URL(rawUrl);
+	} catch {
+		return null;
+	}
+	if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+	const host = stripWww(u.hostname);
+	for (const def of defs) {
+		if (def.hostnames.some((h) => host === h || host.endsWith(`.${h}`))) {
+			const embedUrl = def.toEmbedUrl(u);
+			if (embedUrl) return { def, embedUrl };
+		}
+	}
+	const embedUrl = GENERIC_DEF.toEmbedUrl(u);
+	return embedUrl ? { def: GENERIC_DEF, embedUrl } : null;
+}

--- a/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
+++ b/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
@@ -95,7 +95,9 @@ export const GOOGLE_MAPS_DEF: EmbedDefinition = {
 	// real query from the `/place/<name>/`, `@lat,lng`, or `q`/`query` param.
 	toEmbedUrl: (u) => {
 		if (!u.pathname.startsWith("/maps")) return undefined;
-		const at = /@(-?\d+\.?\d*),(-?\d+\.?\d*)/.exec(u.pathname);
+		// `@lat,lng,<zoom>z` — capture the zoom so the embed isn't stuck at a wide
+		// default view. `z` param is unset for a bare `q` (Maps auto-fits the place).
+		const at = /@(-?\d+\.?\d*),(-?\d+\.?\d*)(?:,(\d+\.?\d*)z)?/.exec(u.pathname);
 		const place = /\/place\/([^/@]+)/.exec(u.pathname);
 		const q = u.searchParams.get("q") ?? u.searchParams.get("query");
 		const query =
@@ -103,7 +105,8 @@ export const GOOGLE_MAPS_DEF: EmbedDefinition = {
 			(place ? decodeURIComponent(place[1]).replace(/\+/g, " ") : at ? `${at[1]},${at[2]}` : null);
 		if (!query) return undefined;
 		const ll = at ? `&ll=${at[1]},${at[2]}` : "";
-		return `https://maps.google.com/maps?output=embed&q=${encodeURIComponent(query)}${ll}`;
+		const zoom = at?.[3] ? `&z=${Math.round(Number(at[3]))}` : "";
+		return `https://maps.google.com/maps?output=embed&q=${encodeURIComponent(query)}${ll}${zoom}`;
 	},
 	sandbox: "allow-scripts allow-same-origin allow-popups",
 	allow: "fullscreen",

--- a/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
+++ b/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
@@ -10,6 +10,9 @@ export interface EmbedDefinition {
 	title: string;
 	/** Hostnames (without www.) this definition matches. */
 	hostnames: string[];
+	/** Optional predicate for flexible host matching (e.g. ccTLDs). Takes
+	 * precedence over `hostnames` when present. Host is already `www.`-stripped. */
+	matchHost?: (host: string) => boolean;
 	/** Convert a shareable URL to an embeddable one, or undefined if not embeddable. */
 	toEmbedUrl(url: URL): string | undefined;
 	/** Preferred width/height ratio for a freshly created embed. */
@@ -83,6 +86,10 @@ export const GOOGLE_MAPS_DEF: EmbedDefinition = {
 	id: "google-maps",
 	title: "Google Maps",
 	hostnames: ["google.com", "maps.google.com"],
+	// Match google across ccTLDs (google.co.jp, google.de, maps.google.*, …). The
+	// raw google URL can't be framed (X-Frame-Options); only the `output=embed`
+	// form below can, so recognizing these hosts is what makes Maps embeddable.
+	matchHost: (host) => /^(maps\.)?google\.[a-z.]+$/.test(host),
 	aspect: 4 / 3,
 	// The Maps embed `q` expects an address/coords, NOT a full maps URL. Extract a
 	// real query from the `/place/<name>/`, `@lat,lng`, or `q`/`query` param.
@@ -156,7 +163,10 @@ export function resolveEmbed(
 	if (u.protocol !== "http:" && u.protocol !== "https:") return null;
 	const host = stripWww(u.hostname);
 	for (const def of defs) {
-		if (def.hostnames.some((h) => host === h || host.endsWith(`.${h}`))) {
+		const hostMatches = def.matchHost
+			? def.matchHost(host)
+			: def.hostnames.some((h) => host === h || host.endsWith(`.${h}`));
+		if (hostMatches) {
 			const embedUrl = def.toEmbedUrl(u);
 			if (embedUrl) return { def, embedUrl };
 		}

--- a/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
+++ b/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
@@ -84,10 +84,20 @@ export const GOOGLE_MAPS_DEF: EmbedDefinition = {
 	title: "Google Maps",
 	hostnames: ["google.com", "maps.google.com"],
 	aspect: 4 / 3,
-	toEmbedUrl: (u) =>
-		u.pathname.startsWith("/maps")
-			? `https://maps.google.com/maps?output=embed&q=${encodeURIComponent(u.href)}`
-			: undefined,
+	// The Maps embed `q` expects an address/coords, NOT a full maps URL. Extract a
+	// real query from the `/place/<name>/`, `@lat,lng`, or `q`/`query` param.
+	toEmbedUrl: (u) => {
+		if (!u.pathname.startsWith("/maps")) return undefined;
+		const at = /@(-?\d+\.?\d*),(-?\d+\.?\d*)/.exec(u.pathname);
+		const place = /\/place\/([^/@]+)/.exec(u.pathname);
+		const q = u.searchParams.get("q") ?? u.searchParams.get("query");
+		const query =
+			q ??
+			(place ? decodeURIComponent(place[1]).replace(/\+/g, " ") : at ? `${at[1]},${at[2]}` : null);
+		if (!query) return undefined;
+		const ll = at ? `&ll=${at[1]},${at[2]}` : "";
+		return `https://maps.google.com/maps?output=embed&q=${encodeURIComponent(query)}${ll}`;
+	},
 	sandbox: "allow-scripts allow-same-origin allow-popups",
 	allow: "fullscreen",
 };

--- a/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
+++ b/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
@@ -38,10 +38,15 @@ export const YOUTUBE_DEF: EmbedDefinition = {
 	title: "YouTube",
 	hostnames: ["youtube.com", "youtu.be", "youtube-nocookie.com"],
 	aspect: 16 / 9,
-	// enablejsapi=1 is required for the postMessage player control (watch-party sync).
+	// enablejsapi=1 is required for the postMessage player control (watch-party sync);
+	// origin= is required by the JS API for security and to satisfy YouTube's
+	// referrer/identity check (avoids `embedder.identity.missing.referrer`).
 	toEmbedUrl: (u) => {
 		const id = youtubeId(u);
-		return id ? `https://www.youtube-nocookie.com/embed/${id}?enablejsapi=1&rel=0` : undefined;
+		if (!id) return undefined;
+		const origin = typeof window !== "undefined" ? window.location.origin : "";
+		const originParam = origin ? `&origin=${encodeURIComponent(origin)}` : "";
+		return `https://www.youtube-nocookie.com/embed/${id}?enablejsapi=1&rel=0${originParam}`;
 	},
 	sandbox: "allow-scripts allow-same-origin allow-popups allow-presentation",
 	allow: "autoplay; encrypted-media; picture-in-picture; fullscreen",

--- a/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
+++ b/plugins/usketch-plugin-shape-embed/src/embed-defs.ts
@@ -86,10 +86,11 @@ export const GOOGLE_MAPS_DEF: EmbedDefinition = {
 	id: "google-maps",
 	title: "Google Maps",
 	hostnames: ["google.com", "maps.google.com"],
-	// Match google across ccTLDs (google.co.jp, google.de, maps.google.*, …). The
-	// raw google URL can't be framed (X-Frame-Options); only the `output=embed`
-	// form below can, so recognizing these hosts is what makes Maps embeddable.
-	matchHost: (host) => /^(maps\.)?google\.[a-z.]+$/.test(host),
+	// Match google across ccTLDs (google.com, google.de, google.co.jp,
+	// google.com.au, maps.google.*, …) but ONLY where `google` is the registrable
+	// domain — anchoring the TLD/ccTLD shape rejects spoofs like `google.evil.com`
+	// or `maps.google.evil.com` that a naive `google\.[a-z.]+` would allow.
+	matchHost: (host) => /^(?:maps\.)?google\.(?:com|[a-z]{2}|(?:co|com)\.[a-z]{2})$/.test(host),
 	aspect: 4 / 3,
 	// The Maps embed `q` expects an address/coords, NOT a full maps URL. Extract a
 	// real query from the `/place/<name>/`, `@lat,lng`, or `q`/`query` param.

--- a/plugins/usketch-plugin-shape-embed/src/embed-events.ts
+++ b/plugins/usketch-plugin-shape-embed/src/embed-events.ts
@@ -1,0 +1,16 @@
+/**
+ * Window CustomEvent bridge between the embed shape's in-render controls and the
+ * plugin's setup listener. Kept out of the view module so that module can export
+ * only React components (required for Vite/React Fast Refresh to work — mixing a
+ * component export with a value export disables it and causes stale-closure
+ * crashes on HMR).
+ */
+export const EMBED_ACTION_EVENT = "usketch:embed-action";
+
+export type EmbedAction =
+	| { id: string; action: "set-url"; url: string }
+	| { id: string; action: "activate" | "deactivate" | "toggle-presenter" };
+
+export const emitEmbedAction = (detail: EmbedAction): void => {
+	window.dispatchEvent(new CustomEvent(EMBED_ACTION_EVENT, { detail }));
+};

--- a/plugins/usketch-plugin-shape-embed/src/embed-view.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/embed-view.tsx
@@ -43,6 +43,14 @@ export function EmbedView({ data, rt }: { data: EmbedShapeData; rt: EmbedRuntime
 	const playbackRef = useRef(data.playback);
 	playbackRef.current = data.playback;
 	const [urlDraft, setUrlDraft] = useState("");
+	// Remember the last non-empty URL so that clicking 🔗 (which clears data.url to
+	// reopen the editor) pre-fills the input with the existing URL instead of a
+	// blank field — otherwise an existing embed's URL would have to be retyped.
+	const lastUrlRef = useRef(data.url);
+	useEffect(() => {
+		if (data.url) lastUrlRef.current = data.url;
+		else if (lastUrlRef.current) setUrlDraft(lastUrlRef.current);
+	}, [data.url]);
 
 	const syncable = resolved?.def.syncable === true;
 

--- a/plugins/usketch-plugin-shape-embed/src/embed-view.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/embed-view.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import type { EmbedDefinition, ResolvedEmbed } from "./embed-defs.js";
 import { resolveEmbed } from "./embed-defs.js";
 import { emitEmbedAction } from "./embed-events.js";
-import { needsCorrection, playbackFrom, projectTime } from "./playback.js";
+import { DRIFT_THRESHOLD_S, needsCorrection, playbackFrom, projectTime } from "./playback.js";
 import { createYouTubePlayer, type EmbedPlayer } from "./players/youtube.js";
 import type { EmbedShapeData } from "./types.js";
 
@@ -82,7 +82,7 @@ export function EmbedView({ data, rt }: { data: EmbedShapeData; rt: EmbedRuntime
 			const st = player.getState();
 			if (!st || !needsCorrection(pb, rt.serverClock.now(), st)) return;
 			const target = projectTime(pb, rt.serverClock.now());
-			if (Math.abs(target - st.time) > 0.7) player.seek(target);
+			if (Math.abs(target - st.time) > DRIFT_THRESHOLD_S) player.seek(target);
 			if (pb.playing && !st.playing) player.play();
 			else if (!pb.playing && st.playing) player.pause();
 		}, 1000);

--- a/plugins/usketch-plugin-shape-embed/src/embed-view.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/embed-view.tsx
@@ -1,0 +1,301 @@
+import type { PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import type { ServerClock } from "@edv4h/usketch-sync";
+import { useEffect, useRef, useState } from "react";
+import type { EmbedDefinition, ResolvedEmbed } from "./embed-defs.js";
+import { resolveEmbed } from "./embed-defs.js";
+import { emitEmbedAction } from "./embed-events.js";
+import { needsCorrection, playbackFrom, projectTime } from "./playback.js";
+import { createYouTubePlayer, type EmbedPlayer } from "./players/youtube.js";
+import type { EmbedShapeData } from "./types.js";
+
+/** Per-plugin-instance runtime, passed into the shape view as a prop (no globals,
+ * so multiple boards / StrictMode remounts don't clobber each other). */
+export interface EmbedRuntime {
+	store: PluginContext["store"];
+	serverClock: ServerClock;
+	userId: string;
+	defs: EmbedDefinition[];
+	Chrome: EmbedChrome;
+}
+
+const canControl = (data: EmbedShapeData, userId: string): boolean =>
+	data.syncMode !== "presenter" || data.presenterId === userId;
+
+const btn: React.CSSProperties = {
+	border: "none",
+	background: "rgba(255,255,255,0.15)",
+	color: "#fff",
+	cursor: "pointer",
+	fontSize: 12,
+	lineHeight: 1,
+	padding: "3px 7px",
+	borderRadius: 5,
+	pointerEvents: "auto",
+};
+const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+
+export function EmbedView({ data, rt }: { data: EmbedShapeData; rt: EmbedRuntime }) {
+	// `rt` is always supplied in normal use; the optional-chaining guards keep a
+	// stale-HMR render from throwing (renders a harmless empty state instead).
+	const resolved = data.url && rt ? resolveEmbed(data.url, rt.defs) : null;
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const playerRef = useRef<EmbedPlayer | null>(null);
+	const playbackRef = useRef(data.playback);
+	playbackRef.current = data.playback;
+	const [urlDraft, setUrlDraft] = useState("");
+
+	const syncable = resolved?.def.syncable === true;
+
+	// Create the synced player when a syncable iframe mounts.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: recreate only on shape/embed change
+	useEffect(() => {
+		if (!syncable || !iframeRef.current || !rt) return;
+		const player = createYouTubePlayer(iframeRef.current);
+		playerRef.current = player;
+		player.onUserAction(() => {
+			const cur = rt.store.getShape(data.id) as EmbedShapeData | undefined;
+			if (!cur || !canControl(cur, rt.userId)) return;
+			const st = player.getState();
+			if (!st) return;
+			// Ignore state changes that merely converge to the already-synced state —
+			// that's our own applied correction echoing back, not a genuine user
+			// action — otherwise followers would re-broadcast and oscillate.
+			const pb = playbackRef.current;
+			if (pb && !needsCorrection(pb, rt.serverClock.now(), st)) return;
+			rt.store.updateShape(data.id, {
+				playback: playbackFrom(st, rt.serverClock.now(), rt.userId),
+			} as Partial<ShapeData>);
+		});
+		return () => {
+			player.destroy();
+			playerRef.current = null;
+		};
+	}, [syncable, data.id, resolved?.embedUrl]);
+
+	// Drift-correct the local player toward the synced playback state.
+	useEffect(() => {
+		if (!syncable || !rt) return;
+		const iv = setInterval(() => {
+			const player = playerRef.current;
+			const pb = playbackRef.current;
+			if (!player || !pb) return;
+			const st = player.getState();
+			if (!st || !needsCorrection(pb, rt.serverClock.now(), st)) return;
+			const target = projectTime(pb, rt.serverClock.now());
+			if (Math.abs(target - st.time) > 0.7) player.seek(target);
+			if (pb.playing && !st.playing) player.play();
+			else if (!pb.playing && st.playing) player.pause();
+		}, 1000);
+		return () => clearInterval(iv);
+	}, [syncable, rt]);
+
+	const active = data.isActive === true;
+	const isPresenter = data.syncMode === "presenter";
+	const iAmPresenter = data.presenterId === rt?.userId;
+	const Chrome = rt?.Chrome ?? DefaultEmbedChrome;
+
+	// Plugin-owned body (iframe keeps the sync player ref; a custom Chrome must
+	// render {children} for playback sync to work).
+	const body = resolved ? (
+		<div style={{ width: "100%", height: "100%", position: "relative", background: "#000" }}>
+			<iframe
+				ref={iframeRef}
+				id={`usketch-embed-${data.id}`}
+				src={resolved.embedUrl}
+				title={resolved.def.title}
+				sandbox={resolved.def.sandbox}
+				allow={resolved.def.allow}
+				referrerPolicy="strict-origin-when-cross-origin"
+				style={{
+					width: "100%",
+					height: "100%",
+					border: "none",
+					display: "block",
+					pointerEvents: active ? "auto" : "none",
+				}}
+			/>
+			{!active && (
+				<div
+					style={{
+						position: "absolute",
+						inset: 0,
+						display: "flex",
+						alignItems: "flex-end",
+						justifyContent: "center",
+						paddingBottom: 8,
+						pointerEvents: "none",
+					}}
+				>
+					<span
+						style={{
+							fontSize: 11,
+							color: "#fff",
+							background: "rgba(0,0,0,0.5)",
+							padding: "2px 8px",
+							borderRadius: 10,
+						}}
+					>
+						▶ で操作
+					</span>
+				</div>
+			)}
+		</div>
+	) : (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				gap: 8,
+				padding: 16,
+				background: "#f8fafc",
+			}}
+		>
+			<div style={{ fontSize: 13, color: "#64748b" }}>🔗 URL を貼り付けて埋め込み</div>
+			<input
+				type="url"
+				placeholder="https://www.youtube.com/watch?v=…"
+				value={urlDraft}
+				onChange={(e) => setUrlDraft(e.target.value)}
+				onPointerDown={stop}
+				onKeyDown={(e) => {
+					e.stopPropagation();
+					if (e.key === "Enter" && urlDraft.trim())
+						emitEmbedAction({ id: data.id, action: "set-url", url: urlDraft.trim() });
+				}}
+				onBlur={() =>
+					urlDraft.trim() &&
+					emitEmbedAction({ id: data.id, action: "set-url", url: urlDraft.trim() })
+				}
+				style={{
+					width: "90%",
+					padding: "6px 8px",
+					fontSize: 13,
+					borderRadius: 6,
+					border: "1px solid #cbd5e1",
+					pointerEvents: "auto",
+				}}
+			/>
+		</div>
+	);
+
+	return (
+		<Chrome
+			data={data}
+			resolved={resolved}
+			active={active}
+			syncable={syncable}
+			isPresenter={isPresenter}
+			iAmPresenter={iAmPresenter}
+			onSetUrl={(url) => emitEmbedAction({ id: data.id, action: "set-url", url })}
+			onActivate={() => emitEmbedAction({ id: data.id, action: "activate" })}
+			onDeactivate={() => emitEmbedAction({ id: data.id, action: "deactivate" })}
+			onTogglePresenter={() => emitEmbedAction({ id: data.id, action: "toggle-presenter" })}
+		>
+			{body}
+		</Chrome>
+	);
+}
+
+// ── Default chrome (overridable via plugin `components.Chrome`) ──
+
+export interface EmbedChromeProps {
+	data: EmbedShapeData;
+	resolved: ResolvedEmbed | null;
+	active: boolean;
+	syncable: boolean;
+	isPresenter: boolean;
+	iAmPresenter: boolean;
+	/** Pass "" to clear/re-edit the URL. */
+	onSetUrl: (url: string) => void;
+	onActivate: () => void;
+	onDeactivate: () => void;
+	onTogglePresenter: () => void;
+	/** Plugin-owned body (iframe / URL input). Must be rendered for sync to work. */
+	children: React.ReactNode;
+}
+export type EmbedChrome = (props: EmbedChromeProps) => React.ReactElement;
+
+export function DefaultEmbedChrome(p: EmbedChromeProps) {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				boxSizing: "border-box",
+				display: "flex",
+				flexDirection: "column",
+				background: "#000",
+				border: `${p.data.style.strokeWidth}px solid ${p.data.style.stroke}`,
+				borderRadius: 8,
+				overflow: "hidden",
+				fontFamily: "system-ui, sans-serif",
+				pointerEvents: "none",
+				userSelect: "none",
+			}}
+		>
+			<div
+				style={{
+					height: 28,
+					flex: "0 0 auto",
+					display: "flex",
+					alignItems: "center",
+					gap: 6,
+					padding: "0 6px",
+					background: "#111827",
+					color: "#e5e7eb",
+				}}
+			>
+				<span
+					style={{
+						flex: 1,
+						fontSize: 11,
+						fontWeight: 600,
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+					}}
+				>
+					{p.resolved?.def.title ?? "埋め込み"}
+				</span>
+				{p.resolved && p.syncable && (
+					<button
+						type="button"
+						title={p.isPresenter ? "プレゼンター解除（全員操作可）" : "プレゼンターにする"}
+						style={{ ...btn, background: p.iAmPresenter ? "#7c3aed" : btn.background }}
+						onPointerDown={stop}
+						onClick={(e) => (stop(e), p.onTogglePresenter())}
+					>
+						{p.isPresenter ? "🔒" : "🆓"}
+					</button>
+				)}
+				{p.resolved && (
+					<button
+						type="button"
+						title="URL を変更"
+						style={btn}
+						onPointerDown={stop}
+						onClick={(e) => (stop(e), p.onSetUrl(""))}
+					>
+						🔗
+					</button>
+				)}
+				{p.resolved && (
+					<button
+						type="button"
+						title={p.active ? "操作を終了" : "操作する"}
+						style={btn}
+						onPointerDown={stop}
+						onClick={(e) => (stop(e), p.active ? p.onDeactivate() : p.onActivate())}
+					>
+						{p.active ? "✕" : "▶"}
+					</button>
+				)}
+			</div>
+			<div style={{ flex: 1, minHeight: 0 }}>{p.children}</div>
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-shape-embed/src/external-content-handler.ts
+++ b/plugins/usketch-plugin-shape-embed/src/external-content-handler.ts
@@ -16,24 +16,21 @@ function viewportCenter(ctx: ExternalContentHandlerCtx): { x: number; y: number 
 }
 
 /**
- * `kind:"url"` handler: paste/drop a URL from a KNOWN provider (YouTube, Figma,
- * …) → create an embed shape at the viewport center. Registered at `order: 0`
- * (lowest) so a more specific URL handler could win. Arbitrary links are NOT
- * auto-embedded — most sites refuse framing (`X-Frame-Options`) and would show
- * blank; use the embed tool + URL field for a best-effort generic iframe.
+ * `kind:"url"` handler: paste/drop any http(s) URL → create an embed shape at
+ * the viewport center. Registered at `order: 0` (lowest) so a more specific URL
+ * handler could win. Known providers (YouTube/Figma/Maps/…) get a proper embed
+ * URL; other links use a best-effort generic iframe (note: sites that send
+ * `X-Frame-Options`/`frame-ancestors` — and Google Maps *share* short links —
+ * will render blank; paste the full address-bar Maps URL for a live map).
  */
 export function createEmbedUrlHandler(
 	getDefs: () => EmbedDefinition[],
 ): ExternalContentHandler<"url"> {
-	const isKnownProvider = (url: string) => {
-		const r = resolveEmbed(url, getDefs());
-		return r !== null && r.def.id !== "generic";
-	};
 	return {
 		id: "usketch-plugin-shape-embed:url",
 		kind: "url",
 		order: 0,
-		match: (content) => isKnownProvider(content.url),
+		match: (content) => resolveEmbed(content.url, getDefs()) !== null,
 		handle: (content, ctx) => {
 			const resolved = resolveEmbed(content.url, getDefs());
 			if (!resolved) return;

--- a/plugins/usketch-plugin-shape-embed/src/external-content-handler.ts
+++ b/plugins/usketch-plugin-shape-embed/src/external-content-handler.ts
@@ -1,0 +1,61 @@
+import type {
+	ExternalContentHandler,
+	ExternalContentHandlerCtx,
+	ShapeData,
+} from "@edv4h/usketch-shared";
+import { generateId } from "@edv4h/usketch-shared";
+import { type EmbedDefinition, resolveEmbed } from "./embed-defs.js";
+import type { EmbedShapeData } from "./types.js";
+
+/** World point at the current viewport center (place dropped/pasted embeds there). */
+function viewportCenter(ctx: ExternalContentHandlerCtx): { x: number; y: number } {
+	const vp = ctx.store.getViewport();
+	const w = typeof window !== "undefined" ? window.innerWidth : 0;
+	const h = typeof window !== "undefined" ? window.innerHeight : 0;
+	return { x: (w / 2 - vp.x) / vp.zoom, y: (h / 2 - vp.y) / vp.zoom };
+}
+
+/**
+ * `kind:"url"` handler: paste/drop an http(s) URL → create an embed shape at the
+ * viewport center. Registered at `order: 0` (lowest) so a more specific URL
+ * handler could win. Uses the provider's aspect ratio to size the shape.
+ */
+export function createEmbedUrlHandler(
+	getDefs: () => EmbedDefinition[],
+): ExternalContentHandler<"url"> {
+	return {
+		id: "usketch-plugin-shape-embed:url",
+		kind: "url",
+		order: 0,
+		match: (content) => resolveEmbed(content.url, getDefs()) !== null,
+		handle: (content, ctx) => {
+			const resolved = resolveEmbed(content.url, getDefs());
+			if (!resolved) return;
+			const aspect = resolved.def.aspect ?? 16 / 9;
+			const width = 560;
+			const height = Math.round(width / aspect) + 28; // + header
+			const c = viewportCenter(ctx);
+			const id = generateId();
+			const shape: EmbedShapeData = {
+				id,
+				type: "embed",
+				x: Math.round(c.x - width / 2),
+				y: Math.round(c.y - height / 2),
+				width,
+				height,
+				style: { fill: "#000000", stroke: "#334155", strokeWidth: 1, opacity: 1 },
+				url: content.url,
+				provider: resolved.def.id,
+				isActive: false,
+				syncMode: "free",
+			};
+			ctx.commands.execute({
+				execute: () => {
+					ctx.store.addShape(shape as ShapeData);
+					ctx.store.setSelection([id]);
+				},
+				undo: () => ctx.store.deleteShape(id),
+			});
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-embed/src/external-content-handler.ts
+++ b/plugins/usketch-plugin-shape-embed/src/external-content-handler.ts
@@ -16,18 +16,24 @@ function viewportCenter(ctx: ExternalContentHandlerCtx): { x: number; y: number 
 }
 
 /**
- * `kind:"url"` handler: paste/drop an http(s) URL → create an embed shape at the
- * viewport center. Registered at `order: 0` (lowest) so a more specific URL
- * handler could win. Uses the provider's aspect ratio to size the shape.
+ * `kind:"url"` handler: paste/drop a URL from a KNOWN provider (YouTube, Figma,
+ * …) → create an embed shape at the viewport center. Registered at `order: 0`
+ * (lowest) so a more specific URL handler could win. Arbitrary links are NOT
+ * auto-embedded — most sites refuse framing (`X-Frame-Options`) and would show
+ * blank; use the embed tool + URL field for a best-effort generic iframe.
  */
 export function createEmbedUrlHandler(
 	getDefs: () => EmbedDefinition[],
 ): ExternalContentHandler<"url"> {
+	const isKnownProvider = (url: string) => {
+		const r = resolveEmbed(url, getDefs());
+		return r !== null && r.def.id !== "generic";
+	};
 	return {
 		id: "usketch-plugin-shape-embed:url",
 		kind: "url",
 		order: 0,
-		match: (content) => resolveEmbed(content.url, getDefs()) !== null,
+		match: (content) => isKnownProvider(content.url),
 		handle: (content, ctx) => {
 			const resolved = resolveEmbed(content.url, getDefs());
 			if (!resolved) return;

--- a/plugins/usketch-plugin-shape-embed/src/index.ts
+++ b/plugins/usketch-plugin-shape-embed/src/index.ts
@@ -16,5 +16,12 @@ export {
 	playbackFrom,
 	projectTime,
 } from "./playback.js";
-export { createEmbedShapePlugin, EMBED_TYPE, type EmbedPluginOptions } from "./plugin.js";
+export {
+	createEmbedShapePlugin,
+	DefaultEmbedChrome,
+	EMBED_TYPE,
+	type EmbedChrome,
+	type EmbedChromeProps,
+	type EmbedPluginOptions,
+} from "./plugin.js";
 export type { EmbedShapeData, EmbedSyncMode, PlaybackState } from "./types.js";

--- a/plugins/usketch-plugin-shape-embed/src/index.ts
+++ b/plugins/usketch-plugin-shape-embed/src/index.ts
@@ -11,17 +11,15 @@ export {
 	YOUTUBE_DEF,
 } from "./embed-defs.js";
 export {
+	DefaultEmbedChrome,
+	type EmbedChrome,
+	type EmbedChromeProps,
+} from "./embed-view.js";
+export {
 	DRIFT_THRESHOLD_S,
 	needsCorrection,
 	playbackFrom,
 	projectTime,
 } from "./playback.js";
-export {
-	createEmbedShapePlugin,
-	DefaultEmbedChrome,
-	EMBED_TYPE,
-	type EmbedChrome,
-	type EmbedChromeProps,
-	type EmbedPluginOptions,
-} from "./plugin.js";
+export { createEmbedShapePlugin, EMBED_TYPE, type EmbedPluginOptions } from "./plugin.js";
 export type { EmbedShapeData, EmbedSyncMode, PlaybackState } from "./types.js";

--- a/plugins/usketch-plugin-shape-embed/src/index.ts
+++ b/plugins/usketch-plugin-shape-embed/src/index.ts
@@ -1,0 +1,20 @@
+export {
+	CODESANDBOX_DEF,
+	DEFAULT_EMBED_DEFS,
+	type EmbedDefinition,
+	FIGMA_DEF,
+	GENERIC_DEF,
+	GOOGLE_MAPS_DEF,
+	type ResolvedEmbed,
+	resolveEmbed,
+	VIMEO_DEF,
+	YOUTUBE_DEF,
+} from "./embed-defs.js";
+export {
+	DRIFT_THRESHOLD_S,
+	needsCorrection,
+	playbackFrom,
+	projectTime,
+} from "./playback.js";
+export { createEmbedShapePlugin, EMBED_TYPE, type EmbedPluginOptions } from "./plugin.js";
+export type { EmbedShapeData, EmbedSyncMode, PlaybackState } from "./types.js";

--- a/plugins/usketch-plugin-shape-embed/src/playback.ts
+++ b/plugins/usketch-plugin-shape-embed/src/playback.ts
@@ -1,0 +1,43 @@
+import type { PlaybackState } from "./types.js";
+
+/** Drift threshold (s): re-seek the local player only past this to avoid churn. */
+export const DRIFT_THRESHOLD_S = 0.7;
+
+/**
+ * Project the expected playhead position (s) for a synced playback state at a
+ * given server-clock time. While playing, the head advances from `time` by the
+ * elapsed wall time since `at`; while paused it's frozen at `time`.
+ */
+export function projectTime(state: PlaybackState, serverNowMs: number): number {
+	if (!state.playing) return Math.max(0, state.time);
+	const elapsed = (serverNowMs - state.at) / 1000;
+	return Math.max(0, state.time + elapsed);
+}
+
+/**
+ * Whether the local player (at `localTime`, `localPlaying`) needs correcting to
+ * match the synced state — a play/pause mismatch, or a position drift past the
+ * threshold.
+ */
+export function needsCorrection(
+	state: PlaybackState,
+	serverNowMs: number,
+	local: { playing: boolean; time: number },
+): boolean {
+	if (state.playing !== local.playing) return true;
+	return Math.abs(projectTime(state, serverNowMs) - local.time) > DRIFT_THRESHOLD_S;
+}
+
+/** Build a fresh playback state from a local player action. */
+export function playbackFrom(
+	local: { playing: boolean; time: number },
+	serverNowMs: number,
+	userId: string,
+): PlaybackState {
+	return {
+		playing: local.playing,
+		time: Math.max(0, local.time),
+		at: serverNowMs,
+		updatedBy: userId,
+	};
+}

--- a/plugins/usketch-plugin-shape-embed/src/players/youtube.ts
+++ b/plugins/usketch-plugin-shape-embed/src/players/youtube.ts
@@ -1,0 +1,96 @@
+/**
+ * Minimal YouTube IFrame player controller over `postMessage` (no YT SDK). The
+ * embed URL must carry `enablejsapi=1`. We poll `getCurrentTime`/state via the
+ * documented postMessage protocol and expose play/pause/seek plus a
+ * user-action callback for the watch-party sync layer.
+ */
+
+export interface EmbedPlayer {
+	play(): void;
+	pause(): void;
+	seek(seconds: number): void;
+	/** Latest known {playing, time}; null until the player reports. */
+	getState(): { playing: boolean; time: number } | null;
+	/** Fires when the *user* (not a programmatic apply) plays/pauses/seeks. */
+	onUserAction(cb: () => void): void;
+	destroy(): void;
+}
+
+// YT.PlayerState
+const PLAYING = 1;
+const PAUSED = 2;
+
+export function createYouTubePlayer(iframe: HTMLIFrameElement): EmbedPlayer {
+	let playing = false;
+	let time = 0;
+	let reported = false;
+	let userCb: (() => void) | null = null;
+	// Suppress the user-action callback for state changes we caused ourselves.
+	let suppressUntil = 0;
+	const now = () => Date.now();
+
+	const post = (func: string, args: unknown[] = []) => {
+		iframe.contentWindow?.postMessage(JSON.stringify({ event: "command", func, args }), "*");
+	};
+
+	// Ask the player to start emitting events to us.
+	const startListening = () => {
+		iframe.contentWindow?.postMessage(JSON.stringify({ event: "listening", id: iframe.id }), "*");
+	};
+
+	const onMessage = (e: MessageEvent) => {
+		if (!iframe.contentWindow || e.source !== iframe.contentWindow) return;
+		let data: unknown;
+		try {
+			data = typeof e.data === "string" ? JSON.parse(e.data) : e.data;
+		} catch {
+			return;
+		}
+		const msg = data as { event?: string; info?: unknown };
+		const info = (msg.info ?? {}) as { playerState?: number; currentTime?: number };
+		if (typeof info.currentTime === "number") time = info.currentTime;
+		if (typeof info.playerState === "number") {
+			const wasPlaying = playing;
+			playing = info.playerState === PLAYING;
+			reported = true;
+			// A state flip we didn't initiate = a user action → notify sync layer.
+			if (info.playerState === PLAYING || info.playerState === PAUSED) {
+				if (wasPlaying !== playing && now() > suppressUntil) userCb?.();
+			}
+		}
+	};
+	window.addEventListener("message", onMessage);
+
+	// Kick off listening + poll time (YT pushes onStateChange but time needs polling).
+	const onLoad = () => startListening();
+	iframe.addEventListener("load", onLoad);
+	startListening();
+	const poll = setInterval(() => {
+		startListening();
+	}, 1000);
+
+	return {
+		play() {
+			suppressUntil = now() + 400;
+			post("playVideo");
+		},
+		pause() {
+			suppressUntil = now() + 400;
+			post("pauseVideo");
+		},
+		seek(seconds: number) {
+			suppressUntil = now() + 400;
+			post("seekTo", [Math.max(0, seconds), true]);
+		},
+		getState: () => (reported ? { playing, time } : null),
+		onUserAction(cb) {
+			userCb = cb;
+		},
+		destroy() {
+			clearInterval(poll);
+			window.removeEventListener("message", onMessage);
+			iframe.removeEventListener("load", onLoad);
+			userCb = null;
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-embed/src/players/youtube.ts
+++ b/plugins/usketch-plugin-shape-embed/src/players/youtube.ts
@@ -20,10 +20,14 @@ export interface EmbedPlayer {
 // YT.PlayerState
 const PLAYING = 1;
 const PAUSED = 2;
+// A currentTime report this far off the projected position = a seek (not normal
+// playback progression / a paused hold).
+const SEEK_JUMP_S = 1.0;
 
 export function createYouTubePlayer(iframe: HTMLIFrameElement): EmbedPlayer {
 	let playing = false;
 	let time = 0;
+	let timeAt = 0; // wall-clock ms when `time` was last observed (0 = never)
 	let reported = false;
 	let userCb: (() => void) | null = null;
 	// Suppress the user-action callback for state changes we caused ourselves.
@@ -68,14 +72,29 @@ export function createYouTubePlayer(iframe: HTMLIFrameElement): EmbedPlayer {
 		}
 		const msg = data as { event?: string; info?: unknown };
 		const info = (msg.info ?? {}) as { playerState?: number; currentTime?: number };
-		if (typeof info.currentTime === "number") time = info.currentTime;
+		const t = now();
+		if (typeof info.currentTime === "number") {
+			// Seek detection: a currentTime that jumped away from where normal
+			// playback (or a paused hold) would have taken us = a user seek. This
+			// catches seeks that don't flip playerState (e.g. scrubbing while playing).
+			// Skipped for our own programmatic seeks (suppress window) and the 1st report.
+			if (timeAt !== 0 && t > suppressUntil) {
+				const projected = playing ? time + (t - timeAt) / 1000 : time;
+				if (Math.abs(info.currentTime - projected) > SEEK_JUMP_S) userCb?.();
+			}
+			time = info.currentTime;
+			timeAt = t;
+		}
 		if (typeof info.playerState === "number") {
-			const wasPlaying = playing;
-			playing = info.playerState === PLAYING;
 			reported = true;
-			// A state flip we didn't initiate = a user action → notify sync layer.
+			// Only stable PLAYING/PAUSED update `playing` and emit — transient states
+			// (BUFFERING/CUED/ENDED) would flip `playing` and look like a spurious
+			// user play/pause when it settles back.
 			if (info.playerState === PLAYING || info.playerState === PAUSED) {
-				if (wasPlaying !== playing && now() > suppressUntil) userCb?.();
+				const next = info.playerState === PLAYING;
+				const wasPlaying = playing;
+				playing = next;
+				if (wasPlaying !== next && t > suppressUntil) userCb?.();
 			}
 		}
 	};

--- a/plugins/usketch-plugin-shape-embed/src/players/youtube.ts
+++ b/plugins/usketch-plugin-shape-embed/src/players/youtube.ts
@@ -1,8 +1,9 @@
 /**
  * Minimal YouTube IFrame player controller over `postMessage` (no YT SDK). The
- * embed URL must carry `enablejsapi=1`. We poll `getCurrentTime`/state via the
- * documented postMessage protocol and expose play/pause/seek plus a
- * user-action callback for the watch-party sync layer.
+ * embed URL must carry `enablejsapi=1`. We (re)send the `listening` handshake so
+ * the player pushes `infoDelivery` events (playerState + currentTime) back to
+ * us, and expose play/pause/seek plus a user-action callback for the watch-party
+ * sync layer. Messages are pinned to the iframe's origin in both directions.
  */
 
 export interface EmbedPlayer {
@@ -29,17 +30,36 @@ export function createYouTubePlayer(iframe: HTMLIFrameElement): EmbedPlayer {
 	let suppressUntil = 0;
 	const now = () => Date.now();
 
+	// Pin postMessage to the iframe's origin (e.g. https://www.youtube-nocookie.com)
+	// rather than "*", so control messages can't leak to — and spoofed messages
+	// can't arrive from — a frame navigated to a different origin.
+	let targetOrigin = "*";
+	try {
+		if (iframe.src) targetOrigin = new URL(iframe.src).origin;
+	} catch {
+		// keep "*"
+	}
+
 	const post = (func: string, args: unknown[] = []) => {
-		iframe.contentWindow?.postMessage(JSON.stringify({ event: "command", func, args }), "*");
+		iframe.contentWindow?.postMessage(
+			JSON.stringify({ event: "command", func, args }),
+			targetOrigin,
+		);
 	};
 
 	// Ask the player to start emitting events to us.
 	const startListening = () => {
-		iframe.contentWindow?.postMessage(JSON.stringify({ event: "listening", id: iframe.id }), "*");
+		iframe.contentWindow?.postMessage(
+			JSON.stringify({ event: "listening", id: iframe.id }),
+			targetOrigin,
+		);
 	};
 
 	const onMessage = (e: MessageEvent) => {
 		if (!iframe.contentWindow || e.source !== iframe.contentWindow) return;
+		// Also validate the origin (when known) so a cross-origin frame reusing the
+		// same window can't spoof YouTube protocol messages.
+		if (targetOrigin !== "*" && e.origin !== targetOrigin) return;
 		let data: unknown;
 		try {
 			data = typeof e.data === "string" ? JSON.parse(e.data) : e.data;

--- a/plugins/usketch-plugin-shape-embed/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/plugin.tsx
@@ -11,7 +11,7 @@ import {
 	withRotation,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
-import { createServerClock } from "@edv4h/usketch-sync";
+import { createServerClock, type ServerClock } from "@edv4h/usketch-sync";
 import { DEFAULT_EMBED_DEFS, type EmbedDefinition, resolveEmbed } from "./embed-defs.js";
 import { EMBED_ACTION_EVENT, type EmbedAction } from "./embed-events.js";
 import {
@@ -128,7 +128,11 @@ function EmbedIcon() {
 export interface EmbedPluginOptions {
 	/** Extra provider definitions (added before defaults so they can override). */
 	embeds?: EmbedDefinition[];
-	/** API origin for the shared server clock (playback sync). Omit → local clock. */
+	/** Existing server clock to reuse (e.g. the board-level one shared with Timter),
+	 * so we don't spin up a second `/time` poller. Takes precedence over `apiUrl`. */
+	serverClock?: ServerClock;
+	/** API origin for a server clock created by this plugin when `serverClock` is
+	 * not provided (playback sync). Omit → local clock. */
 	apiUrl?: string;
 	boardId?: string;
 	userId?: string;
@@ -144,7 +148,12 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 
 		setup(ctx: PluginContext) {
 			const defs = [...(options.embeds ?? []), ...DEFAULT_EMBED_DEFS];
-			const serverClock = createServerClock({ baseUrl: options.apiUrl ?? null });
+			// Reuse a provided clock (shared with other features); only create — and
+			// therefore only destroy — our own when none was supplied.
+			const ownClock = options.serverClock
+				? null
+				: createServerClock({ baseUrl: options.apiUrl ?? null });
+			const serverClock = options.serverClock ?? ownClock!;
 			const userId = options.userId ?? "local";
 			const rt: EmbedRuntime = {
 				store: ctx.store,
@@ -292,7 +301,7 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 				offPointer();
 				unsubStore();
 				offUrl();
-				serverClock.destroy();
+				ownClock?.destroy();
 			};
 		},
 	};

--- a/plugins/usketch-plugin-shape-embed/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/plugin.tsx
@@ -244,7 +244,7 @@ function EmbedView({ data }: { data: EmbedShapeData }) {
 					title={resolved.def.title}
 					sandbox={resolved.def.sandbox}
 					allow={resolved.def.allow}
-					referrerPolicy="no-referrer"
+					referrerPolicy="strict-origin-when-cross-origin"
 					style={{
 						width: "100%",
 						height: "100%",

--- a/plugins/usketch-plugin-shape-embed/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/plugin.tsx
@@ -1,0 +1,536 @@
+import {
+	type BoundingBox,
+	type CanvasPointerEvent,
+	generateId,
+	type PluginContext,
+	type Point,
+	type ResizeHandle,
+	type ShapeData,
+	type ToolContext,
+	type UsketchPlugin,
+	withRotation,
+} from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import { createServerClock, type ServerClock } from "@edv4h/usketch-sync";
+import { useEffect, useRef, useState } from "react";
+import { DEFAULT_EMBED_DEFS, type EmbedDefinition, resolveEmbed } from "./embed-defs.js";
+import { createEmbedUrlHandler } from "./external-content-handler.js";
+import { needsCorrection, playbackFrom, projectTime } from "./playback.js";
+import { createYouTubePlayer, type EmbedPlayer } from "./players/youtube.js";
+import type { EmbedShapeData } from "./types.js";
+
+export const EMBED_TYPE = "embed";
+const ACTION_EVENT = "usketch:embed-action";
+
+/** Runtime deps resolved lazily at render time (render fns have no PluginContext). */
+interface EmbedRuntime {
+	store: PluginContext["store"];
+	serverClock: ServerClock;
+	userId: string;
+	defs: EmbedDefinition[];
+}
+let runtime: EmbedRuntime | null = null;
+
+type Action =
+	| { id: string; action: "set-url"; url: string }
+	| { id: string; action: "activate" | "deactivate" | "toggle-presenter" };
+
+const emit = (detail: Action) => window.dispatchEvent(new CustomEvent(ACTION_EVENT, { detail }));
+
+const canControl = (data: EmbedShapeData, userId: string): boolean =>
+	data.syncMode !== "presenter" || data.presenterId === userId;
+
+// ── View ──
+
+const btn: React.CSSProperties = {
+	border: "none",
+	background: "rgba(255,255,255,0.15)",
+	color: "#fff",
+	cursor: "pointer",
+	fontSize: 12,
+	lineHeight: 1,
+	padding: "3px 7px",
+	borderRadius: 5,
+	pointerEvents: "auto",
+};
+const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+
+function EmbedView({ data }: { data: EmbedShapeData }) {
+	const resolved = data.url ? resolveEmbed(data.url, runtime?.defs) : null;
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const playerRef = useRef<EmbedPlayer | null>(null);
+	const playbackRef = useRef(data.playback);
+	playbackRef.current = data.playback;
+	const [urlDraft, setUrlDraft] = useState("");
+
+	const syncable = resolved?.def.syncable === true;
+
+	// Create the synced player when a syncable iframe mounts.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: recreate only on shape/embed change
+	useEffect(() => {
+		if (!syncable || !iframeRef.current || !runtime) return;
+		const rt = runtime;
+		const player = createYouTubePlayer(iframeRef.current);
+		playerRef.current = player;
+		player.onUserAction(() => {
+			const cur = rt.store.getShape(data.id) as EmbedShapeData | undefined;
+			if (!cur || !canControl(cur, rt.userId)) return;
+			const st = player.getState();
+			if (st)
+				rt.store.updateShape(data.id, {
+					playback: playbackFrom(st, rt.serverClock.now(), rt.userId),
+				} as Partial<ShapeData>);
+		});
+		return () => {
+			player.destroy();
+			playerRef.current = null;
+		};
+	}, [syncable, data.id, resolved?.embedUrl]);
+
+	// Drift-correct the local player toward the synced playback state.
+	useEffect(() => {
+		if (!syncable || !runtime) return;
+		const rt = runtime;
+		const iv = setInterval(() => {
+			const player = playerRef.current;
+			const pb = playbackRef.current;
+			if (!player || !pb) return;
+			const st = player.getState();
+			if (!st || !needsCorrection(pb, rt.serverClock.now(), st)) return;
+			const target = projectTime(pb, rt.serverClock.now());
+			if (Math.abs(target - st.time) > 0.7) player.seek(target);
+			if (pb.playing && !st.playing) player.play();
+			else if (!pb.playing && st.playing) player.pause();
+		}, 1000);
+		return () => clearInterval(iv);
+	}, [syncable]);
+
+	// ── URL entry (no url yet) ──
+	if (!resolved) {
+		return (
+			<div
+				style={{
+					width: "100%",
+					height: "100%",
+					boxSizing: "border-box",
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					gap: 8,
+					padding: 16,
+					background: "#f8fafc",
+					border: `${data.style.strokeWidth}px dashed ${data.style.stroke}`,
+					borderRadius: 8,
+					fontFamily: "system-ui, sans-serif",
+					pointerEvents: "none",
+					userSelect: "none",
+				}}
+			>
+				<div style={{ fontSize: 13, color: "#64748b" }}>🔗 URL を貼り付けて埋め込み</div>
+				<input
+					type="url"
+					placeholder="https://www.youtube.com/watch?v=…"
+					value={urlDraft}
+					onChange={(e) => setUrlDraft(e.target.value)}
+					onPointerDown={stop}
+					onKeyDown={(e) => {
+						e.stopPropagation();
+						if (e.key === "Enter" && urlDraft.trim())
+							emit({ id: data.id, action: "set-url", url: urlDraft.trim() });
+					}}
+					onBlur={() =>
+						urlDraft.trim() && emit({ id: data.id, action: "set-url", url: urlDraft.trim() })
+					}
+					style={{
+						width: "90%",
+						padding: "6px 8px",
+						fontSize: 13,
+						borderRadius: 6,
+						border: "1px solid #cbd5e1",
+						pointerEvents: "auto",
+					}}
+				/>
+			</div>
+		);
+	}
+
+	const active = data.isActive === true;
+	const isPresenter = data.syncMode === "presenter";
+	const iAmPresenter = data.presenterId === runtime?.userId;
+
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				boxSizing: "border-box",
+				display: "flex",
+				flexDirection: "column",
+				background: "#000",
+				border: `${data.style.strokeWidth}px solid ${data.style.stroke}`,
+				borderRadius: 8,
+				overflow: "hidden",
+				fontFamily: "system-ui, sans-serif",
+				pointerEvents: "none",
+				userSelect: "none",
+				position: "relative",
+			}}
+		>
+			{/* Header (interactive controls) */}
+			<div
+				style={{
+					height: 28,
+					flex: "0 0 auto",
+					display: "flex",
+					alignItems: "center",
+					gap: 6,
+					padding: "0 6px",
+					background: "#111827",
+					color: "#e5e7eb",
+				}}
+			>
+				<span
+					style={{
+						flex: 1,
+						fontSize: 11,
+						fontWeight: 600,
+						overflow: "hidden",
+						textOverflow: "ellipsis",
+						whiteSpace: "nowrap",
+					}}
+				>
+					{resolved.def.title}
+				</span>
+				{syncable && (
+					<button
+						type="button"
+						title={isPresenter ? "プレゼンター解除（全員操作可）" : "プレゼンターにする"}
+						style={{ ...btn, background: iAmPresenter ? "#7c3aed" : btn.background }}
+						onPointerDown={stop}
+						onClick={(e) => (stop(e), emit({ id: data.id, action: "toggle-presenter" }))}
+					>
+						{isPresenter ? "🔒" : "🆓"}
+					</button>
+				)}
+				<button
+					type="button"
+					title="URL を変更"
+					style={btn}
+					onPointerDown={stop}
+					onClick={(e) => (stop(e), emit({ id: data.id, action: "set-url", url: "" }))}
+				>
+					🔗
+				</button>
+				<button
+					type="button"
+					title={active ? "操作を終了" : "操作する"}
+					style={btn}
+					onPointerDown={stop}
+					onClick={(e) => (
+						stop(e), emit({ id: data.id, action: active ? "deactivate" : "activate" })
+					)}
+				>
+					{active ? "✕" : "▶"}
+				</button>
+			</div>
+
+			{/* iframe */}
+			<div style={{ flex: 1, minHeight: 0, position: "relative" }}>
+				<iframe
+					ref={iframeRef}
+					id={`usketch-embed-${data.id}`}
+					src={resolved.embedUrl}
+					title={resolved.def.title}
+					sandbox={resolved.def.sandbox}
+					allow={resolved.def.allow}
+					referrerPolicy="no-referrer"
+					style={{
+						width: "100%",
+						height: "100%",
+						border: "none",
+						display: "block",
+						pointerEvents: active ? "auto" : "none",
+					}}
+				/>
+				{!active && (
+					// Overlay hint while not interacting (also blocks stray iframe events).
+					<div
+						style={{
+							position: "absolute",
+							inset: 0,
+							display: "flex",
+							alignItems: "flex-end",
+							justifyContent: "center",
+							paddingBottom: 8,
+							pointerEvents: "none",
+							background: "transparent",
+						}}
+					>
+						<span
+							style={{
+								fontSize: 11,
+								color: "#fff",
+								background: "rgba(0,0,0,0.5)",
+								padding: "2px 8px",
+								borderRadius: 10,
+							}}
+						>
+							▶ で操作
+						</span>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ── Geometry ──
+
+function getBounds(data: ShapeData): BoundingBox {
+	return { x: data.x, y: data.y, width: data.width, height: data.height };
+}
+function hitTest(data: ShapeData, point: Point): boolean {
+	return (
+		point.x >= data.x &&
+		point.x <= data.x + data.width &&
+		point.y >= data.y &&
+		point.y <= data.y + data.height
+	);
+}
+function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
+	let { x, y, width, height } = data;
+	switch (handle) {
+		case "se":
+			width += delta.x;
+			height += delta.y;
+			break;
+		case "nw":
+			x += delta.x;
+			y += delta.y;
+			width -= delta.x;
+			height -= delta.y;
+			break;
+		case "ne":
+			y += delta.y;
+			width += delta.x;
+			height -= delta.y;
+			break;
+		case "sw":
+			x += delta.x;
+			width -= delta.x;
+			height += delta.y;
+			break;
+		case "e":
+			width += delta.x;
+			break;
+		case "w":
+			x += delta.x;
+			width -= delta.x;
+			break;
+		case "n":
+			y += delta.y;
+			height -= delta.y;
+			break;
+		case "s":
+			height += delta.y;
+			break;
+	}
+	return { ...data, x, y, width: Math.max(160, width), height: Math.max(120, height) };
+}
+function createDefault(params: { id: string; x: number; y: number }): EmbedShapeData {
+	return {
+		id: params.id,
+		type: EMBED_TYPE,
+		x: params.x,
+		y: params.y,
+		width: 560,
+		height: 340,
+		style: { fill: "#000000", stroke: "#334155", strokeWidth: 1, opacity: 1 },
+		url: "",
+		isActive: false,
+		syncMode: "free",
+	};
+}
+
+function safeOrigin(url: string): string {
+	try {
+		return new URL(url).origin;
+	} catch {
+		return "";
+	}
+}
+function serializeForAi(shape: ShapeData): Record<string, unknown> {
+	const d = shape as EmbedShapeData;
+	// Only the origin (not the full URL) to keep prompts small & avoid leaking query params.
+	return d.url ? { kind: "embed", origin: safeOrigin(d.url), provider: d.provider } : {};
+}
+
+function EmbedIcon() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20" aria-hidden="true">
+			<rect
+				x="2.5"
+				y="4"
+				width="15"
+				height="12"
+				rx="2"
+				fill="none"
+				stroke="currentColor"
+				strokeWidth="1.5"
+			/>
+			<path d="M8 8l3 2-3 2z" fill="currentColor" />
+		</svg>
+	);
+}
+
+// ── Plugin ──
+
+export interface EmbedPluginOptions {
+	/** Extra provider definitions (added before defaults so they can override). */
+	embeds?: EmbedDefinition[];
+	/** API origin for the shared server clock (playback sync). Omit → local clock. */
+	apiUrl?: string;
+	boardId?: string;
+	userId?: string;
+}
+
+export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): UsketchPlugin {
+	return {
+		id: "usketch-plugin-shape-embed",
+		name: "埋め込み",
+
+		setup(ctx: PluginContext) {
+			const defs = [...(options.embeds ?? []), ...DEFAULT_EMBED_DEFS];
+			const serverClock = createServerClock({ baseUrl: options.apiUrl ?? null });
+			const userId = options.userId ?? "local";
+			runtime = { store: ctx.store, serverClock, userId, defs };
+
+			const onAction = (e: Event) => {
+				const detail = (e as CustomEvent<Action>).detail;
+				const shape = ctx.store.getShape(detail.id) as EmbedShapeData | undefined;
+				if (!shape || shape.type !== EMBED_TYPE) return;
+				switch (detail.action) {
+					case "set-url": {
+						const resolved = detail.url ? resolveEmbed(detail.url, defs) : null;
+						ctx.store.updateShape(detail.id, {
+							url: detail.url,
+							provider: resolved?.def.id,
+							playback: undefined,
+						} as Partial<ShapeData>);
+						break;
+					}
+					case "activate":
+						ctx.store.updateShape(detail.id, { isActive: true } as Partial<ShapeData>);
+						break;
+					case "deactivate":
+						ctx.store.updateShape(detail.id, { isActive: false } as Partial<ShapeData>);
+						break;
+					case "toggle-presenter": {
+						// Claim presenter (lock to me) ⇄ release back to free-for-all.
+						const isMine = shape.syncMode === "presenter" && shape.presenterId === userId;
+						ctx.store.updateShape(detail.id, {
+							syncMode: isMine ? "free" : "presenter",
+							presenterId: isMine ? undefined : userId,
+						} as Partial<ShapeData>);
+						break;
+					}
+				}
+			};
+			window.addEventListener(ACTION_EVENT, onAction);
+
+			// Double-click a non-active embed → activate (interact). Uses canvas:pointerdown.
+			let lastDown = { id: "", t: 0 };
+			const offPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+				let hit: EmbedShapeData | null = null;
+				for (const [, s] of ctx.store.getShapes()) {
+					if (s.type === EMBED_TYPE && hitTest(s, event.worldPoint)) hit = s as EmbedShapeData;
+				}
+				if (!hit) {
+					lastDown = { id: "", t: 0 };
+					return;
+				}
+				const t = Date.now();
+				if (lastDown.id === hit.id && t - lastDown.t < 300 && !hit.isActive) {
+					ctx.store.updateShape(hit.id, { isActive: true } as Partial<ShapeData>);
+				}
+				lastDown = { id: hit.id, t };
+			});
+
+			// Deactivate on deselect (so a moved-away embed stops capturing pointer).
+			const unsubStore = ctx.store.subscribe(() => {
+				const sel = ctx.store.getSelection();
+				for (const [id, s] of ctx.store.getShapes()) {
+					if (s.type === EMBED_TYPE && (s as EmbedShapeData).isActive && !sel.has(id)) {
+						ctx.store.updateShape(id, { isActive: false } as Partial<ShapeData>);
+					}
+				}
+			});
+
+			ctx.shapes.register(EMBED_TYPE, {
+				render: (shape) => <EmbedView data={shape as EmbedShapeData} />,
+				getBounds,
+				hitTest: withRotation(hitTest),
+				resize,
+				createDefault,
+				renderTarget: "html",
+				minSize: { width: 160, height: 120 },
+				serializeForAi,
+			});
+
+			// Draw tool.
+			let drawState: { startX: number; startY: number; shapeId: string } | null = null;
+			ctx.tools.register("embed-draw", {
+				icon: EmbedIcon,
+				cursor: "crosshair",
+				order: 44,
+				onPointerDown(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					const id = generateId();
+					drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
+					const shape = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+					shape.width = 0;
+					shape.height = 0;
+					toolCtx.store.addShape(shape);
+				},
+				onPointerMove(toolCtx: ToolContext, event: CanvasPointerEvent) {
+					if (!drawState) return;
+					toolCtx.store.updateShape(drawState.shapeId, {
+						x: Math.min(drawState.startX, event.worldPoint.x),
+						y: Math.min(drawState.startY, event.worldPoint.y),
+						width: Math.abs(event.worldPoint.x - drawState.startX),
+						height: Math.abs(event.worldPoint.y - drawState.startY),
+					});
+				},
+				onPointerUp(toolCtx: ToolContext) {
+					if (!drawState) return;
+					const shape = toolCtx.store.getShape(drawState.shapeId);
+					toolCtx.store.deleteShape(drawState.shapeId);
+					const def =
+						shape && shape.width > 40 && shape.height > 40
+							? (shape as EmbedShapeData)
+							: createDefault({
+									id: drawState.shapeId,
+									x: drawState.startX - 280,
+									y: drawState.startY - 170,
+								});
+					toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, def));
+					toolCtx.store.setSelection([def.id]);
+					drawState = null;
+					toolCtx.store.resetToDefaultTool();
+				},
+			});
+
+			// Paste/drop a URL → create an embed (order 0 = future handlers can win).
+			const offUrl = ctx.externalContent.register(createEmbedUrlHandler(() => defs));
+
+			return () => {
+				window.removeEventListener(ACTION_EVENT, onAction);
+				offPointer();
+				unsubStore();
+				offUrl();
+				serverClock.destroy();
+				runtime = null;
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-shape-embed/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/plugin.tsx
@@ -27,7 +27,8 @@ import type { EmbedShapeData } from "./types.js";
 export const EMBED_TYPE = "embed";
 const ACTION_EVENT = "usketch:embed-action";
 
-/** Runtime deps resolved lazily at render time (render fns have no PluginContext). */
+/** Per-plugin-instance runtime, passed into the shape view as a prop (no globals,
+ * so multiple boards / StrictMode remounts don't clobber each other). */
 interface EmbedRuntime {
 	store: PluginContext["store"];
 	serverClock: ServerClock;
@@ -35,7 +36,6 @@ interface EmbedRuntime {
 	defs: EmbedDefinition[];
 	Chrome: EmbedChrome;
 }
-let runtime: EmbedRuntime | null = null;
 
 type Action =
 	| { id: string; action: "set-url"; url: string }
@@ -61,8 +61,8 @@ const btn: React.CSSProperties = {
 };
 const stop = (e: React.SyntheticEvent) => e.stopPropagation();
 
-function EmbedView({ data }: { data: EmbedShapeData }) {
-	const resolved = data.url ? resolveEmbed(data.url, runtime?.defs) : null;
+function EmbedView({ data, rt }: { data: EmbedShapeData; rt: EmbedRuntime }) {
+	const resolved = data.url ? resolveEmbed(data.url, rt.defs) : null;
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const playerRef = useRef<EmbedPlayer | null>(null);
 	const playbackRef = useRef(data.playback);
@@ -74,18 +74,22 @@ function EmbedView({ data }: { data: EmbedShapeData }) {
 	// Create the synced player when a syncable iframe mounts.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: recreate only on shape/embed change
 	useEffect(() => {
-		if (!syncable || !iframeRef.current || !runtime) return;
-		const rt = runtime;
+		if (!syncable || !iframeRef.current) return;
 		const player = createYouTubePlayer(iframeRef.current);
 		playerRef.current = player;
 		player.onUserAction(() => {
 			const cur = rt.store.getShape(data.id) as EmbedShapeData | undefined;
 			if (!cur || !canControl(cur, rt.userId)) return;
 			const st = player.getState();
-			if (st)
-				rt.store.updateShape(data.id, {
-					playback: playbackFrom(st, rt.serverClock.now(), rt.userId),
-				} as Partial<ShapeData>);
+			if (!st) return;
+			// Ignore state changes that merely converge to the already-synced state —
+			// that's our own applied correction echoing back, not a genuine user
+			// action — otherwise followers would re-broadcast and oscillate.
+			const pb = playbackRef.current;
+			if (pb && !needsCorrection(pb, rt.serverClock.now(), st)) return;
+			rt.store.updateShape(data.id, {
+				playback: playbackFrom(st, rt.serverClock.now(), rt.userId),
+			} as Partial<ShapeData>);
 		});
 		return () => {
 			player.destroy();
@@ -95,8 +99,7 @@ function EmbedView({ data }: { data: EmbedShapeData }) {
 
 	// Drift-correct the local player toward the synced playback state.
 	useEffect(() => {
-		if (!syncable || !runtime) return;
-		const rt = runtime;
+		if (!syncable) return;
 		const iv = setInterval(() => {
 			const player = playerRef.current;
 			const pb = playbackRef.current;
@@ -109,12 +112,12 @@ function EmbedView({ data }: { data: EmbedShapeData }) {
 			else if (!pb.playing && st.playing) player.pause();
 		}, 1000);
 		return () => clearInterval(iv);
-	}, [syncable]);
+	}, [syncable, rt]);
 
 	const active = data.isActive === true;
 	const isPresenter = data.syncMode === "presenter";
-	const iAmPresenter = data.presenterId === runtime?.userId;
-	const Chrome = runtime?.Chrome ?? DefaultEmbedChrome;
+	const iAmPresenter = data.presenterId === rt.userId;
+	const Chrome = rt.Chrome;
 
 	// Plugin-owned body (iframe keeps the sync player ref; a custom Chrome must
 	// render {children} for playback sync to work).
@@ -443,7 +446,7 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 			const defs = [...(options.embeds ?? []), ...DEFAULT_EMBED_DEFS];
 			const serverClock = createServerClock({ baseUrl: options.apiUrl ?? null });
 			const userId = options.userId ?? "local";
-			runtime = {
+			const rt: EmbedRuntime = {
 				store: ctx.store,
 				serverClock,
 				userId,
@@ -466,18 +469,31 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 						break;
 					}
 					case "activate":
+						// Select as well: the deselect watcher below turns off any active
+						// embed that isn't selected, so activating without selecting would
+						// be reverted instantly (e.g. clicking ▶ on an unselected embed).
 						ctx.store.updateShape(detail.id, { isActive: true } as Partial<ShapeData>);
+						ctx.store.setSelection([detail.id]);
 						break;
 					case "deactivate":
 						ctx.store.updateShape(detail.id, { isActive: false } as Partial<ShapeData>);
 						break;
 					case "toggle-presenter": {
-						// Claim presenter (lock to me) ⇄ release back to free-for-all.
-						const isMine = shape.syncMode === "presenter" && shape.presenterId === userId;
-						ctx.store.updateShape(detail.id, {
-							syncMode: isMine ? "free" : "presenter",
-							presenterId: isMine ? undefined : userId,
-						} as Partial<ShapeData>);
+						const isPresenterMode = shape.syncMode === "presenter";
+						const isMine = isPresenterMode && shape.presenterId === userId;
+						// I hold it → release to free-for-all. Nobody holds it → I claim it.
+						// Someone ELSE holds it → do nothing (can't steal presentership).
+						if (isMine) {
+							ctx.store.updateShape(detail.id, {
+								syncMode: "free",
+								presenterId: undefined,
+							} as Partial<ShapeData>);
+						} else if (!isPresenterMode) {
+							ctx.store.updateShape(detail.id, {
+								syncMode: "presenter",
+								presenterId: userId,
+							} as Partial<ShapeData>);
+						}
 						break;
 					}
 				}
@@ -503,7 +519,10 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 			});
 
 			// Deactivate on deselect (so a moved-away embed stops capturing pointer).
-			const unsubStore = ctx.store.subscribe(() => {
+			// Gated on selection changes only — running on every mutation would scan
+			// all shapes on each playback-sync tick, and would also fight `activate`.
+			const unsubStore = ctx.store.onMutation((event) => {
+				if (event.type !== "selection:changed") return;
 				const sel = ctx.store.getSelection();
 				for (const [id, s] of ctx.store.getShapes()) {
 					if (s.type === EMBED_TYPE && (s as EmbedShapeData).isActive && !sel.has(id)) {
@@ -513,7 +532,7 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 			});
 
 			ctx.shapes.register(EMBED_TYPE, {
-				render: (shape) => <EmbedView data={shape as EmbedShapeData} />,
+				render: (shape) => <EmbedView data={shape as EmbedShapeData} rt={rt} />,
 				getBounds,
 				hitTest: withRotation(hitTest),
 				resize,
@@ -574,7 +593,6 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 				unsubStore();
 				offUrl();
 				serverClock.destroy();
-				runtime = null;
 			};
 		},
 	};

--- a/plugins/usketch-plugin-shape-embed/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/plugin.tsx
@@ -13,7 +13,12 @@ import {
 import { createAddShapeCommand } from "@edv4h/usketch-store";
 import { createServerClock, type ServerClock } from "@edv4h/usketch-sync";
 import { useEffect, useRef, useState } from "react";
-import { DEFAULT_EMBED_DEFS, type EmbedDefinition, resolveEmbed } from "./embed-defs.js";
+import {
+	DEFAULT_EMBED_DEFS,
+	type EmbedDefinition,
+	type ResolvedEmbed,
+	resolveEmbed,
+} from "./embed-defs.js";
 import { createEmbedUrlHandler } from "./external-content-handler.js";
 import { needsCorrection, playbackFrom, projectTime } from "./playback.js";
 import { createYouTubePlayer, type EmbedPlayer } from "./players/youtube.js";
@@ -28,6 +33,7 @@ interface EmbedRuntime {
 	serverClock: ServerClock;
 	userId: string;
 	defs: EmbedDefinition[];
+	Chrome: EmbedChrome;
 }
 let runtime: EmbedRuntime | null = null;
 
@@ -105,60 +111,136 @@ function EmbedView({ data }: { data: EmbedShapeData }) {
 		return () => clearInterval(iv);
 	}, [syncable]);
 
-	// ── URL entry (no url yet) ──
-	if (!resolved) {
-		return (
-			<div
-				style={{
-					width: "100%",
-					height: "100%",
-					boxSizing: "border-box",
-					display: "flex",
-					flexDirection: "column",
-					alignItems: "center",
-					justifyContent: "center",
-					gap: 8,
-					padding: 16,
-					background: "#f8fafc",
-					border: `${data.style.strokeWidth}px dashed ${data.style.stroke}`,
-					borderRadius: 8,
-					fontFamily: "system-ui, sans-serif",
-					pointerEvents: "none",
-					userSelect: "none",
-				}}
-			>
-				<div style={{ fontSize: 13, color: "#64748b" }}>🔗 URL を貼り付けて埋め込み</div>
-				<input
-					type="url"
-					placeholder="https://www.youtube.com/watch?v=…"
-					value={urlDraft}
-					onChange={(e) => setUrlDraft(e.target.value)}
-					onPointerDown={stop}
-					onKeyDown={(e) => {
-						e.stopPropagation();
-						if (e.key === "Enter" && urlDraft.trim())
-							emit({ id: data.id, action: "set-url", url: urlDraft.trim() });
-					}}
-					onBlur={() =>
-						urlDraft.trim() && emit({ id: data.id, action: "set-url", url: urlDraft.trim() })
-					}
-					style={{
-						width: "90%",
-						padding: "6px 8px",
-						fontSize: 13,
-						borderRadius: 6,
-						border: "1px solid #cbd5e1",
-						pointerEvents: "auto",
-					}}
-				/>
-			</div>
-		);
-	}
-
 	const active = data.isActive === true;
 	const isPresenter = data.syncMode === "presenter";
 	const iAmPresenter = data.presenterId === runtime?.userId;
+	const Chrome = runtime?.Chrome ?? DefaultEmbedChrome;
 
+	// Plugin-owned body (iframe keeps the sync player ref; a custom Chrome must
+	// render {children} for playback sync to work).
+	const body = resolved ? (
+		<div style={{ width: "100%", height: "100%", position: "relative", background: "#000" }}>
+			<iframe
+				ref={iframeRef}
+				id={`usketch-embed-${data.id}`}
+				src={resolved.embedUrl}
+				title={resolved.def.title}
+				sandbox={resolved.def.sandbox}
+				allow={resolved.def.allow}
+				referrerPolicy="strict-origin-when-cross-origin"
+				style={{
+					width: "100%",
+					height: "100%",
+					border: "none",
+					display: "block",
+					pointerEvents: active ? "auto" : "none",
+				}}
+			/>
+			{!active && (
+				<div
+					style={{
+						position: "absolute",
+						inset: 0,
+						display: "flex",
+						alignItems: "flex-end",
+						justifyContent: "center",
+						paddingBottom: 8,
+						pointerEvents: "none",
+					}}
+				>
+					<span
+						style={{
+							fontSize: 11,
+							color: "#fff",
+							background: "rgba(0,0,0,0.5)",
+							padding: "2px 8px",
+							borderRadius: 10,
+						}}
+					>
+						▶ で操作
+					</span>
+				</div>
+			)}
+		</div>
+	) : (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				gap: 8,
+				padding: 16,
+				background: "#f8fafc",
+			}}
+		>
+			<div style={{ fontSize: 13, color: "#64748b" }}>🔗 URL を貼り付けて埋め込み</div>
+			<input
+				type="url"
+				placeholder="https://www.youtube.com/watch?v=…"
+				value={urlDraft}
+				onChange={(e) => setUrlDraft(e.target.value)}
+				onPointerDown={stop}
+				onKeyDown={(e) => {
+					e.stopPropagation();
+					if (e.key === "Enter" && urlDraft.trim())
+						emit({ id: data.id, action: "set-url", url: urlDraft.trim() });
+				}}
+				onBlur={() =>
+					urlDraft.trim() && emit({ id: data.id, action: "set-url", url: urlDraft.trim() })
+				}
+				style={{
+					width: "90%",
+					padding: "6px 8px",
+					fontSize: 13,
+					borderRadius: 6,
+					border: "1px solid #cbd5e1",
+					pointerEvents: "auto",
+				}}
+			/>
+		</div>
+	);
+
+	return (
+		<Chrome
+			data={data}
+			resolved={resolved}
+			active={active}
+			syncable={syncable}
+			isPresenter={isPresenter}
+			iAmPresenter={iAmPresenter}
+			onSetUrl={(url) => emit({ id: data.id, action: "set-url", url })}
+			onActivate={() => emit({ id: data.id, action: "activate" })}
+			onDeactivate={() => emit({ id: data.id, action: "deactivate" })}
+			onTogglePresenter={() => emit({ id: data.id, action: "toggle-presenter" })}
+		>
+			{body}
+		</Chrome>
+	);
+}
+
+// ── Default chrome (overridable via plugin `components.Chrome`) ──
+
+export interface EmbedChromeProps {
+	data: EmbedShapeData;
+	resolved: ResolvedEmbed | null;
+	active: boolean;
+	syncable: boolean;
+	isPresenter: boolean;
+	iAmPresenter: boolean;
+	/** Pass "" to clear/re-edit the URL. */
+	onSetUrl: (url: string) => void;
+	onActivate: () => void;
+	onDeactivate: () => void;
+	onTogglePresenter: () => void;
+	/** Plugin-owned body (iframe / URL input). Must be rendered for sync to work. */
+	children: React.ReactNode;
+}
+export type EmbedChrome = (props: EmbedChromeProps) => React.ReactElement;
+
+export function DefaultEmbedChrome(p: EmbedChromeProps) {
 	return (
 		<div
 			style={{
@@ -168,16 +250,14 @@ function EmbedView({ data }: { data: EmbedShapeData }) {
 				display: "flex",
 				flexDirection: "column",
 				background: "#000",
-				border: `${data.style.strokeWidth}px solid ${data.style.stroke}`,
+				border: `${p.data.style.strokeWidth}px solid ${p.data.style.stroke}`,
 				borderRadius: 8,
 				overflow: "hidden",
 				fontFamily: "system-ui, sans-serif",
 				pointerEvents: "none",
 				userSelect: "none",
-				position: "relative",
 			}}
 		>
-			{/* Header (interactive controls) */}
 			<div
 				style={{
 					height: 28,
@@ -200,87 +280,43 @@ function EmbedView({ data }: { data: EmbedShapeData }) {
 						whiteSpace: "nowrap",
 					}}
 				>
-					{resolved.def.title}
+					{p.resolved?.def.title ?? "埋め込み"}
 				</span>
-				{syncable && (
+				{p.resolved && p.syncable && (
 					<button
 						type="button"
-						title={isPresenter ? "プレゼンター解除（全員操作可）" : "プレゼンターにする"}
-						style={{ ...btn, background: iAmPresenter ? "#7c3aed" : btn.background }}
+						title={p.isPresenter ? "プレゼンター解除（全員操作可）" : "プレゼンターにする"}
+						style={{ ...btn, background: p.iAmPresenter ? "#7c3aed" : btn.background }}
 						onPointerDown={stop}
-						onClick={(e) => (stop(e), emit({ id: data.id, action: "toggle-presenter" }))}
+						onClick={(e) => (stop(e), p.onTogglePresenter())}
 					>
-						{isPresenter ? "🔒" : "🆓"}
+						{p.isPresenter ? "🔒" : "🆓"}
 					</button>
 				)}
-				<button
-					type="button"
-					title="URL を変更"
-					style={btn}
-					onPointerDown={stop}
-					onClick={(e) => (stop(e), emit({ id: data.id, action: "set-url", url: "" }))}
-				>
-					🔗
-				</button>
-				<button
-					type="button"
-					title={active ? "操作を終了" : "操作する"}
-					style={btn}
-					onPointerDown={stop}
-					onClick={(e) => (
-						stop(e), emit({ id: data.id, action: active ? "deactivate" : "activate" })
-					)}
-				>
-					{active ? "✕" : "▶"}
-				</button>
-			</div>
-
-			{/* iframe */}
-			<div style={{ flex: 1, minHeight: 0, position: "relative" }}>
-				<iframe
-					ref={iframeRef}
-					id={`usketch-embed-${data.id}`}
-					src={resolved.embedUrl}
-					title={resolved.def.title}
-					sandbox={resolved.def.sandbox}
-					allow={resolved.def.allow}
-					referrerPolicy="strict-origin-when-cross-origin"
-					style={{
-						width: "100%",
-						height: "100%",
-						border: "none",
-						display: "block",
-						pointerEvents: active ? "auto" : "none",
-					}}
-				/>
-				{!active && (
-					// Overlay hint while not interacting (also blocks stray iframe events).
-					<div
-						style={{
-							position: "absolute",
-							inset: 0,
-							display: "flex",
-							alignItems: "flex-end",
-							justifyContent: "center",
-							paddingBottom: 8,
-							pointerEvents: "none",
-							background: "transparent",
-						}}
+				{p.resolved && (
+					<button
+						type="button"
+						title="URL を変更"
+						style={btn}
+						onPointerDown={stop}
+						onClick={(e) => (stop(e), p.onSetUrl(""))}
 					>
-						<span
-							style={{
-								fontSize: 11,
-								color: "#fff",
-								background: "rgba(0,0,0,0.5)",
-								padding: "2px 8px",
-								borderRadius: 10,
-							}}
-						>
-							▶ で操作
-						</span>
-					</div>
+						🔗
+					</button>
+				)}
+				{p.resolved && (
+					<button
+						type="button"
+						title={p.active ? "操作を終了" : "操作する"}
+						style={btn}
+						onPointerDown={stop}
+						onClick={(e) => (stop(e), p.active ? p.onDeactivate() : p.onActivate())}
+					>
+						{p.active ? "✕" : "▶"}
+					</button>
 				)}
 			</div>
+			<div style={{ flex: 1, minHeight: 0 }}>{p.children}</div>
 		</div>
 	);
 }
@@ -393,6 +429,9 @@ export interface EmbedPluginOptions {
 	apiUrl?: string;
 	boardId?: string;
 	userId?: string;
+	/** Swap the shape's chrome (header/frame). Behavior (iframe/player) is retained
+	 * as long as the custom Chrome renders its `children`. */
+	components?: { Chrome?: EmbedChrome };
 }
 
 export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): UsketchPlugin {
@@ -404,7 +443,13 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 			const defs = [...(options.embeds ?? []), ...DEFAULT_EMBED_DEFS];
 			const serverClock = createServerClock({ baseUrl: options.apiUrl ?? null });
 			const userId = options.userId ?? "local";
-			runtime = { store: ctx.store, serverClock, userId, defs };
+			runtime = {
+				store: ctx.store,
+				serverClock,
+				userId,
+				defs,
+				Chrome: options.components?.Chrome ?? DefaultEmbedChrome,
+			};
 
 			const onAction = (e: Event) => {
 				const detail = (e as CustomEvent<Action>).detail;

--- a/plugins/usketch-plugin-shape-embed/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/plugin.tsx
@@ -11,319 +11,19 @@ import {
 	withRotation,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand } from "@edv4h/usketch-store";
-import { createServerClock, type ServerClock } from "@edv4h/usketch-sync";
-import { useEffect, useRef, useState } from "react";
+import { createServerClock } from "@edv4h/usketch-sync";
+import { DEFAULT_EMBED_DEFS, type EmbedDefinition, resolveEmbed } from "./embed-defs.js";
+import { EMBED_ACTION_EVENT, type EmbedAction } from "./embed-events.js";
 import {
-	DEFAULT_EMBED_DEFS,
-	type EmbedDefinition,
-	type ResolvedEmbed,
-	resolveEmbed,
-} from "./embed-defs.js";
+	DefaultEmbedChrome,
+	type EmbedChrome,
+	type EmbedRuntime,
+	EmbedView,
+} from "./embed-view.js";
 import { createEmbedUrlHandler } from "./external-content-handler.js";
-import { needsCorrection, playbackFrom, projectTime } from "./playback.js";
-import { createYouTubePlayer, type EmbedPlayer } from "./players/youtube.js";
 import type { EmbedShapeData } from "./types.js";
 
 export const EMBED_TYPE = "embed";
-const ACTION_EVENT = "usketch:embed-action";
-
-/** Per-plugin-instance runtime, passed into the shape view as a prop (no globals,
- * so multiple boards / StrictMode remounts don't clobber each other). */
-interface EmbedRuntime {
-	store: PluginContext["store"];
-	serverClock: ServerClock;
-	userId: string;
-	defs: EmbedDefinition[];
-	Chrome: EmbedChrome;
-}
-
-type Action =
-	| { id: string; action: "set-url"; url: string }
-	| { id: string; action: "activate" | "deactivate" | "toggle-presenter" };
-
-const emit = (detail: Action) => window.dispatchEvent(new CustomEvent(ACTION_EVENT, { detail }));
-
-const canControl = (data: EmbedShapeData, userId: string): boolean =>
-	data.syncMode !== "presenter" || data.presenterId === userId;
-
-// ── View ──
-
-const btn: React.CSSProperties = {
-	border: "none",
-	background: "rgba(255,255,255,0.15)",
-	color: "#fff",
-	cursor: "pointer",
-	fontSize: 12,
-	lineHeight: 1,
-	padding: "3px 7px",
-	borderRadius: 5,
-	pointerEvents: "auto",
-};
-const stop = (e: React.SyntheticEvent) => e.stopPropagation();
-
-function EmbedView({ data, rt }: { data: EmbedShapeData; rt: EmbedRuntime }) {
-	const resolved = data.url ? resolveEmbed(data.url, rt.defs) : null;
-	const iframeRef = useRef<HTMLIFrameElement>(null);
-	const playerRef = useRef<EmbedPlayer | null>(null);
-	const playbackRef = useRef(data.playback);
-	playbackRef.current = data.playback;
-	const [urlDraft, setUrlDraft] = useState("");
-
-	const syncable = resolved?.def.syncable === true;
-
-	// Create the synced player when a syncable iframe mounts.
-	// biome-ignore lint/correctness/useExhaustiveDependencies: recreate only on shape/embed change
-	useEffect(() => {
-		if (!syncable || !iframeRef.current) return;
-		const player = createYouTubePlayer(iframeRef.current);
-		playerRef.current = player;
-		player.onUserAction(() => {
-			const cur = rt.store.getShape(data.id) as EmbedShapeData | undefined;
-			if (!cur || !canControl(cur, rt.userId)) return;
-			const st = player.getState();
-			if (!st) return;
-			// Ignore state changes that merely converge to the already-synced state —
-			// that's our own applied correction echoing back, not a genuine user
-			// action — otherwise followers would re-broadcast and oscillate.
-			const pb = playbackRef.current;
-			if (pb && !needsCorrection(pb, rt.serverClock.now(), st)) return;
-			rt.store.updateShape(data.id, {
-				playback: playbackFrom(st, rt.serverClock.now(), rt.userId),
-			} as Partial<ShapeData>);
-		});
-		return () => {
-			player.destroy();
-			playerRef.current = null;
-		};
-	}, [syncable, data.id, resolved?.embedUrl]);
-
-	// Drift-correct the local player toward the synced playback state.
-	useEffect(() => {
-		if (!syncable) return;
-		const iv = setInterval(() => {
-			const player = playerRef.current;
-			const pb = playbackRef.current;
-			if (!player || !pb) return;
-			const st = player.getState();
-			if (!st || !needsCorrection(pb, rt.serverClock.now(), st)) return;
-			const target = projectTime(pb, rt.serverClock.now());
-			if (Math.abs(target - st.time) > 0.7) player.seek(target);
-			if (pb.playing && !st.playing) player.play();
-			else if (!pb.playing && st.playing) player.pause();
-		}, 1000);
-		return () => clearInterval(iv);
-	}, [syncable, rt]);
-
-	const active = data.isActive === true;
-	const isPresenter = data.syncMode === "presenter";
-	const iAmPresenter = data.presenterId === rt.userId;
-	const Chrome = rt.Chrome;
-
-	// Plugin-owned body (iframe keeps the sync player ref; a custom Chrome must
-	// render {children} for playback sync to work).
-	const body = resolved ? (
-		<div style={{ width: "100%", height: "100%", position: "relative", background: "#000" }}>
-			<iframe
-				ref={iframeRef}
-				id={`usketch-embed-${data.id}`}
-				src={resolved.embedUrl}
-				title={resolved.def.title}
-				sandbox={resolved.def.sandbox}
-				allow={resolved.def.allow}
-				referrerPolicy="strict-origin-when-cross-origin"
-				style={{
-					width: "100%",
-					height: "100%",
-					border: "none",
-					display: "block",
-					pointerEvents: active ? "auto" : "none",
-				}}
-			/>
-			{!active && (
-				<div
-					style={{
-						position: "absolute",
-						inset: 0,
-						display: "flex",
-						alignItems: "flex-end",
-						justifyContent: "center",
-						paddingBottom: 8,
-						pointerEvents: "none",
-					}}
-				>
-					<span
-						style={{
-							fontSize: 11,
-							color: "#fff",
-							background: "rgba(0,0,0,0.5)",
-							padding: "2px 8px",
-							borderRadius: 10,
-						}}
-					>
-						▶ で操作
-					</span>
-				</div>
-			)}
-		</div>
-	) : (
-		<div
-			style={{
-				width: "100%",
-				height: "100%",
-				display: "flex",
-				flexDirection: "column",
-				alignItems: "center",
-				justifyContent: "center",
-				gap: 8,
-				padding: 16,
-				background: "#f8fafc",
-			}}
-		>
-			<div style={{ fontSize: 13, color: "#64748b" }}>🔗 URL を貼り付けて埋め込み</div>
-			<input
-				type="url"
-				placeholder="https://www.youtube.com/watch?v=…"
-				value={urlDraft}
-				onChange={(e) => setUrlDraft(e.target.value)}
-				onPointerDown={stop}
-				onKeyDown={(e) => {
-					e.stopPropagation();
-					if (e.key === "Enter" && urlDraft.trim())
-						emit({ id: data.id, action: "set-url", url: urlDraft.trim() });
-				}}
-				onBlur={() =>
-					urlDraft.trim() && emit({ id: data.id, action: "set-url", url: urlDraft.trim() })
-				}
-				style={{
-					width: "90%",
-					padding: "6px 8px",
-					fontSize: 13,
-					borderRadius: 6,
-					border: "1px solid #cbd5e1",
-					pointerEvents: "auto",
-				}}
-			/>
-		</div>
-	);
-
-	return (
-		<Chrome
-			data={data}
-			resolved={resolved}
-			active={active}
-			syncable={syncable}
-			isPresenter={isPresenter}
-			iAmPresenter={iAmPresenter}
-			onSetUrl={(url) => emit({ id: data.id, action: "set-url", url })}
-			onActivate={() => emit({ id: data.id, action: "activate" })}
-			onDeactivate={() => emit({ id: data.id, action: "deactivate" })}
-			onTogglePresenter={() => emit({ id: data.id, action: "toggle-presenter" })}
-		>
-			{body}
-		</Chrome>
-	);
-}
-
-// ── Default chrome (overridable via plugin `components.Chrome`) ──
-
-export interface EmbedChromeProps {
-	data: EmbedShapeData;
-	resolved: ResolvedEmbed | null;
-	active: boolean;
-	syncable: boolean;
-	isPresenter: boolean;
-	iAmPresenter: boolean;
-	/** Pass "" to clear/re-edit the URL. */
-	onSetUrl: (url: string) => void;
-	onActivate: () => void;
-	onDeactivate: () => void;
-	onTogglePresenter: () => void;
-	/** Plugin-owned body (iframe / URL input). Must be rendered for sync to work. */
-	children: React.ReactNode;
-}
-export type EmbedChrome = (props: EmbedChromeProps) => React.ReactElement;
-
-export function DefaultEmbedChrome(p: EmbedChromeProps) {
-	return (
-		<div
-			style={{
-				width: "100%",
-				height: "100%",
-				boxSizing: "border-box",
-				display: "flex",
-				flexDirection: "column",
-				background: "#000",
-				border: `${p.data.style.strokeWidth}px solid ${p.data.style.stroke}`,
-				borderRadius: 8,
-				overflow: "hidden",
-				fontFamily: "system-ui, sans-serif",
-				pointerEvents: "none",
-				userSelect: "none",
-			}}
-		>
-			<div
-				style={{
-					height: 28,
-					flex: "0 0 auto",
-					display: "flex",
-					alignItems: "center",
-					gap: 6,
-					padding: "0 6px",
-					background: "#111827",
-					color: "#e5e7eb",
-				}}
-			>
-				<span
-					style={{
-						flex: 1,
-						fontSize: 11,
-						fontWeight: 600,
-						overflow: "hidden",
-						textOverflow: "ellipsis",
-						whiteSpace: "nowrap",
-					}}
-				>
-					{p.resolved?.def.title ?? "埋め込み"}
-				</span>
-				{p.resolved && p.syncable && (
-					<button
-						type="button"
-						title={p.isPresenter ? "プレゼンター解除（全員操作可）" : "プレゼンターにする"}
-						style={{ ...btn, background: p.iAmPresenter ? "#7c3aed" : btn.background }}
-						onPointerDown={stop}
-						onClick={(e) => (stop(e), p.onTogglePresenter())}
-					>
-						{p.isPresenter ? "🔒" : "🆓"}
-					</button>
-				)}
-				{p.resolved && (
-					<button
-						type="button"
-						title="URL を変更"
-						style={btn}
-						onPointerDown={stop}
-						onClick={(e) => (stop(e), p.onSetUrl(""))}
-					>
-						🔗
-					</button>
-				)}
-				{p.resolved && (
-					<button
-						type="button"
-						title={p.active ? "操作を終了" : "操作する"}
-						style={btn}
-						onPointerDown={stop}
-						onClick={(e) => (stop(e), p.active ? p.onDeactivate() : p.onActivate())}
-					>
-						{p.active ? "✕" : "▶"}
-					</button>
-				)}
-			</div>
-			<div style={{ flex: 1, minHeight: 0 }}>{p.children}</div>
-		</div>
-	);
-}
-
 // ── Geometry ──
 
 function getBounds(data: ShapeData): BoundingBox {
@@ -455,7 +155,7 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 			};
 
 			const onAction = (e: Event) => {
-				const detail = (e as CustomEvent<Action>).detail;
+				const detail = (e as CustomEvent<EmbedAction>).detail;
 				const shape = ctx.store.getShape(detail.id) as EmbedShapeData | undefined;
 				if (!shape || shape.type !== EMBED_TYPE) return;
 				switch (detail.action) {
@@ -498,7 +198,7 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 					}
 				}
 			};
-			window.addEventListener(ACTION_EVENT, onAction);
+			window.addEventListener(EMBED_ACTION_EVENT, onAction);
 
 			// Double-click a non-active embed → activate (interact). Uses canvas:pointerdown.
 			let lastDown = { id: "", t: 0 };
@@ -588,7 +288,7 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 			const offUrl = ctx.externalContent.register(createEmbedUrlHandler(() => defs));
 
 			return () => {
-				window.removeEventListener(ACTION_EVENT, onAction);
+				window.removeEventListener(EMBED_ACTION_EVENT, onAction);
 				offPointer();
 				unsubStore();
 				offUrl();

--- a/plugins/usketch-plugin-shape-embed/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-embed/src/plugin.tsx
@@ -211,10 +211,14 @@ export function createEmbedShapePlugin(options: EmbedPluginOptions = {}): Usketc
 
 			// Double-click a non-active embed → activate (interact). Uses canvas:pointerdown.
 			let lastDown = { id: "", t: 0 };
+			const rotatedHit = withRotation(hitTest);
 			const offPointer = ctx.events.on<CanvasPointerEvent>("canvas:pointerdown", (event) => {
+				// Topmost embed under the pointer: iterate back→front (zIndex asc) and keep
+				// the last hit, and use the rotation-aware hit-test so rotated/overlapping
+				// embeds resolve correctly.
 				let hit: EmbedShapeData | null = null;
-				for (const [, s] of ctx.store.getShapes()) {
-					if (s.type === EMBED_TYPE && hitTest(s, event.worldPoint)) hit = s as EmbedShapeData;
+				for (const s of ctx.store.getShapesSorted()) {
+					if (s.type === EMBED_TYPE && rotatedHit(s, event.worldPoint)) hit = s as EmbedShapeData;
 				}
 				if (!hit) {
 					lastDown = { id: "", t: 0 };

--- a/plugins/usketch-plugin-shape-embed/src/types.ts
+++ b/plugins/usketch-plugin-shape-embed/src/types.ts
@@ -1,0 +1,28 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+
+/** Synced playback state (watch-party). Times in seconds; `at` is server-epoch ms. */
+export interface PlaybackState {
+	playing: boolean;
+	/** Playhead position (s) as of `at`. */
+	time: number;
+	/** Server-clock epoch (ms) when this state was set. */
+	at: number;
+	updatedBy: string;
+}
+
+export type EmbedSyncMode = "free" | "presenter";
+
+export interface EmbedShapeData extends ShapeData {
+	type: "embed";
+	/** Original (shareable) URL entered by the user. */
+	url: string;
+	/** Resolved provider id (e.g. "youtube"), for debug/serialize. */
+	provider?: string;
+	/** Interact mode: iframe receives pointer events (vs selectable/movable). */
+	isActive?: boolean;
+	/** Synced playback (syncable providers only). */
+	playback?: PlaybackState;
+	/** "free" = anyone controls (LWW); "presenter" = only presenterId controls. */
+	syncMode?: EmbedSyncMode;
+	presenterId?: string;
+}

--- a/plugins/usketch-plugin-shape-embed/tsconfig.json
+++ b/plugins/usketch-plugin-shape-embed/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@edv4h/usketch-plugin-shape-counter':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-counter
+      '@edv4h/usketch-plugin-shape-embed':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-shape-embed
       '@edv4h/usketch-plugin-shape-frame':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-shape-frame
@@ -1648,6 +1651,31 @@ importers:
       '@edv4h/usketch-store':
         specifier: workspace:*
         version: link:../../packages/store
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@25.9.5)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  plugins/usketch-plugin-shape-embed:
+    dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@edv4h/usketch-sync':
+        specifier: workspace:*
+        version: link:../../packages/sync
       react:
         specifier: 19.2.7
         version: 19.2.7


### PR DESCRIPTION
## 概要
外部Webコンテンツを **iframe でキャンバスに埋め込む `embed` シェイプ**（tldraw の [Embed shape](https://tldraw.dev/sdk-features/embed-shape) に着想）。加えて **YouTube は再生位置を全ユーザーで同期**（watch party）。

## 埋め込み
- **プロバイダ許可リスト**: YouTube / Vimeo / Figma / Google Maps / CodeSandbox ＋ 任意 http(s) の汎用フォールバック。既知プロバイダは共有URL→埋め込みURLへ変換（`toEmbedUrl`）し必要最小の iframe `sandbox`/`allow`、**未知URLは strict sandbox（`allow-same-origin` 無し）**。`createEmbedShapePlugin({ embeds })` で定義を追加/上書き（tldraw の `DEFAULT_EMBED_DEFINITIONS` スプレッド相当）。
- **select-vs-interact**（text シェイプ準拠）: 通常は選択/移動/リサイズ可（iframe は `pointerEvents:none`）、**ダブルクリック or ▶ で操作モード**、✕/選択解除で戻る。
- **URL 貼り付け/ドロップ**で埋め込み生成（`kind:"url"` 外部コンテンツハンドラ、order 0＝将来の専用ハンドラが勝てる）。未登録だった url チャネルを埋める唯一の新規部品。

## YouTube 再生同期
- 再生/一時停止/シークを共有 `Y.Doc` の `playback`（`{playing,time,at,updatedBy}`）に保持。各クライアントは **server clock（`@edv4h/usketch-sync`）基準**で位置を投影し、ドリフト（>0.7s）時のみ `seekTo`＋play/pause で補正 → **端末時計ずれに強い追従**。遅参加も現在位置から。
- 制御は**両対応**: 既定「全員操作可（LWW）」、ヘッダ 🔒 で**プレゼンターロック**（`presenterId` の1人が主導、他は追従のみ）。
- YouTube IFrame API を **postMessage で制御（SDK 不要）**、`enablejsapi=1`。

## 変更
- 新規 `plugins/usketch-plugin-shape-embed/`（`embed-defs` / `types` / `playback` / `players/youtube` / `plugin` / `external-content-handler`）。
- `apps/web`: 全ボードで配線（cloud は apiUrl 渡し＝server clock、local は offset 0）。

## 検証
- build（web 含む）緑、**typecheck 163 tasks 緑**、lint 0 error。
- ユニット 13（`embed-defs`: YouTube/各プロバイダ変換・未知→GENERIC strict・非http(s)/不正→null・カスタム上書き / `playback`: project・drift 判定・playbackFrom）。
- 手動確認（cloud 2タブ）: YouTube URL 貼付→埋め込み、片方の再生/シークに他方が追従、🔒 でプレゼンター切替、embed ツール配置、任意URL→汎用iframe。

## 非スコープ / 制約
- YouTube 以外の再生同期（player 抽象で拡張可）、bookmark/OGプレビュー、oEmbed、再生レート/字幕同期は follow-up。
- `X-Frame-Options`/`frame-ancestors` を返すサイトは埋め込み不可（許可リストの embed URL 前提）。追従は YT プレイヤー状態取得精度に依存（±1s 程度）。CSP `frame-src` 制限環境では別途許可が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)