### PR TITLE
fix(changeset): unblock release — drop ignored package from deep-link changeset

### DIFF
--- a/.changeset/deep-link-url-sharing.md
+++ b/.changeset/deep-link-url-sharing.md
@@ -1,6 +1,5 @@
 ---
 "@edv4h/usketch-plugin-deep-link": minor
-"@edv4h/usketch-web": patch
 ---
 
 URLで選択shape・表示位置を共有できるディープリンク機能を追加（Figmaの `?node-id` 相当）


### PR DESCRIPTION
## Problem
Release workflow (`changeset version`) が全リリースで失敗している:

```
Error: Found mixed changeset deep-link-url-sharing
Found ignored packages: @edv4h/usketch-web
Found not ignored packages: @edv4h/usketch-plugin-deep-link
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

`.changeset/deep-link-url-sharing.md` が ignore 対象 (`@edv4h/usketch-web`) と非 ignore の plugin を混在させており、リポジトリ全体の versioning が止まっていた (#894 由来、#897 のリリースもブロック)。

## Fix
`@edv4h/usketch-web` (config.json の ignore 対象=非公開) を changeset から除去。ignore 対象は versioning/publish されないため、公開物への影響なし。

これで pending changeset は非 ignore のみ (deep-link / slide-navigator fitPadding) になり `changeset version` が通る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)