### PR TITLE
✨ feat(deep-link): URLでShape選択・表示位置を共有（Figmaの?node-id相当）

### DIFF
--- a/.changeset/deep-link-url-sharing.md
+++ b/.changeset/deep-link-url-sharing.md
@@ -1,0 +1,10 @@
+---
+"@edv4h/usketch-plugin-deep-link": minor
+"@edv4h/usketch-web": patch
+---
+
+URLで選択shape・表示位置を共有できるディープリンク機能を追加（Figmaの `?node-id` 相当）
+
+- 新規プラグイン `usketch-plugin-deep-link`: `?shape=<id,...>` で選択をライブ同期（`history.replaceState`）、読込時に選択＋自動フレーミング。CRDT未同期のshapeは出現までリトライ。
+- `?x&y&zoom` で厳密なカメラ位置を復元（自動フレーミングより優先）。
+- 共有ダイアログに「この表示へのリンクをコピー」を追加（現在の選択＋pan/zoomを含むURLを生成）。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
 		"@edv4h/usketch-plugin-comments": "workspace:*",
 		"@edv4h/usketch-plugin-community-chat": "workspace:*",
 		"@edv4h/usketch-plugin-container": "workspace:*",
+		"@edv4h/usketch-plugin-deep-link": "workspace:*",
 		"@edv4h/usketch-plugin-side-panel": "workspace:*",
 		"@edv4h/usketch-plugin-ai-copilot": "workspace:*",
 		"@edv4h/usketch-plugin-ai-image": "workspace:*",

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -14,6 +14,7 @@ import { createDotsBgPlugin } from "@edv4h/usketch-plugin-bg-dots";
 import { createGridBgPlugin } from "@edv4h/usketch-plugin-bg-grid";
 import { createCommentsPlugin } from "@edv4h/usketch-plugin-comments";
 import { createAttachablePlugin, createContainerPlugin } from "@edv4h/usketch-plugin-container";
+import { createDeepLinkPlugin } from "@edv4h/usketch-plugin-deep-link";
 import { createDomainDesignPlugin } from "@edv4h/usketch-plugin-domain-design";
 import { createExportPlugin } from "@edv4h/usketch-plugin-export";
 import { createFollowMePlugin } from "@edv4h/usketch-plugin-follow-me";
@@ -446,6 +447,10 @@ export function App() {
 			}),
 		);
 
+		// Deep link: URL ⇄ 選択/視点の同期（Figma の ?node-id 相当）。最後に登録し、
+		// setup が whenSynced 後に走ることで、サーバ視点復元より後に URL アンカーを適用する。
+		extraPlugins.push(createDeepLinkPlugin());
+
 		syncHandle.whenSynced
 			.then(() => {
 				if (cancelled) return;
@@ -733,7 +738,7 @@ export function App() {
 				</div>
 				{/* 閉じタグ: エディタ全体ラッパーの終わり */}
 				{showShare && boardId && (
-					<ShareDialog boardId={boardId} onClose={() => setShowShare(false)} />
+					<ShareDialog boardId={boardId} onClose={() => setShowShare(false)} store={app?.store} />
 				)}
 				{isCloudBoard && wsStatus === "failed" && (
 					<div

--- a/apps/web/src/components/share-dialog.tsx
+++ b/apps/web/src/components/share-dialog.tsx
@@ -1,3 +1,5 @@
+import { encodeDeepLink } from "@edv4h/usketch-plugin-deep-link";
+import type { BoardStore } from "@edv4h/usketch-shared";
 import { useCallback, useEffect, useState } from "react";
 import { api } from "../lib/api.js";
 import { getErrorMessage } from "../lib/errors.js";
@@ -9,12 +11,21 @@ interface Member {
 	image: string | null;
 }
 
-export function ShareDialog({ boardId, onClose }: { boardId: string; onClose: () => void }) {
+export function ShareDialog({
+	boardId,
+	onClose,
+	store,
+}: {
+	boardId: string;
+	onClose: () => void;
+	store?: BoardStore;
+}) {
 	const [members, setMembers] = useState<Member[]>([]);
 	const [isPublic, setIsPublic] = useState(false);
 	const [email, setEmail] = useState("");
 	const [error, setError] = useState("");
 	const [copied, setCopied] = useState(false);
+	const [copiedView, setCopiedView] = useState(false);
 
 	const loadData = useCallback(async () => {
 		try {
@@ -68,6 +79,26 @@ export function ShareDialog({ boardId, onClose }: { boardId: string; onClose: ()
 			await navigator.clipboard.writeText(window.location.href);
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
+		} catch {
+			setError("Failed to copy link");
+		}
+	};
+
+	// Snapshot the current selection AND camera (pan/zoom) into the link, so the
+	// recipient lands on exactly this view. Selection alone is already live in the
+	// address bar; this adds the precise viewport.
+	const handleCopyViewLink = async () => {
+		if (!store) return;
+		try {
+			const selection = [...store.getSelection()].filter((id) => store.getShape(id));
+			const search = encodeDeepLink(window.location.search, {
+				shapeIds: selection,
+				camera: store.getViewport(),
+			});
+			const url = `${window.location.origin}${window.location.pathname}${search}`;
+			await navigator.clipboard.writeText(url);
+			setCopiedView(true);
+			setTimeout(() => setCopiedView(false), 2000);
 		} catch {
 			setError("Failed to copy link");
 		}
@@ -178,6 +209,27 @@ export function ShareDialog({ boardId, onClose }: { boardId: string; onClose: ()
 				>
 					{copied ? "Copied!" : "Copy link"}
 				</button>
+
+				{/* Deep link that also pins the exact pan/zoom (and any selection). */}
+				{store && (
+					<button
+						type="button"
+						onClick={handleCopyViewLink}
+						title="現在の表示位置（座標・ズーム）と選択を含むリンクをコピー"
+						style={{
+							width: "100%",
+							padding: "10px 0",
+							border: "1px solid #ddd",
+							borderRadius: 6,
+							background: "#fafafa",
+							cursor: "pointer",
+							fontSize: 13,
+							marginTop: 8,
+						}}
+					>
+						{copiedView ? "Copied!" : "この表示へのリンクをコピー"}
+					</button>
+				)}
 
 				{/* Add member */}
 				<div style={{ marginTop: 16 }}>

--- a/apps/web/src/components/share-dialog.tsx
+++ b/apps/web/src/components/share-dialog.tsx
@@ -95,7 +95,7 @@ export function ShareDialog({
 				shapeIds: selection,
 				camera: store.getViewport(),
 			});
-			const url = `${window.location.origin}${window.location.pathname}${search}`;
+			const url = `${window.location.origin}${window.location.pathname}${search}${window.location.hash}`;
 			await navigator.clipboard.writeText(url);
 			setCopiedView(true);
 			setTimeout(() => setCopiedView(false), 2000);

--- a/plugins/usketch-plugin-deep-link/README.md
+++ b/plugins/usketch-plugin-deep-link/README.md
@@ -22,7 +22,8 @@
 ```ts
 import { createDeepLinkPlugin } from "@edv4h/usketch-plugin-deep-link";
 
-createApp({ store, plugins: [createDeepLinkPlugin()] });
+// createApp は非同期。
+const app = await createApp({ store, plugins: [createDeepLinkPlugin()] });
 ```
 
 「この表示へのリンク」を作る側（共有ダイアログ等）は `encodeDeepLink` を利用する:

--- a/plugins/usketch-plugin-deep-link/README.md
+++ b/plugins/usketch-plugin-deep-link/README.md
@@ -1,0 +1,45 @@
+# @edv4h/usketch-plugin-deep-link
+
+選択した shape や表示位置を **URL で共有**するためのプラグイン。Figma の
+`?node-id=...`（選択ノードへのリンク）に相当する体験を提供する。
+
+## URL スキーム
+
+```
+?shape=<id>[,<id>...]   選択（複数対応・ライブ同期）
+?x=<n>&y=<n>&zoom=<n>   厳密なカメラ位置（「この表示へのリンク」用）
+```
+
+- **選択はライブ同期**: shape を選ぶと `history.replaceState` で `?shape=` が更新される（履歴は汚さない）。
+- **カメラは明示スナップショット**: pan のたびに書き込むとチラつくため、`encodeDeepLink` で
+  現在の `viewport` を含めた URL をコピーしたときだけ付与する。
+- 読込時は URL を解析し、対象 shape を選択してフォーカスする。shape が CRDT 同期でまだ
+  届いていない場合は `shape:added` を購読して出現までリトライする（タイムアウトあり）。カメラ
+  指定があれば自動フレーミングより優先して厳密復元する。
+
+## 使い方
+
+```ts
+import { createDeepLinkPlugin } from "@edv4h/usketch-plugin-deep-link";
+
+createApp({ store, plugins: [createDeepLinkPlugin()] });
+```
+
+「この表示へのリンク」を作る側（共有ダイアログ等）は `encodeDeepLink` を利用する:
+
+```ts
+import { encodeDeepLink } from "@edv4h/usketch-plugin-deep-link";
+
+const search = encodeDeepLink(window.location.search, {
+	shapeIds: [...store.getSelection()],
+	camera: store.getViewport(),
+});
+const url = `${window.location.origin}${window.location.pathname}${search}`;
+```
+
+## エクスポート
+
+- `createDeepLinkPlugin()` — プラグイン本体。
+- `encodeDeepLink(search, state)` / `decodeDeepLink(search)` — URL ⇄ 状態の純粋関数。
+- `applyDeepLink(store, search, onDone?)` — 読込時の選択＋フォーカス適用（同期待ち込み）。
+- `frameShapes(store, ids, opts?)` — 指定 shape 群へビューポートを合わせる（回転対応・ズーム上限）。

--- a/plugins/usketch-plugin-deep-link/package.json
+++ b/plugins/usketch-plugin-deep-link/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@edv4h/usketch-plugin-deep-link",
+	"version": "0.1.0",
+	"type": "module",
+	"main": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"source": "./src/index.ts",
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		}
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"clean": "rm -rf dist"
+	},
+	"dependencies": {
+		"@edv4h/usketch-core": "workspace:*",
+		"@edv4h/usketch-shared": "workspace:*",
+		"@edv4h/usketch-store": "workspace:*"
+	},
+	"devDependencies": {
+		"typescript": "7.0.2",
+		"vitest": "4.1.10"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"files": [
+		"dist",
+		"README.md"
+	],
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/EdV4H/usketch.git",
+		"directory": "plugins/usketch-plugin-deep-link"
+	},
+	"homepage": "https://github.com/EdV4H/usketch#readme",
+	"bugs": {
+		"url": "https://github.com/EdV4H/usketch/issues"
+	}
+}

--- a/plugins/usketch-plugin-deep-link/src/__tests__/url-state.test.ts
+++ b/plugins/usketch-plugin-deep-link/src/__tests__/url-state.test.ts
@@ -64,6 +64,13 @@ describe("encodeDeepLink", () => {
 		expect(out).toContain("shape=a");
 	});
 
+	it("does not un-escape encoded commas in unrelated params (only the shape list)", () => {
+		const out = encodeDeepLink("?t=a%2Cb", { shapeIds: ["x", "y"] });
+		// The `shape` list stays readable, but `t`'s encoded comma is untouched.
+		expect(out).toContain("t=a%2Cb");
+		expect(out).toContain("shape=x,y");
+	});
+
 	it("only touches provided fields", () => {
 		// camera not provided → existing camera params stay
 		expect(encodeDeepLink("?x=1&y=2&zoom=3", { shapeIds: ["a"] })).toBe("?x=1&y=2&zoom=3&shape=a");

--- a/plugins/usketch-plugin-deep-link/src/__tests__/url-state.test.ts
+++ b/plugins/usketch-plugin-deep-link/src/__tests__/url-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { decodeDeepLink, encodeDeepLink } from "../url-state.js";
+
+describe("decodeDeepLink", () => {
+	it("parses a single shape id", () => {
+		expect(decodeDeepLink("?shape=abc")).toEqual({ shapeIds: ["abc"], camera: null });
+	});
+
+	it("parses multiple comma-separated shape ids", () => {
+		expect(decodeDeepLink("?shape=abc,def,ghi").shapeIds).toEqual(["abc", "def", "ghi"]);
+	});
+
+	it("trims blanks and drops empty entries", () => {
+		expect(decodeDeepLink("?shape=abc,,%20def%20").shapeIds).toEqual(["abc", "def"]);
+	});
+
+	it("parses a camera when x/y/zoom are all present", () => {
+		expect(decodeDeepLink("?x=100&y=-50&zoom=1.5").camera).toEqual({ x: 100, y: -50, zoom: 1.5 });
+	});
+
+	it("ignores a partial camera", () => {
+		expect(decodeDeepLink("?x=100&y=-50").camera).toBeNull();
+	});
+
+	it("rejects a non-positive or non-finite zoom", () => {
+		expect(decodeDeepLink("?x=0&y=0&zoom=0").camera).toBeNull();
+		expect(decodeDeepLink("?x=0&y=0&zoom=abc").camera).toBeNull();
+	});
+
+	it("returns empty state for an empty query", () => {
+		expect(decodeDeepLink("")).toEqual({ shapeIds: [], camera: null });
+	});
+
+	it("parses shape and camera together", () => {
+		expect(decodeDeepLink("?shape=a,b&x=10&y=20&zoom=2")).toEqual({
+			shapeIds: ["a", "b"],
+			camera: { x: 10, y: 20, zoom: 2 },
+		});
+	});
+});
+
+describe("encodeDeepLink", () => {
+	it("sets a readable (unescaped) comma-separated shape list", () => {
+		expect(encodeDeepLink("", { shapeIds: ["a", "b"] })).toBe("?shape=a,b");
+	});
+
+	it("removes the shape param when the selection is empty", () => {
+		expect(encodeDeepLink("?shape=a,b", { shapeIds: [] })).toBe("");
+	});
+
+	it("rounds the camera (x/y integer, zoom 3dp)", () => {
+		expect(encodeDeepLink("", { camera: { x: 10.7, y: -3.2, zoom: 1.23456 } })).toBe(
+			"?x=11&y=-3&zoom=1.235",
+		);
+	});
+
+	it("removes camera params when camera is null", () => {
+		expect(encodeDeepLink("?x=1&y=2&zoom=3", { camera: null })).toBe("");
+	});
+
+	it("preserves unrelated params", () => {
+		const out = encodeDeepLink("?t=token", { shapeIds: ["a"] });
+		expect(out).toContain("t=token");
+		expect(out).toContain("shape=a");
+	});
+
+	it("only touches provided fields", () => {
+		// camera not provided → existing camera params stay
+		expect(encodeDeepLink("?x=1&y=2&zoom=3", { shapeIds: ["a"] })).toBe("?x=1&y=2&zoom=3&shape=a");
+	});
+
+	it("round-trips shape + camera through decode", () => {
+		const search = encodeDeepLink("", {
+			shapeIds: ["a", "b"],
+			camera: { x: 100, y: 200, zoom: 1.5 },
+		});
+		expect(decodeDeepLink(search)).toEqual({
+			shapeIds: ["a", "b"],
+			camera: { x: 100, y: 200, zoom: 1.5 },
+		});
+	});
+});

--- a/plugins/usketch-plugin-deep-link/src/apply.ts
+++ b/plugins/usketch-plugin-deep-link/src/apply.ts
@@ -1,0 +1,78 @@
+import type { BoardStore, StoreEvent } from "@edv4h/usketch-shared";
+import { frameShapes } from "./frame.js";
+import { decodeDeepLink } from "./url-state.js";
+
+/** How long to wait for deep-linked shapes to arrive via CRDT sync before giving up. */
+const SYNC_TIMEOUT_MS = 5000;
+
+/**
+ * Apply the deep link encoded in `search` to the board: select the referenced
+ * shapes and move the viewport onto them (or to an explicit camera).
+ *
+ * Shapes referenced by the URL may not be in the store yet — they stream in via
+ * Yjs sync after mount — so when any are missing we subscribe to `shape:added`
+ * and retry until they all appear or {@link SYNC_TIMEOUT_MS} elapses.
+ *
+ * `onDone` fires exactly once, when application settles (immediately if there is
+ * no anchor to apply). Returns a disposer that cancels any pending wait.
+ */
+export function applyDeepLink(store: BoardStore, search: string, onDone?: () => void): () => void {
+	const { shapeIds, camera } = decodeDeepLink(search);
+
+	let done = false;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let offMutation: (() => void) | null = null;
+
+	const finish = () => {
+		if (done) return;
+		done = true;
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+		}
+		if (offMutation) {
+			offMutation();
+			offMutation = null;
+		}
+		onDone?.();
+	};
+
+	// Nothing to anchor — settle synchronously.
+	if (shapeIds.length === 0 && !camera) {
+		finish();
+		return finish;
+	}
+
+	const presentIds = () => shapeIds.filter((id) => store.getShape(id));
+
+	const applyNow = (ids: string[]) => {
+		if (ids.length > 0) {
+			store.setSelection(ids);
+			// An explicit camera wins over shape-derived framing.
+			if (!camera) frameShapes(store, ids);
+		}
+		if (camera) store.animateViewportTo(camera);
+		finish();
+	};
+
+	// Camera-only, or all shapes already present → apply immediately.
+	const ready = presentIds();
+	if (shapeIds.length === 0 || ready.length === shapeIds.length) {
+		applyNow(ready);
+		return finish;
+	}
+
+	// Some shapes are still syncing — wait for them, then apply.
+	offMutation = store.onMutation((e: StoreEvent) => {
+		if (e.type !== "shape:added") return;
+		const now = presentIds();
+		if (now.length === shapeIds.length) applyNow(now);
+	});
+
+	timer = setTimeout(() => {
+		// Timed out: apply whatever arrived (possibly a partial selection).
+		applyNow(presentIds());
+	}, SYNC_TIMEOUT_MS);
+
+	return finish;
+}

--- a/plugins/usketch-plugin-deep-link/src/apply.ts
+++ b/plugins/usketch-plugin-deep-link/src/apply.ts
@@ -51,7 +51,9 @@ export function applyDeepLink(store: BoardStore, search: string, onDone?: () => 
 			// An explicit camera wins over shape-derived framing.
 			if (!camera) frameShapes(store, ids);
 		}
-		if (camera) store.animateViewportTo(camera);
+		// Instant, not animated: the deep link should land already at its target,
+		// and the animated path can no-op when its rAF loop isn't ticking on load.
+		if (camera) store.animateViewportTo(camera, { animate: false });
 		finish();
 	};
 

--- a/plugins/usketch-plugin-deep-link/src/frame.ts
+++ b/plugins/usketch-plugin-deep-link/src/frame.ts
@@ -6,6 +6,11 @@ export interface FrameOptions {
 	maxZoom?: number;
 	/** Screen-space padding (px) kept around the framed bounds. */
 	padding?: number;
+	/**
+	 * Animate the move. Defaults to `false`: a deep link should land already
+	 * framed (like Figma), and the instant path is reliable even when the
+	 * animation's rAF loop isn't ticking yet during initial load.
+	 */
 	animate?: boolean;
 }
 
@@ -41,7 +46,7 @@ function unionBounds(store: BoardStore, shapeIds: string[]): BoundingBox | null 
  * doesn't zoom to an absurd level. No-op when none of the shapes exist.
  */
 export function frameShapes(store: BoardStore, shapeIds: string[], opts: FrameOptions = {}): void {
-	const { maxZoom = 2, padding = 80, animate = true } = opts;
+	const { maxZoom = 2, padding = 80, animate = false } = opts;
 
 	const bounds = unionBounds(store, shapeIds);
 	if (!bounds) return;

--- a/plugins/usketch-plugin-deep-link/src/frame.ts
+++ b/plugins/usketch-plugin-deep-link/src/frame.ts
@@ -1,5 +1,5 @@
 import type { BoardStore, BoundingBox } from "@edv4h/usketch-shared";
-import { getRotatedAABB, getScreenSize } from "@edv4h/usketch-shared";
+import { getRotatedAABB, getScreenSize, safeRotation } from "@edv4h/usketch-shared";
 
 export interface FrameOptions {
 	/** Never zoom in past this level (keeps a tiny single shape from filling the screen). */
@@ -28,7 +28,9 @@ function unionBounds(store: BoardStore, shapeIds: string[]): BoundingBox | null 
 		found = true;
 		const aabb = getRotatedAABB(
 			{ x: s.x, y: s.y, width: s.width, height: s.height },
-			s.rotation ?? 0,
+			// safeRotation sanitizes NaN/Infinity → 0, matching other bounds codepaths
+			// so a corrupt rotation can't propagate NaN bounds and break framing.
+			safeRotation(s.rotation),
 		);
 		minX = Math.min(minX, aabb.x);
 		minY = Math.min(minY, aabb.y);

--- a/plugins/usketch-plugin-deep-link/src/frame.ts
+++ b/plugins/usketch-plugin-deep-link/src/frame.ts
@@ -1,0 +1,60 @@
+import type { BoardStore, BoundingBox } from "@edv4h/usketch-shared";
+import { getRotatedAABB, getScreenSize } from "@edv4h/usketch-shared";
+
+export interface FrameOptions {
+	/** Never zoom in past this level (keeps a tiny single shape from filling the screen). */
+	maxZoom?: number;
+	/** Screen-space padding (px) kept around the framed bounds. */
+	padding?: number;
+	animate?: boolean;
+}
+
+/** Union AABB of the given shapes in world space (rotation-aware); `null` if none exist. */
+function unionBounds(store: BoardStore, shapeIds: string[]): BoundingBox | null {
+	let minX = Number.POSITIVE_INFINITY;
+	let minY = Number.POSITIVE_INFINITY;
+	let maxX = Number.NEGATIVE_INFINITY;
+	let maxY = Number.NEGATIVE_INFINITY;
+	let found = false;
+
+	for (const id of shapeIds) {
+		const s = store.getShape(id);
+		if (!s) continue;
+		found = true;
+		const aabb = getRotatedAABB(
+			{ x: s.x, y: s.y, width: s.width, height: s.height },
+			s.rotation ?? 0,
+		);
+		minX = Math.min(minX, aabb.x);
+		minY = Math.min(minY, aabb.y);
+		maxX = Math.max(maxX, aabb.x + aabb.width);
+		maxY = Math.max(maxY, aabb.y + aabb.height);
+	}
+
+	if (!found) return null;
+	return { x: minX, y: minY, width: Math.max(maxX - minX, 1), height: Math.max(maxY - minY, 1) };
+}
+
+/**
+ * Center + zoom the viewport onto `shapeIds`. Zoom is chosen to fit the union
+ * bounds with padding, clamped to `[0.1, maxZoom]` so a single small shape
+ * doesn't zoom to an absurd level. No-op when none of the shapes exist.
+ */
+export function frameShapes(store: BoardStore, shapeIds: string[], opts: FrameOptions = {}): void {
+	const { maxZoom = 2, padding = 80, animate = true } = opts;
+
+	const bounds = unionBounds(store, shapeIds);
+	if (!bounds) return;
+
+	const screen = getScreenSize();
+	const fitW = (screen.width - padding * 2) / bounds.width;
+	const fitH = (screen.height - padding * 2) / bounds.height;
+	const zoom = Math.min(Math.max(Math.min(fitW, fitH), 0.1), maxZoom);
+
+	const cx = bounds.x + bounds.width / 2;
+	const cy = bounds.y + bounds.height / 2;
+	store.animateViewportTo(
+		{ x: screen.width / 2 - cx * zoom, y: screen.height / 2 - cy * zoom, zoom },
+		{ animate },
+	);
+}

--- a/plugins/usketch-plugin-deep-link/src/index.ts
+++ b/plugins/usketch-plugin-deep-link/src/index.ts
@@ -1,0 +1,4 @@
+export { applyDeepLink } from "./apply.js";
+export { type FrameOptions, frameShapes } from "./frame.js";
+export { createDeepLinkPlugin } from "./plugin.js";
+export { type DeepLinkState, decodeDeepLink, encodeDeepLink } from "./url-state.js";

--- a/plugins/usketch-plugin-deep-link/src/plugin.ts
+++ b/plugins/usketch-plugin-deep-link/src/plugin.ts
@@ -1,0 +1,62 @@
+import type { PluginContext, StoreEvent, UsketchPlugin } from "@edv4h/usketch-shared";
+import { applyDeepLink } from "./apply.js";
+import { encodeDeepLink } from "./url-state.js";
+
+/** Coalesce rapid selection changes (e.g. marquee) into a single URL write. */
+const WRITE_DEBOUNCE_MS = 150;
+
+/**
+ * Deep-link plugin: keeps the URL in sync with the current selection and
+ * restores selection/viewport from the URL on load — like Figma's `?node-id`.
+ *
+ * Framework-agnostic: it reads `window.location` and writes via
+ * `history.replaceState`, so it needs no router. Selection is synced live;
+ * an exact camera (`?x&y&zoom`) is only produced by an explicit "copy view
+ * link" action, not on every pan.
+ */
+export function createDeepLinkPlugin(): UsketchPlugin {
+	return {
+		id: "usketch-plugin-deep-link",
+		name: "ディープリンク",
+
+		setup(ctx: PluginContext) {
+			if (typeof window === "undefined") return () => {};
+
+			const store = ctx.store;
+			// Suppress URL writes until the initial apply settles, so restoring a
+			// selection from the URL doesn't immediately rewrite it (or clobber the
+			// camera during the async wait-for-sync window).
+			let applying = true;
+			let writeTimer: ReturnType<typeof setTimeout> | null = null;
+
+			const writeUrl = () => {
+				const selection = [...store.getSelection()].filter((id) => store.getShape(id));
+				const search = encodeDeepLink(window.location.search, { shapeIds: selection });
+				const url = `${window.location.pathname}${search}${window.location.hash}`;
+				window.history.replaceState(null, "", url);
+			};
+
+			const scheduleWrite = () => {
+				if (applying) return;
+				if (writeTimer) clearTimeout(writeTimer);
+				writeTimer = setTimeout(writeUrl, WRITE_DEBOUNCE_MS);
+			};
+
+			// Restore selection/viewport from the URL (waits for CRDT sync if needed).
+			const disposeApply = applyDeepLink(store, window.location.search, () => {
+				applying = false;
+			});
+
+			// Live selection → URL.
+			const offMutation = store.onMutation((e: StoreEvent) => {
+				if (e.type === "selection:changed") scheduleWrite();
+			});
+
+			return () => {
+				if (writeTimer) clearTimeout(writeTimer);
+				offMutation();
+				disposeApply();
+			};
+		},
+	};
+}

--- a/plugins/usketch-plugin-deep-link/src/url-state.ts
+++ b/plugins/usketch-plugin-deep-link/src/url-state.ts
@@ -77,8 +77,12 @@ export function encodeDeepLink(search: string, state: Partial<DeepLinkState>): s
 		}
 	}
 
-	// URLSearchParams percent-encodes the comma separator; restore it so the
-	// `shape` list stays human-readable (comma is a valid query sub-delim).
-	const qs = params.toString().replace(/%2C/g, ",");
+	// URLSearchParams percent-encodes the comma separator; restore it *only*
+	// within the `shape` param so the id list stays human-readable (comma is a
+	// valid query sub-delim). Other params keep their exact encoding, per the
+	// "unrelated params are preserved" contract.
+	const qs = params
+		.toString()
+		.replace(/(^|&)(shape=)([^&]*)/, (_m, pre, key, val) => pre + key + val.replace(/%2C/g, ","));
 	return qs ? `?${qs}` : "";
 }

--- a/plugins/usketch-plugin-deep-link/src/url-state.ts
+++ b/plugins/usketch-plugin-deep-link/src/url-state.ts
@@ -1,0 +1,84 @@
+import type { Viewport } from "@edv4h/usketch-shared";
+
+/**
+ * Deep-link state carried in the URL query string.
+ *
+ * - `shapeIds`: selected shapes (Figma's `node-id` equivalent, but plural).
+ * - `camera`: exact pan/zoom to restore. `null` when the link only anchors a
+ *   selection and framing should be derived from the shapes instead.
+ */
+export interface DeepLinkState {
+	shapeIds: string[];
+	camera: Viewport | null;
+}
+
+const SHAPE_PARAM = "shape";
+const X_PARAM = "x";
+const Y_PARAM = "y";
+const ZOOM_PARAM = "zoom";
+
+/** Round to `dp` decimal places (keeps the zoom param short). */
+function roundTo(n: number, dp: number): number {
+	const f = 10 ** dp;
+	return Math.round(n * f) / f;
+}
+
+/** Parse a query string (`location.search`) into a {@link DeepLinkState}. */
+export function decodeDeepLink(search: string): DeepLinkState {
+	const params = new URLSearchParams(search);
+
+	const shapeRaw = params.get(SHAPE_PARAM);
+	const shapeIds = shapeRaw
+		? shapeRaw
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean)
+		: [];
+
+	const xs = params.get(X_PARAM);
+	const ys = params.get(Y_PARAM);
+	const zs = params.get(ZOOM_PARAM);
+	let camera: Viewport | null = null;
+	if (xs !== null && ys !== null && zs !== null) {
+		const x = Number(xs);
+		const y = Number(ys);
+		const zoom = Number(zs);
+		if (Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(zoom) && zoom > 0) {
+			camera = { x, y, zoom };
+		}
+	}
+
+	return { shapeIds, camera };
+}
+
+/**
+ * Merge deep-link fields into an existing query string, returning the new
+ * `search` (including the leading `?`, or `""` when empty). Only the fields
+ * present in `state` are touched, so unrelated params (e.g. tracking tokens)
+ * are preserved. Passing `shapeIds: []` / `camera: null` removes those params.
+ */
+export function encodeDeepLink(search: string, state: Partial<DeepLinkState>): string {
+	const params = new URLSearchParams(search);
+
+	if (state.shapeIds !== undefined) {
+		if (state.shapeIds.length > 0) params.set(SHAPE_PARAM, state.shapeIds.join(","));
+		else params.delete(SHAPE_PARAM);
+	}
+
+	if (state.camera !== undefined) {
+		if (state.camera) {
+			params.set(X_PARAM, String(Math.round(state.camera.x)));
+			params.set(Y_PARAM, String(Math.round(state.camera.y)));
+			params.set(ZOOM_PARAM, String(roundTo(state.camera.zoom, 3)));
+		} else {
+			params.delete(X_PARAM);
+			params.delete(Y_PARAM);
+			params.delete(ZOOM_PARAM);
+		}
+	}
+
+	// URLSearchParams percent-encodes the comma separator; restore it so the
+	// `shape` list stays human-readable (comma is a valid query sub-delim).
+	const qs = params.toString().replace(/%2C/g, ",");
+	return qs ? `?${qs}` : "";
+}

--- a/plugins/usketch-plugin-deep-link/src/url-state.ts
+++ b/plugins/usketch-plugin-deep-link/src/url-state.ts
@@ -79,8 +79,8 @@ export function encodeDeepLink(search: string, state: Partial<DeepLinkState>): s
 
 	// URLSearchParams percent-encodes the comma separator; restore it *only*
 	// within the `shape` param so the id list stays human-readable (comma is a
-	// valid query sub-delim). Other params keep their exact encoding, per the
-	// "unrelated params are preserved" contract.
+	// valid query sub-delim). Unrelated params keep their key/value (though
+	// URLSearchParams may normalize their escaping/ordering when re-serializing).
 	const qs = params
 		.toString()
 		.replace(/(^|&)(shape=)([^&]*)/, (_m, pre, key, val) => pre + key + val.replace(/%2C/g, ","));

--- a/plugins/usketch-plugin-deep-link/tsconfig.json
+++ b/plugins/usketch-plugin-deep-link/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.lib.json",
+	"compilerOptions": {
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,9 @@ importers:
       '@edv4h/usketch-plugin-container':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-container
+      '@edv4h/usketch-plugin-deep-link':
+        specifier: workspace:*
+        version: link:../../plugins/usketch-plugin-deep-link
       '@edv4h/usketch-plugin-domain-design':
         specifier: workspace:*
         version: link:../../plugins/usketch-plugin-domain-design
@@ -1052,6 +1055,25 @@ importers:
       '@types/react':
         specifier: 19.2.18
         version: 19.2.18
+      typescript:
+        specifier: 7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@types/node@25.9.5)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.2.0(@types/node@25.9.5)(esbuild@0.28.1)(tsx@4.21.0)(yaml@2.8.3))
+
+  plugins/usketch-plugin-deep-link:
+    dependencies:
+      '@edv4h/usketch-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@edv4h/usketch-shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@edv4h/usketch-store':
+        specifier: workspace:*
+        version: link:../../packages/store
+    devDependencies:
       typescript:
         specifier: 7.0.2
         version: 7.0.2


### PR DESCRIPTION
## 概要

選択したShapeや現在の表示位置を **URLで共有** できるディープリンク機能を追加。Figmaの `?node-id=...` に相当する体験。

## URLスキーム

```
?shape=<id>[,<id>...]   選択（複数対応・ライブ同期）
?x=<n>&y=<n>&zoom=<n>   厳密なカメラ位置（「この表示へのリンク」用）
```

- **選択はライブ同期**: Shapeを選ぶと `history.replaceState` で `?shape=` が更新（履歴は汚さない）。
- **読込時**: URLを解析して選択＋フォーカス。CRDT未同期のShapeは `shape:added` を購読し出現までリトライ（timeout付き）。
- **カメラ**: `?x&y&zoom` があれば自動フレーミングより優先して厳密復元。
- **共有ダイアログ**に「この表示へのリンクをコピー」を追加（現在の選択＋pan/zoom入り）。

## 実装

- 新規フレームワーク非依存プラグイン `usketch-plugin-deep-link`（`URLSearchParams` + `history.replaceState`、tldrawと同型。routerに非依存）。
- `apps/web` に登録し、共有ダイアログを拡張。

## 検証（dev serverでブラウザ実機確認済み）

- ✅ 選択のライブ同期（単一 `?shape=dlA` / 複数 `?shape=dlA,dlB` / 解除で除去）
- ✅ 読込時に選択＋中央フォーカス（単一shapeを画面中央にセンタリング）
- ✅ 複数shapeのfitフレーミング（両方が画面に収まる）
- ✅ `?x&y&zoom` で厳密なカメラ復元
- ✅ 存在しないID → クラッシュせず無視
- ✅ 単体テスト15件（encode/decode往復・エッジ）green、web typecheck / biome lint green

> Note: 読込時のフレーミング/カメラは `animate:false`（即時ジャンプ）。`animate:true` はrAF駆動で読込直後やタブ非表示時にtweenが進まないため、Figma同様の即着地に統一。

🤖 Generated with [Claude Code](https://claude.com/claude-code)