### PR TITLE
feat(presentation): add fitPadding option to fill viewport on present

### DIFF
--- a/.changeset/slide-navigator-fit-padding.md
+++ b/.changeset/slide-navigator-fit-padding.md
@@ -1,0 +1,7 @@
+---
+"@edv4h/usketch-plugin-presentation": minor
+---
+
+`SlideNavigator` / `createPresentationPlugin` に `fitPadding` オプションを追加。
+
+`gotoIndex` の `store.fitToBounds` に渡す余白 (px) をホストから指定できる (省略時は従来どおり 40)。発表でスライドを画角いっぱい (上下または左右が画角の端に接する) に収めたいときは `fitPadding: 0` を渡す。余白 0 で生じるレターボックスは `mask` で暗転できる。

--- a/plugins/usketch-plugin-presentation/src/plugin.tsx
+++ b/plugins/usketch-plugin-presentation/src/plugin.tsx
@@ -52,6 +52,12 @@ export interface PresentationPluginOptions {
 	onExit?: () => void;
 	/** present 時に画角 (現スライド) 以外の Canvas を暗幕で隠すか (overlay トグルの初期値)。 */
 	mask?: boolean;
+	/**
+	 * スライドに寄せるときの fitToBounds 余白 (px)。省略時 40。
+	 * 発表でスライドを画角いっぱい (上下または左右が端に接する) にしたいときは 0。
+	 * 余白 0 のレターボックスは mask で暗転できる。
+	 */
+	fitPadding?: number;
 }
 
 function defaultGetViewportSize(): { width: number; height: number } {
@@ -82,6 +88,7 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 	const renderEditUI = opts.renderEditUI ?? true;
 	const onExit = opts.onExit;
 	const mask = opts.mask;
+	const fitPadding = opts.fitPadding;
 
 	return {
 		id: "presentation",
@@ -89,6 +96,7 @@ export function createPresentationPlugin(opts: PresentationPluginOptions): Usket
 		setup(ctx: PluginContext) {
 			let nav: SlideNavigator | null = new SlideNavigator(ctx.store, getViewportSize, {
 				isSlide,
+				fitPadding,
 			});
 			const unregisters: Array<() => void> = [];
 			const navRef = nav;

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.test.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.test.ts
@@ -75,9 +75,28 @@ describe("SlideNavigator isSlide predicate", () => {
 		nav.gotoIndex(1);
 
 		expect(nav.getCurrentIndex()).toBe(1);
+		// 既定の余白 40 で fitToBounds に渡す。
 		expect(fit).toHaveBeenCalledWith(
 			{ x: 500, y: 300, width: 200, height: 150 },
 			{ width: 800, height: 600 },
+			40,
+		);
+		nav.destroy();
+	});
+
+	it("fitPadding を渡すと fitToBounds の余白として使う (発表の画角いっぱい=0)", () => {
+		const store = createBoardStore();
+		store.addShape(shape({ id: "f1", type: "frame", x: 0, y: 0, width: 100, height: 100 }));
+		store.addShape(shape({ id: "f2", type: "frame", x: 500, y: 300, width: 200, height: 150 }));
+		const fit = vi.spyOn(store, "fitToBounds");
+
+		const nav = new SlideNavigator(store, viewport, { fitPadding: 0 });
+		nav.gotoIndex(1);
+
+		expect(fit).toHaveBeenCalledWith(
+			{ x: 500, y: 300, width: 200, height: 150 },
+			{ width: 800, height: 600 },
+			0,
 		);
 		nav.destroy();
 	});

--- a/plugins/usketch-plugin-presentation/src/slide-navigator.ts
+++ b/plugins/usketch-plugin-presentation/src/slide-navigator.ts
@@ -13,6 +13,12 @@ export interface SlideNavigatorOptions {
 	 * 「スライド指定した Frame だけ」や専用の画角 shape を対象にしたいときに差し替える。
 	 */
 	isSlide?: IsSlide;
+	/**
+	 * gotoIndex の fitToBounds に渡す余白（px）。省略時は 40。
+	 * 発表用途でスライドを画角いっぱい（上下または左右が端に接する）に収めたい
+	 * ときは 0 を渡す。余白 0 で生じるレターボックスはホスト側のマスク等で扱う。
+	 */
+	fitPadding?: number;
 }
 
 /**
@@ -35,6 +41,8 @@ export class SlideNavigator {
 	private frameIds: Set<string>;
 	/** スライド判定述語（省略時は Frame）。 */
 	private readonly isSlide: IsSlide;
+	/** fitToBounds の余白（px）。省略時 40。発表で画角いっぱいにしたいときは 0。 */
+	private readonly fitPadding: number;
 
 	constructor(
 		private readonly store: BoardStore,
@@ -42,6 +50,7 @@ export class SlideNavigator {
 		options: SlideNavigatorOptions = {},
 	) {
 		this.isSlide = options.isSlide ?? defaultIsSlide;
+		this.fitPadding = options.fitPadding ?? 40;
 		this.getViewportSize = getViewportSize;
 		const initialSlides = this.getSlides();
 		this.frameIds = new Set(initialSlides.map((s) => s.id));
@@ -137,7 +146,7 @@ export class SlideNavigator {
 				width: target.width,
 				height: target.height,
 			};
-			this.store.fitToBounds(bounds, this.getViewportSize());
+			this.store.fitToBounds(bounds, this.getViewportSize(), this.fitPadding);
 		}
 		for (const l of this.changeListeners) l(clamped);
 	}


### PR DESCRIPTION
## Summary
`SlideNavigator` / `createPresentationPlugin` に `fitPadding` オプションを追加。`gotoIndex` の `store.fitToBounds` に渡す余白(px)をホストから指定できる(省略時 40 = 従来どおり)。

発表でスライドを**画角いっぱい**(上下または左右がビューポートの端に接する)に収めたいときは `fitPadding: 0` を渡す。余白 0 で生じるレターボックスは `mask` で暗転できる。

## Changes
- `SlideNavigatorOptions.fitPadding?: number`(既定 40)。`gotoIndex` の `fitToBounds(bounds, viewport, fitPadding)` に反映。
- `createPresentationPlugin` の `fitPadding?` を `SlideNavigator` へスレッド。
- test: 既定 40 / `fitPadding: 0` の両方で `fitToBounds` の第3引数を検証。

## Test plan
- [x] `pnpm --filter @edv4h/usketch-plugin-presentation test`(7 pass)
- [x] `tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)