### PR TITLE
✨ feat(map): チーム陣地の色塗りをチームモード時だけ表示

### DIFF
--- a/.changeset/team-layer-mode-gate.md
+++ b/.changeset/team-layer-mode-gate.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-map": patch
+---
+
+チームの陣地色塗り（TeamAreaLayer）をチームモード時だけ表示するように変更。入場バナー（EnterBanner）と同じく `map ツール + team サブモード` のときのみ描画し、他モードでは地図がすっきり見えるようにした。

--- a/plugins/usketch-plugin-map/src/team/team-layer.tsx
+++ b/plugins/usketch-plugin-map/src/team/team-layer.tsx
@@ -128,10 +128,12 @@ export function TeamAreaLayer({
 	}, [store]);
 
 	// Territory paint is only shown while actually in team mode (map tool + team
-	// submode) — mirrors the EnterBanner indicator gating.
+	// submode) — mirrors the EnterBanner indicator gating. Check the mode first so
+	// we skip the shape scan in getTeamMap on every non-team-mode re-render.
 	const inTeamMode = store.getActiveToolId() === MAP_TOOL_ID && tool.mode === "team";
+	if (!inTeamMode) return null;
 	const team = getTeamMap(store);
-	if (!inTeamMode || !team || Object.keys(team.owner).length === 0) return null;
+	if (!team || Object.keys(team.owner).length === 0) return null;
 
 	const vp = store.getViewport();
 	const visible = visibleWorldRect(store);

--- a/plugins/usketch-plugin-map/src/team/team-layer.tsx
+++ b/plugins/usketch-plugin-map/src/team/team-layer.tsx
@@ -7,6 +7,8 @@ import { useEffect, useRef, useState } from "react";
 import { type Cells, exposedEdges, parseCellKey } from "../autotile.js";
 import { blockFactor, downsampleCells, type TileDetail, tileDetail } from "../lod.js";
 import { visibleCellRange, visibleWorldRect } from "../map-layer.js";
+import { MAP_TOOL_ID } from "../map-tool-id.js";
+import { useMapToolState } from "../tool-state.js";
 import type { OwnerMap, TeamInfo } from "./team-map-shape.js";
 import { getTeamMap, teamRegionAnchors } from "./team-ops.js";
 
@@ -109,6 +111,7 @@ export function TeamAreaLayer({
 	store: BoardStore;
 	renderMode?: RenderMode;
 }) {
+	const tool = useMapToolState();
 	const [, force] = useState(0);
 	const rafRef = useRef(0);
 
@@ -124,8 +127,11 @@ export function TeamAreaLayer({
 		};
 	}, [store]);
 
+	// Territory paint is only shown while actually in team mode (map tool + team
+	// submode) — mirrors the EnterBanner indicator gating.
+	const inTeamMode = store.getActiveToolId() === MAP_TOOL_ID && tool.mode === "team";
 	const team = getTeamMap(store);
-	if (!team || Object.keys(team.owner).length === 0) return null;
+	if (!inTeamMode || !team || Object.keys(team.owner).length === 0) return null;
 
 	const vp = store.getViewport();
 	const visible = visibleWorldRect(store);


### PR DESCRIPTION
## Summary

チームの陣地（`TeamAreaLayer` の色塗り＋国境枠＋チーム名ラベル）を、**マップツールの team サブモードのとき**だけ表示するようにゲートしました。

これまで陣地レイヤーはモード非依存で常時描画されており、入場バナー（`EnterBanner`）だけがチームモード時限定でした。表示の一貫性がなかったため、陣地レイヤーも同じ条件（`activeTool === MAP_TOOL_ID && tool.mode === "team"`）に揃えています。

- `useMapToolState()` でサブモードを購読し、`store.getActiveToolId()` で active tool を判定（どちらも既存の再描画購読でリアクティブ）
- team モード外では `return null` → 地形・アイコンだけのすっきりした地図に

## Test plan

- [x] `pnpm --filter '@edv4h/usketch-plugin-map' typecheck test build`（62 tests green）
- [x] `pnpm biome check --diagnostic-level=error`
- 手動: community `m` → チームモードで陣地色塗り表示 → 別モード/別ツールに切替で陣地が消える → 戻すと再表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)