### PR TITLE
fix(tool-helpers): attachable children (stickers/kimochi) stay selectable under a non-container parent

### DIFF
--- a/.changeset/attachable-child-selectable.md
+++ b/.changeset/attachable-child-selectable.md
@@ -1,0 +1,7 @@
+---
+"@edv4h/usketch-tool-helpers": patch
+---
+
+attachable な子 (sticker / kimochi 等) を、貼り付き先が非コンテナでも単独で選択できるようにする。
+
+`findShapeAtPoint` / marquee は、親を持つ shape のクリック/範囲選択時に「親が container.selectableChildren を宣言していなければ最上位祖先を返す」設計だった。attachable な子は overlap で貼り付くだけで grouping ではないため、非コンテナ (付箋・テキスト等) に貼ると親が選択され、子を掴んで剥がせなかった。attachable な子はヒットした子自身を返すよう修正 (frame/island の selectableChildren や group の祖先解決は不変)。

--- a/packages/usketch-tool-helpers/src/__tests__/hover.test.ts
+++ b/packages/usketch-tool-helpers/src/__tests__/hover.test.ts
@@ -129,6 +129,41 @@ describe("findShapeAtPoint", () => {
 		expect(findShapeAtPoint(ctx, { x: 20, y: 20 })).toBe("g");
 	});
 
+	it("keeps an attachable child selectable under a non-container parent", () => {
+		// Stickers/kimochi attach by overlap (attachable) but must stay
+		// independently selectable so they can be peeled off — unlike group
+		// members, they do NOT resolve to the parent.
+		const ctx = createTestToolContext();
+		ctx.shapes.register("sticker", {
+			type: "sticker",
+			minSize: { width: 1, height: 1 },
+			hitTest: (data, point) =>
+				point.x >= data.x &&
+				point.x <= data.x + data.width &&
+				point.y >= data.y &&
+				point.y <= data.y + data.height,
+			getBounds: (data) => ({ x: data.x, y: data.y, width: data.width, height: data.height }),
+			render: () => null,
+			attachable: { follow: true },
+		} as unknown as ShapeDefinition);
+		// Parent is a plain rect (a non-container the sticker was stuck onto).
+		ctx.store.addShape(
+			makeShape({ id: "note", type: "rect", x: 0, y: 0, width: 200, height: 200 }),
+		);
+		ctx.store.addShape(
+			makeShape({
+				id: "sticker",
+				type: "sticker",
+				x: 10,
+				y: 10,
+				width: 50,
+				height: 50,
+				parentId: "note",
+			}),
+		);
+		expect(findShapeAtPoint(ctx, { x: 20, y: 20 })).toBe("sticker");
+	});
+
 	it("honors a per-instance selectableChildren predicate on a custom type", () => {
 		// A single "wireframe" type whose meta.component === "card" is a container
 		// with selectable children; other components are plain shapes.

--- a/packages/usketch-tool-helpers/src/__tests__/marquee.test.ts
+++ b/packages/usketch-tool-helpers/src/__tests__/marquee.test.ts
@@ -1,3 +1,4 @@
+import type { ShapeDefinition } from "@edv4h/usketch-shared";
 import { describe, expect, it } from "vitest";
 import { boxContains, boxesIntersect, startMarqueeSession } from "../marquee.js";
 import { createTestToolContext, makePointerEvent, makeShape } from "./test-helpers.js";
@@ -42,6 +43,40 @@ describe("startMarqueeSession", () => {
 		const session = startMarqueeSession({ ctx, startWorldPoint: { x: -10, y: -10 } });
 		const u = session.update(makePointerEvent({ x: 100, y: 100 }));
 		expect([...u.hitIds]).toEqual(["normal"]);
+	});
+
+	it("selects an attachable child individually, not its parent", () => {
+		const ctx = createTestToolContext();
+		ctx.shapes.register("sticker", {
+			type: "sticker",
+			minSize: { width: 1, height: 1 },
+			hitTest: (data, point) =>
+				point.x >= data.x &&
+				point.x <= data.x + data.width &&
+				point.y >= data.y &&
+				point.y <= data.y + data.height,
+			getBounds: (data) => ({ x: data.x, y: data.y, width: data.width, height: data.height }),
+			render: () => null,
+			attachable: { follow: true },
+		} as unknown as ShapeDefinition);
+		ctx.store.addShape(
+			makeShape({ id: "note", type: "rect", x: 0, y: 0, width: 100, height: 100 }),
+		);
+		ctx.store.addShape(
+			makeShape({
+				id: "sticker",
+				type: "sticker",
+				x: 10,
+				y: 10,
+				width: 30,
+				height: 30,
+				parentId: "note",
+			}),
+		);
+		const session = startMarqueeSession({ ctx, startWorldPoint: { x: 5, y: 5 } });
+		const u = session.update(makePointerEvent({ x: 60, y: 60 }));
+		// The sticker resolves to itself (attachable), not to its "note" parent.
+		expect(u.hitIds.has("sticker")).toBe(true);
 	});
 
 	it("commit() returns null for tiny accidental drags below minDragDistance", () => {

--- a/packages/usketch-tool-helpers/src/hover.ts
+++ b/packages/usketch-tool-helpers/src/hover.ts
@@ -8,7 +8,7 @@ import type {
 	ToolContext,
 	Viewport,
 } from "@edv4h/usketch-shared";
-import { hasSelectableChildren, safeRotation } from "@edv4h/usketch-shared";
+import { hasSelectableChildren, isAttachable, safeRotation } from "@edv4h/usketch-shared";
 import {
 	getTopLevelAncestor,
 	isEffectivelyHidden,
@@ -184,6 +184,13 @@ export function findShapeAtPoint(
 		if (typeof data.parentId === "string") {
 			const parent = ctx.store.getShape(data.parentId);
 			if (parent && hasSelectableChildren(ctx.shapes.get(parent.type), parent)) {
+				return id;
+			}
+			// Attachable children (e.g. stickers, kimochi) stick to a shape by
+			// overlap but stay independently selectable — you must be able to grab
+			// and peel them off. They are not "grouped" into the parent, so resolve
+			// to the hit child itself rather than the top-level ancestor.
+			if (isAttachable(def, data)) {
 				return id;
 			}
 			// The resolved ancestor — not the hit child — is what we return, so it

--- a/packages/usketch-tool-helpers/src/marquee.ts
+++ b/packages/usketch-tool-helpers/src/marquee.ts
@@ -1,5 +1,5 @@
 import type { BoundingBox, CanvasPointerEvent, Point, ToolContext } from "@edv4h/usketch-shared";
-import { hasSelectableChildren } from "@edv4h/usketch-shared";
+import { hasSelectableChildren, isAttachable } from "@edv4h/usketch-shared";
 import {
 	getTopLevelAncestor,
 	isEffectivelyHidden,
@@ -128,6 +128,10 @@ export function findShapesInRect(
 		if (typeof data.parentId === "string") {
 			const parent = ctx.store.getShape(data.parentId);
 			if (parent && hasSelectableChildren(ctx.shapes.get(parent.type), parent)) {
+				ids.add(id);
+			} else if (isAttachable(def, data)) {
+				// Attachable children (stickers/kimochi) stay independently
+				// selectable rather than resolving to the parent (see hover.ts).
 				ids.add(id);
 			} else {
 				const ancestor = getTopLevelAncestor(ctx.store, id);


### PR DESCRIPTION
## Problem

Stickers (and kimochi) attach to any shape by overlap via `attachable.follow`. But once a sticker was stuck onto a **non-container** shape (a sticky note, text, basic shape, …), it became **impossible to select or drag — so you could never peel it off**. Clicking the sticker selected its parent instead.

Root cause: `findShapeAtPoint` (and the marquee collector) resolve a hit child that has a `parentId` to its **top-level ancestor** unless the parent is a container with `selectableChildren` (frame/island). That rule is right for *group members*, but an `attachable` child is not "grouped" into its parent — it's a stick-on decoration that must stay independently selectable.

## Fix

In both `findShapeAtPoint` (hover.ts) and the marquee collector (marquee.ts), return the hit child itself when it is `attachable` (`isAttachable(def, data)`), before falling back to ancestor resolution.

- frame/island `container.selectableChildren` → unchanged (child already returned).
- group members (non-attachable, container without `selectableChildren`) → still resolve to the group ancestor.
- attachable children (stickers/kimochi) on any parent → now selectable/peelable.

## Test plan
- [x] `pnpm --filter @edv4h/usketch-tool-helpers build`
- [x] `pnpm --filter @edv4h/usketch-tool-helpers test` (50 pass; +2 new: hover + marquee attachable-child cases)
- [x] `biome check` clean
- [ ] Manual: stick a sticker onto a sticky note, then click/drag the sticker → it selects and moves independently; drag it off → it detaches.

Changeset: `@edv4h/usketch-tool-helpers` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)