### PR TITLE
✨ feat(card): デッキのユーティリティアクション追加（Draw N / Draw to hand / Spread）

### DIFF
--- a/.changeset/card-deck-utility-actions.md
+++ b/.changeset/card-deck-utility-actions.md
@@ -1,0 +1,11 @@
+---
+"@edv4h/usketch-plugin-shape-card": minor
+---
+
+デッキのユーティリティアクションを追加（Control HUD の Card グループに自動表示）
+
+- **Draw cards to board**（既定5枚・枚数パラメータ）: 山札上から N 枚を場に1列で展開。
+- **Draw to hand**（既定1枚・枚数パラメータ）: 山札上から N 枚を場に出さず直接ローカル手札へ。
+- **Spread deck**: 山札の全カードを回転なし・等間隔の折り返しグリッドで場に展開し、山札を空にする。
+
+いずれも単一コマンドで Undo/Redo 可能。純関数 `drawN`（deck.ts）と `gridPositions`（geometry.ts）を追加。

--- a/plugins/usketch-plugin-shape-card/src/__tests__/deck.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/deck.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { drawTop, shuffle } from "../deck.js";
+import { drawN, drawTop, shuffle } from "../deck.js";
 
 describe("drawTop", () => {
 	it("returns the top card (index 0) and the rest", () => {
@@ -18,6 +18,38 @@ describe("drawTop", () => {
 		const input = ["a", "b"];
 		drawTop(input);
 		expect(input).toEqual(["a", "b"]);
+	});
+});
+
+describe("drawN", () => {
+	it("draws the top n cards and returns the rest", () => {
+		const { drawn, rest } = drawN(["a", "b", "c", "d", "e"], 3);
+		expect(drawn).toEqual(["a", "b", "c"]);
+		expect(rest).toEqual(["d", "e"]);
+	});
+
+	it("draws all when n equals the length", () => {
+		const { drawn, rest } = drawN(["a", "b"], 2);
+		expect(drawn).toEqual(["a", "b"]);
+		expect(rest).toEqual([]);
+	});
+
+	it("clamps n to the available count (does not overdraw)", () => {
+		const { drawn, rest } = drawN(["a", "b"], 5);
+		expect(drawn).toEqual(["a", "b"]);
+		expect(rest).toEqual([]);
+	});
+
+	it("draws nothing for n <= 0 or an empty deck", () => {
+		expect(drawN(["a", "b"], 0)).toEqual({ drawn: [], rest: ["a", "b"] });
+		expect(drawN(["a", "b"], -3)).toEqual({ drawn: [], rest: ["a", "b"] });
+		expect(drawN<string>([], 3)).toEqual({ drawn: [], rest: [] });
+	});
+
+	it("does not mutate the input", () => {
+		const input = ["a", "b", "c"];
+		drawN(input, 2);
+		expect(input).toEqual(["a", "b", "c"]);
 	});
 });
 

--- a/plugins/usketch-plugin-shape-card/src/__tests__/geometry.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/geometry.test.ts
@@ -1,6 +1,42 @@
 import type { ShapeData } from "@edv4h/usketch-shared";
 import { describe, expect, it } from "vitest";
-import { makeAspectResize, rectHitTest } from "../geometry.js";
+import { gridPositions, makeAspectResize, rectHitTest } from "../geometry.js";
+
+describe("gridPositions", () => {
+	const opts = { stepX: 10, stepY: 20, originX: 100, originY: 200 };
+
+	it("lays out a single row when cols >= count", () => {
+		const pos = gridPositions(3, { ...opts, cols: 3 });
+		expect(pos).toEqual([
+			{ x: 100, y: 200 },
+			{ x: 110, y: 200 },
+			{ x: 120, y: 200 },
+		]);
+	});
+
+	it("wraps to the next row when count exceeds cols", () => {
+		const pos = gridPositions(5, { ...opts, cols: 2 });
+		expect(pos).toEqual([
+			{ x: 100, y: 200 }, // row 0
+			{ x: 110, y: 200 },
+			{ x: 100, y: 220 }, // row 1
+			{ x: 110, y: 220 },
+			{ x: 100, y: 240 }, // row 2
+		]);
+	});
+
+	it("returns an empty array for count 0", () => {
+		expect(gridPositions(0, { ...opts, cols: 3 })).toEqual([]);
+	});
+
+	it("treats cols < 1 as a single column", () => {
+		const pos = gridPositions(2, { ...opts, cols: 0 });
+		expect(pos).toEqual([
+			{ x: 100, y: 200 },
+			{ x: 100, y: 220 },
+		]);
+	});
+});
 
 const base: ShapeData = {
 	id: "c1",

--- a/plugins/usketch-plugin-shape-card/src/deck.ts
+++ b/plugins/usketch-plugin-shape-card/src/deck.ts
@@ -18,3 +18,12 @@ export function drawTop<T>(cards: readonly T[]): { card: T | null; rest: T[] } {
 	const [card, ...rest] = cards;
 	return { card, rest };
 }
+
+/**
+ * 上から `n` 枚引く。`n` は `[0, length]` にクランプするので、残り枚数より多く要求しても
+ * 引けるだけ引く。`drawn` は先頭 `n` 枚（index 0 が一番上）、`rest` は残り。元配列は破壊しない。
+ */
+export function drawN<T>(cards: readonly T[], n: number): { drawn: T[]; rest: T[] } {
+	const count = Math.max(0, Math.min(Math.floor(n), cards.length));
+	return { drawn: cards.slice(0, count), rest: cards.slice(count) };
+}

--- a/plugins/usketch-plugin-shape-card/src/geometry.ts
+++ b/plugins/usketch-plugin-shape-card/src/geometry.ts
@@ -17,6 +17,25 @@ export function rectHitTest(data: ShapeData, point: Point): boolean {
 export const MIN_CARD_WIDTH = 60;
 
 /**
+ * `count` 個を `origin` から `stepX`/`stepY` 間隔で並べたグリッド座標を返す（純関数・回転なし）。
+ * `cols` 列ごとに折り返すので、`cols = count` なら 1 行、`cols < count` なら複数行になる。
+ * カードを場に整列展開する（Draw N / Spread deck）ときの配置に使う。
+ */
+export function gridPositions(
+	count: number,
+	opts: { cols: number; stepX: number; stepY: number; originX: number; originY: number },
+): Point[] {
+	const cols = Math.max(1, Math.floor(opts.cols));
+	const positions: Point[] = [];
+	for (let i = 0; i < Math.max(0, Math.floor(count)); i++) {
+		const col = i % cols;
+		const row = Math.floor(i / cols);
+		positions.push({ x: opts.originX + col * opts.stepX, y: opts.originY + row * opts.stepY });
+	}
+	return positions;
+}
+
+/**
  * アスペクト比を固定したリサイズを生成する。比は shape の card-type から取得し、
  * 取れない場合は現在の縦横比にフォールバックする。ハンドルの反対側を固定する。
  */

--- a/plugins/usketch-plugin-shape-card/src/index.ts
+++ b/plugins/usketch-plugin-shape-card/src/index.ts
@@ -7,7 +7,7 @@ export type { PlayingCardFields, Suit } from "./card-types/playing-card.js";
 export { playingCardType } from "./card-types/playing-card.js";
 export type { UnoCardFields, UnoColor } from "./card-types/uno.js";
 export { unoCardType } from "./card-types/uno.js";
-export { drawTop, shuffle } from "./deck.js";
+export { drawN, drawTop, shuffle } from "./deck.js";
 export {
 	CARD_TYPE,
 	createBareCardShape,

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -12,7 +12,7 @@ import {
 	zIndexAfterAll,
 } from "@edv4h/usketch-shared";
 import { createAddShapeCommand, createUpdateShapeCommand } from "@edv4h/usketch-store";
-import { drawTop, shuffle } from "./deck.js";
+import { drawN, drawTop, shuffle } from "./deck.js";
 import {
 	CARD_TYPE,
 	createBareCardShape,
@@ -20,7 +20,7 @@ import {
 	createDeckShape,
 	DECK_TYPE,
 } from "./factory.js";
-import { getBounds, makeAspectResize, rectHitTest } from "./geometry.js";
+import { getBounds, gridPositions, makeAspectResize, rectHitTest } from "./geometry.js";
 import { type CardHandAwareness, createHandStore, type HandCardEntry } from "./hand-store.js";
 import { HandTray } from "./hand-tray.js";
 import {
@@ -313,6 +313,109 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				emitPlacement(newCard);
 			}
 
+			// N 個の zIndex を「全 shape の上」に積んで返す。各値は直前を含めて計算するので
+			// 互いに重ならず、この順で上へ重なる（配置は非重複だが決定的な前後関係を保つ）。
+			function zStackAboveAll(count: number): string[] {
+				let allZ = ctx.store.getShapesSorted().map((s) => s.zIndex);
+				const out: string[] = [];
+				for (let i = 0; i < count; i++) {
+					const z = zIndexAfterAll(allZ);
+					out.push(z);
+					allZ = [...allZ, z];
+				}
+				return out;
+			}
+
+			// デッキから複数の card fields を取り出し、指定レイアウトで場に展開する共通処理。
+			// `layout(n)` は n 枚ぶんのワールド座標を返す。単一 Command で Undo/Redo 可能。
+			function spreadCards(
+				deck: ShapeData,
+				drawn: Record<string, unknown>[],
+				restCards: Record<string, unknown>[],
+				layout: (n: number) => Point[],
+			) {
+				const meta = readDeckMeta(deck);
+				const cardType = meta.cardType;
+				const def = cardType ? registry.get(cardType) : undefined;
+				if (!def || !cardType || drawn.length === 0) return;
+
+				const positions = layout(drawn.length);
+				const zStack = zStackAboveAll(drawn.length);
+				const newCards = drawn.map((fields, i) =>
+					createCardShape(def, {
+						x: positions[i]?.x ?? deck.x,
+						y: positions[i]?.y ?? deck.y,
+						fields,
+						zIndex: zStack[i],
+					}),
+				);
+
+				const deckBefore: DeckMeta = {
+					cardType,
+					cards: [...drawn, ...restCards],
+					faceDown: meta.faceDown ?? true,
+				};
+				const deckAfter: DeckMeta = { cardType, cards: restCards, faceDown: meta.faceDown ?? true };
+
+				ctx.commands.execute({
+					execute() {
+						ctx.store.updateShape(deck.id, { meta: deckAfter as ShapeData["meta"] });
+						for (const c of newCards) ctx.store.addShape(c);
+					},
+					undo() {
+						for (const c of newCards) ctx.store.deleteShape(c.id);
+						ctx.store.updateShape(deck.id, { meta: deckBefore as ShapeData["meta"] });
+					},
+				});
+				ctx.store.setSelection(newCards.map((c) => c.id));
+				for (const c of newCards) emitPlacement(c);
+			}
+
+			const SPREAD_GAP = 16;
+
+			// 場に N 枚引く: デッキの右隣に1列で並べる。
+			function drawManyFromDeck(deck: ShapeData, count: number) {
+				const meta = readDeckMeta(deck);
+				const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+				if (!def) return;
+				const { drawn, rest } = drawN(meta.cards ?? [], count);
+				const stepX = def.defaultSize.width + SPREAD_GAP;
+				spreadCards(deck, drawn, rest, (n) =>
+					gridPositions(n, {
+						cols: n, // 1 行
+						stepX,
+						stepY: 0,
+						originX: deck.x + deck.width + SPREAD_GAP,
+						originY: deck.y,
+					}),
+				);
+			}
+
+			// デッキをバラす: 全カードを回転なし・等間隔の折り返しグリッドで場に展開し、山札を空にする。
+			function scatterDeck(deck: ShapeData) {
+				const meta = readDeckMeta(deck);
+				const def = meta.cardType ? registry.get(meta.cardType) : undefined;
+				if (!def) return;
+				const cards = meta.cards ?? [];
+				if (cards.length === 0) return;
+				const stepX = def.defaultSize.width + SPREAD_GAP;
+				const stepY = def.defaultSize.height + SPREAD_GAP;
+				// 画面幅（ワールド換算）に収まる列数で折り返す。
+				const vw = typeof window !== "undefined" ? window.innerWidth : 1200;
+				const zoom = ctx.store.getViewport().zoom || 1;
+				const availableWorld = (vw * 0.9) / zoom;
+				const cols = Math.max(1, Math.min(cards.length, Math.floor(availableWorld / stepX)));
+				spreadCards(deck, cards, [], (n) =>
+					gridPositions(n, {
+						cols,
+						stepX,
+						stepY,
+						originX: deck.x + deck.width + SPREAD_GAP,
+						originY: deck.y,
+					}),
+				);
+			}
+
 			// ── 手札(hand): 内容はローカル限定、枚数だけ awareness 共有（#671 / 真 private は #686） ──
 			const localUserId = opts.userId ?? "local";
 			const handStore = createHandStore(localUserId, opts.boardId);
@@ -394,6 +497,41 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				emitPlacement(card);
 			}
 
+			// 手札に N 枚引く: デッキから取り出し、場に出さず直接ローカル手札へ入れる（Undo 可能）。
+			function drawToHandFromDeck(deck: ShapeData, count: number) {
+				const meta = readDeckMeta(deck);
+				const cardType = meta.cardType;
+				const def = cardType ? registry.get(cardType) : undefined;
+				if (!def || !cardType) return;
+				const cards = meta.cards ?? [];
+				const { drawn, rest } = drawN(cards, count);
+				if (drawn.length === 0) return;
+
+				const entries: HandCardEntry[] = drawn.map((fields) => ({
+					id: generateId(),
+					cardType,
+					fields: fields as Record<string, unknown>,
+					width: def.defaultSize.width,
+					height: def.defaultSize.height,
+				}));
+
+				const deckBefore: DeckMeta = { cardType, cards, faceDown: meta.faceDown ?? true };
+				const deckAfter: DeckMeta = { cardType, cards: rest, faceDown: meta.faceDown ?? true };
+
+				ctx.commands.execute({
+					execute() {
+						ctx.store.updateShape(deck.id, { meta: deckAfter as ShapeData["meta"] });
+						for (const e of entries) handStore.addToHand(e);
+						broadcastHandCount();
+					},
+					undo() {
+						for (const e of entries) handStore.removeFromHand(e.id);
+						ctx.store.updateShape(deck.id, { meta: deckBefore as ShapeData["meta"] });
+						broadcastHandCount();
+					},
+				});
+			}
+
 			// ── 操作メニュー / トレイからのイベント ──
 			const offFlip = ctx.events.on<{ id: string }>("card:flip", ({ id }) => {
 				const shape = ctx.store.getShape(id);
@@ -402,6 +540,24 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 			const offDraw = ctx.events.on<{ id: string }>("card-deck:draw", ({ id }) => {
 				const deck = ctx.store.getShape(id);
 				if (enableDeck && deck?.type === DECK_TYPE) drawFromDeck(deck);
+			});
+			const offDrawMany = ctx.events.on<{ id: string; count: number }>(
+				"card-deck:draw-many",
+				({ id, count }) => {
+					const deck = ctx.store.getShape(id);
+					if (enableDeck && deck?.type === DECK_TYPE) drawManyFromDeck(deck, count);
+				},
+			);
+			const offDrawToHand = ctx.events.on<{ id: string; count: number }>(
+				"card-deck:draw-to-hand",
+				({ id, count }) => {
+					const deck = ctx.store.getShape(id);
+					if (enableDeck && deck?.type === DECK_TYPE) drawToHandFromDeck(deck, count);
+				},
+			);
+			const offScatter = ctx.events.on<{ id: string }>("card-deck:scatter", ({ id }) => {
+				const deck = ctx.store.getShape(id);
+				if (enableDeck && deck?.type === DECK_TYPE) scatterDeck(deck);
 			});
 			const offToHand = ctx.events.on<{ id: string }>("card:to-hand", ({ id }) =>
 				moveCardToHand(id),
@@ -475,6 +631,39 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 							run: () => {
 								const id = selectedOfType(DECK_TYPE);
 								if (id) ctx.events.emit("card-deck:shuffle", { id });
+							},
+						}),
+						ctx.actions.register({
+							id: "card-deck:draw-many",
+							label: "Draw cards to board",
+							group: "Card",
+							params: [{ name: "count", type: "number", default: 5, min: 1, max: 52, step: 1 }],
+							isEnabled: () => selectedOfType(DECK_TYPE) !== undefined,
+							run: ({ count }) => {
+								const id = selectedOfType(DECK_TYPE);
+								if (id) ctx.events.emit("card-deck:draw-many", { id, count: Number(count) || 5 });
+							},
+						}),
+						ctx.actions.register({
+							id: "card-deck:draw-to-hand",
+							label: "Draw to hand",
+							group: "Card",
+							params: [{ name: "count", type: "number", default: 1, min: 1, max: 52, step: 1 }],
+							isEnabled: () => selectedOfType(DECK_TYPE) !== undefined,
+							run: ({ count }) => {
+								const id = selectedOfType(DECK_TYPE);
+								if (id)
+									ctx.events.emit("card-deck:draw-to-hand", { id, count: Number(count) || 1 });
+							},
+						}),
+						ctx.actions.register({
+							id: "card-deck:scatter",
+							label: "Spread deck",
+							group: "Card",
+							isEnabled: () => selectedOfType(DECK_TYPE) !== undefined,
+							run: () => {
+								const id = selectedOfType(DECK_TYPE);
+								if (id) ctx.events.emit("card-deck:scatter", { id });
 							},
 						}),
 					);
@@ -705,6 +894,9 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				offShuffleShortcut?.();
 				offFlip();
 				offDraw();
+				offDrawMany();
+				offDrawToHand();
+				offScatter();
 				offToHand();
 				offPlayFromHand();
 				for (const off of offActions) off();


### PR DESCRIPTION
## 概要

デッキ（`card-deck` shape = cards 配列のデータパイル）向けに、テーブルトップでよく使うユーティリティアクションを3つ追加。すべて `ctx.actions.register` で登録され **Control HUD の Card グループに自動表示**（独自ツールバーは作らない＝方針どおり）。

| アクション | 内容 | パラメータ |
|---|---|---|
| **Draw cards to board** | 山札上から N 枚を場に1列で展開 | `count`（既定5・1〜52） |
| **Draw to hand** | 山札上から N 枚を場に出さず直接ローカル手札へ | `count`（既定1・1〜52） |
| **Spread deck** | 全カードを回転なし・等間隔の折り返しグリッドで展開し山札を空に | なし |

いずれも**単一コマンドで Undo/Redo 可能**、デッキ選択中のみ有効。

## 実装

- `deck.ts`: 純関数 `drawN(cards, n)`（[0,length] にクランプ・非破壊）を追加。
- `geometry.ts`: 純関数 `gridPositions(count, {cols,stepX,stepY,origin})`（回転なし整列・行折り返し）を追加。
- `plugin.tsx`: `drawManyFromDeck` / `drawToHandFromDeck` / `scatterDeck` ハンドラ＋3アクション＋イベントを追加。既存の `drawFromDeck` / `createCardShape` / `handStore` / `emitPlacement` / command パターンを再利用。

## 検証

- ✅ 単体テスト追加: `drawN`（5ケース）/ `gridPositions`（4ケース）。プラグイン全テスト green。build / lint OK。
- ✅ **dev server 実機確認**（12枚デッキで）:
  - Draw 5 → 山札12→7、場に5枚が等間隔1列（step=幅+16）、5枚選択。
  - Draw to hand 3 → 山札7→4、場は増えず、手札 localStorage +3。
  - Spread deck → 山札4→0（空 shape 残存）、場に4枚グリッド展開。
  - Undo → 各アクションがクリーンに逆再生（手札・山札・場すべて復元）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)