### PR TITLE
📝 docs: LayerRenderContext に viewportBounds を追記

### DIFF
--- a/apps/docs/src/content/docs-ja/concepts/layer-system.mdx
+++ b/apps/docs/src/content/docs-ja/concepts/layer-system.mdx
@@ -39,6 +39,7 @@ interface LayerRenderContext {
   hoveredShapeId: string | null;            // ホバー中のシェイプ ID（無ければ null）
   theme: Theme;                             // 有効なテーマ
   renderMode: RenderMode;                   // 現在の LOD 描画モード
+  viewportBounds: BoundingBox;              // world 座標の可視領域（per-shape の画角 LOD/カリング用）
 }
 ```
 

--- a/apps/docs/src/content/docs-ja/reference/shared.mdx
+++ b/apps/docs/src/content/docs-ja/reference/shared.mdx
@@ -211,6 +211,9 @@ interface LayerRenderContext {
   theme: Theme;
   // 現在の LOD レンダーモード。レイヤーは出力をこれに合わせる。
   renderMode: RenderMode;
+  // world 座標の可視領域（viewport＋canvas サイズから算出）。per-shape の画角判定
+  // （画角外 LOD・カリング）に使える。canvas 計測前は width/height が 0。
+  viewportBounds: BoundingBox;
 }
 
 interface LayerManager {

--- a/apps/docs/src/content/docs/concepts/layer-system.mdx
+++ b/apps/docs/src/content/docs/concepts/layer-system.mdx
@@ -39,6 +39,7 @@ interface LayerRenderContext {
   hoveredShapeId: string | null;            // Id of the hovered shape, or null
   theme: Theme;                             // Active theme
   renderMode: RenderMode;                   // Current LOD render mode
+  viewportBounds: BoundingBox;              // Visible region in world coords (per-shape viewport LOD/culling)
 }
 ```
 

--- a/apps/docs/src/content/docs/reference/shared.mdx
+++ b/apps/docs/src/content/docs/reference/shared.mdx
@@ -216,6 +216,10 @@ interface LayerRenderContext {
   theme: Theme;
   // Current LOD render mode. Layers should adapt their output accordingly.
   renderMode: RenderMode;
+  // Visible region in world coords (from viewport + canvas size). Enables
+  // per-shape viewport decisions (off-screen LOD, culling). width/height are 0
+  // until the canvas is measured.
+  viewportBounds: BoundingBox;
 }
 
 interface LayerManager {


### PR DESCRIPTION
## 概要

per-shape viewport LOD（#786）で追加した公開フィールド `LayerRenderContext.viewportBounds`（world 座標の可視領域）が、ドキュメントの `LayerRenderContext` スニペットに未記載だったので追記します。

ドキュメント全面刷新（#785）と機能 PR（#786）が別々にマージされた結果、#785 が刷新したスニペットに #786 のフィールドが反映されず抜けていました（#786 は無関係な docs 混入を避けるため docs 変更を持たない形でマージ）。

## 変更

`LayerRenderContext` スニペットに `viewportBounds: BoundingBox` を追記（en/ja × concepts/reference の4ファイル）。

- `apps/docs/src/content/docs/concepts/layer-system.mdx`
- `apps/docs/src/content/docs-ja/concepts/layer-system.mdx`
- `apps/docs/src/content/docs/reference/shared.mdx`
- `apps/docs/src/content/docs-ja/reference/shared.mdx`

## 検証

- ✅ docs build（astro, 113 pages）green

🤖 Generated with [Claude Code](https://claude.com/claude-code)