### PR TITLE
🐛 fix(map): LOD 引き時のパフォーマンス改善（mid の pattern 撤廃＋常時ブロック統合）

### DIFF
--- a/.changeset/map-lod-perf.md
+++ b/.changeset/map-lod-perf.md
@@ -1,0 +1,14 @@
+---
+"@edv4h/usketch-plugin-map": patch
+---
+
+Map タイル LOD の引き（ズームアウト）時のパフォーマンスを大幅改善。
+
+これまでの中間段（mid）はズームアウトしてもセルごとに SVG pattern 塗りを続けており、
+画面に大量のセルが入ると pattern 付き `<rect>` が数千〜数万個生成されて激重になっていた。
+
+- LOD を **full / coarse の2段**に整理:
+  - **full**（画面上タイル ≥ 24px）: pattern＋外周strip＋揺らぎ。**可視セル範囲のみ**走査（O(可視)、O(全セル)でない）。
+  - **coarse**（< 24px＝引き）: **pattern をやめて単色**、かつ**必ずブロック統合**（`ceil` で factor ≥ 2）。
+    画面上のブロックサイズを ~24px に保つため、**描画ノード数が地図サイズ・ズームに依存せず頭打ち**に。
+- 揺らぎ filter は full のみ。global `renderMode === "lod"` は常に coarse。

--- a/plugins/usketch-plugin-map/src/__tests__/lod.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/lod.test.ts
@@ -3,25 +3,27 @@ import type { Cells } from "../autotile.js";
 import { blockFactor, downsampleCells, tileDetail } from "../lod.js";
 
 describe("tileDetail", () => {
-	it("picks tier by on-screen tile size", () => {
-		expect(tileDetail(40)).toBe("full"); // 40px/tile → full
-		expect(tileDetail(14)).toBe("full");
-		expect(tileDetail(10)).toBe("mid");
-		expect(tileDetail(6)).toBe("mid");
-		expect(tileDetail(3)).toBe("low");
+	it("is full only when tiles are big enough on screen", () => {
+		expect(tileDetail(40)).toBe("full");
+		expect(tileDetail(24)).toBe("full");
+		expect(tileDetail(20)).toBe("coarse");
+		expect(tileDetail(6)).toBe("coarse");
 	});
-	it("global lod mode caps detail at mid", () => {
-		expect(tileDetail(40, "lod")).toBe("mid");
-		expect(tileDetail(3, "lod")).toBe("low");
+	it("global lod mode forces coarse", () => {
+		expect(tileDetail(40, "lod")).toBe("coarse");
 	});
 });
 
 describe("blockFactor", () => {
-	it("is 1 when tiles are large, grows as they shrink", () => {
-		expect(blockFactor(12)).toBe(1);
-		expect(blockFactor(4)).toBe(3); // round(12/4)
-		expect(blockFactor(1)).toBe(12);
+	it("merges more as tiles shrink, keeping ~constant on-screen block size", () => {
+		expect(blockFactor(24)).toBe(1); // ceil(24/24)
+		expect(blockFactor(12)).toBe(2); // ceil(24/12)
+		expect(blockFactor(8)).toBe(3);
+		expect(blockFactor(6)).toBe(4);
 		expect(blockFactor(0)).toBe(1); // guard
+	});
+	it("is always ≥2 below the full threshold (coarse never renders per-cell)", () => {
+		for (let px = 1; px < 24; px++) expect(blockFactor(px)).toBeGreaterThanOrEqual(2);
 	});
 });
 

--- a/plugins/usketch-plugin-map/src/__tests__/visible-range.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/visible-range.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { visibleCellRange } from "../map-layer.js";
+
+const rect = (left: number, top: number, right: number, bottom: number): DOMRectReadOnly =>
+	({
+		left,
+		top,
+		right,
+		bottom,
+		x: left,
+		y: top,
+		width: right - left,
+		height: bottom - top,
+		toJSON() {},
+	}) as unknown as DOMRectReadOnly;
+
+describe("visibleCellRange", () => {
+	it("returns null when the viewport is unknown", () => {
+		expect(visibleCellRange(null, 40)).toBeNull();
+	});
+
+	it("excludes a cell when the (exclusive) edge lands exactly on a tile boundary", () => {
+		// right=80, tile=40 → cells 0,1 overlap [0,80); cell 2 starts at 80 → excluded.
+		expect(visibleCellRange(rect(0, 0, 80, 40), 40)).toEqual({ c0: 0, c1: 1, r0: 0, r1: 0 });
+	});
+
+	it("includes a partially-covered cell just past a boundary", () => {
+		expect(visibleCellRange(rect(0, 0, 81, 40), 40)).toEqual({ c0: 0, c1: 2, r0: 0, r1: 0 });
+	});
+});

--- a/plugins/usketch-plugin-map/src/lod.ts
+++ b/plugins/usketch-plugin-map/src/lod.ts
@@ -1,50 +1,50 @@
-// Level-of-detail for the terrain MapLayer. When tiles get small on screen (zoom
-// out, or a large map), the per-cell pattern fills + autotile edge strips + cell
-// separators are invisible yet expensive, so we render progressively simpler:
-//   full → pattern + autotile strips + wobble
-//   mid  → pattern fill only (no strips/separators/wobble)
-//   low  → flat colour, cells downsampled into merged blocks (fewer DOM nodes)
+// Level-of-detail for the terrain MapLayer. Zoomed out, a large map puts a huge
+// number of cells on screen; per-cell SVG pattern fills (and the wobble filter)
+// then cost far too much. Two tiers keep the rendered node count bounded:
+//   full   → per-cell pattern + autotile strips + wobble (only when tiles are big,
+//            so few cells are visible)
+//   coarse → flat colour, cells always merged into blocks sized to stay ~constant
+//            on screen, so the node count is capped regardless of map size / zoom
 import type { RenderMode } from "@edv4h/usketch-shared";
 import { type Cells, cellKey, parseCellKey } from "./autotile.js";
 import type { TerrainKey } from "./terrain.js";
 
-export type TileDetail = "full" | "mid" | "low";
+export type TileDetail = "full" | "coarse";
 
-/** On-screen px per tile at/above which full detail is worthwhile. */
-export const FULL_MIN_PX = 14;
-/** On-screen px per tile at/above which the pattern fill is still worthwhile. */
-export const MID_MIN_PX = 6;
-/** Target on-screen px per merged block in the low tier. */
-export const LOW_BLOCK_PX = 12;
+/** On-screen px per tile at/above which full (pattern) detail is affordable. */
+export const FULL_MIN_PX = 24;
+/** Target on-screen px per merged block in the coarse tier. */
+export const COARSE_BLOCK_PX = 24;
 
 /**
- * Pick a detail tier from the on-screen tile size (world tile × zoom, in px).
- * A global `renderMode` of "lod" caps detail at "mid" so the map simplifies in
- * step with the rest of the canvas.
+ * Pick a detail tier from the on-screen tile size (world tile × zoom, in px). A
+ * global `renderMode` of "lod" forces coarse so the map simplifies in step with
+ * the rest of the canvas.
  */
 export function tileDetail(screenTilePx: number, renderMode?: RenderMode): TileDetail {
-	if (renderMode === "lod") return screenTilePx >= MID_MIN_PX ? "mid" : "low";
-	if (screenTilePx >= FULL_MIN_PX) return "full";
-	if (screenTilePx >= MID_MIN_PX) return "mid";
-	return "low";
+	if (renderMode === "lod") return "coarse";
+	return screenTilePx >= FULL_MIN_PX ? "full" : "coarse";
 }
 
-/** How many cells per side to merge into one block in the low tier (≥1). */
+/**
+ * Cells per side to merge into one block in the coarse tier (≥1). Uses `ceil` so
+ * that below the full threshold the factor is always ≥2 — coarse never falls back
+ * to one node per cell, keeping the on-screen block size ~`COARSE_BLOCK_PX`.
+ */
 export function blockFactor(screenTilePx: number): number {
 	if (screenTilePx <= 0) return 1;
-	return Math.max(1, Math.round(LOW_BLOCK_PX / screenTilePx));
+	return Math.max(1, Math.ceil(COARSE_BLOCK_PX / screenTilePx));
 }
 
-// Cache the (expensive) block map per cells object + factor. Keyed by the `cells`
-// object identity, so pan/zoom (which reuse the same `cells`) hit the cache and a
-// tilemap edit (new `cells` object) is a natural miss; the WeakMap lets the old
-// entry be GC'd. Avoids an O(totalCells) recompute every frame when zoomed out.
+// Cache the (O(totalCells)) block map per cells object + factor. Keyed by the
+// `cells` object identity, so pan (same cells) hits the cache and a tilemap edit
+// (new cells object) is a natural miss; the WeakMap lets the old entry be GC'd.
 const downsampleCache = new WeakMap<Cells, Map<number, Record<string, TerrainKey>>>();
 
 /**
  * Downsample cells into `factor`×`factor` blocks, each labelled with its majority
- * terrain. Keys are BLOCK coordinates (`blockCol,blockRow`). A block spans world
- * rect `[bc*factor*tile … ]`. Reduces DOM node count by up to factor² when far out.
+ * terrain. Keys are BLOCK coordinates (`blockCol,blockRow`); a block spans world
+ * rect `[bc*factor*tile … ]`. Reduces node count by up to factor² when far out.
  */
 export function downsampleCells(cells: Cells, factor: number): Record<string, TerrainKey> {
 	if (factor <= 1) return { ...cells };

--- a/plugins/usketch-plugin-map/src/map-layer.tsx
+++ b/plugins/usketch-plugin-map/src/map-layer.tsx
@@ -67,17 +67,21 @@ interface CellRange {
 	r1: number;
 }
 
-/** Visible cell index range (inclusive), or null when the viewport is unknown. */
-function visibleCellRange(
+/**
+ * Visible cell index range (inclusive), or null when the viewport is unknown.
+ * `right`/`bottom` are exclusive edges, so the end index uses `ceil - 1` — a cell
+ * only counts if it actually overlaps the rect (no extra row/col on a boundary).
+ */
+export function visibleCellRange(
 	visible: DOMRectReadOnly | null | undefined,
 	tile: number,
 ): CellRange | null {
 	if (!visible) return null;
 	return {
 		c0: Math.floor(visible.left / tile),
-		c1: Math.floor(visible.right / tile),
+		c1: Math.ceil(visible.right / tile) - 1,
 		r0: Math.floor(visible.top / tile),
-		r1: Math.floor(visible.bottom / tile),
+		r1: Math.ceil(visible.bottom / tile) - 1,
 	};
 }
 

--- a/plugins/usketch-plugin-map/src/map-layer.tsx
+++ b/plugins/usketch-plugin-map/src/map-layer.tsx
@@ -3,13 +3,13 @@
 // paints it; input is handled by the map tool, not this layer (pointer-events:none).
 import type { BoardStore, RenderMode } from "@edv4h/usketch-shared";
 import { useEffect, useRef, useState } from "react";
-import { type Cells, exposedEdges, parseCellKey } from "./autotile.js";
+import { type Cells, cellKey, exposedEdges, parseCellKey } from "./autotile.js";
 import { genStateStore } from "./gen-state.js";
 import { blockFactor, downsampleCells, type TileDetail, tileDetail } from "./lod.js";
 import { terrainCssVars } from "./palette.js";
 import { renderConfigStore } from "./render-config.js";
 import { renderSvgNodes } from "./svg-nodes.js";
-import { TERRAINS, type TerrainKey, terrainDarkVar, terrainPatternId } from "./terrain.js";
+import { TERRAINS, terrainDarkVar, terrainPatternId } from "./terrain.js";
 import { isTileMap, type TileMapShapeData } from "./tilemap-shape.js";
 
 export const WOBBLE_FILTER_ID = "uskmap-wobble";
@@ -60,8 +60,85 @@ function culled(x: number, y: number, size: number, visible?: DOMRectReadOnly | 
 	);
 }
 
-/** Low tier: flat-colour, cells downsampled into merged blocks (fewest nodes). */
-function renderLowCells(
+interface CellRange {
+	c0: number;
+	c1: number;
+	r0: number;
+	r1: number;
+}
+
+/** Visible cell index range (inclusive), or null when the viewport is unknown. */
+function visibleCellRange(
+	visible: DOMRectReadOnly | null | undefined,
+	tile: number,
+): CellRange | null {
+	if (!visible) return null;
+	return {
+		c0: Math.floor(visible.left / tile),
+		c1: Math.floor(visible.right / tile),
+		r0: Math.floor(visible.top / tile),
+		r1: Math.floor(visible.bottom / tile),
+	};
+}
+
+/**
+ * Full tier: per-cell pattern + autotile strips. Walks only the visible cell
+ * RANGE (O(visible), not O(totalCells)) — full only runs zoomed in, so the range
+ * is small even for a huge map.
+ */
+function renderFullCells(
+	cells: Cells,
+	tile: number,
+	visible?: DOMRectReadOnly | null,
+): React.ReactElement[] {
+	const nodes: React.ReactElement[] = [];
+	const t = EDGE_RATIO * tile;
+	const emit = (c: number, r: number) => {
+		const terrain = cells[cellKey(c, r)];
+		if (!terrain) return;
+		const x = c * tile;
+		const y = r * tile;
+		const k = cellKey(c, r);
+		nodes.push(
+			<rect
+				key={`${k}:base`}
+				x={x}
+				y={y}
+				width={tile}
+				height={tile}
+				fill={`url(#${terrainPatternId(terrain)})`}
+				stroke={CELL_LINE}
+				strokeWidth={1}
+			/>,
+		);
+		const edge = exposedEdges(cells, c, r);
+		const dark = terrainDarkVar(terrain);
+		const strip = (sx: number, sy: number, sw: number, sh: number, sk: string) => (
+			<rect key={sk} x={sx} y={sy} width={sw} height={sh} fill={dark} opacity={EDGE_OPACITY} />
+		);
+		if (edge.n) nodes.push(strip(x, y, tile, t, `${k}:n`));
+		if (edge.s) nodes.push(strip(x, y + tile - t, tile, t, `${k}:s`));
+		if (edge.w) nodes.push(strip(x, y, t, tile, `${k}:w`));
+		if (edge.e) nodes.push(strip(x + tile - t, y, t, tile, `${k}:e`));
+	};
+	const range = visibleCellRange(visible, tile);
+	if (range) {
+		for (let r = range.r0; r <= range.r1; r++)
+			for (let c = range.c0; c <= range.c1; c++) emit(c, r);
+	} else {
+		for (const key of Object.keys(cells)) {
+			const [c, r] = parseCellKey(key);
+			emit(c, r);
+		}
+	}
+	return nodes;
+}
+
+/**
+ * Coarse tier: flat colour, cells downsampled into merged blocks. Node count is
+ * bounded by the on-screen block size regardless of map size / zoom.
+ */
+function renderCoarseCells(
 	cells: Cells,
 	tile: number,
 	screenTilePx: number,
@@ -80,47 +157,6 @@ function renderLowCells(
 	return nodes;
 }
 
-/** Full/mid tiers: per-cell pattern fill; full adds autotile edge strips + separators. */
-function renderPatternCells(
-	cells: Cells,
-	tile: number,
-	full: boolean,
-	visible?: DOMRectReadOnly | null,
-): React.ReactElement[] {
-	const nodes: React.ReactElement[] = [];
-	for (const [key, terrain] of Object.entries(cells)) {
-		const [c, r] = parseCellKey(key);
-		const x = c * tile;
-		const y = r * tile;
-		if (culled(x, y, tile, visible)) continue;
-		const pat = `url(#${terrainPatternId(terrain as TerrainKey)})`;
-		nodes.push(
-			<rect
-				key={`${key}:base`}
-				x={x}
-				y={y}
-				width={tile}
-				height={tile}
-				fill={pat}
-				stroke={full ? CELL_LINE : undefined}
-				strokeWidth={full ? 1 : undefined}
-			/>,
-		);
-		if (!full) continue;
-		const edge = exposedEdges(cells, c, r);
-		const t = EDGE_RATIO * tile;
-		const dark = terrainDarkVar(terrain as TerrainKey);
-		const strip = (sx: number, sy: number, sw: number, sh: number, k: string) => (
-			<rect key={k} x={sx} y={sy} width={sw} height={sh} fill={dark} opacity={EDGE_OPACITY} />
-		);
-		if (edge.n) nodes.push(strip(x, y, tile, t, `${key}:n`));
-		if (edge.s) nodes.push(strip(x, y + tile - t, tile, t, `${key}:s`));
-		if (edge.w) nodes.push(strip(x, y, t, tile, `${key}:w`));
-		if (edge.e) nodes.push(strip(x + tile - t, y, t, tile, `${key}:e`));
-	}
-	return nodes;
-}
-
 function renderCells(
 	cells: Cells,
 	tile: number,
@@ -128,8 +164,8 @@ function renderCells(
 	screenTilePx: number,
 	visible?: DOMRectReadOnly | null,
 ): React.ReactElement[] {
-	if (detail === "low") return renderLowCells(cells, tile, screenTilePx, visible);
-	return renderPatternCells(cells, tile, detail === "full", visible);
+	if (detail === "full") return renderFullCells(cells, tile, visible);
+	return renderCoarseCells(cells, tile, screenTilePx, visible);
 }
 
 /** Visible world rect from the current viewport (best-effort, window-sized). */


### PR DESCRIPTION
## 問題

Map タイルの LOD がズームアウト（引き）時に効かず、**めちゃ重い**。

原因: これまでの LOD は full / **mid** / low の3段だったが、**mid（中間ズーム）がセルごとに SVG pattern 塗りを続けていた**。引きにすると画面に大量のセルが入るため、pattern 付き `<rect>` が数千〜数万ノード生成され、pattern 塗りの合成コスト＋ノード数で激重になっていた。加えて full/mid はフレーム毎に**全セルを走査**（O(totalCells)）していた。

## 修正

LOD を **full / coarse の2段**に整理し、引き時のコストを地図サイズ・ズームに依存しない上限に:

- **full**（画面上タイル ≥ 24px＝ズームイン時のみ）: pattern＋外周strip＋揺らぎ。**可視セル範囲のみ**を走査（`O(可視セル)`、全セル走査を廃止）。full は拡大時だけなので可視セルは少数。
- **coarse**（< 24px＝引き）: **pattern をやめて単色塗り**。かつ `blockFactor = ceil(24 / screenTilePx)`（`ceil` なので閾値未満は必ず factor ≥ 2）で**常にブロック統合**。画面上のブロックサイズを ~24px に保つため、**描画ノード数が地図サイズ・ズームに関係なく頭打ち**になる。
- 揺らぎ filter は **full のみ**（引きでは不可視かつ高コスト）。global `renderMode === "lod"` は常に coarse。
- `downsampleCells` は WeakMap キャッシュ（cells×factor）済みなので、pan は再計算なし。

## テスト

- `tileDetail`（full/coarse 閾値・lod 強制）、`blockFactor`（`ceil`・閾値未満は必ず ≥2）、`downsampleCells`（多数決・ブロック座標・キャッシュ）。計 42 tests green、typecheck / biome / build OK。

## 確認

community `m` → 地形生成 → 引く（ズームアウト）と pattern→単色ブロックへ切り替わり、大きな地図でも重くならない。寄る（ズームイン）と full 詳細（pattern＋外周＋揺らぎ）に戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)