### PR TITLE
✨ feat(presentation): present オーバーレイに onExit と画角外マスクを追加

### DIFF
--- a/.changeset/present-overlay-onexit-mask.md
+++ b/.changeset/present-overlay-onexit-mask.md
@@ -1,0 +1,9 @@
+---
+"@edv4h/usketch-plugin-presentation": minor
+---
+
+`PresentModeOverlay` / `createPresentationPlugin` に発表オーバーレイの拡張を追加。
+
+- **`onExit`**: 発表を抜ける処理をホストから注入できる（`PresentModeOverlay` の `onExit` prop / `createPresentationPlugin` の `onExit` option）。省略時は従来どおり URL クエリ (`?mode=edit`) を書き換える。これまで終了ボタンは URL 駆動固定で、state 駆動のホストではクリックしても抜けられなかったのを解消。
+- **`mask`**: 発表中に現スライド（画角）以外の Canvas を暗幕で隠すマスクを追加。オーバーレイ内のトグルボタンで ON/OFF でき、`mask` prop/option でその初期値を渡せる。viewport のアニメーションにも追従する。
+- `SlideNavigator` に `getCurrentBounds()`（現スライドの world 矩形）と `getStore()`（ホスト overlay が viewport 取得/購読に使う）を追加。

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -45,6 +45,13 @@ export interface PresentationPluginOptions {
 	 * present モードのオーバーレイとショートカットだけ流用できる。
 	 */
 	renderEditUI?: boolean;
+	/**
+	 * present オーバーレイの「終了」操作。省略時は URL クエリ (?mode=edit) を書き換える。
+	 * state 駆動のホストは `() => setPresenting(false)` 等を渡す。
+	 */
+	onExit?: () => void;
+	/** present 時に画角 (現スライド) 以外の Canvas を暗幕で隠すか (overlay トグルの初期値)。 */
+	mask?: boolean;
 }
 
 function defaultGetViewportSize(): { width: number; height: number } {
@@ -73,6 +80,8 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 	const getViewportSize = opts.getViewportSize ?? defaultGetViewportSize;
 	const isSlide = opts.isSlide;
 	const renderEditUI = opts.renderEditUI ?? true;
+	const onExit = opts.onExit;
+	const mask = opts.mask;
 
 	return {
 		id: "presentation",
@@ -178,6 +187,8 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 							subscribeMode={subscribeMode}
 							navigateToBoard={navigateToBoard}
 							renderEditUI={renderEditUI}
+							onExit={onExit}
+							mask={mask}
 						/>
 					);
 				},
@@ -207,6 +218,8 @@ interface PresentationLayerProps {
 	subscribeMode: (listener: () => void) => () => void;
 	navigateToBoard: () => void;
 	renderEditUI: boolean;
+	onExit?: () => void;
+	mask?: boolean;
 }
 
 function PresentationLayer({
@@ -218,11 +231,13 @@ function PresentationLayer({
 	subscribeMode,
 	navigateToBoard,
 	renderEditUI,
+	onExit,
+	mask,
 }: PresentationLayerProps) {
 	const [mode, setMode] = usePresentationMode(getMode, subscribeMode);
 	void setMode;
 	if (mode === "off") return null;
-	if (mode === "present") return <PresentModeOverlay nav={nav} />;
+	if (mode === "present") return <PresentModeOverlay nav={nav} onExit={onExit} mask={mask} />;
 	void renderCtx;
 	// edit モードのパネルはホスト側が持つ場合 renderEditUI=false で抑止する。
 	if (!renderEditUI) return null;

--- a/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
+++ b/plugins/usketch-plugin-presentation/src/present-mode-overlay.tsx
@@ -4,12 +4,35 @@ import type { SlideNavigator } from "./slide-navigator.js";
 
 interface Props {
 	nav: SlideNavigator;
+	/**
+	 * 発表を抜ける処理。省略時は URL クエリ (?present=1&mode=edit) を書き換える
+	 * (後方互換)。state 駆動のホストは `() => setPresenting(false)` 等を渡す。
+	 */
+	onExit?: () => void;
+	/** 画角 (現スライド) 以外の Canvas を暗幕で隠すか。overlay 内トグルの初期値。 */
+	mask?: boolean;
 }
 
-export function PresentModeOverlay({ nav }: Props) {
+/** onExit 未指定時のフォールバック (URL クエリで edit モードへ)。 */
+function defaultExit(): void {
+	const url = new URL(window.location.href);
+	url.searchParams.set("present", "1");
+	url.searchParams.set("mode", "edit");
+	window.history.replaceState(null, "", url.toString());
+	window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+const MASK_BG = "rgba(12,12,16,0.92)";
+
+export function PresentModeOverlay({ nav, onExit, mask }: Props) {
 	const [index, setIndex] = useState(nav.getCurrentIndex());
 	const [total, setTotal] = useState(nav.getSlides().length);
 	const [visible, setVisible] = useState(true);
+	const [masked, setMasked] = useState(mask ?? false);
+	// viewport 変化 (fit アニメ含む) でマスク位置を再計算させるためのリビジョン。
+	const [, forceTick] = useState(0);
+
+	const store = nav.getStore();
 
 	useEffect(() => {
 		const unsub = nav.onChange((i) => {
@@ -18,6 +41,9 @@ export function PresentModeOverlay({ nav }: Props) {
 		});
 		return unsub;
 	}, [nav]);
+
+	// viewport (fitToBounds のアニメーション含む) の変化にマスクを追従させる。
+	useEffect(() => store.subscribe(() => forceTick((t) => t + 1)), [store]);
 
 	// 発表モードに入った直後は Canvas コンテナサイズが edit → 画面全体に切り替わる
 	// 途中でもあり得る。React のレイアウト確定 (double rAF) を待って先頭スライドに fit する。
@@ -51,6 +77,8 @@ export function PresentModeOverlay({ nav }: Props) {
 			window.removeEventListener("keydown", showAndSchedule);
 		};
 	}, []);
+
+	const exit = onExit ?? defaultExit;
 
 	if (total === 0) {
 		return createPortal(
@@ -88,13 +116,18 @@ export function PresentModeOverlay({ nav }: Props) {
 
 	const progress = total > 1 ? index / (total - 1) : 1;
 
-	const exitPresent = () => {
-		const url = new URL(window.location.href);
-		url.searchParams.set("present", "1");
-		url.searchParams.set("mode", "edit");
-		window.history.replaceState(null, "", url.toString());
-		window.dispatchEvent(new PopStateEvent("popstate"));
-	};
+	// 現スライドの画面矩形 (Canvas ローカル座標 = viewport 変換)。Canvas がほぼ全画面の
+	// 前提。マスクはこの矩形の外側を暗幕で覆う。
+	const bounds = nav.getCurrentBounds();
+	const vp = store.getViewport();
+	const rect = bounds
+		? {
+				left: bounds.x * vp.zoom + vp.x,
+				top: bounds.y * vp.zoom + vp.y,
+				w: bounds.width * vp.zoom,
+				h: bounds.height * vp.zoom,
+			}
+		: null;
 
 	return createPortal(
 		<div
@@ -103,149 +136,258 @@ export function PresentModeOverlay({ nav }: Props) {
 				inset: 0,
 				zIndex: 500,
 				pointerEvents: "none",
-				opacity: visible ? 1 : 0,
-				transition: "opacity 0.3s",
 				fontFamily: "var(--font-sans, system-ui)",
 			}}
 		>
-			{/* 閉じるボタン (右上) */}
-			<button
-				type="button"
-				onClick={exitPresent}
-				title="編集モードに戻る (Esc)"
-				aria-label="編集モードに戻る"
-				style={{
-					position: "absolute",
-					top: 16,
-					right: 16,
-					appearance: "none",
-					background: "rgba(255,255,255,0.1)",
-					backdropFilter: "blur(16px)",
-					WebkitBackdropFilter: "blur(16px)",
-					border: "1px solid rgba(255,255,255,0.1)",
-					color: "white",
-					cursor: "pointer",
-					width: 36,
-					height: 36,
-					borderRadius: 10,
-					display: "flex",
-					alignItems: "center",
-					justifyContent: "center",
-					pointerEvents: "auto",
-					padding: 0,
-				}}
-			>
-				<svg
-					width="14"
-					height="14"
-					viewBox="0 0 16 16"
-					fill="none"
-					stroke="currentColor"
-					strokeWidth="1.5"
-					strokeLinecap="round"
-					strokeLinejoin="round"
-					aria-hidden="true"
-				>
-					<path d="m3.5 3.5 9 9M12.5 3.5l-9 9" />
-				</svg>
-			</button>
+			{/* 画角外マスク: 常時表示 (操作UIのフェードとは独立)。現スライド矩形の外側を
+			上下左右 4 枚の暗幕で覆う。 */}
+			{masked && rect && (
+				<>
+					<div
+						style={{
+							position: "absolute",
+							left: 0,
+							right: 0,
+							top: 0,
+							height: Math.max(0, rect.top),
+							background: MASK_BG,
+						}}
+					/>
+					<div
+						style={{
+							position: "absolute",
+							left: 0,
+							right: 0,
+							top: rect.top + rect.h,
+							bottom: 0,
+							background: MASK_BG,
+						}}
+					/>
+					<div
+						style={{
+							position: "absolute",
+							left: 0,
+							top: rect.top,
+							width: Math.max(0, rect.left),
+							height: rect.h,
+							background: MASK_BG,
+						}}
+					/>
+					<div
+						style={{
+							position: "absolute",
+							left: rect.left + rect.w,
+							right: 0,
+							top: rect.top,
+							height: rect.h,
+							background: MASK_BG,
+						}}
+					/>
+				</>
+			)}
 
-			{/* 上部プログレスバー */}
+			{/* 操作UI: 一定時間で自動フェード。 */}
 			<div
 				style={{
 					position: "absolute",
-					top: 0,
-					left: 0,
-					right: 0,
-					height: 3,
-					background: "rgba(255,255,255,0.1)",
+					inset: 0,
+					pointerEvents: "none",
+					opacity: visible ? 1 : 0,
+					transition: "opacity 0.3s",
 				}}
 			>
-				<div
-					style={{
-						height: "100%",
-						width: `${progress * 100}%`,
-						background: "var(--brand-gradient)",
-						transition: "width 0.3s",
-					}}
-				/>
-			</div>
-
-			{/* 下部ナビ pill */}
-			<div
-				style={{
-					position: "absolute",
-					bottom: 24,
-					left: "50%",
-					transform: "translateX(-50%)",
-					display: "flex",
-					alignItems: "center",
-					gap: 2,
-					padding: 4,
-					borderRadius: 999,
-					background: "rgba(20,20,25,0.85)",
-					backdropFilter: "blur(20px)",
-					WebkitBackdropFilter: "blur(20px)",
-					border: "1px solid rgba(255,255,255,0.1)",
-					pointerEvents: "auto",
-					boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
-				}}
-			>
-				<NavButton
-					disabled={index === 0}
-					onClick={() => nav.prev()}
-					ariaLabel="前のスライド"
-					direction="prev"
-				/>
-				<div
-					style={{
-						padding: "0 12px",
-						fontSize: 13,
-						fontFamily: "var(--font-mono)",
-						letterSpacing: 0,
-						minWidth: 60,
-						textAlign: "center",
-					}}
-				>
-					<span style={{ color: "white", fontWeight: 600 }}>{index + 1}</span>
-					<span style={{ color: "rgba(255,255,255,0.5)" }}> / {total}</span>
-				</div>
-				<NavButton
-					disabled={index >= total - 1}
-					onClick={() => nav.next()}
-					ariaLabel="次のスライド"
-					direction="next"
-				/>
-				<div
-					style={{
-						width: 1,
-						height: 20,
-						background: "rgba(255,255,255,0.15)",
-						margin: "0 4px",
-					}}
-				/>
+				{/* 閉じるボタン (右上) */}
 				<button
 					type="button"
-					onClick={exitPresent}
+					onClick={exit}
 					title="発表を終了 (Esc)"
 					aria-label="発表を終了"
 					style={{
+						position: "absolute",
+						top: 16,
+						right: 16,
 						appearance: "none",
-						border: "none",
-						background: "transparent",
+						background: "rgba(255,255,255,0.1)",
+						backdropFilter: "blur(16px)",
+						WebkitBackdropFilter: "blur(16px)",
+						border: "1px solid rgba(255,255,255,0.1)",
 						color: "white",
 						cursor: "pointer",
-						height: 34,
-						padding: "0 12px",
-						borderRadius: 999,
+						width: 36,
+						height: 36,
+						borderRadius: 10,
 						display: "flex",
 						alignItems: "center",
-						fontSize: 12,
-						fontFamily: "inherit",
+						justifyContent: "center",
+						pointerEvents: "auto",
+						padding: 0,
 					}}
 				>
-					終了
+					<svg
+						width="14"
+						height="14"
+						viewBox="0 0 16 16"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="1.5"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						aria-hidden="true"
+					>
+						<path d="m3.5 3.5 9 9M12.5 3.5l-9 9" />
+					</svg>
 				</button>
+
+				{/* 上部プログレスバー */}
+				<div
+					style={{
+						position: "absolute",
+						top: 0,
+						left: 0,
+						right: 0,
+						height: 3,
+						background: "rgba(255,255,255,0.1)",
+					}}
+				>
+					<div
+						style={{
+							height: "100%",
+							width: `${progress * 100}%`,
+							background: "var(--brand-gradient)",
+							transition: "width 0.3s",
+						}}
+					/>
+				</div>
+
+				{/* 下部ナビ pill */}
+				<div
+					style={{
+						position: "absolute",
+						bottom: 24,
+						left: "50%",
+						transform: "translateX(-50%)",
+						display: "flex",
+						alignItems: "center",
+						gap: 2,
+						padding: 4,
+						borderRadius: 999,
+						background: "rgba(20,20,25,0.85)",
+						backdropFilter: "blur(20px)",
+						WebkitBackdropFilter: "blur(20px)",
+						border: "1px solid rgba(255,255,255,0.1)",
+						pointerEvents: "auto",
+						boxShadow: "0 8px 24px rgba(0,0,0,0.5)",
+					}}
+				>
+					<NavButton
+						disabled={index === 0}
+						onClick={() => nav.prev()}
+						ariaLabel="前のスライド"
+						direction="prev"
+					/>
+					<div
+						style={{
+							padding: "0 12px",
+							fontSize: 13,
+							fontFamily: "var(--font-mono)",
+							letterSpacing: 0,
+							minWidth: 60,
+							textAlign: "center",
+						}}
+					>
+						<span style={{ color: "white", fontWeight: 600 }}>{index + 1}</span>
+						<span style={{ color: "rgba(255,255,255,0.5)" }}> / {total}</span>
+					</div>
+					<NavButton
+						disabled={index >= total - 1}
+						onClick={() => nav.next()}
+						ariaLabel="次のスライド"
+						direction="next"
+					/>
+					<div
+						style={{
+							width: 1,
+							height: 20,
+							background: "rgba(255,255,255,0.15)",
+							margin: "0 4px",
+						}}
+					/>
+					{/* 画角外マスクの ON/OFF トグル */}
+					<button
+						type="button"
+						onClick={() => setMasked((m) => !m)}
+						title={masked ? "画角外を表示" : "画角外を隠す"}
+						aria-label={masked ? "画角外を表示" : "画角外を隠す"}
+						aria-pressed={masked}
+						style={{
+							appearance: "none",
+							border: "none",
+							background: masked ? "rgba(255,255,255,0.16)" : "transparent",
+							color: "white",
+							cursor: "pointer",
+							width: 34,
+							height: 34,
+							borderRadius: 999,
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							padding: 0,
+						}}
+					>
+						<svg
+							width="16"
+							height="16"
+							viewBox="0 0 16 16"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="1.5"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							aria-hidden="true"
+						>
+							<rect x="2.5" y="2.5" width="11" height="11" rx="1.5" />
+							<rect
+								x="5.5"
+								y="5.5"
+								width="5"
+								height="5"
+								rx="0.75"
+								fill="currentColor"
+								stroke="none"
+							/>
+						</svg>
+					</button>
+					<div
+						style={{
+							width: 1,
+							height: 20,
+							background: "rgba(255,255,255,0.15)",
+							margin: "0 4px",
+						}}
+					/>
+					<button
+						type="button"
+						onClick={exit}
+						title="発表を終了 (Esc)"
+						aria-label="発表を終了"
+						style={{
+							appearance: "none",
+							border: "none",
+							background: "transparent",
+							color: "white",
+							cursor: "pointer",
+							height: 34,
+							padding: "0 12px",
+							borderRadius: 999,
+							display: "flex",
+							alignItems: "center",
+							fontSize: 12,
+							fontFamily: "inherit",
+						}}
+					>
+						終了
+					</button>
+				</div>
 			</div>
 		</div>,
 		document.body,

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.test.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.test.ts
@@ -81,4 +81,31 @@ describe("SlideNavigator isSlide predicate", () => {
 		);
 		nav.destroy();
 	});
+
+	it("getCurrentBounds は現在スライドの矩形を返す (無ければ null)", () => {
+		const store = createBoardStore();
+		const nav0 = new SlideNavigator(store, viewport);
+		expect(nav0.getCurrentBounds()).toBeNull();
+		nav0.destroy();
+
+		store.addShape(shape({ id: "f1", type: "frame", x: 0, y: 0, width: 100, height: 100 }));
+		store.addShape(shape({ id: "f2", type: "frame", x: 500, y: 300, width: 200, height: 150 }));
+		const nav = new SlideNavigator(store, viewport);
+		expect(nav.getCurrentBounds()).toEqual({ x: 0, y: 0, width: 100, height: 100 });
+		nav.gotoIndex(1);
+		expect(nav.getCurrentBounds()).toEqual({
+			x: 500,
+			y: 300,
+			width: 200,
+			height: 150,
+		});
+		nav.destroy();
+	});
+
+	it("getStore は内部 store を返す", () => {
+		const store = createBoardStore();
+		const nav = new SlideNavigator(store, viewport);
+		expect(nav.getStore()).toBe(store);
+		nav.destroy();
+	});
 });

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -108,6 +108,18 @@ export class SlideNavigator {
 		return this.currentIndex;
 	}
 
+	/** 現在スライドの world 矩形 (回転無視の AABB)。スライドが無ければ null。 */
+	getCurrentBounds(): BoundingBox | null {
+		const slides = this.getSlides();
+		const s = slides[this.currentIndex];
+		return s ? { x: s.x, y: s.y, width: s.width, height: s.height } : null;
+	}
+
+	/** 内部の store。ホスト側 overlay が viewport 購読/取得に使う。 */
+	getStore(): BoardStore {
+		return this.store;
+	}
+
 	gotoIndex(index: number): void {
 		const slides = this.getSlides();
 		if (slides.length === 0) return;


### PR DESCRIPTION
## 概要

発表オーバーレイ (`PresentModeOverlay`) を、埋め込みホスト向けに拡張する。

## 変更内容

### 1. `onExit`（終了処理の注入）
これまで終了ボタン (右上×・下部「終了」) は `?present=1&mode=edit` を書き換える **URL 駆動固定**だった。**state 駆動のホスト**（mode を URL でなく state で持つ）ではクリックしても抜けられなかった。

- `PresentModeOverlay` に `onExit?: () => void` prop、`createPresentationPlugin` に `onExit?` option を追加。省略時は従来の URL 書き換え（後方互換）。

### 2. `mask`（画角外マスク）
発表中に**現スライド（画角）以外の Canvas を暗幕で覆う**マスクを追加（PowerPoint/Keynote のレターボックス相当）。

- 現スライドの矩形を viewport 変換して画面矩形を求め、その外側を上下左右 4 枚の暗幕で覆う
- オーバーレイ内の**トグルボタンで ON/OFF**。`mask` prop/option で初期値を渡せる
- `fitToBounds` のアニメーションにも追従（store 購読）。操作UIの自動フェードとは独立で常時表示

### 3. `SlideNavigator` のアクセサ
- `getCurrentBounds(): BoundingBox | null` — 現スライドの world 矩形
- `getStore(): BoardStore` — ホスト overlay が viewport の取得/購読に使う（マスク算出用）

## テスト
- `getCurrentBounds` / `getStore` の単体テスト追加 → 6 passed
- `pnpm --filter @edv4h/usketch-plugin-presentation... build`（tsc）通過
- biome クリーン（既存 present-edit-overlay の warning 1 件のみ・本 PR 非関連）
- changeset（minor）