### PR TITLE
✨ feat(markdown-to-shape): mermaid sequenceDiagram コンバータ (closes #860)

### DIFF
--- a/.changeset/mermaid-sequence-converter.md
+++ b/.changeset/mermaid-sequence-converter.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-markdown-to-shape": minor
+---
+
+mermaid `sequenceDiagram` コンバータ `createMermaidSequenceConverter` を追加（#860）。参加者（participant/actor、`as` エイリアス対応・暗黙宣言は初出順）を上部のボックス＋ライフラインに、メッセージ（`->` `-->` `->>` `-->>` `-)` `-x` など）をライフライン間の水平コネクタ（ラベル付き・矢印は target 向き）に分解する。フローチャートより高い order で登録され sequenceDiagram を優先的に処理。activate/note/loop 等のブロックは現状スキップ（フェーズ1: 参加者＋メッセージ）。返信線の破線はシェイプモデルに dash が無いため実線で描画。

--- a/apps/web/src/plugins/markdown-adapters.ts
+++ b/apps/web/src/plugins/markdown-adapters.ts
@@ -1,5 +1,6 @@
 import {
 	createMermaidFlowchartConverter,
+	createMermaidSequenceConverter,
 	getMarkdownConverters,
 	mdastText,
 	nodeSource,
@@ -93,6 +94,7 @@ export function createMarkdownAdaptersPlugin(): UsketchPlugin {
 				listToText,
 				blockquoteToText,
 				createMermaidFlowchartConverter(),
+				createMermaidSequenceConverter(),
 			].map((c) => registry.register(c));
 			return () => {
 				for (const off of offs) off();

--- a/plugins/usketch-plugin-markdown-to-shape/src/__tests__/mermaid-sequence.test.ts
+++ b/plugins/usketch-plugin-markdown-to-shape/src/__tests__/mermaid-sequence.test.ts
@@ -1,0 +1,110 @@
+import type { MarkdownConverterContext, MarkdownNode, ShapeRegistry } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import {
+	createMermaidSequenceConverter,
+	isSequenceDiagram,
+	parseSequence,
+} from "../mermaid-sequence.js";
+
+describe("parseSequence", () => {
+	it("returns null for non-sequence diagrams", () => {
+		expect(parseSequence("flowchart TD\nA-->B")).toBeNull();
+		expect(parseSequence("")).toBeNull();
+	});
+
+	it("parses explicit participants (with `as` aliases) and messages", () => {
+		const seq = parseSequence(
+			"sequenceDiagram\nparticipant U as User\nparticipant W as weboard\nU->>W: click\nW-->>U: reply",
+		);
+		expect(seq?.participants).toEqual([
+			{ id: "U", label: "User" },
+			{ id: "W", label: "weboard" },
+		]);
+		expect(seq?.messages).toEqual([
+			{ from: "U", to: "W", text: "click", dashed: false },
+			{ from: "W", to: "U", text: "reply", dashed: true }, // `-->>` = dashed
+		]);
+	});
+
+	it("registers implicit participants in first-appearance order", () => {
+		const seq = parseSequence("sequenceDiagram\nAlice->>Bob: hi\nBob->>Charlie: hey");
+		expect(seq?.participants.map((p) => p.id)).toEqual(["Alice", "Bob", "Charlie"]);
+		expect(seq?.participants.every((p) => p.label === p.id)).toBe(true);
+	});
+
+	it("supports the arrow variants and skips block/decoration lines", () => {
+		const seq = parseSequence(
+			[
+				"sequenceDiagram",
+				"autonumber",
+				"A->B: solid-open",
+				"A-)B: async",
+				"A-xB: cross",
+				"loop every minute",
+				"A->>B: inside-loop",
+				"end",
+				"note over A: ignored",
+			].join("\n"),
+		);
+		expect(seq?.messages.map((m) => m.text)).toEqual([
+			"solid-open",
+			"async",
+			"cross",
+			"inside-loop",
+		]);
+	});
+});
+
+describe("isSequenceDiagram", () => {
+	it("detects the header (ignoring comments/blank lines)", () => {
+		expect(isSequenceDiagram("%% c\n\nsequenceDiagram\nA->>B: x")).toBe(true);
+		expect(isSequenceDiagram("flowchart TD\nA-->B")).toBe(false);
+	});
+});
+
+describe("createMermaidSequenceConverter", () => {
+	const converter = createMermaidSequenceConverter();
+	const ctx: MarkdownConverterContext = {
+		source: "",
+		shapes: {} as ShapeRegistry,
+		origin: { x: 100, y: 50 },
+	};
+	const codeNode = (value: string, lang = "mermaid"): MarkdownNode =>
+		({ type: "code", lang, value }) as unknown as MarkdownNode;
+
+	it("only matches mermaid sequence diagrams", () => {
+		expect(converter.match?.(codeNode("sequenceDiagram\nA->>B: x"))).toBe(true);
+		expect(converter.match?.(codeNode("flowchart TD\nA-->B"))).toBe(false);
+		expect(converter.match?.(codeNode("sequenceDiagram\nA->>B: x", "js"))).toBe(false);
+	});
+
+	it("emits a box + lifeline per participant and a connector per message", () => {
+		const specs = converter.convert(codeNode("sequenceDiagram\nA->>B: hello\nB-->>A: hi"), ctx);
+		const rects = specs.filter((s) => s.type === "rectangle");
+		const connectors = specs.filter((s) => s.type === "connector");
+		expect(rects).toHaveLength(2); // A, B
+		expect(rects.map((r) => r.text).sort()).toEqual(["A", "B"]);
+		// 2 lifelines + 2 messages.
+		expect(connectors).toHaveLength(4);
+		const messages = connectors.filter((c) => typeof c.label === "string");
+		expect(messages.map((m) => m.label)).toEqual(["hello", "hi"]);
+		// Messages are horizontal (same source/target Y) with a forward arrow.
+		for (const m of messages) {
+			const sp = m.sourcePoint as { y: number };
+			const tp = m.targetPoint as { y: number };
+			expect(sp.y).toBe(tp.y);
+			expect(m.arrowHead).toBe("forward");
+		}
+		// Lifelines are vertical, no arrowhead.
+		const lifelines = connectors.filter((c) => c.arrowHead === "none");
+		expect(lifelines).toHaveLength(2);
+		expect(specs.every((s) => typeof s.id === "string")).toBe(true);
+	});
+
+	it("falls back to a markdown shape for an empty diagram", () => {
+		const specs = converter.convert(codeNode("sequenceDiagram\nnote over X: hi"), ctx);
+		// `note` is skipped and X is never introduced by a message → no participants.
+		expect(specs).toHaveLength(1);
+		expect(specs[0].type).toBe("markdown");
+	});
+});

--- a/plugins/usketch-plugin-markdown-to-shape/src/index.ts
+++ b/plugins/usketch-plugin-markdown-to-shape/src/index.ts
@@ -9,5 +9,13 @@ export {
 	type Flowchart,
 	parseFlowchart,
 } from "./mermaid-flowchart.js";
+export {
+	createMermaidSequenceConverter,
+	isSequenceDiagram,
+	parseSequence,
+	type SeqMessage,
+	type SeqParticipant,
+	type Sequence,
+} from "./mermaid-sequence.js";
 export { convertMarkdownToShapes } from "./orchestrator.js";
 export { createMarkdownToShapePlugin } from "./plugin.js";

--- a/plugins/usketch-plugin-markdown-to-shape/src/mermaid-sequence.ts
+++ b/plugins/usketch-plugin-markdown-to-shape/src/mermaid-sequence.ts
@@ -1,0 +1,221 @@
+import {
+	generateId,
+	type MarkdownConverter,
+	type MarkdownNode,
+	type MarkdownShapeSpec,
+} from "@edv4h/usketch-shared";
+import { nodeSource } from "./mdast.js";
+
+// ── Sequence-diagram parsing ──────────────────────────────────────────────────
+
+export interface SeqParticipant {
+	id: string;
+	label: string;
+}
+export interface SeqMessage {
+	from: string;
+	to: string;
+	text: string;
+	/** `-->`/`-->>` (reply) style. Rendered solid for now — the shape model has no
+	 *  dash — but kept so callers/tests can distinguish. */
+	dashed: boolean;
+}
+export interface Sequence {
+	participants: SeqParticipant[];
+	messages: SeqMessage[];
+}
+
+/** Lines that introduce blocks/decorations we don't model yet — skipped. */
+const SKIP =
+	/^(activate|deactivate|note|loop|alt|opt|else|end|par|and|rect|critical|break|autonumber|title|link|links|box|create|destroy)\b/i;
+// `A->>B: text` — dash(es) + arrow head + target + `: message`.
+const MESSAGE = /^(.+?)\s*(-{1,2})(>>|>|\)|x)\s*(.+?)\s*:\s*(.*)$/;
+// `participant Alice` or `participant A as Alice` (also `actor`).
+const PARTICIPANT = /^(?:participant|actor)\s+(\S+)(?:\s+as\s+(.+))?$/i;
+
+function meaningfulLines(code: string): string[] {
+	return code
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l.length > 0 && !l.startsWith("%%"));
+}
+
+/** Cheap check: is this mermaid block a `sequenceDiagram`? */
+export function isSequenceDiagram(code: string): boolean {
+	const lines = meaningfulLines(code);
+	return lines.length > 0 && /^sequenceDiagram\b/i.test(lines[0]);
+}
+
+/**
+ * Parse a (subset of) mermaid `sequenceDiagram` source into participants +
+ * messages. Participants are ordered by declaration, or by first appearance in a
+ * message when not explicitly declared. Block/decoration lines (activate, note,
+ * loop, …) are skipped. Returns null when the block isn't a sequenceDiagram.
+ */
+export function parseSequence(code: string): Sequence | null {
+	const lines = meaningfulLines(code);
+	if (lines.length === 0 || !/^sequenceDiagram\b/i.test(lines[0])) return null;
+
+	const participants: SeqParticipant[] = [];
+	const seen = new Map<string, SeqParticipant>();
+	const addParticipant = (id: string, label?: string) => {
+		const existing = seen.get(id);
+		if (existing) {
+			// A later explicit `as` label upgrades a placeholder registered from a message.
+			if (label && existing.label === existing.id) existing.label = label;
+			return;
+		}
+		const p = { id, label: label ?? id };
+		seen.set(id, p);
+		participants.push(p);
+	};
+
+	const messages: SeqMessage[] = [];
+	for (const line of lines.slice(1)) {
+		if (SKIP.test(line)) continue;
+
+		const pm = PARTICIPANT.exec(line);
+		if (pm) {
+			addParticipant(pm[1], pm[2]?.trim());
+			continue;
+		}
+
+		const mm = MESSAGE.exec(line);
+		if (mm) {
+			const from = mm[1].trim();
+			const to = mm[4].trim();
+			addParticipant(from);
+			addParticipant(to);
+			messages.push({ from, to, text: mm[5].trim(), dashed: mm[2] === "--" });
+		}
+	}
+
+	return { participants, messages };
+}
+
+// ── Layout + conversion ───────────────────────────────────────────────────────
+
+const BOX_H = 44;
+const COL_GAP = 64; // horizontal gap between participant boxes
+const MSG_TOP = 34; // gap from the box bottom to the first message
+const MSG_GAP = 40; // vertical gap between messages
+const SELF_W = 48; // width of a self-message stub
+const boxWidth = (label: string) => Math.max(80, label.length * 8 + 24);
+
+const BOX_STYLE = { fill: "#ffffff", stroke: "#1e1e1e", strokeWidth: 2 };
+const LIFELINE_STYLE = { fill: "transparent", stroke: "#9aa0a6", strokeWidth: 1.5 };
+const MSG_STYLE = { fill: "transparent", stroke: "#1e1e1e", strokeWidth: 2 };
+
+interface Col {
+	x: number; // box left
+	width: number;
+	center: number;
+}
+
+/**
+ * Converter: a ```mermaid``` `sequenceDiagram` → participant boxes along the top,
+ * a lifeline down from each, and one horizontal message connector per message
+ * (labelled, arrow toward the target). Non-sequence mermaid is left to the
+ * flowchart converter; an empty diagram falls back to a `markdown` shape.
+ *
+ * Phase 1 (participants + messages). Activations / notes / fragments (loop/alt)
+ * are skipped for now.
+ */
+export function createMermaidSequenceConverter(): MarkdownConverter {
+	return {
+		id: "markdown-to-shape:mermaid-sequence",
+		nodeTypes: ["code"],
+		// Higher order than the flowchart converter (10) so sequence diagrams win.
+		match: (node: MarkdownNode) =>
+			node.lang === "mermaid" && typeof node.value === "string" && isSequenceDiagram(node.value),
+		order: 20,
+		convert: (node, ctx) => {
+			const code = typeof node.value === "string" ? node.value : "";
+			const seq = parseSequence(code);
+			if (!seq || seq.participants.length === 0) {
+				return [
+					{
+						type: "markdown",
+						meta: { source: nodeSource(node, ctx.source), isEditing: false },
+						style: { fill: "transparent", strokeWidth: 0 },
+					},
+				];
+			}
+
+			// Place participant columns left→right.
+			const cols = new Map<string, Col>();
+			let cursorX = ctx.origin.x;
+			for (const p of seq.participants) {
+				const width = boxWidth(p.label);
+				cols.set(p.id, { x: cursorX, width, center: cursorX + width / 2 });
+				cursorX += width + COL_GAP;
+			}
+
+			const top = ctx.origin.y;
+			const lifelineTop = top + BOX_H;
+			const firstMsgY = lifelineTop + MSG_TOP;
+			const bottomY = firstMsgY + Math.max(1, seq.messages.length) * MSG_GAP;
+
+			const specs: MarkdownShapeSpec[] = [];
+
+			// Participant boxes + lifelines.
+			for (const p of seq.participants) {
+				const col = cols.get(p.id);
+				if (!col) continue;
+				specs.push({
+					type: "rectangle",
+					id: generateId(),
+					x: col.x,
+					y: top,
+					width: col.width,
+					height: BOX_H,
+					style: BOX_STYLE,
+					text: p.label,
+					fontSize: 14,
+					isEditing: false,
+					cornerRadius: 4,
+				});
+				specs.push({
+					type: "connector",
+					id: generateId(),
+					x: col.center,
+					y: lifelineTop,
+					width: 0,
+					height: bottomY - lifelineTop,
+					style: LIFELINE_STYLE,
+					sourcePoint: { x: col.center, y: lifelineTop },
+					targetPoint: { x: col.center, y: bottomY },
+					arrowHead: "none",
+					pathType: "straight",
+				});
+			}
+
+			// Messages: horizontal connectors between lifelines at increasing Y.
+			seq.messages.forEach((msg, i) => {
+				const a = cols.get(msg.from);
+				const b = cols.get(msg.to);
+				if (!a || !b) return;
+				const y = firstMsgY + i * MSG_GAP;
+				// Self-message → a short stub to the right (a full loop is future work).
+				const sp = { x: a.center, y };
+				const tp = a === b ? { x: a.center + SELF_W, y } : { x: b.center, y };
+				specs.push({
+					type: "connector",
+					id: generateId(),
+					x: Math.min(sp.x, tp.x),
+					y,
+					width: Math.abs(tp.x - sp.x),
+					height: 0,
+					style: MSG_STYLE,
+					sourcePoint: sp,
+					targetPoint: tp,
+					arrowHead: "forward",
+					pathType: "straight",
+					label: msg.text || undefined,
+				});
+			});
+
+			return specs;
+		},
+	};
+}


### PR DESCRIPTION
## Summary

Closes #860. `markdown-to-shape` にこれまで無かった **mermaid `sequenceDiagram` コンバータ** `createMermaidSequenceConverter` を追加しました。これまで sequenceDiagram は非フローチャート扱いで `markdown` シェイプにフォールバック（＝分解されない）でしたが、ネイティブ図形に分解されます。

### マッピング（フェーズ1: 参加者＋メッセージ）
- **参加者**（`participant`/`actor`、`X as Label` エイリアス対応、未宣言は初出順で暗黙登録）→ 上部に左→右のラベル付き**ボックス**＋各**ライフライン**（下向きの線）。
- **メッセージ**（`->`・`-->`・`->>`・`-->>`・`-)`・`-x` など）→ 送信元/宛先ライフライン間の**水平コネクタ**（Y を下にずらして配置、ラベル付き、矢印は宛先向き）。自己メッセージは右への短いスタブ。
- `activate`/`deactivate`/`note`/`loop`/`alt`/`opt`/`autonumber` 等のブロックは**スキップ**（activations/notes/fragments は将来対応）。

### 選択の仕組み
フローチャート（order 10）は全 mermaid にマッチしフォールバックするため、本コンバータは **order 20 ＋ `match` を sequenceDiagram 限定**にして優先。フローチャート等は従来どおり。

### 実装
- 新規 `mermaid-sequence.ts`: `parseSequence` / `isSequenceDiagram` / `createMermaidSequenceConverter`、`index.ts` から export。
- `apps/web/src/plugins/markdown-adapters.ts`: 既存アダプタ登録に追加。
- コネクタは `sourcePoint`/`targetPoint`（id 不要のフリー端点）で描画。

## 既知の制限（issue の phased 方針どおり）
- activations（`+`/`-`・activate）、notes、`loop`/`alt`/`opt` フレームは未対応（メッセージ行のみ拾う）。
- 返信線の**破線**（`-->>`）はシェイプの style に dash が無いため実線で描画（`dashed` フラグは parse で保持）。
- 他の mermaid 種別（classDiagram/stateDiagram 等）は引き続きフォールバック。

## Test plan
- [x] `parseSequence`/converter 単体テスト（明示/暗黙参加者・as エイリアス・矢印variants・ブロックskip・箱/ライフライン/メッセージ本数・水平/矢印向き・空図の markdown フォールバック・match 限定）— plugin 29 tests green（flowchart 既存も緑）
- [x] plugin typecheck/build、web typecheck/build、`biome --diagnostic-level=error`（error 0）
- 手動: `sequenceDiagram` のみの markdown シェイプを選択 → `markdown:explode` で箱＋ライフライン＋メッセージ矢印に分解

🤖 Generated with [Claude Code](https://claude.com/claude-code)