### PR TITLE
✨ feat(timter): minSize/defaultSize・minDurationMs オプション＋set-duration (#784, #781)

### DIFF
--- a/.changeset/timter-size-duration-options.md
+++ b/.changeset/timter-size-duration-options.md
@@ -1,0 +1,10 @@
+---
+"@edv4h/usketch-plugin-timter": minor
+---
+
+`createTimterPlugin` にサイズと duration 下限のオプションを追加（#784 / #781）。
+
+- **`minSize` / `defaultSize`（#784）**: timer shape の最小サイズ（既定 120×90）と新規作成サイズ（既定 160×120）をホストから指定可能に。`renderShape` でカスタム UI を置く際、コントロールが折り返さない最小幅を確保できる。ハードコードだった `minSize`・resize クランプ・`createDefault`・draw ツールの既定サイズ/オフセットが全てオプション連動に。
+- **`minDurationMs`（#781）**: countdown の duration 下限（既定 60_000ms）。`1_000` 等にすると 1 分未満（0:30 など秒単位）を許可。`adjust` のクランプが `Math.max(60_000, …)` からこの値基準に変更。
+- **`set-duration` アクション追加（#781）**: `TimerShapeActions.setDuration(ms)` で絶対値の duration を設定可能（`minDurationMs` にクランプ）。ホストの「分:秒」入力から 0:01〜 を直接設定できる。
+- `makeTimerShape` に `size` 引数を追加。

--- a/plugins/usketch-plugin-timter/src/__tests__/timer-shape.test.ts
+++ b/plugins/usketch-plugin-timter/src/__tests__/timer-shape.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { makeTimerShape } from "../timer-shape.js";
+
+describe("makeTimerShape", () => {
+	it("uses the default 160x120 size when none is given (#784)", () => {
+		const s = makeTimerShape({
+			id: "t1",
+			x: 0,
+			y: 0,
+			timerType: "countdown",
+			durationMs: 5 * 60_000,
+			serverNow: 1000,
+		});
+		expect(s.width).toBe(160);
+		expect(s.height).toBe(120);
+	});
+
+	it("honors a custom initial size (#784)", () => {
+		const s = makeTimerShape({
+			id: "t2",
+			x: 0,
+			y: 0,
+			timerType: "countdown",
+			durationMs: 5 * 60_000,
+			serverNow: 1000,
+			size: { width: 340, height: 90 },
+		});
+		expect(s.width).toBe(340);
+		expect(s.height).toBe(90);
+	});
+
+	it("carries a sub-minute duration through creation (#781)", () => {
+		const s = makeTimerShape({
+			id: "t3",
+			x: 0,
+			y: 0,
+			timerType: "countdown",
+			durationMs: 30_000, // 0:30 — makeTimerShape imposes no floor
+			serverNow: 1000,
+		});
+		expect(s.durationMs).toBe(30_000);
+	});
+});

--- a/plugins/usketch-plugin-timter/src/plugin.ts
+++ b/plugins/usketch-plugin-timter/src/plugin.ts
@@ -15,6 +15,9 @@ import {
 } from "./timer-model.js";
 import {
 	coreOf,
+	DEFAULT_MIN_DURATION_MS,
+	DEFAULT_TIMER_MIN_SIZE,
+	DEFAULT_TIMER_SIZE,
 	dispatchTimerShapeAction,
 	makeTimerShape,
 	registerTimerShape,
@@ -36,6 +39,20 @@ export interface TimterPluginOptions {
 	 * which you can also import and wrap.
 	 */
 	renderShape?: TimerShapeRenderer;
+	/**
+	 * Minimum size the timer shape can be resized to. Defaults to `120×90`.
+	 * Raise it when a custom {@link renderShape} needs more room (e.g. a row of
+	 * controls that would otherwise wrap).
+	 */
+	minSize?: { width: number; height: number };
+	/** Size of a newly created timer shape (`createDefault` / timer-draw). Defaults to `160×120`. */
+	defaultSize?: { width: number; height: number };
+	/**
+	 * Lower bound (ms) for a countdown's configured duration, enforced by the
+	 * `adjust` / `set-duration` actions. Defaults to `60_000` (1 min). Set e.g.
+	 * `1_000` to allow sub-minute durations (0:01–).
+	 */
+	minDurationMs?: number;
 }
 
 /**
@@ -53,6 +70,9 @@ export function createTimterPlugin(options: TimterPluginOptions): UsketchPlugin 
 
 		setup(ctx: PluginContext) {
 			const now = () => options.serverClock.now();
+			const minSize = options.minSize ?? DEFAULT_TIMER_MIN_SIZE;
+			const defaultSize = options.defaultSize ?? DEFAULT_TIMER_SIZE;
+			const minDurationMs = options.minDurationMs ?? DEFAULT_MIN_DURATION_MS;
 
 			// ── Timer shape (placeable, movable) — the source of truth ──
 			const disposeShape = registerTimerShape(
@@ -60,6 +80,7 @@ export function createTimterPlugin(options: TimterPluginOptions): UsketchPlugin 
 				options.serverClock,
 				options.userId ?? "local",
 				options.renderShape,
+				{ minSize, defaultSize, minDurationMs },
 			);
 
 			const listTimers = (): TimerShapeData[] =>
@@ -74,11 +95,12 @@ export function createTimterPlugin(options: TimterPluginOptions): UsketchPlugin 
 				const cy = (window.innerHeight / 2 - vp.y) / vp.zoom;
 				const shape = makeTimerShape({
 					id: generateId(),
-					x: cx - 80,
-					y: cy - 60,
+					x: cx - defaultSize.width / 2,
+					y: cy - defaultSize.height / 2,
 					timerType,
 					durationMs,
 					serverNow: now(),
+					size: defaultSize,
 				});
 				ctx.commands.execute(createAddShapeCommand(ctx.store, shape as ShapeData));
 				ctx.store.setSelection([shape.id]);

--- a/plugins/usketch-plugin-timter/src/timer-shape.tsx
+++ b/plugins/usketch-plugin-timter/src/timer-shape.tsx
@@ -29,6 +29,24 @@ export const TIMER_SHAPE_TYPE = "timer";
 const DEFAULT_MINUTES = 5;
 const ACTION_EVENT = "usketch:timter-shape-action";
 
+/** Default shape sizing / duration floor — overridable via {@link TimterPluginOptions}. */
+export const DEFAULT_TIMER_MIN_SIZE = { width: 120, height: 90 };
+export const DEFAULT_TIMER_SIZE = { width: 160, height: 120 };
+export const DEFAULT_MIN_DURATION_MS = 60_000;
+
+/** Host-tunable sizing / duration config threaded into the timer shape. */
+export interface TimerShapeConfig {
+	minSize: { width: number; height: number };
+	defaultSize: { width: number; height: number };
+	minDurationMs: number;
+}
+
+const DEFAULT_TIMER_CONFIG: TimerShapeConfig = {
+	minSize: DEFAULT_TIMER_MIN_SIZE,
+	defaultSize: DEFAULT_TIMER_SIZE,
+	minDurationMs: DEFAULT_MIN_DURATION_MS,
+};
+
 /** A timer as a placeable canvas shape. Timing state mirrors {@link TimerCore}. */
 export interface TimerShapeData extends ShapeData {
 	type: typeof TIMER_SHAPE_TYPE;
@@ -42,7 +60,10 @@ export interface TimerShapeData extends ShapeData {
 export type ShapeAction =
 	| { id: string; action: "toggle" | "reset" | "switch-type" }
 	/** `value` is a delta in **milliseconds** applied to the configured duration. */
-	| { id: string; action: "adjust"; value: number };
+	| { id: string; action: "adjust"; value: number }
+	/** `value` is an **absolute** target duration in milliseconds (clamped to the
+	 * configured `minDurationMs`). Lets a host UI set e.g. 0:30 directly. */
+	| { id: string; action: "set-duration"; value: number };
 
 export const coreOf = (s: TimerShapeData): TimerCore => ({
 	type: s.timerType,
@@ -83,6 +104,9 @@ export interface TimerShapeActions {
 	switchType(): void;
 	/** Change the configured duration by `deltaMs` (duration-based kinds, while paused). */
 	adjust(deltaMs: number): void;
+	/** Set the configured duration to an absolute `ms` (clamped to `minDurationMs`,
+	 * while paused). Use for a host "分:秒" input. */
+	setDuration(ms: number): void;
 }
 
 /**
@@ -270,6 +294,7 @@ function TimerShapeView({
 		reset: () => emit({ id: shape.id, action: "reset" }),
 		switchType: () => emit({ id: shape.id, action: "switch-type" }),
 		adjust: (deltaMs) => emit({ id: shape.id, action: "adjust", value: deltaMs }),
+		setDuration: (ms) => emit({ id: shape.id, action: "set-duration", value: ms }),
 	};
 
 	return render({ shape, core, serverNow, actions });
@@ -322,7 +347,12 @@ function hitTest(data: ShapeData, point: Point): boolean {
 	);
 }
 
-function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
+function resize(
+	data: ShapeData,
+	handle: ResizeHandle,
+	delta: Point,
+	minSize: { width: number; height: number } = DEFAULT_TIMER_MIN_SIZE,
+): ShapeData {
 	let { x, y, width, height } = data;
 	switch (handle) {
 		case "se":
@@ -360,17 +390,26 @@ function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData 
 			height += delta.y;
 			break;
 	}
-	return { ...data, x, y, width: Math.max(120, width), height: Math.max(90, height) };
+	return {
+		...data,
+		x,
+		y,
+		width: Math.max(minSize.width, width),
+		height: Math.max(minSize.height, height),
+	};
 }
 
-function createDefault(params: { id: string; x: number; y: number }): TimerShapeData {
+function createDefault(
+	params: { id: string; x: number; y: number },
+	size: { width: number; height: number } = DEFAULT_TIMER_SIZE,
+): TimerShapeData {
 	return {
 		id: params.id,
 		type: TIMER_SHAPE_TYPE,
 		x: params.x,
 		y: params.y,
-		width: 160,
-		height: 120,
+		width: size.width,
+		height: size.height,
 		style: { fill: "#ffffff", stroke: "#1e1e1e", strokeWidth: 2, opacity: 1 },
 		timerType: "countdown",
 		running: false,
@@ -388,8 +427,10 @@ export function makeTimerShape(params: {
 	timerType: TimerType;
 	durationMs?: number;
 	serverNow: number;
+	/** Initial shape size. Defaults to {@link DEFAULT_TIMER_SIZE}. */
+	size?: { width: number; height: number };
 }): TimerShapeData {
-	const base = createDefault({ id: params.id, x: params.x, y: params.y });
+	const base = createDefault({ id: params.id, x: params.x, y: params.y }, params.size);
 	// The kind's `initial` decides how (or whether) the duration is used —
 	// non-duration kinds like stopwatch ignore it.
 	const dur = params.durationMs ?? DEFAULT_MINUTES * 60_000;
@@ -418,8 +459,10 @@ export function registerTimerShape(
 	serverClock: ServerClock,
 	_userId: string,
 	renderShape: TimerShapeRenderer = defaultRenderTimerShape,
+	config: TimerShapeConfig = DEFAULT_TIMER_CONFIG,
 ): () => void {
 	const now = () => serverClock.now();
+	const { minSize, defaultSize, minDurationMs } = config;
 
 	ctx.shapes.register(TIMER_SHAPE_TYPE, {
 		render: (shape) => (
@@ -431,10 +474,10 @@ export function registerTimerShape(
 		),
 		getBounds,
 		hitTest,
-		resize,
-		createDefault,
+		resize: (data, handle, delta) => resize(data, handle, delta, minSize),
+		createDefault: (params) => createDefault(params, defaultSize),
 		renderTarget: "html",
-		minSize: { width: 120, height: 90 },
+		minSize,
 		simplifiedComponent: SimplifiedTimer,
 	});
 
@@ -471,7 +514,13 @@ export function registerTimerShape(
 			case "adjust": {
 				// `value` is a millisecond delta; only duration-based kinds respond.
 				if (core.running || core.durationMs <= 0) return;
-				next = initialCore(core.type, Math.max(60_000, core.durationMs + detail.value));
+				next = initialCore(core.type, Math.max(minDurationMs, core.durationMs + detail.value));
+				break;
+			}
+			case "set-duration": {
+				// `value` is an absolute target duration; only duration-based kinds respond.
+				if (core.running || core.durationMs <= 0) return;
+				next = initialCore(core.type, Math.max(minDurationMs, detail.value));
 				break;
 			}
 			default:
@@ -491,7 +540,10 @@ export function registerTimerShape(
 		onPointerDown(_toolCtx: ToolContext, event: CanvasPointerEvent) {
 			const id = generateId();
 			drawState = { startX: event.worldPoint.x, startY: event.worldPoint.y, shapeId: id };
-			const shape = createDefault({ id, x: event.worldPoint.x, y: event.worldPoint.y });
+			const shape = createDefault(
+				{ id, x: event.worldPoint.x, y: event.worldPoint.y },
+				defaultSize,
+			);
 			shape.width = 0;
 			shape.height = 0;
 			_toolCtx.store.addShape(shape);
@@ -512,11 +564,14 @@ export function registerTimerShape(
 				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, shape));
 				toolCtx.store.setSelection([shape.id]);
 			} else {
-				const def = createDefault({
-					id: drawState.shapeId,
-					x: drawState.startX - 80,
-					y: drawState.startY - 60,
-				});
+				const def = createDefault(
+					{
+						id: drawState.shapeId,
+						x: drawState.startX - defaultSize.width / 2,
+						y: drawState.startY - defaultSize.height / 2,
+					},
+					defaultSize,
+				);
 				toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, def));
 				toolCtx.store.setSelection([def.id]);
 			}


### PR DESCRIPTION
Issues の上位2件（同じ timter プラグイン）をまとめて対応。

## #784: timer shape の minSize / defaultSize をホストから指定可能に

`renderShape`（#754）でカスタム UI を置くと、最小サイズ 120×90 ではコントロールが折り返す。従来は `ctx.shapes.get("timer")` を spread 再登録する回避策が必要で、登録順・HMR 依存の問題があった。

→ `createTimterPlugin({ minSize?, defaultSize? })` を追加:
- `minSize`（既定 120×90）: 最小リサイズサイズ。ShapeDefinition の `minSize` と `resize` クランプ（別々にハードコードされていた 120/90）を連動。
- `defaultSize`（既定 160×120）: `createDefault` / timer-draw の新規作成サイズ。draw ツールのクリック配置オフセット（`-80/-60`）も `defaultSize/2` に。

## #781: countdown の duration を 1 分未満（秒単位）に

`adjust` が `Math.max(60_000, …)` で 1 分に切り上げていた。

→ `createTimterPlugin({ minDurationMs? })`（既定 60_000）を追加し `adjust` のクランプ基準に。`1_000` にすれば 0:01〜 を許可。
→ 絶対値設定の **`set-duration` アクション**を追加（`TimerShapeActions.setDuration(ms)`）。ホストの「分:秒」入力から目標値を直接設定できる（`minDurationMs` にクランプ）。

## 変更

- `plugins/usketch-plugin-timter/src/plugin.ts`: オプション追加・解決、`registerTimerShape` へ config、`addTimer` の size/offset。
- `plugins/usketch-plugin-timter/src/timer-shape.tsx`: `TimerShapeConfig`＋既定定数、`resize`/`createDefault`/`makeTimerShape` を size 連動、`onAction` の adjust クランプを `minDurationMs` 基準に＋`set-duration` case、`TimerShapeActions.setDuration`。
- tests: `makeTimerShape` の size/sub-minute duration。

## 検証

- ✅ typecheck 162 / lint 0 / timter 15 tests / build
- 既定値は現行と同一（120×90 / 160×120 / 60_000）＝**後方互換**。

Closes #784, #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)