### PR TITLE
♻️ feat(hud): GPU 統計を gpu-renderer 所有の hud パネルへ（テレメトリ移設 第1弾）

### DIFF
--- a/.changeset/hud-telemetry-gpu.md
+++ b/.changeset/hud-telemetry-gpu.md
@@ -1,0 +1,9 @@
+---
+"@edv4h/usketch-gpu-renderer": minor
+"@edv4h/usketch-plugin-debug-hud": patch
+---
+
+HUD テレメトリ移設（第1弾）: GPU 統計を gpu-renderer 所有の HUD パネルへ移設。
+
+- gpu-renderer が `ctx.hud.registerPanel` で「GPU」パネル（Active/Inactive＋counts）を登録するようになり、Debug/Control HUD 側の GPU 専用セクション（`"gpu-renderer:stats"` イベントへのハードコード結合）を除去。
+- GPU 統計は Controls ドックの gpu-renderer プラグインセクションに表示される（GeneralPanel からは削除）。GPU 描画ロジックは無変更。

--- a/packages/gpu-renderer/src/gpu-stats-panel.tsx
+++ b/packages/gpu-renderer/src/gpu-stats-panel.tsx
@@ -1,0 +1,26 @@
+import type { EventBus } from "@edv4h/usketch-shared";
+import { useEffect, useState } from "react";
+import type { GpuRenderStats } from "./renderer.js";
+
+/**
+ * HUD panel showing GPU renderer status/counts. Contributed by the gpu-renderer
+ * plugin via `ctx.hud.registerPanel`, so the Debug/Control HUD no longer needs a
+ * hardcoded GPU section coupled to the `"gpu-renderer:stats"` event. Subscribes
+ * to that event (emitted per GPU render); stays "Inactive" until the first emit.
+ */
+export function GpuStatsPanel({ events }: { events: EventBus }) {
+	const [stats, setStats] = useState<GpuRenderStats | null>(null);
+	useEffect(() => events.on<GpuRenderStats>("gpu-renderer:stats", setStats), [events]);
+
+	if (!stats) {
+		return <div style={{ color: "#888", fontSize: 10 }}>Inactive (DOM only)</div>;
+	}
+	return (
+		<div style={{ fontSize: 10 }}>
+			<div style={{ color: "#4ade80" }}>Active</div>
+			<div>
+				GPU: {stats.gpuShapeCount} (SDF: {stats.sdfCount}, Lines: {stats.polylineCount})
+			</div>
+		</div>
+	);
+}

--- a/packages/gpu-renderer/src/plugin.tsx
+++ b/packages/gpu-renderer/src/plugin.tsx
@@ -1,5 +1,6 @@
 import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
 import { GpuShapeLayer } from "./gpu-shape-layer.js";
+import { GpuStatsPanel } from "./gpu-stats-panel.js";
 
 export interface GpuRendererPluginOptions {
 	mode?: "auto" | "force";
@@ -30,8 +31,17 @@ export function createGpuRendererPlugin(options?: GpuRendererPluginOptions): Usk
 				),
 			});
 
+			// Contribute the GPU stats readout to the Control HUD (owned here rather
+			// than hardcoded in the HUD's General panel).
+			const offHud = ctx.hud.registerPanel({
+				id: "gpu-renderer:stats",
+				title: "GPU",
+				render: () => <GpuStatsPanel events={ctx.events} />,
+			});
+
 			return () => {
 				ctx.layers.unregister("gpu-shapes");
+				offHud();
 			};
 		},
 	};

--- a/plugins/usketch-plugin-debug-hud/src/debug-hud.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/debug-hud.tsx
@@ -181,7 +181,6 @@ export function DebugHud({
 				shapes={shapes}
 				syncStatus={syncStatus}
 				boardMeta={boardMeta}
-				events={events}
 				viewport={viewport}
 				activeToolId={activeToolId}
 			/>

--- a/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
@@ -1,13 +1,12 @@
 import type {
 	BoardStore,
 	CommandRegistry,
-	EventBus,
 	LayerManager,
 	ShapeRegistry,
 	ToolRegistry,
 	Viewport,
 } from "@edv4h/usketch-shared";
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useState, useSyncExternalStore } from "react";
 import type { BoardMetaSnapshot, BoardMetaTrackerLike } from "../board-meta-types.js";
 import { FpsGraph } from "../components/fps-graph.js";
 import type { FpsCounter } from "../fps-counter.js";
@@ -25,12 +24,6 @@ import {
 } from "../styles.js";
 import type { SyncStatusSnapshot, SyncStatusTrackerLike } from "../sync-status-types.js";
 
-interface GpuStats {
-	gpuShapeCount: number;
-	sdfCount: number;
-	polylineCount: number;
-}
-
 interface GeneralPanelProps {
 	store: BoardStore;
 	fpsCounter: FpsCounter;
@@ -41,7 +34,6 @@ interface GeneralPanelProps {
 	shapes: ShapeRegistry;
 	syncStatus?: SyncStatusTrackerLike;
 	boardMeta?: BoardMetaTrackerLike;
-	events: EventBus;
 	viewport: Viewport;
 	activeToolId: string;
 }
@@ -91,7 +83,6 @@ export function GeneralPanel({
 	shapes,
 	syncStatus,
 	boardMeta,
-	events,
 	viewport,
 	activeToolId,
 }: GeneralPanelProps) {
@@ -126,12 +117,6 @@ export function GeneralPanel({
 	const toolCount = tools.getAll().size;
 	const layerCount = layers.getLayers().length;
 	const shapeTypeCount = shapes.getAll().size;
-
-	// GPU renderer stats (emitted by gpu-renderer plugin)
-	const [gpuStats, setGpuStats] = useState<GpuStats | null>(null);
-	useEffect(() => {
-		return events.on<GpuStats>("gpu-renderer:stats", setGpuStats);
-	}, [events]);
 
 	// Phase 2: viewport editing
 	const [editingViewport, setEditingViewport] = useState(false);
@@ -319,22 +304,6 @@ export function GeneralPanel({
 				<div>
 					Tools: {toolCount} · Layers: {layerCount} · Shape types: {shapeTypeCount}
 				</div>
-			</div>
-
-			{/* GPU Renderer */}
-			<div>
-				<div style={LABEL_STYLE}>GPU Renderer</div>
-				{gpuStats ? (
-					<div>
-						<div style={{ color: "#4ade80" }}>Active</div>
-						<div>
-							GPU: {gpuStats.gpuShapeCount} (SDF: {gpuStats.sdfCount}, Lines:{" "}
-							{gpuStats.polylineCount})
-						</div>
-					</div>
-				) : (
-					<div style={{ color: "#888" }}>Inactive (DOM only)</div>
-				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## 概要

HUD リファクタ基盤（#797）の後続。ハードコードされたテレメトリ（GPU/Sync/Members/Board-meta）を各所有者へ移設し、HUD コアの結合と `globalThis.__usketch*` を排除する作業を**順番に個別 PR**で進める、その**第1弾 = GPU 統計**。

GPU はイベントベース・グローバル無し・単一パッケージ（gpu-renderer は React・`ctx` あり）で最もクリーンなため先頭に。

## 変更点

- **`ctx.hud.registerPanel` を初適用**: gpu-renderer プラグインが「GPU」パネル（Active/Inactive＋SDF/Lines counts）を HUD に登録。
- 新規 `packages/gpu-renderer/src/gpu-stats-panel.tsx` — `gpu-renderer:stats` イベントを購読する自己完結コンポーネント（general-panel の描画を移設）。
- HUD コア（`general-panel.tsx`）から **GPU 専用セクション・`GpuStats` 型・`"gpu-renderer:stats"` 購読・不要になった `events` prop** を削除。HUD の GPU への暗黙結合が解消。
- GPU 統計の表示位置が GeneralPanel（右上・常時）→ Controls ドックの gpu-renderer セクション（プラグイン別）へ。これは「プラグインのプロパティをプラグイン配下に自動表示」という本移設の意図どおりの再配置。

## 非スコープ（後続、順に）

第2弾 Board-meta（`__usketchBoardMeta` 排除）→ 第3弾 Presence（`__usketchPresence` → presence-cursor 所有）→ 第4弾 Sync（source 分裂＋シェイプ強調にも使われ最難、専用設計）。

## 検証

- ✅ typecheck 162 / lint 0 / debug-hud 9 tests / gpu-renderer・debug-hud・web build
- GPU 描画ロジック（`renderer:claim-shapes`）は無変更＝回帰なし。表示位置のみ変更。
- 手動（`` ` `` で HUD）: Controls の gpu-renderer セクションに「GPU」パネル、GeneralPanel から GPU 行が消える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)