### PR TITLE
✨ feat(viewport): ロジック起点のビューポート移動をスムーズアニメ化（既定ON）＋ジャンプ処理の共通化

### DIFF
--- a/.changeset/smooth-viewport.md
+++ b/.changeset/smooth-viewport.md
@@ -1,0 +1,15 @@
+---
+"@edv4h/usketch-shared": minor
+"@edv4h/usketch-store": minor
+"@edv4h/usketch-plugin-keyboard-shortcuts": patch
+"@edv4h/usketch-plugin-tool-vim": patch
+"@edv4h/usketch-plugin-whistle": patch
+"@edv4h/usketch-plugin-follow-me": patch
+"@edv4h/usketch-plugin-debug-hud": patch
+---
+
+ロジック起点のビューポート移動（ズーム変更・特定位置へのジャンプ・zoom-to-fit）をスムーズにアニメーションさせ、デフォルト ON にした。連続的なインタラクション（ホイールズーム・ドラッグパン・ミニマップドラッグ）は従来どおり即時。
+
+- store: `animateViewportTo(target, opts?)` を追加（rAF による eased 補間、`prefers-reduced-motion`・rAF 不在・無効時は即時フォールバック、割り込みは即時系メソッドが cancel）。`fitToBounds` は既定でアニメ化。`createBoardStore({ viewportAnimation })` と `setViewportAnimation` / `getViewportAnimation` で enabled/duration/easing を調整可能（既定: 有効・350ms・ease-in-out-cubic）。
+- shared: 各プラグインが個別実装していたジャンプ計算を共通 helper `centerOnWorld` / `zoomBy` / `zoomToLevel` / `fitContent` / `screenCenterWorld` / `getScreenSize` に集約（すべて既定でアニメ）。
+- keyboard-shortcuts / tool-vim / whistle / follow-me / debug-hud を共通 helper に移行。follow-me は追従の応答性のため短めのアニメ（180ms）。

--- a/packages/shared/src/__tests__/viewport.test.ts
+++ b/packages/shared/src/__tests__/viewport.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { BoardStore, ShapeData, Viewport } from "../index.js";
+import {
+	centerOnWorld,
+	easeInOutCubic,
+	fitContent,
+	zoomBy,
+	zoomToLevel,
+} from "../utils/viewport.js";
+
+// Node test env has no `window`, so getScreenSize() → { 1280, 720 }.
+const W = 1280;
+const H = 720;
+
+function shape(id: string, x: number, y: number, width: number, height: number): ShapeData {
+	return { id, type: "rect", x, y, width, height, rotation: 0, opacity: 1 } as ShapeData;
+}
+
+function makeStore(viewport: Viewport, shapes: ShapeData[] = []) {
+	let vp = viewport;
+	const captured: { target?: Viewport; fit?: { bounds: unknown; padding?: number } } = {};
+	const map = new Map(shapes.map((s) => [s.id, s]));
+	const store = {
+		getViewport: () => vp,
+		getShapes: () => map,
+		animateViewportTo: (target: Viewport) => {
+			captured.target = target;
+			vp = target;
+		},
+		fitToBounds: (bounds: unknown, _size: unknown, padding?: number) => {
+			captured.fit = { bounds, padding };
+		},
+	} as unknown as BoardStore;
+	return { store, captured };
+}
+
+describe("easeInOutCubic", () => {
+	it("maps endpoints and midpoint", () => {
+		expect(easeInOutCubic(0)).toBe(0);
+		expect(easeInOutCubic(1)).toBe(1);
+		expect(easeInOutCubic(0.5)).toBeCloseTo(0.5, 5);
+	});
+});
+
+describe("centerOnWorld", () => {
+	it("puts the world point at the screen centre, keeping zoom", () => {
+		const { store, captured } = makeStore({ x: 0, y: 0, zoom: 2 });
+		centerOnWorld(store, { x: 100, y: 50 });
+		expect(captured.target).toEqual({ x: W / 2 - 100 * 2, y: H / 2 - 50 * 2, zoom: 2 });
+	});
+
+	it("re-zooms when a zoom override is given", () => {
+		const { store, captured } = makeStore({ x: 0, y: 0, zoom: 1 });
+		centerOnWorld(store, { x: 10, y: 20 }, { zoom: 4 });
+		expect(captured.target?.zoom).toBe(4);
+	});
+});
+
+describe("zoomToLevel / zoomBy", () => {
+	it("zooms about the screen centre", () => {
+		const { store, captured } = makeStore({ x: 0, y: 0, zoom: 1 });
+		zoomToLevel(store, 2);
+		const cx = W / 2;
+		const cy = H / 2;
+		// scale = 2 → x = cx - (cx - 0)*2
+		expect(captured.target).toEqual({ x: cx - cx * 2, y: cy - cy * 2, zoom: 2 });
+	});
+
+	it("clamps zoom into [0.1, 10]", () => {
+		const { store, captured } = makeStore({ x: 0, y: 0, zoom: 1 });
+		zoomToLevel(store, 999);
+		expect(captured.target?.zoom).toBe(10);
+	});
+
+	it("zoomBy multiplies the current zoom", () => {
+		const { store, captured } = makeStore({ x: 0, y: 0, zoom: 3 });
+		zoomBy(store, 2);
+		expect(captured.target?.zoom).toBe(6);
+	});
+});
+
+describe("fitContent", () => {
+	it("fits the union bounds of all shapes", () => {
+		const { store, captured } = makeStore({ x: 0, y: 0, zoom: 1 }, [
+			shape("a", 0, 0, 100, 100),
+			shape("b", 200, 50, 100, 100),
+		]);
+		fitContent(store);
+		expect(captured.fit?.bounds).toEqual({ x: 0, y: 0, width: 300, height: 150 });
+	});
+
+	it("no-ops on an empty board", () => {
+		const { store, captured } = makeStore({ x: 0, y: 0, zoom: 1 });
+		fitContent(store);
+		expect(captured.fit).toBeUndefined();
+	});
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -62,6 +62,8 @@ export type {
 	TransientRenderer,
 	UiRegistry,
 	UsketchPlugin,
+	ViewportAnimationConfig,
+	ViewportAnimationOptions,
 } from "./types/plugin.js";
 // Shape
 export type { ResizeHandle, ShapeData, ShapeStyle } from "./types/shape.js";
@@ -119,6 +121,16 @@ export {
 } from "./utils/rotation.js";
 // Shape diff
 export { bidiffShape, diffShape } from "./utils/shape-diff.js";
+export {
+	centerOnWorld,
+	easeInOutCubic,
+	fitContent,
+	getScreenSize,
+	screenCenterWorld,
+	type ViewportMoveOptions,
+	zoomBy,
+	zoomToLevel,
+} from "./utils/viewport.js";
 export {
 	getShapeAABB,
 	isShapeOutsideViewport,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -731,6 +731,28 @@ export type StoreEvent =
 /** {@link StoreEvent} の `type` リテラル。store の `notifyMutation` で使用。 */
 export type StoreEventType = StoreEvent["type"];
 
+/**
+ * Default behaviour for programmatic (logic-driven) viewport moves — smooth
+ * animation, on by default. Continuous interactions (wheel-zoom, drag-pan,
+ * minimap-drag) bypass this and stay instant.
+ */
+export interface ViewportAnimationConfig {
+	/** Animate programmatic viewport moves. Default `true`. */
+	enabled: boolean;
+	/** Tween duration in ms. Default `350`. */
+	durationMs: number;
+	/** Easing over normalized time `t∈[0,1]`. Default ease-in-out-cubic. */
+	easing: (t: number) => number;
+}
+
+/** Per-call overrides for {@link BoardStore.animateViewportTo}. */
+export interface ViewportAnimationOptions {
+	durationMs?: number;
+	easing?: (t: number) => number;
+	/** Force instant (`false`) or animated (`true`); omit to use the config default. */
+	animate?: boolean;
+}
+
 export interface BoardStore {
 	getShapes(): ReadonlyMap<string, ShapeData>;
 	/** Return shapes sorted by zIndex (ascending = back to front). Cached internally. */
@@ -767,18 +789,33 @@ export interface BoardStore {
 	resetToDefaultTool(): void;
 
 	getViewport(): Viewport;
+	/** Set the viewport instantly. Cancels any in-flight viewport animation. */
 	setViewport(viewport: Viewport): void;
 	panBy(dx: number, dy: number): void;
 	zoomTo(zoom: number, center: Point): void;
 	/**
+	 * Smoothly tween the viewport to `target` (the default for logic-driven
+	 * jumps/zoom). Falls back to an instant set when animation is disabled,
+	 * `prefers-reduced-motion` is set, no rAF is available (tests/SSR), or
+	 * `opts.animate === false`. A new call or any instant move cancels the
+	 * previous animation.
+	 */
+	animateViewportTo(target: Viewport, opts?: ViewportAnimationOptions): void;
+	/** Current viewport-animation config (defaults: enabled, 350ms, ease-in-out-cubic). */
+	getViewportAnimation(): ViewportAnimationConfig;
+	/** Update the viewport-animation config (partial merge). */
+	setViewportAnimation(config: Partial<ViewportAnimationConfig>): void;
+	/**
 	 * Center the viewport so that `bounds` fits within a rectangle of
 	 * `viewportSize` (in CSS pixels), leaving `padding` pixels on each side.
-	 * `bounds` is in world coordinates.
+	 * `bounds` is in world coordinates. Animates by default (see
+	 * {@link animateViewportTo}); pass `{ animate: false }` for an instant fit.
 	 */
 	fitToBounds(
 		bounds: BoundingBox,
 		viewportSize: { width: number; height: number },
 		padding?: number,
+		opts?: ViewportAnimationOptions,
 	): void;
 
 	getStyleSettings(): ShapeStyle;

--- a/packages/shared/src/utils/viewport.ts
+++ b/packages/shared/src/utils/viewport.ts
@@ -1,0 +1,100 @@
+// Shared, DOM-aware viewport helpers. These consolidate the "getViewport →
+// compute target → move" logic that plugins used to hand-roll (vim, whistle,
+// command-palette, keyboard zoom). They animate by default via
+// `store.animateViewportTo`, so every logic-driven jump/zoom is smooth.
+import type { Point, Viewport } from "../types/geometry.js";
+import type { BoardStore } from "../types/plugin.js";
+
+/** Ease-in-out cubic — the default viewport-animation easing. */
+export function easeInOutCubic(t: number): number {
+	return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+}
+
+/** Canvas pixel size (assumes a full-window canvas; falls back when no `window`). */
+export function getScreenSize(): { width: number; height: number } {
+	if (typeof window === "undefined") return { width: 1280, height: 720 };
+	return { width: window.innerWidth, height: window.innerHeight };
+}
+
+/** World coordinate currently at the screen centre. */
+export function screenCenterWorld(store: BoardStore): Point {
+	const { width, height } = getScreenSize();
+	const vp = store.getViewport();
+	return { x: (width / 2 - vp.x) / vp.zoom, y: (height / 2 - vp.y) / vp.zoom };
+}
+
+/** Shared move options passed through to `animateViewportTo`. */
+export interface ViewportMoveOptions {
+	animate?: boolean;
+	durationMs?: number;
+}
+
+/** Move so that world `point` sits at the screen centre (optionally re-zoom). */
+export function centerOnWorld(
+	store: BoardStore,
+	point: Point,
+	opts: ViewportMoveOptions & { zoom?: number } = {},
+): void {
+	const { width, height } = getScreenSize();
+	const zoom = opts.zoom ?? store.getViewport().zoom;
+	const target: Viewport = {
+		x: width / 2 - point.x * zoom,
+		y: height / 2 - point.y * zoom,
+		zoom,
+	};
+	store.animateViewportTo(target, opts);
+}
+
+/** Zoom to an absolute level about `center` (screen px; default screen centre). */
+export function zoomToLevel(
+	store: BoardStore,
+	zoom: number,
+	opts: ViewportMoveOptions & { center?: Point } = {},
+): void {
+	const { width, height } = getScreenSize();
+	const center = opts.center ?? { x: width / 2, y: height / 2 };
+	const vp = store.getViewport();
+	const clamped = Math.min(Math.max(zoom, 0.1), 10);
+	const scale = clamped / vp.zoom;
+	const target: Viewport = {
+		x: center.x - (center.x - vp.x) * scale,
+		y: center.y - (center.y - vp.y) * scale,
+		zoom: clamped,
+	};
+	store.animateViewportTo(target, opts);
+}
+
+/** Zoom by a multiplicative `factor` about `center` (default screen centre). */
+export function zoomBy(
+	store: BoardStore,
+	factor: number,
+	opts: ViewportMoveOptions & { center?: Point } = {},
+): void {
+	zoomToLevel(store, store.getViewport().zoom * factor, opts);
+}
+
+/** Fit all shapes into view (no-op when the board is empty). */
+export function fitContent(
+	store: BoardStore,
+	opts: ViewportMoveOptions & { padding?: number } = {},
+): void {
+	const shapes = store.getShapes();
+	if (shapes.size === 0) return;
+	let minX = Number.POSITIVE_INFINITY;
+	let minY = Number.POSITIVE_INFINITY;
+	let maxX = Number.NEGATIVE_INFINITY;
+	let maxY = Number.NEGATIVE_INFINITY;
+	for (const s of shapes.values()) {
+		minX = Math.min(minX, s.x);
+		minY = Math.min(minY, s.y);
+		maxX = Math.max(maxX, s.x + s.width);
+		maxY = Math.max(maxY, s.y + s.height);
+	}
+	const width = maxX - minX;
+	const height = maxY - minY;
+	if (width <= 0 || height <= 0) return;
+	store.fitToBounds({ x: minX, y: minY, width, height }, getScreenSize(), opts.padding ?? 40, {
+		animate: opts.animate,
+		durationMs: opts.durationMs,
+	});
+}

--- a/packages/store/src/__tests__/viewport-animation.test.ts
+++ b/packages/store/src/__tests__/viewport-animation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { createBoardStore } from "../board-store.js";
+
+describe("viewport animation config", () => {
+	it("defaults to enabled / 350ms", () => {
+		const store = createBoardStore();
+		const cfg = store.getViewportAnimation();
+		expect(cfg.enabled).toBe(true);
+		expect(cfg.durationMs).toBe(350);
+		expect(typeof cfg.easing).toBe("function");
+	});
+
+	it("honours createBoardStore overrides", () => {
+		const store = createBoardStore({ viewportAnimation: { durationMs: 100 } });
+		const cfg = store.getViewportAnimation();
+		expect(cfg.durationMs).toBe(100);
+		expect(cfg.enabled).toBe(true); // untouched fields keep defaults
+	});
+
+	it("setViewportAnimation merges partial config", () => {
+		const store = createBoardStore();
+		store.setViewportAnimation({ enabled: false });
+		expect(store.getViewportAnimation().enabled).toBe(false);
+		expect(store.getViewportAnimation().durationMs).toBe(350);
+	});
+});
+
+describe("animateViewportTo", () => {
+	it("commits instantly when animation is disabled", () => {
+		const store = createBoardStore({ viewportAnimation: { enabled: false } });
+		store.animateViewportTo({ x: 100, y: 200, zoom: 2 });
+		expect(store.getViewport()).toEqual({ x: 100, y: 200, zoom: 2 });
+	});
+
+	it("commits instantly when opts.animate === false", () => {
+		const store = createBoardStore();
+		store.animateViewportTo({ x: -50, y: 75, zoom: 0.5 }, { animate: false });
+		expect(store.getViewport()).toEqual({ x: -50, y: 75, zoom: 0.5 });
+	});
+
+	it("emits a viewport:changed mutation on commit", () => {
+		const store = createBoardStore({ viewportAnimation: { enabled: false } });
+		const types: string[] = [];
+		store.onMutation((e) => types.push(e.type));
+		store.animateViewportTo({ x: 1, y: 2, zoom: 1 }, { animate: false });
+		expect(types).toContain("viewport:changed");
+	});
+});
+
+describe("fitToBounds", () => {
+	it("centers bounds at the given zoom (instant variant)", () => {
+		const store = createBoardStore();
+		// 200x100 bounds fit into 1000x1000 minus 40px padding → zoom limited by width.
+		store.fitToBounds({ x: 0, y: 0, width: 200, height: 100 }, { width: 1000, height: 1000 }, 40, {
+			animate: false,
+		});
+		const vp = store.getViewport();
+		// availW=920 → zoom = 920/200 = 4.6; center (100,50) at screen centre (500,500).
+		expect(vp.zoom).toBeCloseTo(4.6, 5);
+		expect(vp.x).toBeCloseTo(500 - 100 * 4.6, 5);
+		expect(vp.y).toBeCloseTo(500 - 50 * 4.6, 5);
+	});
+});

--- a/packages/store/src/board-store.ts
+++ b/packages/store/src/board-store.ts
@@ -6,10 +6,13 @@ import type {
 	ShapeStyle,
 	StoreEvent,
 	Viewport,
+	ViewportAnimationConfig,
+	ViewportAnimationOptions,
 } from "@edv4h/usketch-shared";
 import {
 	compareZIndex,
 	DEFAULT_STYLE,
+	easeInOutCubic,
 	getRotatedAABB,
 	safeRotation,
 	zIndexBetween,
@@ -28,7 +31,12 @@ export interface BoardState {
 
 const INITIAL_DEFAULT_TOOL_ID = "select";
 
-export function createBoardStore(): BoardStore {
+export interface BoardStoreOptions {
+	/** Override the default smooth-viewport-animation behaviour (default: on). */
+	viewportAnimation?: Partial<ViewportAnimationConfig>;
+}
+
+export function createBoardStore(options: BoardStoreOptions = {}): BoardStore {
 	const state: BoardState = {
 		shapes: new Map(),
 		selection: new Set(),
@@ -82,6 +90,76 @@ export function createBoardStore(): BoardStore {
 		for (const listener of mutationListeners) {
 			listener(event);
 		}
+	}
+
+	// ── Viewport ─────────────────────────────────────────────────────────────
+	let viewportAnimation: ViewportAnimationConfig = {
+		enabled: options.viewportAnimation?.enabled ?? true,
+		durationMs: options.viewportAnimation?.durationMs ?? 350,
+		easing: options.viewportAnimation?.easing ?? easeInOutCubic,
+	};
+	let viewportRafId: number | null = null;
+
+	function cancelViewportAnimation() {
+		if (viewportRafId !== null && typeof cancelAnimationFrame !== "undefined") {
+			cancelAnimationFrame(viewportRafId);
+		}
+		viewportRafId = null;
+	}
+
+	/** Assign the viewport and fan out the usual change notifications. */
+	function commitViewport(viewport: Viewport) {
+		state.viewport = viewport;
+		notify();
+		notifyMutation({ type: "viewport:changed" });
+	}
+
+	function prefersReducedMotion(): boolean {
+		return (
+			typeof window !== "undefined" &&
+			typeof window.matchMedia === "function" &&
+			window.matchMedia("(prefers-reduced-motion: reduce)").matches
+		);
+	}
+
+	/** rAF tween to `target`, with instant fallback when animation can't/shouldn't run. */
+	function animateViewportTo(target: Viewport, opts?: ViewportAnimationOptions) {
+		cancelViewportAnimation();
+		const duration = opts?.durationMs ?? viewportAnimation.durationMs;
+		const animate = opts?.animate ?? viewportAnimation.enabled;
+		const from = state.viewport;
+		const near =
+			Math.abs(from.x - target.x) < 0.01 &&
+			Math.abs(from.y - target.y) < 0.01 &&
+			Math.abs(from.zoom - target.zoom) < 1e-4;
+		if (
+			!animate ||
+			near ||
+			duration <= 0 ||
+			typeof requestAnimationFrame === "undefined" ||
+			typeof performance === "undefined" ||
+			prefersReducedMotion()
+		) {
+			commitViewport(target);
+			return;
+		}
+		const easing = opts?.easing ?? viewportAnimation.easing;
+		const start = performance.now();
+		const step = (now: number) => {
+			const t = Math.min(1, (now - start) / duration);
+			const k = easing(t);
+			commitViewport({
+				x: from.x + (target.x - from.x) * k,
+				y: from.y + (target.y - from.y) * k,
+				zoom: from.zoom + (target.zoom - from.zoom) * k,
+			});
+			if (t < 1) {
+				viewportRafId = requestAnimationFrame(step);
+			} else {
+				viewportRafId = null;
+			}
+		};
+		viewportRafId = requestAnimationFrame(step);
 	}
 
 	function setActiveToolId(id: string) {
@@ -280,39 +358,48 @@ export function createBoardStore(): BoardStore {
 
 		getViewport: () => state.viewport,
 
+		// Instant setters cancel any in-flight animation so interaction wins.
 		setViewport(viewport: Viewport) {
-			state.viewport = viewport;
-			notify();
-			notifyMutation({ type: "viewport:changed" });
+			cancelViewportAnimation();
+			commitViewport(viewport);
 		},
 
 		panBy(dx: number, dy: number) {
-			state.viewport = {
+			cancelViewportAnimation();
+			commitViewport({
 				...state.viewport,
 				x: state.viewport.x + dx,
 				y: state.viewport.y + dy,
-			};
-			notify();
-			notifyMutation({ type: "viewport:changed" });
+			});
 		},
 
 		zoomTo(zoom: number, center: Point) {
+			cancelViewportAnimation();
 			const clampedZoom = Math.min(Math.max(zoom, 0.1), 10);
 			const oldZoom = state.viewport.zoom;
 			const scale = clampedZoom / oldZoom;
-			state.viewport = {
+			commitViewport({
 				x: center.x - (center.x - state.viewport.x) * scale,
 				y: center.y - (center.y - state.viewport.y) * scale,
 				zoom: clampedZoom,
+			});
+		},
+
+		animateViewportTo,
+		getViewportAnimation: () => ({ ...viewportAnimation }),
+		setViewportAnimation(config: Partial<ViewportAnimationConfig>) {
+			viewportAnimation = {
+				enabled: config.enabled ?? viewportAnimation.enabled,
+				durationMs: config.durationMs ?? viewportAnimation.durationMs,
+				easing: config.easing ?? viewportAnimation.easing,
 			};
-			notify();
-			notifyMutation({ type: "viewport:changed" });
 		},
 
 		fitToBounds(
 			bounds: BoundingBox,
 			viewportSize: { width: number; height: number },
 			padding = 40,
+			opts?: ViewportAnimationOptions,
 		) {
 			if (bounds.width <= 0 || bounds.height <= 0) return;
 			if (viewportSize.width <= 0 || viewportSize.height <= 0) return;
@@ -322,13 +409,15 @@ export function createBoardStore(): BoardStore {
 			const zoom = Math.min(Math.max(rawZoom, 0.1), 10);
 			const cx = bounds.x + bounds.width / 2;
 			const cy = bounds.y + bounds.height / 2;
-			state.viewport = {
-				x: viewportSize.width / 2 - cx * zoom,
-				y: viewportSize.height / 2 - cy * zoom,
-				zoom,
-			};
-			notify();
-			notifyMutation({ type: "viewport:changed" });
+			// Programmatic fit → animate by default (see animateViewportTo fallbacks).
+			animateViewportTo(
+				{
+					x: viewportSize.width / 2 - cx * zoom,
+					y: viewportSize.height / 2 - cy * zoom,
+					zoom,
+				},
+				opts,
+			);
 		},
 
 		getStyleSettings: () => state.styleSettings,

--- a/plugins/usketch-plugin-debug-hud/src/overlays/minimap.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/overlays/minimap.tsx
@@ -1,5 +1,5 @@
 import type { BoardStore, ShapeData, Viewport } from "@edv4h/usketch-shared";
-import { computeMinimap, type MinimapResult } from "@edv4h/usketch-shared";
+import { computeMinimap, type MinimapResult, zoomBy } from "@edv4h/usketch-shared";
 import { STOP_CANVAS_PROPAGATION } from "../stop-propagation.js";
 import {
 	ACCENT_DIM,
@@ -41,12 +41,9 @@ export function Minimap({ store, shapes, viewport, selection, offsetLeft = 8 }: 
 	});
 
 	// Zoom about the screen center, matching the old TopBar zoom controls.
-	const zoomAt = (factor: number) =>
-		store.zoomTo(viewport.zoom * factor, {
-			x: window.innerWidth / 2,
-			y: window.innerHeight / 2,
-		});
-	const resetZoom = () => store.setViewport({ x: 0, y: 0, zoom: 1 });
+	// Discrete button → smooth by default (shared helper animates).
+	const zoomAt = (factor: number) => zoomBy(store, factor);
+	const resetZoom = () => store.animateViewportTo({ x: 0, y: 0, zoom: 1 });
 
 	return (
 		<div

--- a/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
+++ b/plugins/usketch-plugin-debug-hud/src/panels/general-panel.tsx
@@ -78,7 +78,8 @@ export function GeneralPanel({
 		const y = Number.parseFloat(vpDraft.y);
 		const zoom = Number.parseFloat(vpDraft.zoom);
 		if (!Number.isNaN(x) && !Number.isNaN(y) && !Number.isNaN(zoom) && zoom > 0) {
-			store.setViewport({ x, y, zoom });
+			// Applying a typed viewport is a logic-driven jump → smooth by default.
+			store.animateViewportTo({ x, y, zoom });
 		}
 		setEditingViewport(false);
 	};

--- a/plugins/usketch-plugin-follow-me/src/plugin.tsx
+++ b/plugins/usketch-plugin-follow-me/src/plugin.tsx
@@ -1,4 +1,5 @@
 import type { PluginContext, UsketchPlugin } from "@edv4h/usketch-shared";
+import { centerOnWorld } from "@edv4h/usketch-shared";
 import type { WsProviderHandle } from "@edv4h/usketch-sync";
 
 function FollowBanner({ name }: { name: string }) {
@@ -138,15 +139,9 @@ export function createFollowMePlugin(options: FollowMePluginOptions): UsketchPlu
 					const vc = targetState.viewportCenter as { x: number; y: number } | undefined;
 					if (!vc || typeof vc.x !== "number" || typeof vc.y !== "number") return;
 
-					const viewport = ctx.store.getViewport();
-					const screenCenterX = window.innerWidth / 2;
-					const screenCenterY = window.innerHeight / 2;
-					const newX = screenCenterX - vc.x * viewport.zoom;
-					const newY = screenCenterY - vc.y * viewport.zoom;
-
-					if (viewport.x !== newX || viewport.y !== newY) {
-						ctx.store.setViewport({ ...viewport, x: newX, y: newY });
-					}
+					// Continuous follow → short tween so tracking stays responsive
+					// (each retarget cancels the previous animation).
+					centerOnWorld(ctx.store, vc, { durationMs: 180 });
 				}
 			}
 

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/command-palette.tsx
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/command-palette.tsx
@@ -1,4 +1,5 @@
 import type { BoardStore, LayerManager } from "@edv4h/usketch-shared";
+import { centerOnWorld } from "@edv4h/usketch-shared";
 import type { WsProviderHandle } from "@edv4h/usketch-sync";
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 
@@ -29,12 +30,7 @@ function getOnlineUsers(wsProvider: WsProviderHandle): OnlineUser[] {
 }
 
 function jumpToUser(store: BoardStore, vc: { x: number; y: number }): void {
-	const vp = store.getViewport();
-	store.setViewport({
-		...vp,
-		x: window.innerWidth / 2 - vc.x * vp.zoom,
-		y: window.innerHeight / 2 - vc.y * vp.zoom,
-	});
+	centerOnWorld(store, vc);
 }
 
 function CommandPaletteUI({

--- a/plugins/usketch-plugin-keyboard-shortcuts/src/zoom.ts
+++ b/plugins/usketch-plugin-keyboard-shortcuts/src/zoom.ts
@@ -1,56 +1,21 @@
 import type { BoardStore } from "@edv4h/usketch-shared";
+import { fitContent, zoomBy, zoomToLevel } from "@edv4h/usketch-shared";
 
 const ZOOM_STEP = 1.2;
-const FIT_PADDING = 0.9;
 
-function screenCenter(): { x: number; y: number } {
-	return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
-}
-
+// Keyboard zoom is logic-driven → smooth by default (the shared helpers animate).
 export function zoomIn(store: BoardStore): void {
-	const vp = store.getViewport();
-	store.zoomTo(vp.zoom * ZOOM_STEP, screenCenter());
+	zoomBy(store, ZOOM_STEP);
 }
 
 export function zoomOut(store: BoardStore): void {
-	const vp = store.getViewport();
-	store.zoomTo(vp.zoom / ZOOM_STEP, screenCenter());
+	zoomBy(store, 1 / ZOOM_STEP);
 }
 
 export function zoomReset(store: BoardStore): void {
-	store.zoomTo(1, screenCenter());
+	zoomToLevel(store, 1);
 }
 
 export function zoomFit(store: BoardStore): void {
-	const shapes = store.getShapes();
-	if (shapes.size === 0) return;
-
-	let minX = Infinity;
-	let minY = Infinity;
-	let maxX = -Infinity;
-	let maxY = -Infinity;
-
-	for (const shape of shapes.values()) {
-		minX = Math.min(minX, shape.x);
-		minY = Math.min(minY, shape.y);
-		maxX = Math.max(maxX, shape.x + shape.width);
-		maxY = Math.max(maxY, shape.y + shape.height);
-	}
-
-	const contentW = maxX - minX;
-	const contentH = maxY - minY;
-	if (contentW <= 0 || contentH <= 0) return;
-
-	const rawZoom =
-		Math.min(window.innerWidth / contentW, window.innerHeight / contentH) * FIT_PADDING;
-	const zoom = Math.min(10, Math.max(0.1, rawZoom));
-
-	const cx = (minX + maxX) / 2;
-	const cy = (minY + maxY) / 2;
-
-	store.setViewport({
-		x: window.innerWidth / 2 - cx * zoom,
-		y: window.innerHeight / 2 - cy * zoom,
-		zoom,
-	});
+	fitContent(store);
 }

--- a/plugins/usketch-plugin-tool-vim/src/viewport-utils.ts
+++ b/plugins/usketch-plugin-tool-vim/src/viewport-utils.ts
@@ -1,28 +1,12 @@
+// Vim viewport helpers now delegate to the shared, animated viewport utilities
+// so jumps are smooth by default. Kept as thin wrappers to avoid churn at call
+// sites within the vim plugin.
 import type { BoardStore, Point } from "@edv4h/usketch-shared";
+import { centerOnWorld, getScreenSize, screenCenterWorld } from "@edv4h/usketch-shared";
 
-/** ビューポート（キャンバス）のサイズ。テスト等で window が無い場合は既定値。 */
-export function getScreenSize(): { width: number; height: number } {
-	if (typeof window === "undefined") return { width: 1280, height: 720 };
-	return { width: window.innerWidth, height: window.innerHeight };
-}
+export { getScreenSize, screenCenterWorld };
 
-/** 画面中央に対応する world 座標。 */
-export function screenCenterWorld(store: BoardStore): Point {
-	const { width, height } = getScreenSize();
-	const vp = store.getViewport();
-	return {
-		x: (width / 2 - vp.x) / vp.zoom,
-		y: (height / 2 - vp.y) / vp.zoom,
-	};
-}
-
-/** world 座標 `target` が画面中央に来るようビューポートを移動する。 */
+/** world 座標 `target` が画面中央に来るようビューポートを移動する（スムーズ）。 */
 export function centerViewportOn(store: BoardStore, target: Point): void {
-	const { width, height } = getScreenSize();
-	const vp = store.getViewport();
-	store.setViewport({
-		x: width / 2 - target.x * vp.zoom,
-		y: height / 2 - target.y * vp.zoom,
-		zoom: vp.zoom,
-	});
+	centerOnWorld(store, target);
 }

--- a/plugins/usketch-plugin-whistle/src/plugin.tsx
+++ b/plugins/usketch-plugin-whistle/src/plugin.tsx
@@ -1,4 +1,5 @@
 import {
+	centerOnWorld,
 	generateId,
 	type PluginContext,
 	type TransientObject,
@@ -206,12 +207,8 @@ function WhistleIndicatorLayer({
 
 	const handleJump = useCallback(
 		(worldX: number, worldY: number) => {
-			const vp = store.getViewport();
-			store.setViewport({
-				...vp,
-				x: window.innerWidth / 2 - worldX * vp.zoom,
-				y: window.innerHeight / 2 - worldY * vp.zoom,
-			});
+			// Jump to an off-screen whistler → smooth by default.
+			centerOnWorld(store, { x: worldX, y: worldY });
 		},
 		[store],
 	);


### PR DESCRIPTION
## Summary

プログラム（ロジック）で画面倍率を変えたり特定位置へジャンプする際、一瞬で飛ぶのではなく**スムーズにアニメーション**するようにし、**デフォルト ON** にしました。連続的なインタラクション（ホイールズーム・ドラッグパン・ミニマップドラッグ）は従来どおり即時です。

あわせて、各プラグインが個別に実装していた「`getViewport` → 座標計算 → `setViewport`」のジャンプ処理を**共通 API に集約**しました。

### store（アニメ基盤）
- `animateViewportTo(target, opts?)` を追加。rAF による eased 補間（x/y/zoom）。
- **即時フォールバック**: 無効時 / `opts.animate === false` / `prefers-reduced-motion` / rAF・performance 不在（テスト/SSR）/ 目標が現在とほぼ同じ。
- **割り込み**: `setViewport` / `panBy` / `zoomTo` は実行中アニメを cancel（インタラクション優先）。
- `fitToBounds` は既定でアニメ化（`{ animate: false }` で即時）。
- 設定: `createBoardStore({ viewportAnimation })` ＋ `setViewportAnimation` / `getViewportAnimation`（既定: 有効・350ms・ease-in-out-cubic）。

### shared（共通 helper）
`packages/shared/src/utils/viewport.ts` に集約（すべて既定でアニメ）:
`centerOnWorld` / `zoomBy` / `zoomToLevel` / `fitContent` / `screenCenterWorld` / `getScreenSize` / `easeInOutCubic`。

### 移行（自前計算を削除）
- keyboard-shortcuts `zoom.ts`（+/−/リセット/fit）、`command-palette` ユーザージャンプ
- tool-vim `viewport-utils`（`centerViewportOn` 等を shared へ委譲）
- whistle ジャンプ、follow-me（追従は 180ms の短めアニメ）
- debug-hud: viewport 適用・ミニマップのズーム/リセットボタン（ミニマップ**ドラッグは即時のまま**）
- **即時維持**: viewport-nav（ホイール/パン）

## Test plan
- [x] store 89 / shared 96 tests green（新規: `animateViewportTo` の即時フォールバック・設定・`fitToBounds` 数値、helper の `centerOnWorld`/`zoomBy`/`fitContent` 計算）
- [x] 6プラグイン＋store/shared の typecheck/build、web typecheck/build、`biome --diagnostic-level=error`（error 0）
- 手動: whistle/コマンドパレットのジャンプ・キーボード `+/−/0`・zoom-fit・vim ジャンプが滑らか、ホイール/ドラッグ/ミニマップドラッグは即時、OS「視差効果を減らす」で即時

🤖 Generated with [Claude Code](https://claude.com/claude-code)