### PR TITLE
✨ feat(map): 空きマス（未設定タイル）の地形フォールバックを設定可能に

### DIFF
--- a/.changeset/map-empty-terrain.md
+++ b/.changeset/map-empty-terrain.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-map": minor
+---
+
+空きマス（未設定タイル）の扱いを設定可能に。`createMapPlugin({ emptyTerrain: "water" })` オプション、または Control HUD の「空きマス」設定で、未ペイント/画面外のマスを指定地形（例: 海）として**描画＋判定**できる。null（既定）は従来どおり透明。`terrainAtCell(cells, col, row, empty?)` ヘルパで「未設定なら fallback 地形」を取得できる。

--- a/apps/web/src/pages/community/community-page.tsx
+++ b/apps/web/src/pages/community/community-page.tsx
@@ -208,7 +208,9 @@ export function CommunityPage() {
 					portalPlugin,
 					createGroupPlugin(),
 					createIslandPlugin(),
-					createMapPlugin(),
+					// Demo default: unset tiles read as sea, so the world map is an
+					// infinite ocean with painted land (off-map counts as water).
+					createMapPlugin({ emptyTerrain: "water" }),
 					createDomRendererPlugin(),
 				];
 

--- a/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
@@ -6,6 +6,7 @@ import {
 	exposedEdges,
 	floodFill,
 	parseCellKey,
+	terrainAtCell,
 	worldToCell,
 } from "../autotile.js";
 
@@ -37,6 +38,21 @@ describe("cellsBounds", () => {
 	it("handles negative cells", () => {
 		const cells: Cells = { "-1,-1": "grass", "0,0": "grass" };
 		expect(cellsBounds(cells, 40)).toEqual({ x: -40, y: -40, width: 80, height: 80 });
+	});
+});
+
+describe("terrainAtCell", () => {
+	const cells: Cells = { "0,0": "grass" };
+	it("returns the painted terrain when set", () => {
+		expect(terrainAtCell(cells, 0, 0)).toBe("grass");
+		expect(terrainAtCell(cells, 0, 0, "water")).toBe("grass");
+	});
+	it("falls back to the empty terrain for unset cells (off-map = sea)", () => {
+		expect(terrainAtCell(cells, 9, 9, "water")).toBe("water");
+	});
+	it("returns undefined when unset and no fallback given", () => {
+		expect(terrainAtCell(cells, 9, 9)).toBeUndefined();
+		expect(terrainAtCell(cells, 9, 9, null)).toBeUndefined();
 	});
 });
 

--- a/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
@@ -68,6 +68,19 @@ describe("exposedEdges", () => {
 		const cells: Cells = { "0,0": "grass", "1,0": "water" };
 		expect(exposedEdges(cells, 0, 0).e).toBe(true);
 	});
+	it("treats unset neighbours as the empty fallback (no coast against matching empty)", () => {
+		// water tile with all-empty neighbours; empty="water" → no exposed edges.
+		expect(exposedEdges({ "0,0": "water" }, 0, 0, "water")).toEqual({
+			n: false,
+			e: false,
+			s: false,
+			w: false,
+		});
+		// grass tile against empty="water" → still exposed (coastline).
+		expect(exposedEdges({ "0,0": "grass" }, 0, 0, "water").e).toBe(true);
+		// no fallback → unset neighbours are always exposed (prior behaviour).
+		expect(exposedEdges({ "0,0": "water" }, 0, 0).e).toBe(true);
+	});
 });
 
 describe("floodFill", () => {

--- a/plugins/usketch-plugin-map/src/autotile.ts
+++ b/plugins/usketch-plugin-map/src/autotile.ts
@@ -19,6 +19,20 @@ export function worldToCell(x: number, y: number, tile: number): [col: number, r
 	return [Math.floor(x / tile), Math.floor(y / tile)];
 }
 
+/**
+ * Terrain at a cell, treating unset cells as the `empty` fallback (e.g. "water"),
+ * so callers can judge off-map / unpainted space as sea. Returns `undefined` only
+ * when the cell is unset and no fallback is given.
+ */
+export function terrainAtCell(
+	cells: Cells,
+	col: number,
+	row: number,
+	empty?: TerrainKey | null,
+): TerrainKey | undefined {
+	return cells[cellKey(col, row)] ?? empty ?? undefined;
+}
+
 /** Bounding box (world units) enclosing all painted cells. Empty → zero box. */
 export function cellsBounds(cells: Cells, tile: number): BoundingBox {
 	let minC = Infinity;

--- a/plugins/usketch-plugin-map/src/autotile.ts
+++ b/plugins/usketch-plugin-map/src/autotile.ts
@@ -63,12 +63,19 @@ export interface ExposedEdges {
 }
 
 /**
- * Which sides of cell (c,r) border a different terrain (or empty). These get the
- * "one shade darker" strip in the design — the region's outer ring.
+ * Which sides of cell (c,r) border a different terrain. Unset neighbours count as
+ * `empty` (the fallback terrain), so e.g. a water tile next to unpainted space
+ * with `empty="water"` is NOT an exposed edge — no spurious coastline against the
+ * empty-terrain background. `empty` omitted → unset neighbours are always different.
  */
-export function exposedEdges(cells: Cells, col: number, row: number): ExposedEdges {
+export function exposedEdges(
+	cells: Cells,
+	col: number,
+	row: number,
+	empty?: TerrainKey | null,
+): ExposedEdges {
 	const self = cells[cellKey(col, row)];
-	const diff = (c: number, r: number) => cells[cellKey(c, r)] !== self;
+	const diff = (c: number, r: number) => terrainAtCell(cells, c, r, empty) !== self;
 	return {
 		n: diff(col, row - 1),
 		e: diff(col + 1, row),

--- a/plugins/usketch-plugin-map/src/map-layer.tsx
+++ b/plugins/usketch-plugin-map/src/map-layer.tsx
@@ -187,9 +187,12 @@ export function visibleWorldRect(store: BoardStore): DOMRectReadOnly | null {
 export function MapTerrainLayer({
 	store,
 	renderMode,
+	tile: defaultTile,
 }: {
 	store: BoardStore;
 	renderMode?: RenderMode;
+	/** Reference tile size for the empty-terrain background LOD. */
+	tile: number;
 }) {
 	const [, force] = useState(0);
 	const rafRef = useRef(0);
@@ -222,6 +225,11 @@ export function MapTerrainLayer({
 
 	const cssVars = terrainCssVars(cfg.colorMode, cfg.strokeScale);
 
+	// Empty-terrain background: fill the visible area with the fallback terrain so
+	// unpainted / off-map space reads as (e.g.) sea, with painted tiles on top.
+	const empty = cfg.emptyTerrain;
+	const bgCoarse = tileDetail(defaultTile * vp.zoom, renderMode) === "coarse";
+
 	return (
 		<div
 			style={{
@@ -240,6 +248,15 @@ export function MapTerrainLayer({
 			>
 				<MapDefs />
 				<g transform={`translate(${vp.x} ${vp.y}) scale(${vp.zoom})`}>
+					{empty && visible && (
+						<rect
+							x={visible.left}
+							y={visible.top}
+							width={visible.width}
+							height={visible.height}
+							fill={bgCoarse ? `var(--t-${empty})` : `url(#${terrainPatternId(empty)})`}
+						/>
+					)}
 					{tilemaps.map((tm) => {
 						const screenTilePx = tm.tile * vp.zoom;
 						const detail = tileDetail(screenTilePx, renderMode);

--- a/plugins/usketch-plugin-map/src/map-layer.tsx
+++ b/plugins/usketch-plugin-map/src/map-layer.tsx
@@ -9,7 +9,7 @@ import { blockFactor, downsampleCells, type TileDetail, tileDetail } from "./lod
 import { terrainCssVars } from "./palette.js";
 import { renderConfigStore } from "./render-config.js";
 import { renderSvgNodes } from "./svg-nodes.js";
-import { TERRAINS, terrainDarkVar, terrainPatternId } from "./terrain.js";
+import { TERRAINS, type TerrainKey, terrainDarkVar, terrainPatternId } from "./terrain.js";
 import { isTileMap, type TileMapShapeData } from "./tilemap-shape.js";
 
 export const WOBBLE_FILTER_ID = "uskmap-wobble";
@@ -93,7 +93,8 @@ export function visibleCellRange(
 function renderFullCells(
 	cells: Cells,
 	tile: number,
-	visible?: DOMRectReadOnly | null,
+	visible: DOMRectReadOnly | null | undefined,
+	empty: TerrainKey | null,
 ): React.ReactElement[] {
 	const nodes: React.ReactElement[] = [];
 	const t = EDGE_RATIO * tile;
@@ -115,7 +116,9 @@ function renderFullCells(
 				strokeWidth={1}
 			/>,
 		);
-		const edge = exposedEdges(cells, c, r);
+		// Unset neighbours count as `empty` so painted tiles matching the empty
+		// terrain (e.g. water on a water background) don't draw a spurious coast.
+		const edge = exposedEdges(cells, c, r, empty);
 		const dark = terrainDarkVar(terrain);
 		const strip = (sx: number, sy: number, sw: number, sh: number, sk: string) => (
 			<rect key={sk} x={sx} y={sy} width={sw} height={sh} fill={dark} opacity={EDGE_OPACITY} />
@@ -166,9 +169,10 @@ function renderCells(
 	tile: number,
 	detail: TileDetail,
 	screenTilePx: number,
-	visible?: DOMRectReadOnly | null,
+	visible: DOMRectReadOnly | null | undefined,
+	empty: TerrainKey | null,
 ): React.ReactElement[] {
-	if (detail === "full") return renderFullCells(cells, tile, visible);
+	if (detail === "full") return renderFullCells(cells, tile, visible, empty);
 	return renderCoarseCells(cells, tile, screenTilePx, visible);
 }
 
@@ -264,7 +268,7 @@ export function MapTerrainLayer({
 						const useWobble = cfg.lineStyle === "wobble" && detail === "full";
 						return (
 							<g key={tm.id} filter={useWobble ? `url(#${WOBBLE_FILTER_ID})` : undefined}>
-								{renderCells(tm.cells, tm.tile, detail, screenTilePx, visible)}
+								{renderCells(tm.cells, tm.tile, detail, screenTilePx, visible, empty)}
 							</g>
 						);
 					})}

--- a/plugins/usketch-plugin-map/src/plugin.tsx
+++ b/plugins/usketch-plugin-map/src/plugin.tsx
@@ -12,6 +12,7 @@ import { type LineStyle, renderConfigStore } from "./render-config.js";
 import { EnterBanner } from "./team/enter-banner.js";
 import { TeamAreaLayer } from "./team/team-layer.js";
 import { createTeamMapShapeDefinition, TEAM_MAP_TYPE } from "./team/team-map-shape.js";
+import { TERRAINS, type TerrainKey } from "./terrain.js";
 import { createTileMapShapeDefinition, DEFAULT_TILE, TILEMAP_TYPE } from "./tilemap-shape.js";
 import { MapPalette } from "./ui/palette.js";
 import { RangeErasePalette } from "./ui/range-erase-palette.js";
@@ -21,6 +22,12 @@ export interface MapPluginOptions {
 	tile?: number;
 	defaultColorMode?: ColorMode;
 	defaultLineStyle?: LineStyle;
+	/**
+	 * Terrain used for unset cells (e.g. `"water"` → unpainted/off-map space is
+	 * sea). Default undefined = truly empty. Adjustable at runtime via the Control
+	 * HUD "空きマス" setting.
+	 */
+	emptyTerrain?: TerrainKey;
 }
 
 const TERRAIN_LAYER_ID = "usketch-map:terrain";
@@ -31,10 +38,11 @@ const ERASE_PALETTE_LAYER_ID = "usketch-map:erase-palette";
 
 export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 	const tile = options.tile ?? DEFAULT_TILE;
-	if (options.defaultColorMode || options.defaultLineStyle) {
+	if (options.defaultColorMode || options.defaultLineStyle || options.emptyTerrain) {
 		renderConfigStore.set({
 			colorMode: options.defaultColorMode,
 			lineStyle: options.defaultLineStyle,
+			emptyTerrain: options.emptyTerrain,
 		});
 	}
 
@@ -53,7 +61,9 @@ export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 				id: TERRAIN_LAYER_ID,
 				order: 40,
 				fixed: true,
-				render: (lctx) => <MapTerrainLayer store={ctx.store} renderMode={lctx.renderMode} />,
+				render: (lctx) => (
+					<MapTerrainLayer store={ctx.store} renderMode={lctx.renderMode} tile={tile} />
+				),
 			});
 
 			// ── Team areas (above terrain, below shapes) + enter banner overlay ──
@@ -112,13 +122,28 @@ export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 						],
 					},
 					{ name: "strokeScale", label: "線の太さ", type: "number", min: 0.5, max: 2, step: 0.1 },
+					{
+						name: "emptyTerrain",
+						label: "空きマス",
+						type: "enum",
+						options: [
+							{ value: "none", label: "なし" },
+							...TERRAINS.map((t) => ({ value: t.key, label: t.name })),
+						],
+					},
 				],
-				get: (name) =>
-					renderConfigStore.get()[name as keyof ReturnType<typeof renderConfigStore.get>],
+				get: (name) => {
+					if (name === "emptyTerrain") return renderConfigStore.get().emptyTerrain ?? "none";
+					return renderConfigStore.get()[name as keyof ReturnType<typeof renderConfigStore.get>];
+				},
 				set: (name, value) => {
 					if (name === "strokeScale") renderConfigStore.set({ strokeScale: Number(value) });
 					else if (name === "colorMode") renderConfigStore.set({ colorMode: value as ColorMode });
 					else if (name === "lineStyle") renderConfigStore.set({ lineStyle: value as LineStyle });
+					else if (name === "emptyTerrain")
+						renderConfigStore.set({
+							emptyTerrain: value === "none" ? null : (value as TerrainKey),
+						});
 				},
 				subscribe: renderConfigStore.subscribe,
 			});

--- a/plugins/usketch-plugin-map/src/render-config.ts
+++ b/plugins/usketch-plugin-map/src/render-config.ts
@@ -4,6 +4,7 @@
 import { useSyncExternalStore } from "react";
 import type { ColorMode } from "./palette.js";
 import { createReactiveStore } from "./reactive-store.js";
+import type { TerrainKey } from "./terrain.js";
 
 export type LineStyle = "wobble" | "clean";
 
@@ -12,12 +13,19 @@ export interface MapRenderConfig {
 	lineStyle: LineStyle;
 	/** Multiplier on the hand-drawn stroke width (design `--sw`, base 2.6px). */
 	strokeScale: number;
+	/**
+	 * Terrain used for unset cells. When set (e.g. "water"), unpainted / off-map
+	 * space renders and is judged as that terrain — an infinite sea with painted
+	 * land on top. `null` = truly empty (transparent, prior behavior).
+	 */
+	emptyTerrain: TerrainKey | null;
 }
 
 export const renderConfigStore = createReactiveStore<MapRenderConfig>({
 	colorMode: "color",
 	lineStyle: "wobble",
 	strokeScale: 1,
+	emptyTerrain: null,
 });
 
 /** Subscribe a component to the current Tweaks config. */


### PR DESCRIPTION
## 概要

「空きマス（未設定タイル）の扱い」を設定できるようにしました。`emptyTerrain` に地形を指定すると、**未ペイント/画面外のマスをその地形として描画＋判定**します。例えば `"water"` にすれば、無限の海に painted な陸を置く見た目になり、画面外も海として扱えます。既定は `null`（従来どおり透明）。

## 設定方法（2 通り）

- **プラグインオプション**: `createMapPlugin({ emptyTerrain: "water" })`。
- **実行時**: Control HUD（`` ` `` キー）→「RPG マップ」→ **「空きマス」**（なし / 海 / 草原 / …）。

## 実装

- **`render-config.ts`**: `emptyTerrain: TerrainKey | null`（既定 `null`）を追加。
- **`plugin.tsx`**: `MapPluginOptions.emptyTerrain` ＋ HUD の「空きマス」enum（`none` ↔ `null` を変換）。
- **`map-layer.tsx`**: `emptyTerrain` 設定時、可視領域（`visibleWorldRect`）に fallback 地形の**背景**を 1 枚描画（full/mid = pattern、coarse = 単色）。painted タイルはその上に描画され、境界には従来のオートタイル陰影（＝海岸線）が出る。背景は 1 ノード＋viewport カリングで軽量。
- **`autotile.ts`**: `terrainAtCell(cells, col, row, empty?)` 純ヘルパ（未設定なら fallback を返す）を追加 → 判定ロジックから「空きマス＝海」を問い合わせ可能。

## テスト / 確認

- `terrainAtCell` の単体テスト（painted 優先 / 未設定→fallback / fallback 無しは undefined）。プラグイン test 61 green、全体 typecheck 164/164、`biome check` エラー 0、build OK。
- community: HUD「空きマス」を「海」にすると、未ペイント領域が海パターンで埋まり、陸の周囲が海岸線に。ズームアウトで単色 LOD。

**community（デモ）のデフォルトを `emptyTerrain: "water"` に設定済み**（ワールドマップは未ペイント=海の無限の海に）。他アプリでの既定は従来どおり off。

🤖 Generated with [Claude Code](https://claude.com/claude-code)