### PR TITLE
✨ feat(map): 地形タイルの LOD（ズーム連動の描画簡略化）

### DIFF
--- a/.changeset/map-tile-lod.md
+++ b/.changeset/map-tile-lod.md
@@ -1,0 +1,15 @@
+---
+"@edv4h/usketch-plugin-map": minor
+---
+
+MapLayer（地形タイル）に LOD（Level of Detail）を追加。
+
+画面上のタイルサイズ（`tile × zoom` px）と全体の `renderMode` に応じて段階的に簡略化し、
+ズームアウトや大きなマップでの描画コスト（SVG ノード数・pattern/filter）を抑える:
+
+- **full**（14px/tile 以上）: pattern＋オートタイル外周strip＋セル境界＋揺らぎ filter（従来）。
+- **mid**（6px 以上）: pattern 塗りのみ（strip/境界/揺らぎなし）。
+- **low**（6px 未満）: 単色塗り＋セルを N×N ブロックに**ダウンサンプル（多数決）**して DOM ノードを削減。
+
+グローバル `renderMode === "lod"` のときは最大でも mid に制限。pure ロジック（tier 判定・
+ブロック係数・ダウンサンプル）に単体テストを追加。

--- a/plugins/usketch-plugin-map/src/__tests__/lod.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/lod.test.ts
@@ -44,4 +44,10 @@ describe("downsampleCells", () => {
 		const out = downsampleCells(cells, 2); // cells 4,5 → block 2
 		expect(out["2,2"]).toBe("forest");
 	});
+	it("caches the block map per cells object + factor (same reference)", () => {
+		const cells: Cells = { "0,0": "grass", "1,0": "water" };
+		expect(downsampleCells(cells, 2)).toBe(downsampleCells(cells, 2)); // cache hit
+		const other: Cells = { "0,0": "grass", "1,0": "water" };
+		expect(downsampleCells(other, 2)).not.toBe(downsampleCells(cells, 2)); // different object
+	});
 });

--- a/plugins/usketch-plugin-map/src/__tests__/lod.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/lod.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { Cells } from "../autotile.js";
+import { blockFactor, downsampleCells, tileDetail } from "../lod.js";
+
+describe("tileDetail", () => {
+	it("picks tier by on-screen tile size", () => {
+		expect(tileDetail(40)).toBe("full"); // 40px/tile → full
+		expect(tileDetail(14)).toBe("full");
+		expect(tileDetail(10)).toBe("mid");
+		expect(tileDetail(6)).toBe("mid");
+		expect(tileDetail(3)).toBe("low");
+	});
+	it("global lod mode caps detail at mid", () => {
+		expect(tileDetail(40, "lod")).toBe("mid");
+		expect(tileDetail(3, "lod")).toBe("low");
+	});
+});
+
+describe("blockFactor", () => {
+	it("is 1 when tiles are large, grows as they shrink", () => {
+		expect(blockFactor(12)).toBe(1);
+		expect(blockFactor(4)).toBe(3); // round(12/4)
+		expect(blockFactor(1)).toBe(12);
+		expect(blockFactor(0)).toBe(1); // guard
+	});
+});
+
+describe("downsampleCells", () => {
+	it("returns a shallow copy when factor <= 1", () => {
+		const cells: Cells = { "0,0": "grass" };
+		const out = downsampleCells(cells, 1);
+		expect(out).toEqual(cells);
+		expect(out).not.toBe(cells);
+	});
+	it("merges a factor×factor block to its majority terrain", () => {
+		// One 2×2 block: 3 grass + 1 water → grass.
+		const cells: Cells = { "0,0": "grass", "1,0": "grass", "0,1": "grass", "1,1": "water" };
+		const out = downsampleCells(cells, 2);
+		expect(Object.keys(out)).toEqual(["0,0"]); // single block at block-coord 0,0
+		expect(out["0,0"]).toBe("grass");
+	});
+	it("keys are block coordinates", () => {
+		const cells: Cells = { "4,4": "forest", "5,5": "forest" };
+		const out = downsampleCells(cells, 2); // cells 4,5 → block 2
+		expect(out["2,2"]).toBe("forest");
+	});
+});

--- a/plugins/usketch-plugin-map/src/lod.ts
+++ b/plugins/usketch-plugin-map/src/lod.ts
@@ -1,0 +1,68 @@
+// Level-of-detail for the terrain MapLayer. When tiles get small on screen (zoom
+// out, or a large map), the per-cell pattern fills + autotile edge strips + cell
+// separators are invisible yet expensive, so we render progressively simpler:
+//   full → pattern + autotile strips + wobble
+//   mid  → pattern fill only (no strips/separators/wobble)
+//   low  → flat colour, cells downsampled into merged blocks (fewer DOM nodes)
+import { type Cells, cellKey, parseCellKey } from "./autotile.js";
+import type { TerrainKey } from "./terrain.js";
+
+export type TileDetail = "full" | "mid" | "low";
+
+/** On-screen px per tile at/above which full detail is worthwhile. */
+export const FULL_MIN_PX = 14;
+/** On-screen px per tile at/above which the pattern fill is still worthwhile. */
+export const MID_MIN_PX = 6;
+/** Target on-screen px per merged block in the low tier. */
+export const LOW_BLOCK_PX = 12;
+
+/**
+ * Pick a detail tier from the on-screen tile size (world tile × zoom, in px).
+ * A global `renderMode` of "lod" caps detail at "mid" so the map simplifies in
+ * step with the rest of the canvas.
+ */
+export function tileDetail(screenTilePx: number, renderMode?: string): TileDetail {
+	if (renderMode === "lod") return screenTilePx >= MID_MIN_PX ? "mid" : "low";
+	if (screenTilePx >= FULL_MIN_PX) return "full";
+	if (screenTilePx >= MID_MIN_PX) return "mid";
+	return "low";
+}
+
+/** How many cells per side to merge into one block in the low tier (≥1). */
+export function blockFactor(screenTilePx: number): number {
+	if (screenTilePx <= 0) return 1;
+	return Math.max(1, Math.round(LOW_BLOCK_PX / screenTilePx));
+}
+
+/**
+ * Downsample cells into `factor`×`factor` blocks, each labelled with its majority
+ * terrain. Keys are BLOCK coordinates (`blockCol,blockRow`). A block spans world
+ * rect `[bc*factor*tile … ]`. Reduces DOM node count by up to factor² when far out.
+ */
+export function downsampleCells(cells: Cells, factor: number): Record<string, TerrainKey> {
+	if (factor <= 1) return { ...cells };
+	const votes = new Map<string, Map<TerrainKey, number>>();
+	for (const [key, terrain] of Object.entries(cells)) {
+		const [c, r] = parseCellKey(key);
+		const bk = cellKey(Math.floor(c / factor), Math.floor(r / factor));
+		let m = votes.get(bk);
+		if (!m) {
+			m = new Map();
+			votes.set(bk, m);
+		}
+		m.set(terrain, (m.get(terrain) ?? 0) + 1);
+	}
+	const out: Record<string, TerrainKey> = {};
+	for (const [bk, m] of votes) {
+		let best: TerrainKey | null = null;
+		let bestN = -1;
+		for (const [t, n] of m) {
+			if (n > bestN) {
+				bestN = n;
+				best = t;
+			}
+		}
+		if (best) out[bk] = best;
+	}
+	return out;
+}

--- a/plugins/usketch-plugin-map/src/lod.ts
+++ b/plugins/usketch-plugin-map/src/lod.ts
@@ -4,6 +4,7 @@
 //   full → pattern + autotile strips + wobble
 //   mid  → pattern fill only (no strips/separators/wobble)
 //   low  → flat colour, cells downsampled into merged blocks (fewer DOM nodes)
+import type { RenderMode } from "@edv4h/usketch-shared";
 import { type Cells, cellKey, parseCellKey } from "./autotile.js";
 import type { TerrainKey } from "./terrain.js";
 
@@ -21,7 +22,7 @@ export const LOW_BLOCK_PX = 12;
  * A global `renderMode` of "lod" caps detail at "mid" so the map simplifies in
  * step with the rest of the canvas.
  */
-export function tileDetail(screenTilePx: number, renderMode?: string): TileDetail {
+export function tileDetail(screenTilePx: number, renderMode?: RenderMode): TileDetail {
 	if (renderMode === "lod") return screenTilePx >= MID_MIN_PX ? "mid" : "low";
 	if (screenTilePx >= FULL_MIN_PX) return "full";
 	if (screenTilePx >= MID_MIN_PX) return "mid";
@@ -34,6 +35,12 @@ export function blockFactor(screenTilePx: number): number {
 	return Math.max(1, Math.round(LOW_BLOCK_PX / screenTilePx));
 }
 
+// Cache the (expensive) block map per cells object + factor. Keyed by the `cells`
+// object identity, so pan/zoom (which reuse the same `cells`) hit the cache and a
+// tilemap edit (new `cells` object) is a natural miss; the WeakMap lets the old
+// entry be GC'd. Avoids an O(totalCells) recompute every frame when zoomed out.
+const downsampleCache = new WeakMap<Cells, Map<number, Record<string, TerrainKey>>>();
+
 /**
  * Downsample cells into `factor`×`factor` blocks, each labelled with its majority
  * terrain. Keys are BLOCK coordinates (`blockCol,blockRow`). A block spans world
@@ -41,6 +48,14 @@ export function blockFactor(screenTilePx: number): number {
  */
 export function downsampleCells(cells: Cells, factor: number): Record<string, TerrainKey> {
 	if (factor <= 1) return { ...cells };
+	let byFactor = downsampleCache.get(cells);
+	if (!byFactor) {
+		byFactor = new Map();
+		downsampleCache.set(cells, byFactor);
+	}
+	const cached = byFactor.get(factor);
+	if (cached) return cached;
+
 	const votes = new Map<string, Map<TerrainKey, number>>();
 	for (const [key, terrain] of Object.entries(cells)) {
 		const [c, r] = parseCellKey(key);
@@ -64,5 +79,6 @@ export function downsampleCells(cells: Cells, factor: number): Record<string, Te
 		}
 		if (best) out[bk] = best;
 	}
+	byFactor.set(factor, out);
 	return out;
 }

--- a/plugins/usketch-plugin-map/src/map-layer.tsx
+++ b/plugins/usketch-plugin-map/src/map-layer.tsx
@@ -1,10 +1,11 @@
 // MapLayer — renders the RPG terrain behind all shapes. Reads the tilemap
 // DATA from the shape store (single source of truth, synced + undoable) and
 // paints it; input is handled by the map tool, not this layer (pointer-events:none).
-import type { BoardStore } from "@edv4h/usketch-shared";
+import type { BoardStore, RenderMode } from "@edv4h/usketch-shared";
 import { useEffect, useRef, useState } from "react";
 import { type Cells, exposedEdges, parseCellKey } from "./autotile.js";
 import { genStateStore } from "./gen-state.js";
+import { blockFactor, downsampleCells, type TileDetail, tileDetail } from "./lod.js";
 import { terrainCssVars } from "./palette.js";
 import { renderConfigStore } from "./render-config.js";
 import { renderSvgNodes } from "./svg-nodes.js";
@@ -52,22 +53,46 @@ function MapDefs() {
 	);
 }
 
-interface CellRects {
-	nodes: React.ReactElement[];
+function culled(x: number, y: number, size: number, visible?: DOMRectReadOnly | null): boolean {
+	return (
+		!!visible &&
+		(x > visible.right || y > visible.bottom || x + size < visible.left || y + size < visible.top)
+	);
 }
 
-function renderCells(cells: Cells, tile: number, visible?: DOMRectReadOnly | null): CellRects {
+/** Low tier: flat-colour, cells downsampled into merged blocks (fewest nodes). */
+function renderLowCells(
+	cells: Cells,
+	tile: number,
+	screenTilePx: number,
+	visible?: DOMRectReadOnly | null,
+): React.ReactElement[] {
+	const factor = blockFactor(screenTilePx);
+	const bt = factor * tile;
+	const nodes: React.ReactElement[] = [];
+	for (const [bk, terrain] of Object.entries(downsampleCells(cells, factor))) {
+		const [bc, br] = parseCellKey(bk);
+		const x = bc * bt;
+		const y = br * bt;
+		if (culled(x, y, bt, visible)) continue;
+		nodes.push(<rect key={bk} x={x} y={y} width={bt} height={bt} fill={`var(--t-${terrain})`} />);
+	}
+	return nodes;
+}
+
+/** Full/mid tiers: per-cell pattern fill; full adds autotile edge strips + separators. */
+function renderPatternCells(
+	cells: Cells,
+	tile: number,
+	full: boolean,
+	visible?: DOMRectReadOnly | null,
+): React.ReactElement[] {
 	const nodes: React.ReactElement[] = [];
 	for (const [key, terrain] of Object.entries(cells)) {
 		const [c, r] = parseCellKey(key);
 		const x = c * tile;
 		const y = r * tile;
-		if (
-			visible &&
-			(x > visible.right || y > visible.bottom || x + tile < visible.left || y + tile < visible.top)
-		) {
-			continue; // simple viewport cull
-		}
+		if (culled(x, y, tile, visible)) continue;
 		const pat = `url(#${terrainPatternId(terrain as TerrainKey)})`;
 		nodes.push(
 			<rect
@@ -77,10 +102,11 @@ function renderCells(cells: Cells, tile: number, visible?: DOMRectReadOnly | nul
 				width={tile}
 				height={tile}
 				fill={pat}
-				stroke={CELL_LINE}
-				strokeWidth={1}
+				stroke={full ? CELL_LINE : undefined}
+				strokeWidth={full ? 1 : undefined}
 			/>,
 		);
+		if (!full) continue;
 		const edge = exposedEdges(cells, c, r);
 		const t = EDGE_RATIO * tile;
 		const dark = terrainDarkVar(terrain as TerrainKey);
@@ -92,7 +118,18 @@ function renderCells(cells: Cells, tile: number, visible?: DOMRectReadOnly | nul
 		if (edge.w) nodes.push(strip(x, y, t, tile, `${key}:w`));
 		if (edge.e) nodes.push(strip(x + tile - t, y, t, tile, `${key}:e`));
 	}
-	return { nodes };
+	return nodes;
+}
+
+function renderCells(
+	cells: Cells,
+	tile: number,
+	detail: TileDetail,
+	screenTilePx: number,
+	visible?: DOMRectReadOnly | null,
+): React.ReactElement[] {
+	if (detail === "low") return renderLowCells(cells, tile, screenTilePx, visible);
+	return renderPatternCells(cells, tile, detail === "full", visible);
 }
 
 /** Visible world rect from the current viewport (best-effort, window-sized). */
@@ -107,7 +144,13 @@ function visibleWorldRect(store: BoardStore): DOMRectReadOnly | null {
 	return new DOMRectReadOnly(left, top, right - left, bottom - top);
 }
 
-export function MapTerrainLayer({ store }: { store: BoardStore }) {
+export function MapTerrainLayer({
+	store,
+	renderMode,
+}: {
+	store: BoardStore;
+	renderMode?: RenderMode;
+}) {
 	const [, force] = useState(0);
 	const rafRef = useRef(0);
 
@@ -156,13 +199,18 @@ export function MapTerrainLayer({ store }: { store: BoardStore }) {
 				style={{ display: "block", overflow: "visible", ...cssVars } as React.CSSProperties}
 			>
 				<MapDefs />
-				<g
-					transform={`translate(${vp.x} ${vp.y}) scale(${vp.zoom})`}
-					filter={cfg.lineStyle === "wobble" ? `url(#${WOBBLE_FILTER_ID})` : undefined}
-				>
-					{tilemaps.map((tm) => (
-						<g key={tm.id}>{renderCells(tm.cells, tm.tile, visible).nodes}</g>
-					))}
+				<g transform={`translate(${vp.x} ${vp.y}) scale(${vp.zoom})`}>
+					{tilemaps.map((tm) => {
+						const screenTilePx = tm.tile * vp.zoom;
+						const detail = tileDetail(screenTilePx, renderMode);
+						// Wobble only pays off (and is only visible) at full detail.
+						const useWobble = cfg.lineStyle === "wobble" && detail === "full";
+						return (
+							<g key={tm.id} filter={useWobble ? `url(#${WOBBLE_FILTER_ID})` : undefined}>
+								{renderCells(tm.cells, tm.tile, detail, screenTilePx, visible)}
+							</g>
+						);
+					})}
 					{pending && (pending.w > 0 || pending.h > 0) && (
 						<rect
 							x={pending.x}

--- a/plugins/usketch-plugin-map/src/plugin.tsx
+++ b/plugins/usketch-plugin-map/src/plugin.tsx
@@ -44,7 +44,7 @@ export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 				id: TERRAIN_LAYER_ID,
 				order: 40,
 				fixed: true,
-				render: () => <MapTerrainLayer store={ctx.store} />,
+				render: (lctx) => <MapTerrainLayer store={ctx.store} renderMode={lctx.renderMode} />,
 			});
 
 			// ── Tool ──


### PR DESCRIPTION
## 概要

MapLayer（地形タイル）に **LOD（Level of Detail）** を追加します。MapLayer はセルごとに pattern 塗り＋オートタイル外周strip＋セル境界線＋揺らぎ filter を描いており、ズームアウトや大きなマップだと SVG ノード数・pattern/filter コストで重くなります。**画面上のタイルサイズ**（`tile × zoom` px）に応じて段階的に簡略化します。

## 段階

| tier | 条件（px/tile） | 描画 |
|---|---|---|
| **full** | ≥ 14 | pattern＋外周strip＋セル境界＋揺らぎ filter（従来どおり） |
| **mid** | ≥ 6 | pattern 塗りのみ（strip/境界/揺らぎ省略） |
| **low** | < 6 | 単色塗り＋セルを N×N ブロックに**ダウンサンプル（多数決）**して DOM ノードを削減 |

- ブロック係数は目標 ~12px/ブロックになるよう `round(12 / screenTilePx)`。
- 揺らぎ filter は full のみ（低ズームでは不可視かつ高コスト）。
- グローバル `renderMode === "lod"` のときは最大でも mid に制限（キャンバス全体の LOD と歩調を合わせる）。既存の viewport cull はそのまま。

## 実装

- `lod.ts`（純ロジック）: `tileDetail(screenTilePx, renderMode)` / `blockFactor` / `downsampleCells`（多数決で block→terrain）。
- `map-layer.tsx`: tilemap ごとに tier を算出し、full/mid=pattern・low=ブロック単色で描画。wobble を tilemap 単位の `<g filter>` へ。`plugin.tsx` から `renderMode` を渡す。

## テスト

- tier 閾値 / block 係数 / ダウンサンプル（多数決・ブロック座標）の単体テスト。計 40 tests green、typecheck / biome / build OK。

## 確認

community `m` → 地形を生成/描画 → ズームアウトすると外周strip→単色ブロックへ段階的に簡略化され、ズームインで detail が戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)