### PR TITLE
✨ feat(map): RPG マップ・タイルペイントプラグイン（community）

### DIFF
--- a/.changeset/community-map-plugin.md
+++ b/.changeset/community-map-plugin.md
@@ -1,0 +1,20 @@
+---
+"@edv4h/usketch-plugin-map": minor
+---
+
+RPG マップ・タイルペイントプラグイン `@edv4h/usketch-plugin-map` を新規追加。
+
+デザイン「手描きRPGマップ・素材」の語彙を uSketch の layer/shape/tool 機構に実装:
+
+- **地形タイルペイント**: 12 種の地形（草原/森/水辺/砂漠/山/道/雪原/沼地/溶岩/石床/畑/花畑）を
+  40×40 グリッドにブラシで塗る。外周（辺）が一段濃くなるオートタイル。ブラシ / 消しゴム / 塗りつぶし。
+- **アイコン 36 種**（ランドマーク12・オブジェクト12・マーカー12）をパレットから選んでスタンプ配置。
+- **Tweaks**: カラフル⇔モノクロ、揺らぎ線⇔クリーン線、線の太さ（パレット＋Control HUD 両対応）。
+
+アーキテクチャ: 地形の描画は専用 **MapLayer**（全 shape の背面）、地形データは data-only の
+`tilemap` shape に保持（shape ストア経由で Yjs 同期・Undo が無料。`island` と同じ
+「データは shape・描画は layer」パターン）。アイコンは通常の選択可能な `map-icon` shape。
+SVG 素材は `dangerouslySetInnerHTML` 不使用（パース済みノード木を React で描画）。
+
+community ページ（ワールドマップ空間）の基本プラグインに組み込み（`createMapPlugin()`）。
+ツール `map`（ショートカット `m`、アバターのラジアルメニューにも表示）。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
 		"@edv4h/usketch-plugin-shape-community-region": "workspace:*",
 		"@edv4h/usketch-plugin-canvas-filter": "workspace:*",
 		"@edv4h/usketch-plugin-shape-island": "workspace:*",
+		"@edv4h/usketch-plugin-map": "workspace:*",
 		"@edv4h/usketch-plugin-shape-image": "workspace:*",
 		"@edv4h/usketch-plugin-shape-openui": "workspace:*",
 		"@edv4h/usketch-plugin-tool-openui": "workspace:*",

--- a/apps/web/src/pages/community/community-page.tsx
+++ b/apps/web/src/pages/community/community-page.tsx
@@ -12,6 +12,7 @@ import { createCommunityChatPlugin } from "@edv4h/usketch-plugin-community-chat"
 import { createRippleEffectPlugin } from "@edv4h/usketch-plugin-effect-ripple";
 import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
 import { createKeyboardShortcutsPlugin } from "@edv4h/usketch-plugin-keyboard-shortcuts";
+import { createMapPlugin } from "@edv4h/usketch-plugin-map";
 import { createPresenceCursorPlugin } from "@edv4h/usketch-plugin-presence-cursor";
 import { createReactionsPlugin } from "@edv4h/usketch-plugin-reactions";
 import {
@@ -207,6 +208,7 @@ export function CommunityPage() {
 					portalPlugin,
 					createGroupPlugin(),
 					createIslandPlugin(),
+					createMapPlugin(),
 					createDomRendererPlugin(),
 				];
 

--- a/plugins/usketch-plugin-map/README.md
+++ b/plugins/usketch-plugin-map/README.md
@@ -1,0 +1,43 @@
+# @edv4h/usketch-plugin-map
+
+RPG マップ・タイルペイントプラグイン。community ページ（ワールドマップ空間）で、
+手描きワイヤーフレーム調の地形タイルを塗り、ランドマーク/オブジェクト/マーカーの
+アイコンを配置できる。
+
+## 特徴
+
+- **地形タイルペイント**: 12 種の地形（草原/森/水辺/砂漠/山/道/雪原/沼地/溶岩/石床/畑/花畑）を
+  40×40 グリッドにブラシで塗る。隣接判定で外周（辺）が一段濃くなるオートタイル。
+  ブラシ / 消しゴム / 塗りつぶし（flood-fill）。
+- **アイコン 36 種**: ランドマーク12・オブジェクト12・マーカー12 をパレットから選んでスタンプ配置。
+- **Tweaks**: カラフル⇔モノクロ、揺らぎ線⇔クリーン線、線の太さ。パレットと Control HUD の両方から。
+
+## アーキテクチャ
+
+- **地形の描画は MapLayer**（`ctx.layers`, 低 `order` で全 shape の背面）。
+- **地形データは data-only の `tilemap` shape** に保持 → shape ストア経由で Yjs 同期・Undo が無料。
+  `tilemap` は `render:()=>null` / `hitTest:()=>false` / `locked` で選択対象にならない substrate。
+- **アイコンは通常の `map-icon` shape**（選択・移動・リサイズ可、前面）。
+- SVG 素材は `dangerouslySetInnerHTML` を使わず、パース済みノード木（`svg-nodes.tsx`）を
+  `React.createElement` で描画（XSS 安全・リポジトリ方針に準拠）。
+
+## 使い方
+
+```ts
+import { createMapPlugin } from "@edv4h/usketch-plugin-map";
+
+const plugins = [
+  // ...community base plugins
+  createMapPlugin({ tile: 40, defaultColorMode: "color", defaultLineStyle: "wobble" }),
+];
+```
+
+ツール `map`（ショートカット `m`、アバターのラジアルメニューにも表示）を選ぶとパレットが開く。
+
+## オプション（`createMapPlugin`）
+
+| option | default | 説明 |
+|---|---|---|
+| `tile` | `40` | タイル辺（world 単位） |
+| `defaultColorMode` | `"color"` | 初期配色（`color` / `mono`） |
+| `defaultLineStyle` | `"wobble"` | 初期線種（`wobble` / `clean`） |

--- a/plugins/usketch-plugin-map/README.md
+++ b/plugins/usketch-plugin-map/README.md
@@ -16,7 +16,8 @@ RPG マップ・タイルペイントプラグイン。community ページ（ワ
 
 - **地形の描画は MapLayer**（`ctx.layers`, 低 `order` で全 shape の背面）。
 - **地形データは data-only の `tilemap` shape** に保持 → shape ストア経由で Yjs 同期・Undo が無料。
-  `tilemap` は `render:()=>null` / `hitTest:()=>false` / `locked` で選択対象にならない substrate。
+  `tilemap` は描画を持たず（`render` は空の `<g/>` を返す）/ `hitTest:()=>false` / `locked` で
+  選択対象にならない substrate。
 - **アイコンは通常の `map-icon` shape**（選択・移動・リサイズ可、前面）。
 - SVG 素材は `dangerouslySetInnerHTML` を使わず、パース済みノード木（`svg-nodes.tsx`）を
   `React.createElement` で描画（XSS 安全・リポジトリ方針に準拠）。

--- a/plugins/usketch-plugin-map/package.json
+++ b/plugins/usketch-plugin-map/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "@edv4h/usketch-plugin-map",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*"
+	},
+	"peerDependencies": {
+		"react": ">=19"
+	},
+	"devDependencies": {
+		"@types/react": "19.2.17",
+		"typescript": "7.0.2",
+		"vitest": "4.1.10"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-map"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+	type Cells,
+	cellKey,
+	cellsBounds,
+	exposedEdges,
+	floodFill,
+	parseCellKey,
+	worldToCell,
+} from "../autotile.js";
+
+describe("cell keys", () => {
+	it("round-trips key <-> coords (incl. negatives)", () => {
+		expect(cellKey(3, -2)).toBe("3,-2");
+		expect(parseCellKey("3,-2")).toEqual([3, -2]);
+		expect(parseCellKey("-10,-20")).toEqual([-10, -20]);
+	});
+});
+
+describe("worldToCell", () => {
+	it("floors world coords into the grid", () => {
+		expect(worldToCell(0, 0, 40)).toEqual([0, 0]);
+		expect(worldToCell(39, 39, 40)).toEqual([0, 0]);
+		expect(worldToCell(40, 80, 40)).toEqual([1, 2]);
+		expect(worldToCell(-1, -1, 40)).toEqual([-1, -1]);
+	});
+});
+
+describe("cellsBounds", () => {
+	it("returns zero box when empty", () => {
+		expect(cellsBounds({}, 40)).toEqual({ x: 0, y: 0, width: 0, height: 0 });
+	});
+	it("encloses all painted cells", () => {
+		const cells: Cells = { "0,0": "grass", "2,1": "water" };
+		expect(cellsBounds(cells, 40)).toEqual({ x: 0, y: 0, width: 120, height: 80 });
+	});
+	it("handles negative cells", () => {
+		const cells: Cells = { "-1,-1": "grass", "0,0": "grass" };
+		expect(cellsBounds(cells, 40)).toEqual({ x: -40, y: -40, width: 80, height: 80 });
+	});
+});
+
+describe("exposedEdges", () => {
+	it("all sides exposed for an isolated cell", () => {
+		expect(exposedEdges({ "0,0": "grass" }, 0, 0)).toEqual({ n: true, e: true, s: true, w: true });
+	});
+	it("shared side with same terrain is not exposed", () => {
+		const cells: Cells = { "0,0": "grass", "1,0": "grass" };
+		expect(exposedEdges(cells, 0, 0)).toEqual({ n: true, e: false, s: true, w: true });
+	});
+	it("different terrain neighbour is exposed", () => {
+		const cells: Cells = { "0,0": "grass", "1,0": "water" };
+		expect(exposedEdges(cells, 0, 0).e).toBe(true);
+	});
+});
+
+describe("floodFill", () => {
+	it("fills connected same-terrain region", () => {
+		const cells: Cells = { "0,0": "grass", "1,0": "grass", "2,0": "water" };
+		const keys = floodFill(cells, 0, 0);
+		expect(new Set(keys)).toEqual(new Set(["0,0", "1,0"]));
+	});
+	it("does not cross a different terrain", () => {
+		const cells: Cells = { "0,0": "grass", "1,0": "water", "2,0": "grass" };
+		expect(floodFill(cells, 0, 0)).toEqual(["0,0"]);
+	});
+	it("empty-cell fill requires a bounding box and stays inside it", () => {
+		const cells: Cells = {};
+		expect(floodFill(cells, 0, 0)).toEqual([]); // unbounded empty → nothing
+		const keys = floodFill(cells, 0, 0, { minC: 0, minR: 0, maxC: 1, maxR: 1 });
+		expect(new Set(keys)).toEqual(new Set(["0,0", "1,0", "0,1", "1,1"]));
+	});
+});

--- a/plugins/usketch-plugin-map/src/__tests__/definitions.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/definitions.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { ICON_CATEGORIES, ICONS, ICONS_BY_KEY } from "../icons.js";
+import { TERRAIN_KEYS, TERRAINS, terrainPatternId } from "../terrain.js";
+
+describe("terrain definitions", () => {
+	it("has 12 terrains with unique keys and non-empty patterns", () => {
+		expect(TERRAINS).toHaveLength(12);
+		expect(new Set(TERRAIN_KEYS).size).toBe(12);
+		for (const t of TERRAINS) {
+			expect(t.nodes.length).toBeGreaterThan(0);
+			expect(t.patternWidth).toBeGreaterThan(0);
+			expect(t.patternHeight).toBeGreaterThan(0);
+		}
+	});
+	it("derives a stable pattern id", () => {
+		expect(terrainPatternId("grass")).toBe("uskmap-pat-grass");
+	});
+});
+
+describe("icon definitions", () => {
+	it("has 36 icons, 12 per category, unique keys", () => {
+		expect(ICONS).toHaveLength(36);
+		expect(new Set(ICONS.map((i) => i.key)).size).toBe(36);
+		for (const c of ICON_CATEGORIES) {
+			expect(ICONS.filter((i) => i.category === c.id)).toHaveLength(12);
+		}
+	});
+	it("every icon has viewBox + markup and is indexed", () => {
+		for (const i of ICONS) {
+			expect(i.viewBox).toMatch(/^[\d.\s-]+$/);
+			expect(i.nodes.length).toBeGreaterThan(0);
+			expect(ICONS_BY_KEY.get(i.key)).toBe(i);
+		}
+	});
+});

--- a/plugins/usketch-plugin-map/src/__tests__/reactive-store.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/reactive-store.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest";
+import { createReactiveStore } from "../reactive-store.js";
+
+describe("createReactiveStore", () => {
+	it("applies partial patches", () => {
+		const s = createReactiveStore({ a: 1, b: 2 });
+		s.set({ a: 5 });
+		expect(s.get()).toEqual({ a: 5, b: 2 });
+	});
+
+	it("ignores undefined keys (does not clobber existing values)", () => {
+		const s = createReactiveStore<{ a: number; b: string }>({ a: 1, b: "x" });
+		s.set({ a: undefined, b: "y" });
+		expect(s.get()).toEqual({ a: 1, b: "y" }); // a preserved
+	});
+
+	it("does not notify when nothing changes", () => {
+		const s = createReactiveStore({ a: 1 });
+		const listener = vi.fn();
+		s.subscribe(listener);
+		s.set({ a: 1 });
+		s.set({ a: undefined });
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it("notifies subscribers on change and unsubscribes", () => {
+		const s = createReactiveStore({ a: 1 });
+		const listener = vi.fn();
+		const unsub = s.subscribe(listener);
+		s.set({ a: 2 });
+		expect(listener).toHaveBeenCalledTimes(1);
+		unsub();
+		s.set({ a: 3 });
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+});

--- a/plugins/usketch-plugin-map/src/autotile.ts
+++ b/plugins/usketch-plugin-map/src/autotile.ts
@@ -1,0 +1,106 @@
+// Pure grid/autotile helpers for the tilemap. No DOM — unit-tested directly.
+import type { BoundingBox } from "@edv4h/usketch-shared";
+import type { TerrainKey } from "./terrain.js";
+
+export type Cells = Record<string, TerrainKey>;
+
+/** Sparse-map key for a cell. */
+export function cellKey(col: number, row: number): string {
+	return `${col},${row}`;
+}
+
+export function parseCellKey(key: string): [col: number, row: number] {
+	const i = key.indexOf(",");
+	return [Number(key.slice(0, i)), Number(key.slice(i + 1))];
+}
+
+/** World point → grid cell (origin at world 0,0; tiles are `tile` wide/tall). */
+export function worldToCell(x: number, y: number, tile: number): [col: number, row: number] {
+	return [Math.floor(x / tile), Math.floor(y / tile)];
+}
+
+/** Bounding box (world units) enclosing all painted cells. Empty → zero box. */
+export function cellsBounds(cells: Cells, tile: number): BoundingBox {
+	let minC = Infinity;
+	let minR = Infinity;
+	let maxC = -Infinity;
+	let maxR = -Infinity;
+	for (const key of Object.keys(cells)) {
+		const [c, r] = parseCellKey(key);
+		if (c < minC) minC = c;
+		if (r < minR) minR = r;
+		if (c > maxC) maxC = c;
+		if (r > maxR) maxR = r;
+	}
+	if (minC === Infinity) return { x: 0, y: 0, width: 0, height: 0 };
+	return {
+		x: minC * tile,
+		y: minR * tile,
+		width: (maxC - minC + 1) * tile,
+		height: (maxR - minR + 1) * tile,
+	};
+}
+
+export interface ExposedEdges {
+	n: boolean;
+	e: boolean;
+	s: boolean;
+	w: boolean;
+}
+
+/**
+ * Which sides of cell (c,r) border a different terrain (or empty). These get the
+ * "one shade darker" strip in the design — the region's outer ring.
+ */
+export function exposedEdges(cells: Cells, col: number, row: number): ExposedEdges {
+	const self = cells[cellKey(col, row)];
+	const diff = (c: number, r: number) => cells[cellKey(c, r)] !== self;
+	return {
+		n: diff(col, row - 1),
+		e: diff(col + 1, row),
+		s: diff(col, row + 1),
+		w: diff(col - 1, row),
+	};
+}
+
+export interface CellBox {
+	minC: number;
+	minR: number;
+	maxC: number;
+	maxR: number;
+}
+
+/**
+ * Connected region (4-neighbour) of cells sharing the start cell's current
+ * terrain. Returns the keys to repaint. When the start cell is empty, `box`
+ * (in cell coordinates) is required to keep the flood bounded.
+ */
+export function floodFill(
+	cells: Cells,
+	startCol: number,
+	startRow: number,
+	box?: CellBox,
+): string[] {
+	const target = cells[cellKey(startCol, startRow)]; // TerrainKey | undefined (empty)
+	if (target === undefined && !box) return [];
+	const inBox = (c: number, r: number) =>
+		!box || (c >= box.minC && c <= box.maxC && r >= box.minR && r <= box.maxR);
+	if (!inBox(startCol, startRow)) return [];
+
+	const out: string[] = [];
+	const seen = new Set<string>();
+	const stack: [number, number][] = [[startCol, startRow]];
+	while (stack.length) {
+		const next = stack.pop();
+		if (!next) break;
+		const [c, r] = next;
+		const key = cellKey(c, r);
+		if (seen.has(key)) continue;
+		if (!inBox(c, r)) continue;
+		if (cells[key] !== target) continue;
+		seen.add(key);
+		out.push(key);
+		stack.push([c + 1, r], [c - 1, r], [c, r + 1], [c, r - 1]);
+	}
+	return out;
+}

--- a/plugins/usketch-plugin-map/src/icons.ts
+++ b/plugins/usketch-plugin-map/src/icons.ts
@@ -1,0 +1,966 @@
+// GENERATED from design (RPGマップ素材.dc.html). 36 map icons (landmark/object/marker).
+// `nodes` is a parsed SVG element tree (see svg-nodes.tsx) rendered via
+// React.createElement — no dangerouslySetInnerHTML.
+import type { SvgNode } from "./svg-nodes.js";
+
+export type IconCategory = "landmark" | "object" | "marker";
+
+export interface IconDef {
+	key: string;
+	en: string;
+	ja: string;
+	category: IconCategory;
+	viewBox: string;
+	nodes: SvgNode[];
+}
+
+export const ICONS: readonly IconDef[] = [
+	{
+		key: "town",
+		en: "Town",
+		ja: "町",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M10 42 V24 L24 14 L38 24 V42 Z", fill: "var(--orange)" } },
+					{ t: "path", a: { d: "M6 24 L24 10 L42 24", fill: "none" } },
+					{ t: "rect", a: { x: "20", y: "30", width: "8", height: "12", fill: "var(--stroke)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "castle",
+		en: "Castle",
+		ja: "城",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{
+						t: "path",
+						a: { d: "M8 42 V18 H14 V24 H20 V18 H28 V24 H34 V18 H40 V42 Z", fill: "var(--purple)" },
+					},
+					{ t: "path", a: { d: "M20 42 V32 H28 V42", fill: "var(--stroke)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "cave",
+		en: "Cave",
+		ja: "洞窟",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M6 42 Q11 18 24 18 Q37 18 42 42 Z", fill: "var(--t-mtn)" } },
+					{ t: "path", a: { d: "M17 42 Q17 27 24 27 Q31 27 31 42 Z", fill: "var(--stroke)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "tower",
+		en: "Tower",
+		ja: "塔",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M16 44 V16 H32 V44 Z", fill: "var(--blue)" } },
+					{ t: "path", a: { d: "M14 16 L24 6 L34 16", fill: "var(--red)" } },
+					{ t: "path", a: { d: "M34 8 L42 6 L40 12 L34 12", fill: "var(--yellow)" } },
+					{ t: "path", a: { d: "M34 6 V16", fill: "none" } },
+					{ t: "rect", a: { x: "21", y: "34", width: "6", height: "10", fill: "var(--stroke)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "shrine",
+		en: "Shrine",
+		ja: "神社",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M8 18 Q24 10 40 18", fill: "none" } },
+					{ t: "path", a: { d: "M5 24 H43", fill: "none", "stroke-width": "3.4" } },
+					{ t: "path", a: { d: "M13 24 V44 M35 24 V44", fill: "var(--red)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "temple",
+		en: "Temple",
+		ja: "寺院",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M6 40 Q6 22 16 22 H32 Q42 22 42 40 Z", fill: "var(--teal)" } },
+					{ t: "path", a: { d: "M14 22 V12 H34 V22", fill: "var(--teal)" } },
+					{ t: "path", a: { d: "M20 40 V30 H28 V40", fill: "var(--stroke)" } },
+					{ t: "path", a: { d: "M12 8 H36 L34 12 H14 Z", fill: "var(--red)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "lighthouse",
+		en: "Lighthouse",
+		ja: "灯台",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M16 44 V14 H32 V44 Z", fill: "var(--card)" } },
+					{ t: "path", a: { d: "M16 24 H32 M16 34 H32", fill: "none" } },
+					{ t: "path", a: { d: "M17 14 L24 5 L31 14", fill: "var(--red)" } },
+					{ t: "circle", a: { cx: "24", cy: "19", r: "3.4", fill: "var(--yellow)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "windmill",
+		en: "Windmill",
+		ja: "風車",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M13 44 L19 18 H29 L35 44 Z", fill: "var(--card)" } },
+					{ t: "path", a: { d: "M17 36 H31", fill: "none" } },
+					{ t: "path", a: { d: "M21 44 V38 H27 V44", fill: "var(--stroke)" } },
+					{
+						t: "path",
+						a: { d: "M24 16 L24 2 L34 8 Z", fill: "var(--teal)", "stroke-width": "2.4" },
+					},
+					{
+						t: "path",
+						a: { d: "M24 16 L38 16 L32 26 Z", fill: "var(--teal)", "stroke-width": "2.4" },
+					},
+					{
+						t: "path",
+						a: { d: "M24 16 L24 30 L14 24 Z", fill: "var(--teal)", "stroke-width": "2.4" },
+					},
+					{
+						t: "path",
+						a: { d: "M24 16 L10 16 L16 6 Z", fill: "var(--teal)", "stroke-width": "2.4" },
+					},
+				],
+			},
+		],
+	},
+	{
+		key: "port",
+		en: "Port",
+		ja: "港",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M4 30 H20 V42 H4 Z", fill: "var(--brown)" } },
+					{ t: "path", a: { d: "M12 30 V42", fill: "none" } },
+					{ t: "path", a: { d: "M28 6 V32", fill: "none" } },
+					{ t: "path", a: { d: "M28 8 L42 15 L28 22 Z", fill: "var(--red)" } },
+					{ t: "path", a: { d: "M20 32 H44 L38 42 H26 Z", fill: "var(--blue)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "ruins",
+		en: "Ruins",
+		ja: "遺跡",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M6 42 H42", fill: "none", "stroke-width": "3.4" } },
+					{ t: "path", a: { d: "M10 42 V18 L14 14 V42 Z", fill: "var(--t-stone)" } },
+					{ t: "path", a: { d: "M22 42 V24 L26 20 V42 Z", fill: "var(--t-stone)" } },
+					{ t: "path", a: { d: "M34 42 V12 L38 8 V42 Z", fill: "var(--t-stone)" } },
+					{ t: "path", a: { d: "M14 20 H22 M26 26 H34", fill: "none" } },
+				],
+			},
+		],
+	},
+	{
+		key: "mine",
+		en: "Mine",
+		ja: "鉱山",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M4 42 Q8 22 24 22 Q40 22 44 42 Z", fill: "var(--t-mtn)" } },
+					{
+						t: "path",
+						a: { d: "M16 42 V32 Q16 26 24 26 Q32 26 32 32 V42 Z", fill: "var(--stroke)" },
+					},
+					{
+						t: "path",
+						a: {
+							d: "M13 42 V30 M35 42 V30",
+							fill: "none",
+							stroke: "var(--brown)",
+							"stroke-width": "3.4",
+						},
+					},
+					{
+						t: "path",
+						a: { d: "M10 30 H38", fill: "none", stroke: "var(--brown)", "stroke-width": "3.4" },
+					},
+				],
+			},
+		],
+	},
+	{
+		key: "graveyard",
+		en: "Graveyard",
+		ja: "墓地",
+		category: "landmark",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M4 42 H44", fill: "none", "stroke-width": "3.4" } },
+					{
+						t: "path",
+						a: { d: "M10 42 V20 Q10 12 18 12 Q26 12 26 20 V42 Z", fill: "var(--muted)" },
+					},
+					{ t: "path", a: { d: "M18 18 V32 M12 24 H24", fill: "none" } },
+					{
+						t: "path",
+						a: { d: "M32 42 V26 Q32 20 37 20 Q42 20 42 26 V42 Z", fill: "var(--muted)" },
+					},
+				],
+			},
+		],
+	},
+	{
+		key: "chest",
+		en: "Chest",
+		ja: "宝箱",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M8 20 Q8 12 24 12 Q40 12 40 20 V40 H8 Z", fill: "var(--yellow)" } },
+					{ t: "path", a: { d: "M8 22 H40", fill: "none" } },
+					{ t: "rect", a: { x: "20", y: "20", width: "8", height: "9", fill: "var(--stroke)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "signpost",
+		en: "Signpost",
+		ja: "看板",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M24 12 V44", fill: "none" } },
+					{ t: "path", a: { d: "M6 8 H26 L32 14 L26 20 H6 Z", fill: "var(--brown)" } },
+					{ t: "path", a: { d: "M24 22 H42 L38 27 L42 32 H24", fill: "var(--brown)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "campfire",
+		en: "Campfire",
+		ja: "たき火",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M24 12 Q30 22 24 30 Q18 22 24 12 Z", fill: "var(--red)" } },
+					{ t: "path", a: { d: "M24 22 Q27 27 24 30 Q21 27 24 22 Z", fill: "var(--yellow)" } },
+					{
+						t: "path",
+						a: {
+							d: "M10 42 L38 34 M38 42 L10 34",
+							fill: "none",
+							stroke: "var(--brown)",
+							"stroke-width": "3.4",
+						},
+					},
+				],
+			},
+		],
+	},
+	{
+		key: "bridge",
+		en: "Bridge",
+		ja: "橋",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M4 20 Q24 6 44 20", fill: "none" } },
+					{ t: "path", a: { d: "M6 22 H42", fill: "none" } },
+					{ t: "path", a: { d: "M11 22 V40 M37 22 V40", fill: "none" } },
+					{ t: "path", a: { d: "M6 30 H42 M18 22 V30 M30 22 V30", fill: "var(--orange)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "boat",
+		en: "Boat",
+		ja: "船",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M24 8 V30", fill: "none" } },
+					{ t: "path", a: { d: "M24 10 L38 16 L24 22 Z", fill: "var(--red)" } },
+					{ t: "path", a: { d: "M8 34 H40 L34 44 H14 Z", fill: "var(--brown)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "well",
+		en: "Well",
+		ja: "井戸",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M10 8 L24 4 L38 8 L34 14 H14 Z", fill: "var(--red)" } },
+					{ t: "path", a: { d: "M12 14 V44 M36 14 V44", fill: "none" } },
+					{ t: "path", a: { d: "M12 26 H36", fill: "none" } },
+					{ t: "ellipse", a: { cx: "24", cy: "26", rx: "9", ry: "6", fill: "var(--t-water)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "tree",
+		en: "Tree",
+		ja: "木",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M24 44 V26", fill: "none" } },
+					{ t: "path", a: { d: "M24 28 Q8 26 10 12 Q24 12 24 28 Z", fill: "var(--green)" } },
+					{ t: "path", a: { d: "M24 28 Q40 26 38 12 Q24 12 24 28 Z", fill: "var(--t-forest)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "rock",
+		en: "Rock",
+		ja: "岩",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{
+						t: "path",
+						a: {
+							d: "M6 38 Q4 22 16 20 Q22 8 32 16 Q44 18 42 32 Q40 40 30 38 Z",
+							fill: "var(--t-mtn)",
+						},
+					},
+					{ t: "path", a: { d: "M16 30 L22 24 L28 30", fill: "none" } },
+				],
+			},
+		],
+	},
+	{
+		key: "mushroom",
+		en: "Mushroom",
+		ja: "キノコ",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M24 44 V26", fill: "none" } },
+					{
+						t: "path",
+						a: { d: "M8 24 Q8 8 24 8 Q40 8 40 24 Q32 28 24 24 Q16 28 8 24 Z", fill: "var(--red)" },
+					},
+					{ t: "circle", a: { cx: "18", cy: "16", r: "2.6", fill: "var(--card)" } },
+					{ t: "circle", a: { cx: "29", cy: "19", r: "2", fill: "var(--card)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "tent",
+		en: "Tent",
+		ja: "テント",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M6 40 L24 10 L42 40 Z", fill: "var(--teal)" } },
+					{ t: "path", a: { d: "M24 10 V40", fill: "none" } },
+					{ t: "path", a: { d: "M16 40 L24 22 L32 40 Z", fill: "var(--stroke)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "barrel",
+		en: "Barrel",
+		ja: "樽",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M14 8 Q6 24 14 40 H34 Q42 24 34 8 Z", fill: "var(--brown)" } },
+					{ t: "path", a: { d: "M9 16 H39 M9 32 H39", fill: "none" } },
+				],
+			},
+		],
+	},
+	{
+		key: "gate",
+		en: "Gate",
+		ja: "門",
+		category: "object",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M10 42 V14 Q10 6 24 6 Q38 6 38 14 V42", fill: "var(--purple)" } },
+					{ t: "path", a: { d: "M10 20 H38", fill: "none" } },
+					{
+						t: "path",
+						a: { d: "M18 42 V26 Q18 20 24 20 Q30 20 30 26 V42", fill: "var(--stroke)" },
+					},
+				],
+			},
+		],
+	},
+	{
+		key: "player-pin",
+		en: "Player Pin",
+		ja: "現在地",
+		category: "marker",
+		viewBox: "0 0 40 52",
+		nodes: [
+			{
+				t: "path",
+				a: {
+					d: "M20 50 C6 32 4 24 4 18 A16 16 0 0 1 36 18 C36 24 34 32 20 50 Z",
+					fill: "var(--red)",
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+				},
+			},
+			{
+				t: "circle",
+				a: {
+					cx: "20",
+					cy: "18",
+					r: "7",
+					fill: "#fff",
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+				},
+			},
+		],
+	},
+	{
+		key: "quest",
+		en: "Quest",
+		ja: "クエスト",
+		category: "marker",
+		viewBox: "0 0 40 44",
+		nodes: [
+			{
+				t: "circle",
+				a: {
+					cx: "20",
+					cy: "18",
+					r: "15",
+					fill: "var(--yellow)",
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+				},
+			},
+			{
+				t: "path",
+				a: {
+					d: "M20 9 V21 M20 26 V27.6",
+					fill: "none",
+					stroke: "var(--stroke)",
+					"stroke-width": "3.6",
+					"stroke-linecap": "round",
+				},
+			},
+		],
+	},
+	{
+		key: "flag",
+		en: "Flag",
+		ja: "拠点旗",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M14 44 V6", fill: "none" } },
+					{ t: "path", a: { d: "M14 8 H38 L32 15 L38 22 H14 Z", fill: "var(--green)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "monster",
+		en: "Monster",
+		ja: "敵",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{
+						t: "path",
+						a: {
+							d: "M8 42 Q6 20 24 20 Q42 20 40 42 Q34 37 30 42 Q26 37 24 42 Q22 37 18 42 Q14 37 8 42 Z",
+							fill: "var(--green)",
+						},
+					},
+					{ t: "circle", a: { cx: "18", cy: "29", r: "3", fill: "#fff" } },
+					{ t: "circle", a: { cx: "30", cy: "29", r: "3", fill: "#fff" } },
+					{ t: "circle", a: { cx: "18", cy: "29", r: "1.2", fill: "var(--stroke)" } },
+					{ t: "circle", a: { cx: "30", cy: "29", r: "1.2", fill: "var(--stroke)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "objective",
+		en: "Objective",
+		ja: "目標",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "path",
+				a: {
+					d: "M24 6 L30 18 L44 20 L34 30 L36 44 L24 37 L12 44 L14 30 L4 20 L18 18 Z",
+					fill: "var(--yellow)",
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+				},
+			},
+		],
+	},
+	{
+		key: "compass",
+		en: "Compass",
+		ja: "方位",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "circle", a: { cx: "24", cy: "24", r: "18", fill: "var(--card)" } },
+					{ t: "path", a: { d: "M24 8 V13 M24 35 V40 M8 24 H13 M35 24 H40", fill: "none" } },
+					{ t: "path", a: { d: "M24 24 L33 15 L27 27 Z", fill: "var(--red)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "danger",
+		en: "Danger",
+		ja: "危険地帯",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M24 6 L44 40 H4 Z", fill: "var(--orange)" } },
+					{ t: "path", a: { d: "M24 18 V28 M24 33 V34.4", fill: "none", "stroke-width": "3.6" } },
+				],
+			},
+		],
+	},
+	{
+		key: "shop",
+		en: "Shop",
+		ja: "店",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "path", a: { d: "M10 18 H38 L35 42 H13 Z", fill: "var(--teal)" } },
+					{ t: "path", a: { d: "M18 22 V14 Q18 7 24 7 Q30 7 30 14 V22", fill: "none" } },
+				],
+			},
+		],
+	},
+	{
+		key: "warp",
+		en: "Warp",
+		ja: "ワープ",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{
+						t: "ellipse",
+						a: { cx: "24", cy: "24", rx: "19", ry: "10", fill: "none", stroke: "var(--purple)" },
+					},
+					{
+						t: "ellipse",
+						a: { cx: "24", cy: "24", rx: "10", ry: "19", fill: "none", stroke: "var(--purple)" },
+					},
+					{ t: "circle", a: { cx: "24", cy: "24", r: "6", fill: "var(--purple)" } },
+				],
+			},
+		],
+	},
+	{
+		key: "heal",
+		en: "Heal",
+		ja: "回復",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{
+						t: "path",
+						a: {
+							d: "M24 42 C10 30 5 24 5 17 A11 11 0 0 1 24 11 A11 11 0 0 1 43 17 C43 24 38 30 24 42 Z",
+							fill: "var(--pink)",
+						},
+					},
+					{
+						t: "path",
+						a: {
+							d: "M24 18 V30 M18 24 H30",
+							fill: "none",
+							stroke: "var(--card)",
+							"stroke-width": "3.4",
+						},
+					},
+				],
+			},
+		],
+	},
+	{
+		key: "key",
+		en: "Key",
+		ja: "鍵",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{ t: "circle", a: { cx: "16", cy: "16", r: "9", fill: "var(--yellow)" } },
+					{ t: "circle", a: { cx: "16", cy: "16", r: "3", fill: "var(--card)" } },
+					{ t: "path", a: { d: "M22 22 L40 40 M34 34 L30 38 M38 38 L34 42", fill: "none" } },
+				],
+			},
+		],
+	},
+	{
+		key: "save",
+		en: "Save",
+		ja: "セーブ",
+		category: "marker",
+		viewBox: "0 0 48 48",
+		nodes: [
+			{
+				t: "g",
+				a: {
+					stroke: "var(--stroke)",
+					"stroke-width": "3",
+					"stroke-linejoin": "round",
+					"stroke-linecap": "round",
+				},
+				c: [
+					{
+						t: "rect",
+						a: { x: "7", y: "7", width: "34", height: "34", rx: "6", fill: "var(--blue)" },
+					},
+					{
+						t: "path",
+						a: {
+							d: "M16 20 L22 27 L33 15",
+							fill: "none",
+							stroke: "var(--card)",
+							"stroke-width": "4",
+						},
+					},
+				],
+			},
+		],
+	},
+];
+
+export const ICONS_BY_KEY: ReadonlyMap<string, IconDef> = new Map(ICONS.map((i) => [i.key, i]));
+
+export const ICON_CATEGORIES: readonly { id: IconCategory; label: string }[] = [
+	{ id: "landmark", label: "ランドマーク" },
+	{ id: "object", label: "オブジェクト" },
+	{ id: "marker", label: "マーカー" },
+];

--- a/plugins/usketch-plugin-map/src/index.ts
+++ b/plugins/usketch-plugin-map/src/index.ts
@@ -1,0 +1,12 @@
+export { ICONS, type IconCategory, type IconDef } from "./icons.js";
+export { MAP_ICON_TYPE, type MapIconShapeData } from "./map-icon-shape.js";
+export { MAP_TOOL_ID } from "./map-tool-id.js";
+export type { ColorMode } from "./palette.js";
+export { createMapPlugin, type MapPluginOptions } from "./plugin.js";
+export {
+	type LineStyle,
+	type MapRenderConfig,
+	renderConfigStore,
+} from "./render-config.js";
+export { TERRAINS, type TerrainDef, type TerrainKey } from "./terrain.js";
+export { DEFAULT_TILE, TILEMAP_TYPE, type TileMapShapeData } from "./tilemap-shape.js";

--- a/plugins/usketch-plugin-map/src/map-icon-shape.tsx
+++ b/plugins/usketch-plugin-map/src/map-icon-shape.tsx
@@ -1,0 +1,142 @@
+// `map-icon` — a placed landmark/object/marker. A normal selectable/movable/
+// resizable SVG shape (foreground, above the terrain MapLayer). The icon kind is
+// stored in `meta.iconKey`; the SVG markup comes from the design (icons.ts).
+import type {
+	BoundingBox,
+	Point,
+	ResizeHandle,
+	ShapeData,
+	ShapeDefinition,
+} from "@edv4h/usketch-shared";
+import { generateId, withRotation } from "@edv4h/usketch-shared";
+import { ICONS_BY_KEY, type IconCategory } from "./icons.js";
+import { WOBBLE_FILTER_ID } from "./map-layer.js";
+import { terrainCssVars } from "./palette.js";
+import { useRenderConfig } from "./render-config.js";
+import { renderSvgNodes } from "./svg-nodes.js";
+
+export const MAP_ICON_TYPE = "map-icon";
+export const DEFAULT_ICON_SIZE = 48;
+
+export interface MapIconShapeData extends ShapeData {
+	type: "map-icon";
+	meta: { iconKey: string; category: IconCategory };
+}
+
+export function makeMapIcon(
+	iconKey: string,
+	category: IconCategory,
+	x: number,
+	y: number,
+	size = DEFAULT_ICON_SIZE,
+): MapIconShapeData {
+	return {
+		id: generateId(),
+		type: "map-icon",
+		x: Math.round(x - size / 2),
+		y: Math.round(y - size / 2),
+		width: size,
+		height: size,
+		style: { fill: "transparent", stroke: "transparent", strokeWidth: 0, opacity: 1 },
+		meta: { iconKey, category },
+	};
+}
+
+function parseViewBox(vb: string): [number, number, number, number] {
+	const p = vb.split(/[\s,]+/).map(Number);
+	return [p[0] || 0, p[1] || 0, p[2] || 48, p[3] || 48];
+}
+
+function MapIconBody({ data }: { data: MapIconShapeData }) {
+	const cfg = useRenderConfig();
+	const icon = ICONS_BY_KEY.get(data.meta?.iconKey ?? "");
+	if (!icon) return <g />;
+	const [vx, vy, vw, vh] = parseViewBox(icon.viewBox);
+	const sx = data.width / vw;
+	const sy = data.height / vh;
+	const cssVars = terrainCssVars(cfg.colorMode, cfg.strokeScale);
+	return (
+		<g
+			style={cssVars as React.CSSProperties}
+			filter={cfg.lineStyle === "wobble" ? `url(#${WOBBLE_FILTER_ID})` : undefined}
+		>
+			<g transform={`translate(${data.x} ${data.y}) scale(${sx} ${sy}) translate(${-vx} ${-vy})`}>
+				{renderSvgNodes(icon.nodes, `icon-${icon.key}`)}
+			</g>
+		</g>
+	);
+}
+
+function baseHitTest(data: ShapeData, point: Point): boolean {
+	return (
+		point.x >= data.x &&
+		point.x <= data.x + data.width &&
+		point.y >= data.y &&
+		point.y <= data.y + data.height
+	);
+}
+
+function resize(data: ShapeData, handle: ResizeHandle, delta: Point): ShapeData {
+	let { x, y, width, height } = data;
+	switch (handle) {
+		case "se":
+			width += delta.x;
+			height += delta.y;
+			break;
+		case "nw":
+			x += delta.x;
+			y += delta.y;
+			width -= delta.x;
+			height -= delta.y;
+			break;
+		case "ne":
+			y += delta.y;
+			width += delta.x;
+			height -= delta.y;
+			break;
+		case "sw":
+			x += delta.x;
+			width -= delta.x;
+			height += delta.y;
+			break;
+		case "e":
+			width += delta.x;
+			break;
+		case "w":
+			x += delta.x;
+			width -= delta.x;
+			break;
+		case "n":
+			y += delta.y;
+			height -= delta.y;
+			break;
+		case "s":
+			height += delta.y;
+			break;
+	}
+	return { ...data, x, y, width: Math.max(16, width), height: Math.max(16, height) };
+}
+
+export const mapIconShapeDefinition: ShapeDefinition = {
+	render: (data) => <MapIconBody data={data as MapIconShapeData} />,
+	renderTarget: "svg",
+	getBounds: (data): BoundingBox => ({
+		x: data.x,
+		y: data.y,
+		width: data.width,
+		height: data.height,
+	}),
+	hitTest: withRotation(baseHitTest),
+	resize,
+	minSize: { width: 16, height: 16 },
+	createDefault: (params): ShapeData => makeMapIcon("town", "landmark", params.x, params.y),
+	serializeForAi: (data): Record<string, unknown> => {
+		const d = data as MapIconShapeData;
+		const icon = ICONS_BY_KEY.get(d.meta?.iconKey ?? "");
+		return { kind: "map-icon", icon: d.meta?.iconKey, text: icon?.en };
+	},
+	debugFields: (data): Record<string, unknown> => {
+		const d = data as MapIconShapeData;
+		return { iconKey: d.meta?.iconKey, category: d.meta?.category };
+	},
+};

--- a/plugins/usketch-plugin-map/src/map-layer.tsx
+++ b/plugins/usketch-plugin-map/src/map-layer.tsx
@@ -1,0 +1,166 @@
+// MapLayer — renders the RPG terrain behind all shapes. Reads the tilemap
+// DATA from the shape store (single source of truth, synced + undoable) and
+// paints it; input is handled by the map tool, not this layer (pointer-events:none).
+import type { BoardStore } from "@edv4h/usketch-shared";
+import { useEffect, useRef, useState } from "react";
+import { type Cells, exposedEdges, parseCellKey } from "./autotile.js";
+import { terrainCssVars } from "./palette.js";
+import { renderConfigStore } from "./render-config.js";
+import { renderSvgNodes } from "./svg-nodes.js";
+import { TERRAINS, type TerrainKey, terrainDarkVar, terrainPatternId } from "./terrain.js";
+import { isTileMap, type TileMapShapeData } from "./tilemap-shape.js";
+
+export const WOBBLE_FILTER_ID = "uskmap-wobble";
+
+const EDGE_RATIO = 0.22; // dark "one shade darker" ring thickness, fraction of a tile
+const EDGE_OPACITY = 0.42;
+const CELL_LINE = "rgba(20,20,20,.06)";
+
+/** Shared SVG defs: 12 terrain patterns + the hand-drawn wobble filter. */
+function MapDefs() {
+	return (
+		<defs>
+			{TERRAINS.map((t) => (
+				<pattern
+					key={t.key}
+					id={terrainPatternId(t.key)}
+					width={t.patternWidth}
+					height={t.patternHeight}
+					patternUnits="userSpaceOnUse"
+				>
+					{renderSvgNodes(t.nodes, `pat-${t.key}`)}
+				</pattern>
+			))}
+			<filter id={WOBBLE_FILTER_ID}>
+				<feTurbulence
+					type="fractalNoise"
+					baseFrequency="0.014"
+					numOctaves="2"
+					seed="7"
+					result="n"
+				/>
+				<feDisplacementMap
+					in="SourceGraphic"
+					in2="n"
+					scale="2.1"
+					xChannelSelector="R"
+					yChannelSelector="G"
+				/>
+			</filter>
+		</defs>
+	);
+}
+
+interface CellRects {
+	nodes: React.ReactElement[];
+}
+
+function renderCells(cells: Cells, tile: number, visible?: DOMRectReadOnly | null): CellRects {
+	const nodes: React.ReactElement[] = [];
+	for (const [key, terrain] of Object.entries(cells)) {
+		const [c, r] = parseCellKey(key);
+		const x = c * tile;
+		const y = r * tile;
+		if (
+			visible &&
+			(x > visible.right || y > visible.bottom || x + tile < visible.left || y + tile < visible.top)
+		) {
+			continue; // simple viewport cull
+		}
+		const pat = `url(#${terrainPatternId(terrain as TerrainKey)})`;
+		nodes.push(
+			<rect
+				key={`${key}:base`}
+				x={x}
+				y={y}
+				width={tile}
+				height={tile}
+				fill={pat}
+				stroke={CELL_LINE}
+				strokeWidth={1}
+			/>,
+		);
+		const edge = exposedEdges(cells, c, r);
+		const t = EDGE_RATIO * tile;
+		const dark = terrainDarkVar(terrain as TerrainKey);
+		const strip = (sx: number, sy: number, sw: number, sh: number, k: string) => (
+			<rect key={k} x={sx} y={sy} width={sw} height={sh} fill={dark} opacity={EDGE_OPACITY} />
+		);
+		if (edge.n) nodes.push(strip(x, y, tile, t, `${key}:n`));
+		if (edge.s) nodes.push(strip(x, y + tile - t, tile, t, `${key}:s`));
+		if (edge.w) nodes.push(strip(x, y, t, tile, `${key}:w`));
+		if (edge.e) nodes.push(strip(x + tile - t, y, t, tile, `${key}:e`));
+	}
+	return { nodes };
+}
+
+/** Visible world rect from the current viewport (best-effort, window-sized). */
+function visibleWorldRect(store: BoardStore): DOMRectReadOnly | null {
+	if (typeof window === "undefined") return null;
+	const vp = store.getViewport();
+	const pad = 64;
+	const left = (-vp.x - pad) / vp.zoom;
+	const top = (-vp.y - pad) / vp.zoom;
+	const right = (window.innerWidth - vp.x + pad) / vp.zoom;
+	const bottom = (window.innerHeight - vp.y + pad) / vp.zoom;
+	return new DOMRectReadOnly(left, top, right - left, bottom - top);
+}
+
+export function MapTerrainLayer({ store }: { store: BoardStore }) {
+	const [, force] = useState(0);
+	const rafRef = useRef(0);
+
+	useEffect(() => {
+		const rerender = () => {
+			cancelAnimationFrame(rafRef.current);
+			rafRef.current = requestAnimationFrame(() => force((n) => n + 1));
+		};
+		const u1 = store.subscribe(rerender);
+		const u2 = renderConfigStore.subscribe(rerender);
+		return () => {
+			u1();
+			u2();
+			cancelAnimationFrame(rafRef.current);
+		};
+	}, [store]);
+
+	const vp = store.getViewport();
+	const cfg = renderConfigStore.get();
+	const visible = visibleWorldRect(store);
+
+	const tilemaps: TileMapShapeData[] = [];
+	for (const [, shape] of store.getShapes()) {
+		if (isTileMap(shape)) tilemaps.push(shape);
+	}
+
+	const cssVars = terrainCssVars(cfg.colorMode, cfg.strokeScale);
+
+	return (
+		<div
+			style={{
+				position: "absolute",
+				inset: 0,
+				width: "100%",
+				height: "100%",
+				pointerEvents: "none",
+				overflow: "hidden",
+			}}
+		>
+			<svg
+				width="100%"
+				height="100%"
+				style={{ display: "block", overflow: "visible", ...cssVars } as React.CSSProperties}
+			>
+				<MapDefs />
+				<g
+					transform={`translate(${vp.x} ${vp.y}) scale(${vp.zoom})`}
+					filter={cfg.lineStyle === "wobble" ? `url(#${WOBBLE_FILTER_ID})` : undefined}
+				>
+					{tilemaps.map((tm) => (
+						<g key={tm.id}>{renderCells(tm.cells, tm.tile, visible).nodes}</g>
+					))}
+				</g>
+			</svg>
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-map/src/map-tool-id.ts
+++ b/plugins/usketch-plugin-map/src/map-tool-id.ts
@@ -1,0 +1,2 @@
+/** The map tool id, shared by the tool registration and the palette. */
+export const MAP_TOOL_ID = "map";

--- a/plugins/usketch-plugin-map/src/map-tool.tsx
+++ b/plugins/usketch-plugin-map/src/map-tool.tsx
@@ -1,0 +1,199 @@
+// The `map` tool: brush / eraser / fill terrain cells, and stamp icons.
+// Terrain edits mutate the (single) tilemap shape live during a stroke, then
+// commit the whole stroke as ONE undoable command on pointer-up. Stamping adds
+// a map-icon via createAddShapeCommand. The palette switches the active submode.
+import type {
+	CanvasPointerEvent,
+	Command,
+	ShapeData,
+	ToolContext,
+	ToolDefinition,
+} from "@edv4h/usketch-shared";
+import { createAddShapeCommand } from "@edv4h/usketch-store";
+import {
+	type CellBox,
+	type Cells,
+	cellKey,
+	cellsBounds,
+	floodFill,
+	worldToCell,
+} from "./autotile.js";
+import { ICONS_BY_KEY } from "./icons.js";
+import { makeMapIcon } from "./map-icon-shape.js";
+import { DEFAULT_TILE, isTileMap, makeTileMap, type TileMapShapeData } from "./tilemap-shape.js";
+import { toolStateStore } from "./tool-state.js";
+
+function MapToolIcon() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+			<path
+				d="M3 5 L8 3 L12 5 L17 3 V15 L12 17 L8 15 L3 17 Z"
+				fill="#a9d888"
+				stroke="#141414"
+				strokeWidth="1.4"
+				strokeLinejoin="round"
+			/>
+			<path d="M8 3 V15 M12 5 V17" stroke="#141414" strokeWidth="1.1" />
+		</svg>
+	);
+}
+
+function cellsEqual(a: Cells, b: Cells): boolean {
+	const ak = Object.keys(a);
+	if (ak.length !== Object.keys(b).length) return false;
+	for (const k of ak) if (a[k] !== b[k]) return false;
+	return true;
+}
+
+export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefinition {
+	interface Stroke {
+		tilemapId: string;
+		created: boolean;
+		prevCells: Cells;
+	}
+	let stroke: Stroke | null = null;
+	let lastKey = "";
+
+	/** The single shared tilemap, creating it (live) if none exists yet. */
+	function resolveTilemap(ctx: ToolContext): { id: string; created: boolean } {
+		for (const [, s] of ctx.store.getShapes()) {
+			if (isTileMap(s)) return { id: s.id, created: false };
+		}
+		const tm = makeTileMap(tile);
+		ctx.store.addShape(tm);
+		return { id: tm.id, created: true };
+	}
+
+	function currentCells(ctx: ToolContext, id: string): Cells {
+		const s = ctx.store.getShape(id) as TileMapShapeData | undefined;
+		return s ? { ...s.cells } : {};
+	}
+
+	function applyCells(ctx: ToolContext, id: string, cells: Cells): void {
+		// `cells` is an intrinsic field of TileMapShapeData, outside the base
+		// ShapeData type — cast at the store boundary (as freedraw does for points).
+		ctx.store.updateShape(id, { cells, ...cellsBounds(cells, tile) } as Partial<ShapeData>);
+	}
+
+	function paintAt(ctx: ToolContext, event: CanvasPointerEvent): void {
+		if (!stroke) return;
+		const [c, r] = worldToCell(event.worldPoint.x, event.worldPoint.y, tile);
+		const key = cellKey(c, r);
+		if (key === lastKey) return;
+		lastKey = key;
+		const { mode, terrain } = toolStateStore.get();
+		const cells = currentCells(ctx, stroke.tilemapId);
+		if (mode === "eraser") {
+			if (!(key in cells)) return;
+			delete cells[key];
+		} else {
+			if (cells[key] === terrain) return;
+			cells[key] = terrain;
+		}
+		applyCells(ctx, stroke.tilemapId, cells);
+	}
+
+	function doFill(ctx: ToolContext, event: CanvasPointerEvent): void {
+		if (!stroke) return;
+		const [c, r] = worldToCell(event.worldPoint.x, event.worldPoint.y, tile);
+		const { terrain } = toolStateStore.get();
+		const cells = currentCells(ctx, stroke.tilemapId);
+		// Empty-cell fills are bounded to the current painted region so the flood
+		// is finite; painted-cell fills are naturally bounded by the region.
+		const b = cellsBounds(cells, tile);
+		const box: CellBox | undefined =
+			Object.keys(cells).length === 0
+				? undefined
+				: {
+						minC: Math.floor(b.x / tile),
+						minR: Math.floor(b.y / tile),
+						maxC: Math.floor(b.x / tile) + b.width / tile - 1,
+						maxR: Math.floor(b.y / tile) + b.height / tile - 1,
+					};
+		const keys = floodFill(cells, c, r, box);
+		if (keys.length === 0) return;
+		for (const k of keys) cells[k] = terrain;
+		applyCells(ctx, stroke.tilemapId, cells);
+	}
+
+	function commit(ctx: ToolContext): void {
+		if (!stroke) return;
+		const { tilemapId, created, prevCells } = stroke;
+		stroke = null;
+		lastKey = "";
+		const shape = ctx.store.getShape(tilemapId) as TileMapShapeData | undefined;
+		const nextCells = shape ? shape.cells : {};
+
+		if (created) {
+			// Newly created this stroke: commit as an add (undo deletes it).
+			if (!shape || Object.keys(nextCells).length === 0) {
+				if (shape) ctx.store.deleteShape(tilemapId);
+				return;
+			}
+			const finalShape = { ...shape } as ShapeData;
+			ctx.store.deleteShape(tilemapId);
+			ctx.commands.execute(createAddShapeCommand(ctx.store, finalShape));
+			return;
+		}
+
+		// Edited an existing tilemap: commit the cells diff (undo restores prev).
+		if (cellsEqual(prevCells, nextCells)) return;
+		const prev = prevCells;
+		const next = { ...nextCells };
+		const prevBounds = cellsBounds(prev, tile);
+		const nextBounds = cellsBounds(next, tile);
+		const command: Command = {
+			execute: () =>
+				ctx.store.updateShape(tilemapId, { cells: next, ...nextBounds } as Partial<ShapeData>),
+			undo: () =>
+				ctx.store.updateShape(tilemapId, { cells: prev, ...prevBounds } as Partial<ShapeData>),
+		};
+		ctx.commands.execute(command);
+	}
+
+	function placeIcon(ctx: ToolContext, event: CanvasPointerEvent): void {
+		const { iconKey } = toolStateStore.get();
+		const def = ICONS_BY_KEY.get(iconKey);
+		if (!def) return;
+		const shape = makeMapIcon(iconKey, def.category, event.worldPoint.x, event.worldPoint.y);
+		ctx.commands.execute(createAddShapeCommand(ctx.store, shape));
+		ctx.store.setSelection([shape.id]);
+	}
+
+	return {
+		icon: MapToolIcon,
+		cursor: "crosshair",
+		shortcut: "m",
+		order: 45,
+		onPointerDown(ctx, event) {
+			const { mode } = toolStateStore.get();
+			if (mode === "stamp") {
+				placeIcon(ctx, event);
+				return;
+			}
+			const target = resolveTilemap(ctx);
+			stroke = {
+				tilemapId: target.id,
+				created: target.created,
+				prevCells: currentCells(ctx, target.id),
+			};
+			lastKey = "";
+			if (mode === "fill") doFill(ctx, event);
+			else paintAt(ctx, event);
+		},
+		onPointerMove(ctx, event) {
+			if (!stroke) return;
+			const { mode } = toolStateStore.get();
+			if (mode === "brush" || mode === "eraser") paintAt(ctx, event);
+		},
+		onPointerUp(ctx) {
+			commit(ctx);
+			// Keep the map tool active for continuous painting/stamping.
+		},
+		onDeactivate() {
+			// Abort an in-flight stroke without committing a partial undo entry.
+			stroke = null;
+			lastKey = "";
+		},
+	};
+}

--- a/plugins/usketch-plugin-map/src/map-tool.tsx
+++ b/plugins/usketch-plugin-map/src/map-tool.tsx
@@ -190,10 +190,24 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 			commit(ctx);
 			// Keep the map tool active for continuous painting/stamping.
 		},
-		onDeactivate() {
-			// Abort an in-flight stroke without committing a partial undo entry.
-			stroke = null;
-			lastKey = "";
+		onDeactivate(ctx) {
+			// Tool switched / left mid-stroke with no pointerUp: don't leave a
+			// half-painted, non-undoable state. Roll the live edits back to where
+			// the stroke started (delete a tilemap created this stroke; restore the
+			// previous cells of an edited one), then clear.
+			if (stroke) {
+				const { tilemapId, created, prevCells } = stroke;
+				if (created) {
+					ctx.store.deleteShape(tilemapId);
+				} else {
+					ctx.store.updateShape(tilemapId, {
+						cells: prevCells,
+						...cellsBounds(prevCells, tile),
+					} as Partial<ShapeData>);
+				}
+				stroke = null;
+				lastKey = "";
+			}
 		},
 	};
 }

--- a/plugins/usketch-plugin-map/src/palette.ts
+++ b/plugins/usketch-plugin-map/src/palette.ts
@@ -1,0 +1,97 @@
+// GENERATED from design (RPGマップ素材.dc.html). Terrain/icon color CSS variables.
+// color = カラフル, mono = モノクロ（Tweaks）。stroke/card は固定。
+export type ColorMode = "color" | "mono";
+
+const COLOR_VARS: Record<string, string> = {
+	"--red": "#EF5350",
+	"--blue": "#4A7FB8",
+	"--purple": "#6C5CD6",
+	"--teal": "#2AA1A8",
+	"--yellow": "#F6C124",
+	"--green": "#25A05B",
+	"--pink": "#F48CB4",
+	"--orange": "#F0913E",
+	"--brown": "#9A6A3C",
+	"--t-grass": "#A9D888",
+	"--t-forest": "#71B96C",
+	"--t-water": "#8CC3E6",
+	"--t-sand": "#F0DBA3",
+	"--t-mtn": "#C7B6A0",
+	"--t-path": "#E7CF9E",
+	"--t-grass-d": "#82C15E",
+	"--t-forest-d": "#4E9E58",
+	"--t-water-d": "#5EA8D6",
+	"--t-sand-d": "#E3C071",
+	"--t-mtn-d": "#A8927A",
+	"--t-path-d": "#CBB07A",
+	"--t-snow": "#E9F2F8",
+	"--t-swamp": "#9BAE74",
+	"--t-lava": "#EE9264",
+	"--t-stone": "#CDCAC3",
+	"--t-farm": "#DDBB7E",
+	"--t-flower": "#C4E3A5",
+	"--t-snow-d": "#BCD3E3",
+	"--t-swamp-d": "#6F8850",
+	"--t-lava-d": "#CE5638",
+	"--t-stone-d": "#ABA79E",
+	"--t-farm-d": "#B99350",
+	"--t-flower-d": "#95CA79",
+};
+
+const MONO_VARS: Record<string, string> = {
+	"--red": "#E7E8EB",
+	"--blue": "#E7E8EB",
+	"--purple": "#E7E8EB",
+	"--teal": "#E7E8EB",
+	"--yellow": "#EEEFF2",
+	"--green": "#E7E8EB",
+	"--pink": "#EEEFF2",
+	"--orange": "#EEEFF2",
+	"--brown": "#DCDCDF",
+	"--t-grass": "#EDEEF0",
+	"--t-forest": "#DDDFE3",
+	"--t-water": "#EAEFF3",
+	"--t-sand": "#F1F1F0",
+	"--t-mtn": "#DDDDE0",
+	"--t-path": "#EDE9E2",
+	"--t-grass-d": "#CFD1D6",
+	"--t-forest-d": "#CFD1D6",
+	"--t-water-d": "#D6DBE0",
+	"--t-sand-d": "#DEDDDA",
+	"--t-mtn-d": "#BFBFC5",
+	"--t-path-d": "#D9D4CC",
+	"--t-snow": "#F4F5F7",
+	"--t-swamp": "#DFE0DC",
+	"--t-lava": "#E9E9EB",
+	"--t-stone": "#E2E2E4",
+	"--t-farm": "#EDEAE3",
+	"--t-flower": "#EAEEE9",
+	"--t-snow-d": "#D8DADF",
+	"--t-swamp-d": "#C8CAC5",
+	"--t-lava-d": "#CFCFD3",
+	"--t-stone-d": "#C8C8CB",
+	"--t-farm-d": "#D7D2C9",
+	"--t-flower-d": "#CFD5CE",
+};
+
+/** Fixed (mode-independent) design tokens shared by terrain + icons. */
+const BASE_VARS: Record<string, string> = {
+	"--uskmap-stroke": "#141414",
+	"--uskmap-card": "#FFFFFF",
+};
+
+/**
+ * CSS custom properties to place on a container so the raw SVG markup (which
+ * references `var(--t-grass)`, `var(--red)`, `var(--stroke)`, ...) resolves.
+ * `strokeScale` scales the hand-drawn stroke width (design `--sw`, base 2.6px).
+ */
+export function terrainCssVars(mode: ColorMode, strokeScale = 1): Record<string, string> {
+	const src = mode === "mono" ? MONO_VARS : COLOR_VARS;
+	const out: Record<string, string> = { ...BASE_VARS };
+	for (const [k, v] of Object.entries(src)) out[k] = v;
+	// design markup uses bare --stroke/--card; alias them.
+	out["--stroke"] = BASE_VARS["--uskmap-stroke"];
+	out["--card"] = BASE_VARS["--uskmap-card"];
+	out["--sw"] = `${2.6 * strokeScale}px`;
+	return out;
+}

--- a/plugins/usketch-plugin-map/src/plugin.tsx
+++ b/plugins/usketch-plugin-map/src/plugin.tsx
@@ -1,0 +1,103 @@
+// createMapPlugin — registers the RPG map feature: the terrain MapLayer, the
+// data-only `tilemap` shape, the foreground `map-icon` shape, the `map` tool
+// (brush/eraser/fill/stamp), the on-canvas palette, and the Tweaks HUD settings.
+import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import { MAP_ICON_TYPE, mapIconShapeDefinition } from "./map-icon-shape.js";
+import { MapTerrainLayer } from "./map-layer.js";
+import { createMapToolDefinition } from "./map-tool.js";
+import { MAP_TOOL_ID } from "./map-tool-id.js";
+import type { ColorMode } from "./palette.js";
+import { type LineStyle, renderConfigStore } from "./render-config.js";
+import { createTileMapShapeDefinition, DEFAULT_TILE, TILEMAP_TYPE } from "./tilemap-shape.js";
+import { MapPalette } from "./ui/palette.js";
+
+export interface MapPluginOptions {
+	/** Tile size in world units. Default 40 (matches the design grid). */
+	tile?: number;
+	defaultColorMode?: ColorMode;
+	defaultLineStyle?: LineStyle;
+}
+
+const TERRAIN_LAYER_ID = "usketch-map:terrain";
+const PALETTE_LAYER_ID = "usketch-map:palette";
+
+export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
+	const tile = options.tile ?? DEFAULT_TILE;
+	if (options.defaultColorMode || options.defaultLineStyle) {
+		renderConfigStore.set({
+			colorMode: options.defaultColorMode,
+			lineStyle: options.defaultLineStyle,
+		});
+	}
+
+	return {
+		id: "usketch-plugin-map",
+		name: "RPG マップ",
+
+		setup(ctx: PluginContext) {
+			// ── Shapes (tilemap = data-only substrate, map-icon = foreground) ──
+			ctx.shapes.register(TILEMAP_TYPE, createTileMapShapeDefinition(tile));
+			ctx.shapes.register(MAP_ICON_TYPE, mapIconShapeDefinition);
+
+			// ── Terrain MapLayer (renders behind all shapes) ──
+			ctx.layers.register({
+				id: TERRAIN_LAYER_ID,
+				order: 40,
+				fixed: true,
+				render: () => <MapTerrainLayer store={ctx.store} />,
+			});
+
+			// ── Tool ──
+			ctx.tools.register(MAP_TOOL_ID, createMapToolDefinition(tile));
+
+			// ── Palette (shown while the map tool is active) ──
+			ctx.layers.register({
+				id: PALETTE_LAYER_ID,
+				order: 196,
+				fixed: true,
+				render: () => <MapPalette store={ctx.store} />,
+			});
+
+			// ── Tweaks as declarative HUD settings (mirror the palette) ──
+			const unregisterHud = ctx.hud.registerSettings({
+				id: "usketch-map:tweaks",
+				label: "RPG マップ",
+				fields: [
+					{
+						name: "colorMode",
+						label: "配色",
+						type: "enum",
+						options: [
+							{ value: "color", label: "カラフル" },
+							{ value: "mono", label: "モノクロ" },
+						],
+					},
+					{
+						name: "lineStyle",
+						label: "線",
+						type: "enum",
+						options: [
+							{ value: "wobble", label: "揺らぎ" },
+							{ value: "clean", label: "クリーン" },
+						],
+					},
+					{ name: "strokeScale", label: "線の太さ", type: "number", min: 0.5, max: 2, step: 0.1 },
+				],
+				get: (name) =>
+					renderConfigStore.get()[name as keyof ReturnType<typeof renderConfigStore.get>],
+				set: (name, value) => {
+					if (name === "strokeScale") renderConfigStore.set({ strokeScale: Number(value) });
+					else if (name === "colorMode") renderConfigStore.set({ colorMode: value as ColorMode });
+					else if (name === "lineStyle") renderConfigStore.set({ lineStyle: value as LineStyle });
+				},
+				subscribe: renderConfigStore.subscribe,
+			});
+
+			return () => {
+				ctx.layers.unregister(TERRAIN_LAYER_ID);
+				ctx.layers.unregister(PALETTE_LAYER_ID);
+				unregisterHud();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-map/src/reactive-store.ts
+++ b/plugins/usketch-plugin-map/src/reactive-store.ts
@@ -1,0 +1,33 @@
+// Minimal module-scoped reactive store (get/set/subscribe) for useSyncExternalStore.
+// Used for plugin-local UI state (Tweaks, active tool mode) that is intentionally
+// NOT synced across clients — it is presentation/interaction state, not board data.
+
+export interface ReactiveStore<T> {
+	get(): T;
+	set(patch: Partial<T>): void;
+	subscribe(listener: () => void): () => void;
+}
+
+export function createReactiveStore<T extends object>(initial: T): ReactiveStore<T> {
+	let state = initial;
+	const listeners = new Set<() => void>();
+	return {
+		get: () => state,
+		set(patch) {
+			let changed = false;
+			for (const k of Object.keys(patch) as (keyof T)[]) {
+				if (patch[k] !== undefined && patch[k] !== state[k]) {
+					changed = true;
+					break;
+				}
+			}
+			if (!changed) return;
+			state = { ...state, ...patch };
+			for (const l of listeners) l();
+		},
+		subscribe(listener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+	};
+}

--- a/plugins/usketch-plugin-map/src/reactive-store.ts
+++ b/plugins/usketch-plugin-map/src/reactive-store.ts
@@ -14,15 +14,19 @@ export function createReactiveStore<T extends object>(initial: T): ReactiveStore
 	return {
 		get: () => state,
 		set(patch) {
+			// Skip `undefined` keys so a partial update (e.g. only `lineStyle`) never
+			// clobbers an unrelated field with `undefined`.
+			const next = { ...state };
 			let changed = false;
 			for (const k of Object.keys(patch) as (keyof T)[]) {
-				if (patch[k] !== undefined && patch[k] !== state[k]) {
+				const v = patch[k];
+				if (v !== undefined && v !== state[k]) {
+					next[k] = v as T[keyof T];
 					changed = true;
-					break;
 				}
 			}
 			if (!changed) return;
-			state = { ...state, ...patch };
+			state = next;
 			for (const l of listeners) l();
 		},
 		subscribe(listener) {

--- a/plugins/usketch-plugin-map/src/render-config.ts
+++ b/plugins/usketch-plugin-map/src/render-config.ts
@@ -1,0 +1,30 @@
+// Visual "Tweaks" for the map: colorful⇔mono, wobble⇔clean line, stroke width.
+// Module-scoped so shapes/layers can subscribe before plugin setup runs. This is
+// look-and-feel state (app-local), not synced board data.
+import { useSyncExternalStore } from "react";
+import type { ColorMode } from "./palette.js";
+import { createReactiveStore } from "./reactive-store.js";
+
+export type LineStyle = "wobble" | "clean";
+
+export interface MapRenderConfig {
+	colorMode: ColorMode;
+	lineStyle: LineStyle;
+	/** Multiplier on the hand-drawn stroke width (design `--sw`, base 2.6px). */
+	strokeScale: number;
+}
+
+export const renderConfigStore = createReactiveStore<MapRenderConfig>({
+	colorMode: "color",
+	lineStyle: "wobble",
+	strokeScale: 1,
+});
+
+/** Subscribe a component to the current Tweaks config. */
+export function useRenderConfig(): MapRenderConfig {
+	return useSyncExternalStore(
+		renderConfigStore.subscribe,
+		renderConfigStore.get,
+		renderConfigStore.get,
+	);
+}

--- a/plugins/usketch-plugin-map/src/svg-nodes.tsx
+++ b/plugins/usketch-plugin-map/src/svg-nodes.tsx
@@ -1,0 +1,44 @@
+// Renders a parsed SVG element tree (from terrain.ts / icons.ts) with
+// React.createElement — deliberately NOT dangerouslySetInnerHTML, matching the
+// repo's XSS-safe policy. The data is static bundled design markup; this keeps
+// it as real React SVG elements with proper (camelCased) attributes.
+import { createElement, type ReactElement } from "react";
+
+export interface SvgNode {
+	/** Tag name (rect, g, path, circle, ellipse, line, polyline, polygon, …). */
+	t: string;
+	/** Presentational attributes, as authored (hyphenated names are converted). */
+	a: Record<string, string>;
+	/** Child nodes. */
+	c?: SvgNode[];
+}
+
+// Attribute names that must NOT be naively hyphen→camel converted the generic way.
+const ATTR_MAP: Record<string, string> = {
+	class: "className",
+	"xlink:href": "xlinkHref",
+};
+
+/** Convert an SVG attribute name to its React (camelCase) form. */
+function toReactAttr(name: string): string {
+	if (ATTR_MAP[name]) return ATTR_MAP[name];
+	if (name.includes("-")) {
+		return name.replace(/-([a-z])/g, (_, ch: string) => ch.toUpperCase());
+	}
+	return name;
+}
+
+function toProps(a: Record<string, string>, key: string): Record<string, unknown> {
+	const props: Record<string, unknown> = { key };
+	for (const [k, v] of Object.entries(a)) props[toReactAttr(k)] = v;
+	return props;
+}
+
+/** Render a list of SVG nodes to React elements. */
+export function renderSvgNodes(nodes: readonly SvgNode[], keyPrefix = "n"): ReactElement[] {
+	return nodes.map((node, i) => {
+		const key = `${keyPrefix}-${i}`;
+		const children = node.c ? renderSvgNodes(node.c, key) : undefined;
+		return createElement(node.t, toProps(node.a, key), children);
+	});
+}

--- a/plugins/usketch-plugin-map/src/terrain.ts
+++ b/plugins/usketch-plugin-map/src/terrain.ts
@@ -1,0 +1,340 @@
+// GENERATED from design (RPGマップ素材.dc.html). 12 terrain tile definitions.
+// `nodes` is a parsed SVG element tree (see svg-nodes.tsx) rendered via
+// React.createElement — no dangerouslySetInnerHTML. Fills reference design CSS
+// vars (var(--t-*)) provided by terrainCssVars().
+import type { SvgNode } from "./svg-nodes.js";
+
+export type TerrainKey =
+	| "grass"
+	| "forest"
+	| "water"
+	| "sand"
+	| "mtn"
+	| "path"
+	| "snow"
+	| "swamp"
+	| "lava"
+	| "stone"
+	| "farm"
+	| "flower";
+
+export interface TerrainDef {
+	key: TerrainKey;
+	name: string;
+	en: string;
+	patternWidth: number;
+	patternHeight: number;
+	nodes: SvgNode[];
+}
+
+export const TERRAINS: readonly TerrainDef[] = [
+	{
+		key: "grass",
+		name: "草原",
+		en: "Grass",
+		patternWidth: 24,
+		patternHeight: 24,
+		nodes: [
+			{ t: "rect", a: { width: "24", height: "24", fill: "var(--t-grass)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-grass-d)",
+					"stroke-width": "1.6",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M5 18 V13 M3 16 L5 13 L7 16" } },
+					{ t: "path", a: { d: "M16 22 V17 M14 20 L16 17 L18 20" } },
+					{ t: "path", a: { d: "M13 9 V5 M11 7 L13 5 L15 7" } },
+				],
+			},
+		],
+	},
+	{
+		key: "forest",
+		name: "森",
+		en: "Forest",
+		patternWidth: 26,
+		patternHeight: 26,
+		nodes: [
+			{ t: "rect", a: { width: "26", height: "26", fill: "var(--t-forest)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-forest-d)",
+					"stroke-width": "1.6",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M4 15 a4 4 0 1 1 8 0" } },
+					{ t: "path", a: { d: "M8 15 V19" } },
+					{ t: "path", a: { d: "M17 25 a4 4 0 1 1 8 0" } },
+					{ t: "path", a: { d: "M17 6 a3.4 3.4 0 1 1 6.8 0" } },
+				],
+			},
+		],
+	},
+	{
+		key: "water",
+		name: "水辺",
+		en: "Water",
+		patternWidth: 24,
+		patternHeight: 24,
+		nodes: [
+			{ t: "rect", a: { width: "24", height: "24", fill: "var(--t-water)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-water-d)",
+					"stroke-width": "1.6",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M0 6 Q6 2 12 6 T24 6" } },
+					{ t: "path", a: { d: "M0 14 Q6 10 12 14 T24 14" } },
+					{ t: "path", a: { d: "M0 22 Q6 18 12 22 T24 22" } },
+				],
+			},
+		],
+	},
+	{
+		key: "sand",
+		name: "砂漠",
+		en: "Sand",
+		patternWidth: 22,
+		patternHeight: 22,
+		nodes: [
+			{ t: "rect", a: { width: "22", height: "22", fill: "var(--t-sand)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-sand-d)",
+					"stroke-width": "1.5",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M2 8 Q8 4 14 8" } },
+					{ t: "path", a: { d: "M9 16 Q15 12 21 16" } },
+				],
+			},
+			{
+				t: "g",
+				a: { fill: "var(--t-sand-d)" },
+				c: [
+					{ t: "circle", a: { cx: "6", cy: "17", r: "1" } },
+					{ t: "circle", a: { cx: "18", cy: "5", r: "1" } },
+				],
+			},
+		],
+	},
+	{
+		key: "mtn",
+		name: "山",
+		en: "Mountain",
+		patternWidth: 24,
+		patternHeight: 24,
+		nodes: [
+			{ t: "rect", a: { width: "24", height: "24", fill: "var(--t-mtn)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-mtn-d)",
+					"stroke-width": "1.6",
+					"stroke-linecap": "round",
+					"stroke-linejoin": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M3 15 l4 -5 l4 5" } },
+					{ t: "path", a: { d: "M14 22 l4 -5 l4 5" } },
+					{ t: "path", a: { d: "M13 8 l3 -4 l3 4" } },
+				],
+			},
+		],
+	},
+	{
+		key: "path",
+		name: "道",
+		en: "Road",
+		patternWidth: 20,
+		patternHeight: 20,
+		nodes: [
+			{ t: "rect", a: { width: "20", height: "20", fill: "var(--t-path)" } },
+			{
+				t: "g",
+				a: { fill: "var(--t-path-d)" },
+				c: [
+					{ t: "circle", a: { cx: "5", cy: "6", r: "2" } },
+					{ t: "circle", a: { cx: "14", cy: "12", r: "2.2" } },
+					{ t: "circle", a: { cx: "9", cy: "16", r: "1.6" } },
+				],
+			},
+		],
+	},
+	{
+		key: "snow",
+		name: "雪原",
+		en: "Snow",
+		patternWidth: 24,
+		patternHeight: 24,
+		nodes: [
+			{ t: "rect", a: { width: "24", height: "24", fill: "var(--t-snow)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-snow-d)",
+					"stroke-width": "1.5",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M6 4 V10 M3.4 5.6 L8.6 8.6 M8.6 5.6 L3.4 8.6" } },
+					{ t: "path", a: { d: "M17 15 V20 M14.8 16.2 L19.2 18.8 M19.2 16.2 L14.8 18.8" } },
+					{ t: "path", a: { d: "M0 13 Q5 11 10 13" } },
+				],
+			},
+		],
+	},
+	{
+		key: "swamp",
+		name: "沼地",
+		en: "Swamp",
+		patternWidth: 26,
+		patternHeight: 26,
+		nodes: [
+			{ t: "rect", a: { width: "26", height: "26", fill: "var(--t-swamp)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-swamp-d)",
+					"stroke-width": "1.6",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M5 22 V14 M8 22 V16 M2 22 V17" } },
+					{ t: "path", a: { d: "M17 10 a3.6 3.6 0 1 0 7.2 0 a3.6 3.6 0 1 0 -7.2 0" } },
+					{ t: "path", a: { d: "M13 24 Q17 21 21 24" } },
+				],
+			},
+		],
+	},
+	{
+		key: "lava",
+		name: "溶岩",
+		en: "Lava",
+		patternWidth: 24,
+		patternHeight: 24,
+		nodes: [
+			{ t: "rect", a: { width: "24", height: "24", fill: "var(--t-lava)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-lava-d)",
+					"stroke-width": "1.7",
+					"stroke-linecap": "round",
+					"stroke-linejoin": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M1 5 L7 9 L4 15 L9 20" } },
+					{ t: "path", a: { d: "M14 2 L17 8 L23 10" } },
+					{ t: "path", a: { d: "M13 22 L18 17 L24 19" } },
+				],
+			},
+		],
+	},
+	{
+		key: "stone",
+		name: "石床",
+		en: "Stone Floor",
+		patternWidth: 26,
+		patternHeight: 20,
+		nodes: [
+			{ t: "rect", a: { width: "26", height: "20", fill: "var(--t-stone)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-stone-d)",
+					"stroke-width": "1.6",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M0 10 H26 M0 20 H26" } },
+					{ t: "path", a: { d: "M8 0 V10 M20 10 V20" } },
+				],
+			},
+		],
+	},
+	{
+		key: "farm",
+		name: "畑",
+		en: "Farmland",
+		patternWidth: 22,
+		patternHeight: 22,
+		nodes: [
+			{ t: "rect", a: { width: "22", height: "22", fill: "var(--t-farm)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-farm-d)",
+					"stroke-width": "1.7",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M0 5 Q11 2.5 22 5" } },
+					{ t: "path", a: { d: "M0 12 Q11 9.5 22 12" } },
+					{ t: "path", a: { d: "M0 19 Q11 16.5 22 19" } },
+				],
+			},
+		],
+	},
+	{
+		key: "flower",
+		name: "花畑",
+		en: "Flower Field",
+		patternWidth: 24,
+		patternHeight: 24,
+		nodes: [
+			{ t: "rect", a: { width: "24", height: "24", fill: "var(--t-flower)" } },
+			{
+				t: "g",
+				a: {
+					stroke: "var(--t-flower-d)",
+					"stroke-width": "1.5",
+					"stroke-linecap": "round",
+					fill: "none",
+				},
+				c: [
+					{ t: "path", a: { d: "M4 20 V15 M15 11 V6" } },
+					{
+						t: "path",
+						a: {
+							d: "M4 12 a2.4 2.4 0 1 0 4.8 0 a2.4 2.4 0 1 0 -4.8 0",
+							transform: "translate(-2 1)",
+						},
+					},
+					{ t: "path", a: { d: "M13 3 a2.4 2.4 0 1 0 4.8 0 a2.4 2.4 0 1 0 -4.8 0" } },
+					{ t: "path", a: { d: "M17 20 a2 2 0 1 0 4 0 a2 2 0 1 0 -4 0" } },
+				],
+			},
+		],
+	},
+];
+
+export const TERRAIN_KEYS: readonly TerrainKey[] = TERRAINS.map((t) => t.key);
+
+export function terrainPatternId(key: TerrainKey): string {
+	return `uskmap-pat-${key}`;
+}
+
+export function terrainDarkVar(key: TerrainKey): string {
+	return `var(--t-${key}-d)`;
+}

--- a/plugins/usketch-plugin-map/src/tilemap-shape.tsx
+++ b/plugins/usketch-plugin-map/src/tilemap-shape.tsx
@@ -1,0 +1,91 @@
+// The `tilemap` shape is a DATA-ONLY record: it holds the painted terrain cells
+// so they persist + sync (Yjs) + undo through the shape store, but it draws
+// NOTHING itself — the MapLayer renders the terrain behind all shapes. It is
+// locked and non-hit-testable so it never behaves as a selectable object.
+import type { BoundingBox, ShapeData, ShapeDefinition } from "@edv4h/usketch-shared";
+import { generateId } from "@edv4h/usketch-shared";
+import { type Cells, cellKey, cellsBounds, parseCellKey } from "./autotile.js";
+import type { TerrainKey } from "./terrain.js";
+
+export const TILEMAP_TYPE = "tilemap";
+export const DEFAULT_TILE = 40;
+
+export interface TileMapShapeData extends ShapeData {
+	type: "tilemap";
+	tile: number;
+	cells: Cells;
+}
+
+export function isTileMap(shape: ShapeData): shape is TileMapShapeData {
+	return shape.type === TILEMAP_TYPE;
+}
+
+/** Create a new empty tilemap (locked substrate). */
+export function makeTileMap(tile: number): TileMapShapeData {
+	const bounds = { x: 0, y: 0, width: 0, height: 0 };
+	return {
+		id: generateId(),
+		type: "tilemap",
+		x: bounds.x,
+		y: bounds.y,
+		width: bounds.width,
+		height: bounds.height,
+		style: { fill: "transparent", stroke: "transparent", strokeWidth: 0, opacity: 1 },
+		tile,
+		cells: {},
+		locked: true,
+	};
+}
+
+/** Bounds patch to keep x/y/width/height in sync with the painted cells. */
+export function boundsPatch(cells: Cells, tile: number): BoundingBox {
+	return cellsBounds(cells, tile);
+}
+
+export function createTileMapShapeDefinition(tile: number = DEFAULT_TILE): ShapeDefinition {
+	return {
+		// Drawing is done by the MapLayer; the shape itself renders nothing.
+		render: () => <g />,
+		renderTarget: "svg",
+		getBounds: (data): BoundingBox => {
+			const d = data as TileMapShapeData;
+			return cellsBounds(d.cells ?? {}, d.tile ?? tile);
+		},
+		// Never selectable via pointer — it is a substrate, not an object.
+		hitTest: () => false,
+		resizable: false,
+		resize: (data): ShapeData => data,
+		createDefault: (params): ShapeData => ({
+			...makeTileMap(tile),
+			id: params.id,
+		}),
+		// Locked, so user-move is not expected; support it anyway by shifting cells
+		// on whole-tile deltas (keeps the grid aligned).
+		move: (data, dx, dy): Partial<ShapeData> => {
+			const d = data as TileMapShapeData;
+			const t = d.tile ?? tile;
+			const dc = Math.round(dx / t);
+			const dr = Math.round(dy / t);
+			if (dc === 0 && dr === 0) return {};
+			const next: Cells = {};
+			for (const [key, terrain] of Object.entries(d.cells)) {
+				const [c, r] = parseCellKey(key);
+				next[cellKey(c + dc, r + dr)] = terrain;
+			}
+			return { cells: next, ...cellsBounds(next, t) } as Partial<ShapeData>;
+		},
+		serializeForAi: (data): Record<string, unknown> => {
+			const d = data as TileMapShapeData;
+			const used = new Set<TerrainKey>(Object.values(d.cells ?? {}));
+			return {
+				kind: "tilemap",
+				tileCount: Object.keys(d.cells ?? {}).length,
+				terrains: [...used],
+			};
+		},
+		debugFields: (data): Record<string, unknown> => {
+			const d = data as TileMapShapeData;
+			return { tile: d.tile, cellCount: Object.keys(d.cells ?? {}).length };
+		},
+	};
+}

--- a/plugins/usketch-plugin-map/src/tool-state.ts
+++ b/plugins/usketch-plugin-map/src/tool-state.ts
@@ -1,0 +1,25 @@
+// Active map-tool interaction state, shared between the palette UI and the tool.
+// Module-scoped, app-local (not synced).
+import { useSyncExternalStore } from "react";
+import { createReactiveStore } from "./reactive-store.js";
+import type { TerrainKey } from "./terrain.js";
+
+export type MapMode = "brush" | "eraser" | "fill" | "stamp";
+
+export interface MapToolState {
+	mode: MapMode;
+	terrain: TerrainKey;
+	/** Icon key (from ICONS) used by the "stamp" mode. */
+	iconKey: string;
+}
+
+export const toolStateStore = createReactiveStore<MapToolState>({
+	mode: "brush",
+	terrain: "grass",
+	iconKey: "town",
+});
+
+/** Subscribe a component to the current map-tool state. */
+export function useMapToolState(): MapToolState {
+	return useSyncExternalStore(toolStateStore.subscribe, toolStateStore.get, toolStateStore.get);
+}

--- a/plugins/usketch-plugin-map/src/ui/palette.tsx
+++ b/plugins/usketch-plugin-map/src/ui/palette.tsx
@@ -1,0 +1,210 @@
+// Map palette — a fixed on-canvas panel shown while the `map` tool is active.
+// Lets the user pick the paint mode, terrain, icon, and visual Tweaks. All state
+// lives in the module stores (tool-state / render-config); this is just the UI.
+import type { BoardStore } from "@edv4h/usketch-shared";
+import { useEffect, useState } from "react";
+import { ICON_CATEGORIES, ICONS, type IconCategory } from "../icons.js";
+import { WOBBLE_FILTER_ID } from "../map-layer.js";
+import { MAP_TOOL_ID } from "../map-tool-id.js";
+import { terrainCssVars } from "../palette.js";
+import { renderConfigStore, useRenderConfig } from "../render-config.js";
+import { renderSvgNodes } from "../svg-nodes.js";
+import { TERRAINS, terrainPatternId } from "../terrain.js";
+import { type MapMode, toolStateStore, useMapToolState } from "../tool-state.js";
+
+const MODES: { id: MapMode; label: string }[] = [
+	{ id: "brush", label: "ブラシ" },
+	{ id: "eraser", label: "消しゴム" },
+	{ id: "fill", label: "塗りつぶし" },
+	{ id: "stamp", label: "アイコン" },
+];
+
+function useActiveTool(store: BoardStore): string {
+	const [id, setId] = useState(store.getActiveToolId());
+	useEffect(() => {
+		const u = store.subscribe(() => setId(store.getActiveToolId()));
+		return u;
+	}, [store]);
+	return id;
+}
+
+const CARD = "#FFFFFF";
+const STROKE = "#141414";
+
+function chipStyle(active: boolean): React.CSSProperties {
+	return {
+		border: `2px solid ${STROKE}`,
+		borderRadius: 10,
+		background: active ? "#F6C124" : CARD,
+		padding: "5px 10px",
+		font: "600 12px system-ui, sans-serif",
+		cursor: "pointer",
+		lineHeight: 1,
+	};
+}
+
+export function MapPalette({ store }: { store: BoardStore }) {
+	const activeTool = useActiveTool(store);
+	const tool = useMapToolState();
+	const cfg = useRenderConfig();
+	const [cat, setCat] = useState<IconCategory>("landmark");
+
+	if (activeTool !== MAP_TOOL_ID) return null;
+
+	const cssVars = terrainCssVars(cfg.colorMode, cfg.strokeScale);
+	const wobble = cfg.lineStyle === "wobble" ? `url(#${WOBBLE_FILTER_ID})` : undefined;
+
+	return (
+		<div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
+			<div
+				style={{
+					position: "absolute",
+					left: 14,
+					top: "50%",
+					transform: "translateY(-50%)",
+					pointerEvents: "auto",
+					width: 244,
+					maxHeight: "84vh",
+					overflowY: "auto",
+					background: "#FBF9F4",
+					border: `2.6px dashed ${STROKE}`,
+					borderRadius: 16,
+					padding: 14,
+					boxShadow: "0 6px 24px rgba(0,0,0,.14)",
+					...(cssVars as React.CSSProperties),
+				}}
+			>
+				<div style={{ font: "700 15px system-ui, sans-serif", marginBottom: 10 }}>🗺 RPG マップ</div>
+
+				{/* Mode */}
+				<div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginBottom: 12 }}>
+					{MODES.map((m) => (
+						<button
+							type="button"
+							key={m.id}
+							onClick={() => toolStateStore.set({ mode: m.id })}
+							style={chipStyle(tool.mode === m.id)}
+						>
+							{m.label}
+						</button>
+					))}
+				</div>
+
+				{/* Terrain palette (brush/eraser/fill) */}
+				{tool.mode !== "stamp" && (
+					<div style={{ marginBottom: 12 }}>
+						<div style={{ font: "600 11px system-ui", color: "#8a8a88", marginBottom: 6 }}>
+							地形
+						</div>
+						<div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 6 }}>
+							{TERRAINS.map((t) => (
+								<button
+									type="button"
+									key={t.key}
+									title={`${t.name} / ${t.en}`}
+									onClick={() => toolStateStore.set({ terrain: t.key })}
+									style={{
+										border: `2px solid ${tool.terrain === t.key ? "#EF5350" : STROKE}`,
+										borderRadius: 8,
+										padding: 0,
+										overflow: "hidden",
+										cursor: "pointer",
+										aspectRatio: "1",
+										background: CARD,
+									}}
+								>
+									<svg width="100%" height="100%" viewBox="0 0 40 40" style={{ display: "block" }}>
+										<rect width="40" height="40" fill={`url(#${terrainPatternId(t.key)})`} />
+									</svg>
+								</button>
+							))}
+						</div>
+					</div>
+				)}
+
+				{/* Icon palette (stamp) */}
+				{tool.mode === "stamp" && (
+					<div style={{ marginBottom: 12 }}>
+						<div style={{ display: "flex", gap: 6, marginBottom: 8 }}>
+							{ICON_CATEGORIES.map((c) => (
+								<button
+									type="button"
+									key={c.id}
+									onClick={() => setCat(c.id)}
+									style={chipStyle(cat === c.id)}
+								>
+									{c.label}
+								</button>
+							))}
+						</div>
+						<div style={{ display: "grid", gridTemplateColumns: "repeat(4,1fr)", gap: 6 }}>
+							{ICONS.filter((i) => i.category === cat).map((i) => (
+								<button
+									type="button"
+									key={i.key}
+									title={`${i.ja} / ${i.en}`}
+									onClick={() => toolStateStore.set({ iconKey: i.key })}
+									style={{
+										border: `2px solid ${tool.iconKey === i.key ? "#EF5350" : STROKE}`,
+										borderRadius: 8,
+										padding: 3,
+										cursor: "pointer",
+										aspectRatio: "1",
+										background: CARD,
+									}}
+								>
+									<svg width="100%" height="100%" viewBox={i.viewBox} filter={wobble}>
+										{renderSvgNodes(i.nodes, `pal-${i.key}`)}
+									</svg>
+								</button>
+							))}
+						</div>
+					</div>
+				)}
+
+				{/* Tweaks */}
+				<div style={{ borderTop: `2px dashed ${STROKE}`, paddingTop: 10 }}>
+					<div style={{ font: "600 11px system-ui", color: "#8a8a88", marginBottom: 6 }}>
+						Tweaks
+					</div>
+					<div style={{ display: "flex", flexWrap: "wrap", gap: 6, alignItems: "center" }}>
+						<button
+							type="button"
+							onClick={() =>
+								renderConfigStore.set({ colorMode: cfg.colorMode === "color" ? "mono" : "color" })
+							}
+							style={chipStyle(false)}
+						>
+							{cfg.colorMode === "color" ? "カラフル" : "モノクロ"}
+						</button>
+						<button
+							type="button"
+							onClick={() =>
+								renderConfigStore.set({
+									lineStyle: cfg.lineStyle === "wobble" ? "clean" : "wobble",
+								})
+							}
+							style={chipStyle(false)}
+						>
+							{cfg.lineStyle === "wobble" ? "揺らぎ線" : "クリーン線"}
+						</button>
+						<label
+							style={{ font: "600 11px system-ui", display: "flex", alignItems: "center", gap: 4 }}
+						>
+							線
+							<input
+								type="range"
+								min={0.5}
+								max={2}
+								step={0.1}
+								value={cfg.strokeScale}
+								onChange={(e) => renderConfigStore.set({ strokeScale: Number(e.target.value) })}
+								style={{ width: 80 }}
+							/>
+						</label>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/plugins/usketch-plugin-map/tsconfig.json
+++ b/plugins/usketch-plugin-map/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"jsx": "react-jsx"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       '@edv4h/usketch-plugin-laser':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-laser
+      '@edv4h/usketch-plugin-map':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-map
       '@edv4h/usketch-plugin-markdown-to-shape':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-markdown-to-shape
@@ -1220,6 +1223,28 @@ importers:
       '@edv4h/usketch-sync':
         specifier: workspace:*
         version: link:../../packages/sync
+      react:
+        specifier: 19.2.8
+        version: 19.2.8
+    devDependencies:
+      '@types/react':
+        specifier: 19.2.17
+        version: 19.2.17
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@25.9.5)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  plugins/usketch-plugin-map:
+    dependencies:
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
       react:
         specifier: 19.2.8
         version: 19.2.8


### PR DESCRIPTION
## 概要

Canvas 上に「RPG のマップの要領で領域を定義する」ための **Map プラグイン** `@edv4h/usketch-plugin-map` を新規追加し、**community ページ（ワールドマップ空間）** の基本プラグインに組み込みます。Claude Design「手描きRPGマップ・素材」のビジュアル語彙（12 地形タイル＋36 アイコン＋手描き調 Tweaks）を uSketch の layer/shape/tool 機構に実装しました。

## 機能

- **地形タイルペイント**: 12 種（草原/森/水辺/砂漠/山/道/雪原/沼地/溶岩/石床/畑/花畑）を 40×40 グリッドにブラシで塗る。隣接判定で外周（辺）が一段濃くなるオートタイル。**ブラシ / 消しゴム / 塗りつぶし（flood-fill）**。
- **アイコン 36 種**（ランドマーク12・オブジェクト12・マーカー12）をパレットのカテゴリタブから選んでスタンプ配置（選択・移動・リサイズ可）。
- **Tweaks**: カラフル⇔モノクロ / 揺らぎ線⇔クリーン線 / 線の太さ。オンキャンバスのパレットと Control HUD の両方から即時反映。

## アーキテクチャ（設計判断）

MapLayer の意図（描画・z-order）と、同期・Undo の現実（uSketch で無料なのは shape ストアのみ）を両立:

- **地形の描画 = 専用 MapLayer**（`ctx.layers`, `order:40` で全 shape の背面・world 座標・`pointer-events:none`）。
- **地形データ = data-only の `tilemap` shape**（`render:()=>null` / `hitTest:()=>false` / `locked`）。shape ストア経由で **Yjs 同期・Undo が無料**。`shape-island` と同じ「データは shape・描画は layer」パターン。community は shape を同期するため**共有ワールドマップ**になります。
- **アイコン = 通常の `map-icon` shape**（前面・選択/移動/リサイズ可）。
- SVG 素材は **`dangerouslySetInnerHTML` 不使用**。パース済み SVG ノード木を `React.createElement` で描画（`svg-nodes.tsx`）— リポジトリの XSS 安全方針に準拠。
- ペイントはツールが `store.updateShape` でライブ更新し、**1 ストローク = 1 undoable コマンド**として `pointerUp` でコミット。

## 配線

`apps/web/src/pages/community/community-page.tsx` の `basePlugins` に `createMapPlugin()` を追加（メインの Whiteboard ボードには入れていません）。ツール `map`（ショートカット `m`）はアバターのラジアルメニューにも自動表示されます。

## テスト / 検証

- 単体テスト 15 件（autotile 近傍・flood-fill・セル量子化・cellsBounds・terrain/icon 定義数 12/36）。
- 全体 typecheck 164/164、`biome check` エラー 0、プラグイン build/test green。
- Vite dev で community-page および全プラグインモジュールの transform がエラーなく解決することを確認。

## 拡張性

`createMapPlugin({ tile, terrains?, icons?, defaultColorMode, defaultLineStyle })`。terrain/icon は data 駆動、`cells` はマップ非依存の疎グリッドで複数 tilemap にも耐える設計。

🤖 Generated with [Claude Code](https://claude.com/claude-code)