### PR TITLE
✨ feat(presentation): スライド判定を差し替え可能にし PresentModeOverlay を公開

### DIFF
--- a/.changeset/presentation-isslide-predicate.md
+++ b/.changeset/presentation-isslide-predicate.md
@@ -1,0 +1,5 @@
+---
+"@edv4h/usketch-plugin-presentation": minor
+---
+
+`SlideNavigator` / `createPresentationPlugin` に `isSlide` 述語を注入できるように。省略時は従来どおり Frame シェイプをスライドとして扱うが、`(shape) => boolean` を渡すことで「スライド指定した Frame だけ」や専用の画角 shape をスライドとして扱えるようになった（`SlideNavigatorOptions` / `IsSlide` 型を export）。あわせて `createPresentationPlugin` に `renderEditUI?: boolean`（既定 true）を追加し、`false` にすると edit モードのスライド一覧オーバーレイを抑止して present モードのオーバーレイとショートカットだけをホストから流用できる。ホストが独自 present UI を組めるよう `PresentModeOverlay` も export。

--- a/plugins/usketch-plugin-presentation/src/index.ts
+++ b/plugins/usketch-plugin-presentation/src/index.ts
@@ -1,3 +1,5 @@
 export type { PresentationMode, PresentationPluginOptions } from "./plugin.js";
 export { createPresentationPlugin } from "./plugin.js";
+export { PresentModeOverlay } from "./present-mode-overlay.js";
+export type { IsSlide, SlideNavigatorOptions } from "./slide-navigator.js";
 export { SlideNavigator } from "./slide-navigator.js";

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -7,6 +7,7 @@ import type {
 import { useEffect, useState } from "react";
 import { PresentEditOverlay } from "./present-edit-overlay.js";
 import { PresentModeOverlay } from "./present-mode-overlay.js";
+import type { IsSlide } from "./slide-navigator.js";
 import { SlideNavigator } from "./slide-navigator.js";
 
 /** "off" = プレゼン UI 非表示（通常のホワイトボード扱い） */
@@ -33,6 +34,17 @@ export interface PresentationPluginOptions {
 	 * stage のサイズを返したい。省略時は window.innerWidth/Height を使う。
 	 */
 	getViewportSize?: () => { width: number; height: number };
+	/**
+	 * どの shape を「スライド」として扱うかの述語。省略時は Frame シェイプ。
+	 * ホスト側で「スライド指定した Frame だけ」や専用の画角 shape を対象にしたいときに渡す。
+	 */
+	isSlide?: IsSlide;
+	/**
+	 * edit モードのオーバーレイ（スライド一覧パネル）を plugin 側で描画するか。
+	 * 省略時は true。ホスト側で独自のスライド一覧 UI を持つ場合は false にして、
+	 * present モードのオーバーレイとショートカットだけ流用できる。
+	 */
+	renderEditUI?: boolean;
 }
 
 function defaultGetViewportSize(): { width: number; height: number } {
@@ -59,12 +71,16 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 	const subscribeMode = opts.subscribeMode ?? defaultSubscribeMode;
 	const navigateToBoard = opts.navigateToBoard ?? defaultNavigateToBoard;
 	const getViewportSize = opts.getViewportSize ?? defaultGetViewportSize;
+	const isSlide = opts.isSlide;
+	const renderEditUI = opts.renderEditUI ?? true;
 
 	return {
 		id: "presentation",
 		name: "Presentation",
 		setup(ctx: PluginContext) {
-			let nav: SlideNavigator | null = new SlideNavigator(ctx.store, getViewportSize);
+			let nav: SlideNavigator | null = new SlideNavigator(ctx.store, getViewportSize, {
+				isSlide,
+			});
 			const unregisters: Array<() => void> = [];
 			const navRef = nav;
 
@@ -161,6 +177,7 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 							getMode={getMode}
 							subscribeMode={subscribeMode}
 							navigateToBoard={navigateToBoard}
+							renderEditUI={renderEditUI}
 						/>
 					);
 				},
@@ -189,6 +206,7 @@ interface PresentationLayerProps {
 	getMode: () => PresentationMode;
 	subscribeMode: (listener: () => void) => () => void;
 	navigateToBoard: () => void;
+	renderEditUI: boolean;
 }
 
 function PresentationLayer({
@@ -199,12 +217,15 @@ function PresentationLayer({
 	getMode,
 	subscribeMode,
 	navigateToBoard,
+	renderEditUI,
 }: PresentationLayerProps) {
 	const [mode, setMode] = usePresentationMode(getMode, subscribeMode);
 	void setMode;
 	if (mode === "off") return null;
 	if (mode === "present") return <PresentModeOverlay nav={nav} />;
 	void renderCtx;
+	// edit モードのパネルはホスト側が持つ場合 renderEditUI=false で抑止する。
+	if (!renderEditUI) return null;
 	return (
 		<PresentEditOverlay
 			nav={nav}

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.test.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.test.ts
@@ -1,0 +1,84 @@
+import type { ShapeData } from "@edv4h/usketch-shared";
+import { createBoardStore } from "@edv4h/usketch-store";
+import { describe, expect, it, vi } from "vitest";
+import { SlideNavigator } from "./slide-navigator.js";
+
+function shape(overrides: Partial<ShapeData> = {}): ShapeData {
+	return {
+		id: overrides.id ?? "s1",
+		type: overrides.type ?? "rectangle",
+		x: 0,
+		y: 0,
+		width: 100,
+		height: 100,
+		style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		...overrides,
+	};
+}
+
+const viewport = () => ({ width: 800, height: 600 });
+
+describe("SlideNavigator isSlide predicate", () => {
+	it("既定では Frame シェイプだけをスライドにする", () => {
+		const store = createBoardStore();
+		store.addShape(shape({ id: "f1", type: "frame" }));
+		store.addShape(shape({ id: "r1", type: "rectangle" }));
+		store.addShape(shape({ id: "f2", type: "frame" }));
+
+		const nav = new SlideNavigator(store, viewport);
+		expect(nav.getSlides().map((s) => s.id)).toEqual(["f1", "f2"]);
+		nav.destroy();
+	});
+
+	it("isSlide を渡すと Frame 以外や条件付き Frame をスライドにできる", () => {
+		const store = createBoardStore();
+		store.addShape(shape({ id: "f1", type: "frame", meta: { isSlide: true } }));
+		store.addShape(shape({ id: "f2", type: "frame" })); // フラグ無し → 除外
+		store.addShape(shape({ id: "f3", type: "frame", meta: { isSlide: true } }));
+
+		const nav = new SlideNavigator(store, viewport, {
+			isSlide: (s) => s.type === "frame" && s.meta?.isSlide === true,
+		});
+		expect(nav.getSlides().map((s) => s.id)).toEqual(["f1", "f3"]);
+		nav.destroy();
+	});
+
+	it("スライド化フラグの付け外しで一覧と onChange が更新される", () => {
+		const store = createBoardStore();
+		store.addShape(shape({ id: "f1", type: "frame", meta: { isSlide: true } }));
+
+		const nav = new SlideNavigator(store, viewport, {
+			isSlide: (s) => s.type === "frame" && s.meta?.isSlide === true,
+		});
+		const onChange = vi.fn();
+		nav.onChange(onChange);
+		expect(nav.getSlides()).toHaveLength(1);
+
+		// フラグを外す → スライドから外れ、一覧が空になり通知される
+		store.updateShape("f1", { meta: { isSlide: false } });
+		expect(nav.getSlides()).toHaveLength(0);
+		expect(onChange).toHaveBeenCalled();
+
+		// もう一度立てる → 復帰
+		store.updateShape("f1", { meta: { isSlide: true } });
+		expect(nav.getSlides().map((s) => s.id)).toEqual(["f1"]);
+		nav.destroy();
+	});
+
+	it("gotoIndex で対象スライドの矩形に fitToBounds する", () => {
+		const store = createBoardStore();
+		store.addShape(shape({ id: "f1", type: "frame", x: 0, y: 0, width: 100, height: 100 }));
+		store.addShape(shape({ id: "f2", type: "frame", x: 500, y: 300, width: 200, height: 150 }));
+		const fit = vi.spyOn(store, "fitToBounds");
+
+		const nav = new SlideNavigator(store, viewport);
+		nav.gotoIndex(1);
+
+		expect(nav.getCurrentIndex()).toBe(1);
+		expect(fit).toHaveBeenCalledWith(
+			{ x: 500, y: 300, width: 200, height: 150 },
+			{ width: 800, height: 600 },
+		);
+		nav.destroy();
+	});
+});

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -1,8 +1,24 @@
 import type { BoardStore, BoundingBox, ShapeData } from "@edv4h/usketch-shared";
 
+/** ある shape をスライドとして扱うかどうかを判定する述語。 */
+export type IsSlide = (shape: ShapeData) => boolean;
+
+/** 既定のスライド判定: Frame シェイプをスライドとして扱う。 */
+const defaultIsSlide: IsSlide = (s) => s.type === "frame";
+
+export interface SlideNavigatorOptions {
+	/**
+	 * どの shape を「スライド」として扱うかの述語。
+	 * 省略時は Frame シェイプ（`type === "frame"`）。ホスト側で
+	 * 「スライド指定した Frame だけ」や専用の画角 shape を対象にしたいときに差し替える。
+	 */
+	isSlide?: IsSlide;
+}
+
 /**
- * Frame シェイプを表示順（zIndex 昇順）で並べたものを「スライド」と解釈する。
- * 新しいドメイン概念を Frame に持ち込まないのがポイント。
+ * スライド（既定では Frame シェイプ）を表示順（zIndex 昇順）で並べたものを
+ * 「スライド」と解釈する。新しいドメイン概念を持ち込まないのがポイント。
+ * `options.isSlide` でスライドとして扱う shape を差し替えられる。
  */
 export class SlideNavigator {
 	private currentIndex = 0;
@@ -17,11 +33,15 @@ export class SlideNavigator {
 	private getViewportSize: () => { width: number; height: number };
 	/** 現在 Frame として扱っている shape id。`shape:removed` で id が消えたかどうかの判定に使う。 */
 	private frameIds: Set<string>;
+	/** スライド判定述語（省略時は Frame）。 */
+	private readonly isSlide: IsSlide;
 
 	constructor(
 		private readonly store: BoardStore,
 		getViewportSize: () => { width: number; height: number },
+		options: SlideNavigatorOptions = {},
 	) {
+		this.isSlide = options.isSlide ?? defaultIsSlide;
 		this.getViewportSize = getViewportSize;
 		const initialSlides = this.getSlides();
 		this.frameIds = new Set(initialSlides.map((s) => s.id));
@@ -55,9 +75,12 @@ export class SlideNavigator {
 
 	/**
 	 * mutation がスライド一覧に影響するか判定する。
-	 * - shape:added / shape:updated → 対象 shape が frame のときだけ影響（非フレームのドラッグ等は無視）
-	 * - shape:removed → 削除された id が現在の frame セットにあったときだけ影響
+	 * - shape:added / shape:updated → 対象 shape がスライドのときだけ影響（非スライドのドラッグ等は無視）
+	 * - shape:removed → 削除された id が現在のスライドセットにあったときだけ影響
 	 * - shapes:z-index-initialized → 常に影響
+	 *
+	 * NOTE: `shape:updated` は「スライド化フラグの付け外し」でも発火するため、
+	 * 現在スライドセットに含まれる id なら（今は非スライドでも）影響ありとして通す。
 	 */
 	private isSlideRelatedMutation(type: string, payload: unknown): boolean {
 		if (type === "shapes:z-index-initialized") return true;
@@ -71,12 +94,14 @@ export class SlideNavigator {
 			// id が取れない想定外形式は安全側で通す
 			return true;
 		}
+		// 既にスライドだった shape の更新（＝スライド解除も含む）は影響あり。
+		if (this.frameIds.has(id)) return true;
 		const shape = this.store.getShape(id);
-		return shape?.type === "frame";
+		return shape ? this.isSlide(shape) : false;
 	}
 
 	getSlides(): ShapeData[] {
-		return this.store.getShapesSorted().filter((s) => s.type === "frame");
+		return this.store.getShapesSorted().filter((s) => this.isSlide(s));
 	}
 
 	getCurrentIndex(): number {


### PR DESCRIPTION
## 概要

`@edv4h/usketch-plugin-presentation` を、埋め込みホスト（Frame をそのままスライドにしたくない・独自のスライド一覧 UI を持つアプリ）から使いやすくする拡張。後方互換。

## 変更内容

### 1. `isSlide` 述語の注入
- `SlideNavigator` コンストラクタに第3引数 `options?: { isSlide?: (shape) => boolean }` を追加
- `createPresentationPlugin` の options にも `isSlide?:` を追加して委譲
- 省略時は従来どおり Frame（`type === "frame"`）をスライド扱い → **既存挙動は不変**
- `SlideNavigatorOptions` / `IsSlide` 型を export
- 用途例: `isSlide: (s) => s.type === "frame" && s.meta?.isSlide === true`（スライド指定した Frame だけ）や専用の画角 shape

### 2. スライド解除の検知
`isSlideRelatedMutation` は、現在スライドセットに含まれる id の `shape:updated` を常に影響ありとして扱うよう修正。述語ベースだと「スライド化フラグを外した Frame」は更新時点で `isSlide=false` になり検知漏れするため、一覧・`onChange` が正しく更新されるようにした。

### 3. `renderEditUI` オプション
- `createPresentationPlugin({ renderEditUI: false })` で edit モードの浮遊スライド一覧オーバーレイを抑止
- present モードのオーバーレイとキーボードショートカットはそのまま流用でき、ホストが独自のスライド一覧 UI を持てる

### 4. `PresentModeOverlay` を export
ホストが present state で全画面 present UI を直接描画できるように。

## テスト

- `SlideNavigator` の isSlide テストを追加（既定=Frame のみ / 述語で条件付き Frame / スライド解除で一覧・onChange 更新 / gotoIndex の fitToBounds）→ 4 passed
- `pnpm --filter @edv4h/usketch-plugin-presentation... build`（tsc 型チェック）通過
- biome クリーン
- changeset（minor）