### PR TITLE
✨ feat(map): 「アクティブ拠点を削除」アクションを追加

### DIFF
--- a/.changeset/base-delete-action.md
+++ b/.changeset/base-delete-action.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-map": minor
+---
+
+拠点をレジストリごと削除する「アクティブ拠点を削除」アクションを HUD に追加。アクティブ拠点を選んで実行すると、その拠点が一覧から消え領地も消える（ビーコンアイコンの `meta.baseId` も解除、アイコン自体は残す）。undo 可能。`deleteBase(deps, baseId)` を base-ops に追加。

--- a/plugins/usketch-plugin-map/src/__tests__/base-ops.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/base-ops.test.ts
@@ -1,6 +1,7 @@
+import type { BoardStore, Command, CommandRegistry, ShapeData } from "@edv4h/usketch-shared";
 import { describe, expect, it } from "vitest";
 import type { BaseInfo } from "../base/base-map-shape.js";
-import { baseIdAtWorld, baseRegionAnchors } from "../base/base-ops.js";
+import { baseIdAtWorld, baseRegionAnchors, deleteBase } from "../base/base-ops.js";
 import type { Territory } from "../base/territory.js";
 
 describe("baseIdAtWorld", () => {
@@ -32,5 +33,69 @@ describe("baseRegionAnchors", () => {
 	it("skips bases with no owned cells and unknown base ids", () => {
 		const territory: Territory = { "0,0": "ghost" }; // base not in registry
 		expect(baseRegionAnchors(territory, bases, 40)).toEqual([]);
+	});
+});
+
+describe("deleteBase", () => {
+	function harness() {
+		const shapes = new Map<string, ShapeData>();
+		shapes.set("bm", {
+			id: "bm",
+			type: "base-map",
+			tile: 40,
+			bases: {
+				b1: { name: "B1", color: "#f00", radius: 5, beaconIconId: "i1" },
+				b2: { name: "B2", color: "#00f", radius: 5 },
+			},
+		} as unknown as ShapeData);
+		shapes.set("i1", {
+			id: "i1",
+			type: "map-icon",
+			x: 0,
+			y: 0,
+			width: 40,
+			height: 40,
+			meta: { iconKey: "town", category: "landmark", baseId: "b1" },
+		} as unknown as ShapeData);
+		let last: Command | null = null;
+		const store = {
+			getShapes: () => shapes,
+			getShape: (id: string) => shapes.get(id),
+			updateShape: (id: string, patch: Partial<ShapeData>) => {
+				const s = shapes.get(id);
+				if (s) shapes.set(id, { ...s, ...patch });
+			},
+		} as unknown as BoardStore;
+		const commands = {
+			execute: (c: Command) => {
+				last = c;
+				c.execute();
+			},
+		} as unknown as CommandRegistry;
+		return { shapes, store, commands, getLast: () => last };
+	}
+
+	it("removes the base and clears its beacon icon's baseId; undo restores", () => {
+		const h = harness();
+		deleteBase({ store: h.store, commands: h.commands, tile: 40 }, "b1");
+		expect(Object.keys((h.shapes.get("bm") as { bases: object }).bases)).toEqual(["b2"]);
+		expect((h.shapes.get("i1") as { meta: { baseId?: string } }).meta.baseId).toBeUndefined();
+
+		h.getLast()?.undo();
+		expect(Object.keys((h.shapes.get("bm") as { bases: object }).bases).sort()).toEqual([
+			"b1",
+			"b2",
+		]);
+		expect((h.shapes.get("i1") as { meta: { baseId?: string } }).meta.baseId).toBe("b1");
+	});
+
+	it("is a no-op when the base does not exist", () => {
+		const h = harness();
+		deleteBase({ store: h.store, commands: h.commands, tile: 40 }, "ghost");
+		expect(h.getLast()).toBeNull();
+		expect(Object.keys((h.shapes.get("bm") as { bases: object }).bases).sort()).toEqual([
+			"b1",
+			"b2",
+		]);
 	});
 });

--- a/plugins/usketch-plugin-map/src/base/base-ops.ts
+++ b/plugins/usketch-plugin-map/src/base/base-ops.ts
@@ -168,3 +168,46 @@ export function setBeacon(deps: BaseDeps, iconId: string, baseId: string): void 
 	};
 	deps.commands.execute(command);
 }
+
+/**
+ * Remove a base from the registry (its derived territory disappears). Also clears
+ * `meta.baseId` on the base's beacon icon, if any — the icon itself is kept.
+ * Undoable. No-op if the base doesn't exist.
+ */
+export function deleteBase(deps: BaseDeps, baseId: string): void {
+	const { id } = resolveBaseMap(deps.store, deps.tile);
+	const shape = deps.store.getShape(id) as BaseMapShapeData | undefined;
+	const base = shape?.bases[baseId];
+	if (!shape || !base) return;
+
+	const prevBases = shape.bases;
+	const nextBases: Record<string, BaseInfo> = {};
+	for (const [bid, info] of Object.entries(prevBases)) {
+		if (bid !== baseId) nextBases[bid] = info;
+	}
+
+	const edits: { id: string; prev: MapIconShapeData["meta"]; next: MapIconShapeData["meta"] }[] =
+		[];
+	if (base.beaconIconId) {
+		const icon = deps.store.getShape(base.beaconIconId) as MapIconShapeData | undefined;
+		if (icon && icon.type === MAP_ICON_TYPE) {
+			edits.push({
+				id: base.beaconIconId,
+				prev: icon.meta,
+				next: { ...icon.meta, baseId: undefined },
+			});
+		}
+	}
+
+	const command: Command = {
+		execute: () => {
+			deps.store.updateShape(id, { bases: nextBases } as Partial<ShapeData>);
+			for (const e of edits) deps.store.updateShape(e.id, { meta: e.next } as Partial<ShapeData>);
+		},
+		undo: () => {
+			deps.store.updateShape(id, { bases: prevBases } as Partial<ShapeData>);
+			for (const e of edits) deps.store.updateShape(e.id, { meta: e.prev } as Partial<ShapeData>);
+		},
+	};
+	deps.commands.execute(command);
+}

--- a/plugins/usketch-plugin-map/src/hud/register-map-hud.ts
+++ b/plugins/usketch-plugin-map/src/hud/register-map-hud.ts
@@ -4,7 +4,7 @@
 import type { ActionParam, PluginContext, ShapeData } from "@edv4h/usketch-shared";
 import type { CellBox } from "../autotile.js";
 import { type BaseMapShapeData, DEFAULT_BASE_RADIUS } from "../base/base-map-shape.js";
-import { createBase, getBaseMap, resolveBaseMap } from "../base/base-ops.js";
+import { createBase, deleteBase, getBaseMap, resolveBaseMap } from "../base/base-ops.js";
 import { baseStateStore } from "../base/base-state.js";
 import { genStateStore } from "../gen-state.js";
 import { generateIntoBox, viewportCellBox } from "../generate.js";
@@ -180,6 +180,24 @@ export function registerMapHud(ctx: PluginContext, tile: number): () => void {
 				const name = String(args.name ?? "").trim() || `拠点${count + 1}`;
 				const id = createBase(deps, name, String(args.color ?? "#EF5350"));
 				baseStateStore.set({ activeBaseId: id });
+			},
+		}),
+	);
+	offs.push(
+		ctx.actions.register({
+			id: "map:base-delete",
+			group: "拠点",
+			label: "アクティブ拠点を削除",
+			isEnabled: () => {
+				const active = baseStateStore.get().activeBaseId;
+				return !!active && !!getBaseMap(ctx.store)?.bases[active];
+			},
+			run: () => {
+				const active = baseStateStore.get().activeBaseId;
+				if (!active) return;
+				deleteBase(deps, active);
+				const remaining = Object.keys(getBaseMap(ctx.store)?.bases ?? {});
+				baseStateStore.set({ activeBaseId: remaining[0] ?? null });
 			},
 		}),
 	);


### PR DESCRIPTION
## Summary

拠点をレジストリごと削除する手段が無かったため、HUD に **「アクティブ拠点を削除」** アクションを追加しました（拠点グループ）。

- アクティブ拠点を選んで実行 → その拠点が「拠点: アクティブ」一覧から消え、派生テリトリーも消える。
- ビーコンアイコンの `meta.baseId` を解除（**アイコン自体は残す**）。
- undo 可能。削除後はアクティブ拠点を残りの拠点（無ければ null）に切替。
- `isEnabled`: アクティブ拠点が存在するときのみ。

コア: `deleteBase(deps, baseId)` を `base/base-ops.ts` に追加。

### 補足（既存の消し方）
- ビーコンだけ消したい: **消しゴムモードでビーコンのアイコンをクリック** → アイコン削除で領地は消えるが拠点エントリは残る。
- 拠点ごと消したい: 本アクション。

## Test plan
- [x] `deleteBase` 単体テスト2件（削除＋icon meta 解除＋undo / 存在しない拠点は no-op）— map 70 tests green
- [x] map typecheck/build、web typecheck、`biome --diagnostic-level=error`（error 0）
- 手動: 拠点作成→アクティブ→「アクティブ拠点を削除」で一覧・領地から消える、undo で戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)