### PR TITLE
👷 fix(release): verify ゲートを tag フォールバックで誤判定しないよう修正

### DIFF
--- a/.changeset/release-verify-gate-tag-fallback.md
+++ b/.changeset/release-verify-gate-tag-fallback.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI: release.yml の「Verify publish succeeded」ゲートに tag ベースのフォールバック判定を追加。tag push の transient エラーで changesets が `published` 出力をセットできずに赤くなる誤判定を解消（パッケージリリースなし）。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,16 +124,40 @@ jobs:
             echo "npm publish succeeded (published=true); the step failure was the transient tag push, now reconciled."
             exit 0
           fi
+
           # The `commit_refs` tag-push failure can abort the changesets action
           # *before* it sets `published`, even though `changeset publish` already
           # finished publishing to npm. `changeset publish` creates each package's
-          # local git tag only after that package publishes, so package tags on
-          # the release commit are concrete evidence that npm publish succeeded.
-          published_tags=$(git tag --points-at HEAD | grep '@' || true)
-          if [ -n "$published_tags" ]; then
-            echo "published output was unset, but package tags exist on the release commit — npm publish succeeded:"
-            echo "$published_tags"
-            exit 0
+          # local git tag only after that package publishes, so a per-package tag
+          # on the release commit is concrete evidence that package published.
+          #
+          # Don't accept "any tag" — a publish that fails partway would leave some
+          # tags and mask an incomplete release. Instead require a tag for *every*
+          # package whose version was bumped in this release commit.
+          mapfile -t changed < <(git diff --name-only "HEAD^1" HEAD -- '**/package.json' 'package.json' || true)
+          bumped=0
+          missing=""
+          for f in "${changed[@]}"; do
+            [ -f "$f" ] || continue
+            [ "$(node -p "require('./$f').private === true" 2>/dev/null || echo false)" = "true" ] && continue
+            new_ver=$(node -p "require('./$f').version" 2>/dev/null || echo "")
+            name=$(node -p "require('./$f').name" 2>/dev/null || echo "")
+            [ -z "$name" ] || [ -z "$new_ver" ] && continue
+            old_ver=$(git show "HEAD^1:$f" 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).version" 2>/dev/null || echo "")
+            [ "$new_ver" = "$old_ver" ] && continue   # version unchanged → not a publish target
+            bumped=$((bumped + 1))
+            if ! git tag --points-at HEAD | grep -qx "$name@$new_ver"; then
+              missing="$missing $name@$new_ver"
+            fi
+          done
+
+          if [ -n "$missing" ]; then
+            echo "::error::publish incomplete — no release tag for:$missing"
+            exit 1
           fi
-          echo "::error::changesets step failed and no packages were published."
-          exit 1
+          if [ "$bumped" -eq 0 ]; then
+            echo "::error::changesets step failed and no packages were published."
+            exit 1
+          fi
+          echo "published output was unset, but all $bumped bumped package(s) have tags on the release commit — npm publish succeeded."
+          exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,21 @@ jobs:
       - name: Verify publish succeeded
         if: ${{ always() && steps.changesets.outcome == 'failure' }}
         run: |
+          # Primary signal: the action's own `published` output.
           if [ "${{ steps.changesets.outputs.published }}" = "true" ]; then
-            echo "npm publish succeeded; the changesets step failure was the transient tag push, now reconciled."
-          else
-            echo "::error::changesets step failed and no packages were published."
-            exit 1
+            echo "npm publish succeeded (published=true); the step failure was the transient tag push, now reconciled."
+            exit 0
           fi
+          # The `commit_refs` tag-push failure can abort the changesets action
+          # *before* it sets `published`, even though `changeset publish` already
+          # finished publishing to npm. `changeset publish` creates each package's
+          # local git tag only after that package publishes, so package tags on
+          # the release commit are concrete evidence that npm publish succeeded.
+          published_tags=$(git tag --points-at HEAD | grep '@' || true)
+          if [ -n "$published_tags" ]; then
+            echo "published output was unset, but package tags exist on the release commit — npm publish succeeded:"
+            echo "$published_tags"
+            exit 0
+          fi
+          echo "::error::changesets step failed and no packages were published."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
             old_ver=$(git show "HEAD^1:$f" 2>/dev/null | node -pe "JSON.parse(require('fs').readFileSync(0,'utf8')).version" 2>/dev/null || echo "")
             [ "$new_ver" = "$old_ver" ] && continue   # version unchanged → not a publish target
             bumped=$((bumped + 1))
-            if ! git tag --points-at HEAD | grep -qx "$name@$new_ver"; then
+            if ! git tag --points-at HEAD | grep -Fqx "$name@$new_ver"; then
               missing="$missing $name@$new_ver"
             fi
           done


### PR DESCRIPTION
## 背景

Release ワークフローの「Verify publish succeeded」ゲートが、**publish 成功済みでも赤くなる**誤判定を起こしていた（直近の core@2.4.0 / shared@4.10.0 リリースでも発生）。

### 原因
`changeset publish` はパッケージごとに `git push origin <tag>` を実行するが、80+パッケージの連続 push で GitHub の `remote: fatal error in commit_refs`（transient）を踏むことがある。すると changesets アクションが **`published` 出力をセットする前に非0終了**する。

ゲートは `steps.changesets.outputs.published == "true"` だけで判定していたため、npm publish は成功しているのに `published` が空 → 「no packages published」と誤判定して `exit 1`。

## 修正

`published` が未セットのときのフォールバックとして、**リリースコミットに付いたパッケージtag** を根拠に publish 成功を判定する。`changeset publish` は各パッケージを npm publish した**後**にローカルtagを作る（失敗したのは push だけでローカルtagは存在する）ため、`git tag --points-at HEAD` にパッケージtagがあれば publish は成功している。

- `published=true` → 従来どおり成功。
- `published` 未セット but HEAD にパッケージtagあり → 成功（transient tag-push の誤判定を解消）。
- どちらでもない → 従来どおり本物の失敗として `exit 1`。

reconcile 系ステップ（tag 再push・GitHub Release 補完）は変更なし。パッケージリリースは伴わない（空 changeset）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)