### PR TITLE
♻️ refactor(card): 手札を独自トレイから Control HUD の Hand パネルへ移行

### DIFF
--- a/.changeset/hand-hud-panel.md
+++ b/.changeset/hand-hud-panel.md
@@ -1,0 +1,7 @@
+---
+"@edv4h/usketch-plugin-shape-card": minor
+---
+
+手札(Hand)を独自の下部固定トレイから Control HUD の「Hand」パネルへ移行
+
+プラグインUIはHUDに登録する方針に合わせ、独自トレイUI（`ctx.layers.register("card-hand")` の画面下部固定オーバーレイ）を廃止し、`ctx.hud.registerPanel` で「Hand」パネルとして登録。カード面サムネ＋「場に出す」ボタン＋他者枚数を HUD 内に表示する（挙動・privacyモデルは不変）。

--- a/plugins/usketch-plugin-shape-card/src/__tests__/hand-flow.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/hand-flow.test.ts
@@ -42,6 +42,7 @@ function harness() {
 		shapes: { register: noop, get: () => undefined },
 		tools: { register: noop },
 		layers: { register: noop, unregister: noop },
+		hud: { registerPanel: () => noop, registerSettings: () => noop },
 		shortcuts: { register: () => noop },
 		store: {
 			getShape: (id: string) => shapes.get(id),

--- a/plugins/usketch-plugin-shape-card/src/__tests__/hand-panel.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/hand-panel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { sumOthers } from "../hand-panel.js";
+import type { CardHandAwareness } from "../hand-store.js";
+
+function fakeAwareness(
+	selfClientId: number,
+	states: [number, Record<string, unknown>][],
+): CardHandAwareness {
+	return {
+		setLocalStateField() {},
+		getStates: () => new Map(states),
+		on() {},
+		off() {},
+		doc: { clientID: selfClientId },
+	};
+}
+
+describe("sumOthers", () => {
+	it("returns 0 without awareness", () => {
+		expect(sumOthers(undefined, "me")).toBe(0);
+	});
+
+	it("sums other clients' counts, excluding self client", () => {
+		const aw = fakeAwareness(1, [
+			[1, { cardHand: { userId: "me", count: 3 } }], // self client → excluded
+			[2, { cardHand: { userId: "u2", count: 2 } }],
+			[3, { cardHand: { userId: "u3", count: 4 } }],
+		]);
+		expect(sumOthers(aw, "me")).toBe(6);
+	});
+
+	it("does not double-count the same user on another client", () => {
+		const aw = fakeAwareness(1, [
+			[2, { cardHand: { userId: "me", count: 5 } }], // same user, different client → excluded
+			[3, { cardHand: { userId: "u3", count: 4 } }],
+		]);
+		expect(sumOthers(aw, "me")).toBe(4);
+	});
+
+	it("ignores states without a numeric count", () => {
+		const aw = fakeAwareness(1, [
+			[2, {}],
+			[3, { cardHand: { userId: "u3" } }],
+			[4, { cardHand: { userId: "u4", count: 1 } }],
+		]);
+		expect(sumOthers(aw, "me")).toBe(1);
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/__tests__/plugin-resizable.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/plugin-resizable.test.ts
@@ -36,6 +36,7 @@ function registeredDefs(opts: CreateCardPluginOptions): Map<string, ShapeDefinit
 		},
 		tools: { register: noop },
 		layers: { register: noop, unregister: noop },
+		hud: { registerPanel: () => noop, registerSettings: () => noop },
 		actions: {
 			register: () => noop,
 			unregister: noop,

--- a/plugins/usketch-plugin-shape-card/src/hand-panel.tsx
+++ b/plugins/usketch-plugin-shape-card/src/hand-panel.tsx
@@ -1,27 +1,31 @@
-import { useApp } from "@edv4h/usketch-canvas-engine";
 import type React from "react";
 import { useSyncExternalStore } from "react";
 import type { CardHandAwareness, HandStore } from "./hand-store.js";
 import type { CardTypeDefinition } from "./types.js";
 
 /**
- * Bottom-fixed hand tray (#671). Shows **this client's** hand — contents live
- * only in `handStore` (localStorage), never on the network. Others' hands show
- * as a count only (read from awareness `cardHand.count`). Each card has a
- * "場に出す" (play) button; playing emits `card:play-from-hand`.
+ * Hand panel for the Control HUD (#671). Registered via `ctx.hud.registerPanel`
+ * — the hand is no longer a bespoke bottom-fixed tray, so it lives inside the
+ * HUD like every other plugin surface.
+ *
+ * Shows **this client's** hand — contents live only in `handStore`
+ * (localStorage), never on the network. Others' hands show as a count only
+ * (read from awareness `cardHand.count`). Each card has a "場に出す" (play)
+ * button that calls `onPlay(id)` (the plugin emits `card:play-from-hand`).
  */
-export function HandTray({
+export function HandPanel({
 	handStore,
 	registry,
 	localUserId,
 	awareness,
+	onPlay,
 }: {
 	handStore: HandStore;
 	registry: Map<string, CardTypeDefinition>;
 	localUserId: string;
 	awareness?: CardHandAwareness;
+	onPlay: (id: string) => void;
 }) {
-	const app = useApp();
 	const hand = useSyncExternalStore(handStore.subscribe, handStore.getHand, handStore.getHand);
 
 	// Sum of other clients' hand counts (contents never shared — count only).
@@ -35,39 +39,45 @@ export function HandTray({
 		() => sumOthers(awareness, localUserId),
 	);
 
+	// Hidden entirely when there is nothing to show (matches the old tray), so
+	// the HUD doesn't carry an empty "Hand" section on non-card boards.
 	if (hand.length === 0 && othersCount === 0) return null;
 
 	return (
 		<div style={wrapStyle}>
-			<div style={trayStyle} onPointerDown={(e) => e.stopPropagation()}>
-				{hand.map((entry) => {
-					const def = registry.get(entry.cardType);
-					const aspect = def?.aspectRatio ?? 0.7;
-					const h = 96;
-					const w = Math.round(h * aspect);
-					return (
-						<div key={entry.id} style={cardWrapStyle}>
-							<div style={{ width: w, height: h, ...faceBoxStyle }}>
-								{def ? def.renderFront(entry.fields) : <UnknownFace />}
+			{hand.length > 0 ? (
+				<div style={cardsStyle}>
+					{hand.map((entry) => {
+						const def = registry.get(entry.cardType);
+						const aspect = def?.aspectRatio ?? 0.7;
+						const h = 64;
+						const w = Math.round(h * aspect);
+						return (
+							<div key={entry.id} style={cardWrapStyle}>
+								<div style={{ width: w, height: h, ...faceBoxStyle }}>
+									{def ? def.renderFront(entry.fields) : <UnknownFace />}
+								</div>
+								<button
+									type="button"
+									onClick={() => onPlay(entry.id)}
+									style={playBtnStyle}
+									title="場に出す"
+								>
+									場に出す
+								</button>
 							</div>
-							<button
-								type="button"
-								onClick={() => app.events.emit("card:play-from-hand", { id: entry.id })}
-								style={playBtnStyle}
-								title="場に出す"
-							>
-								場に出す
-							</button>
-						</div>
-					);
-				})}
-				{othersCount > 0 && <div style={othersStyle}>🂠 他 {othersCount}枚</div>}
-			</div>
+						);
+					})}
+				</div>
+			) : (
+				<div style={emptyStyle}>手札なし</div>
+			)}
+			{othersCount > 0 && <div style={othersStyle}>🂠 他 {othersCount}枚</div>}
 		</div>
 	);
 }
 
-function sumOthers(awareness: CardHandAwareness | undefined, localUserId: string): number {
+export function sumOthers(awareness: CardHandAwareness | undefined, localUserId: string): number {
 	if (!awareness) return 0;
 	let total = 0;
 	const selfClient = awareness.doc.clientID;
@@ -86,57 +96,53 @@ function UnknownFace() {
 }
 
 const wrapStyle: React.CSSProperties = {
-	position: "absolute",
-	left: 0,
-	right: 0,
-	bottom: 12,
 	display: "flex",
-	justifyContent: "center",
-	pointerEvents: "none",
+	flexDirection: "column",
+	gap: 6,
+	fontFamily: "system-ui, sans-serif",
 };
 
-const trayStyle: React.CSSProperties = {
+const cardsStyle: React.CSSProperties = {
 	display: "flex",
+	flexWrap: "wrap",
 	alignItems: "flex-end",
-	gap: 8,
-	padding: "8px 12px",
-	background: "rgba(255,255,255,0.95)",
-	borderRadius: 12,
-	boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
-	fontFamily: "system-ui, sans-serif",
-	maxWidth: "90%",
-	overflowX: "auto",
-	pointerEvents: "auto",
+	gap: 6,
+	maxHeight: 220,
+	overflowY: "auto",
 };
 
 const cardWrapStyle: React.CSSProperties = {
 	display: "flex",
 	flexDirection: "column",
 	alignItems: "center",
-	gap: 4,
+	gap: 3,
 };
 
 const faceBoxStyle: React.CSSProperties = {
-	borderRadius: 6,
+	borderRadius: 5,
 	overflow: "hidden",
-	boxShadow: "0 1px 4px rgba(0,0,0,0.2)",
+	boxShadow: "0 1px 4px rgba(0,0,0,0.25)",
 	background: "#fff",
 };
 
 const playBtnStyle: React.CSSProperties = {
-	height: 22,
-	padding: "0 8px",
+	height: 20,
+	padding: "0 6px",
 	border: "1px solid #2680eb",
 	borderRadius: 5,
 	background: "#e8f0fe",
 	color: "#2680eb",
-	fontSize: 11,
+	fontSize: 10,
 	cursor: "pointer",
 };
 
+const emptyStyle: React.CSSProperties = {
+	color: "#888",
+	fontSize: 12,
+	padding: "2px 0",
+};
+
 const othersStyle: React.CSSProperties = {
-	alignSelf: "center",
-	padding: "0 8px",
 	color: "#666",
 	fontSize: 12,
 	whiteSpace: "nowrap",

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -21,8 +21,8 @@ import {
 	DECK_TYPE,
 } from "./factory.js";
 import { getBounds, gridPositions, makeAspectResize, rectHitTest } from "./geometry.js";
+import { HandPanel } from "./hand-panel.js";
 import { type CardHandAwareness, createHandStore, type HandCardEntry } from "./hand-store.js";
-import { HandTray } from "./hand-tray.js";
 import {
 	injectPlacementStyles,
 	PLACEMENT_TRANSIENT_TYPE,
@@ -870,17 +870,19 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 
 			// カード操作の追従メニューは Control HUD の Action(card:*)に統合したため撤去。
 
-			// ── 手札トレイ層（画面下部固定 HUD。自分の手札のみ中身表示） ──
-			ctx.layers.register({
-				id: "card-hand",
-				order: 90,
-				fixed: true,
+			// ── 手札は Control HUD の「Hand」パネルとして登録（独自トレイUIは廃止） ──
+			// 自分の手札のみ中身を表示。他者は枚数のみ（awareness）。
+			const offHandPanel = ctx.hud.registerPanel({
+				id: "usketch-plugin-shape-card:hand",
+				title: "Hand",
+				order: 0,
 				render: () => (
-					<HandTray
+					<HandPanel
 						handStore={handStore}
 						registry={registry}
 						localUserId={localUserId}
 						awareness={awareness}
+						onPlay={(id) => ctx.events.emit("card:play-from-hand", { id })}
 					/>
 				),
 			});
@@ -900,7 +902,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				offToHand();
 				offPlayFromHand();
 				for (const off of offActions) off();
-				ctx.layers.unregister("card-hand");
+				offHandPanel();
 				awareness?.setLocalStateField("cardHand", null);
 			};
 		},


### PR DESCRIPTION
## 概要

手札(Hand)UI を**独自の下部固定トレイ**から **Control HUD の「Hand」パネル**へ移行。プロジェクト方針（プラグインUIは必ず HUD に登録、独自ツールバー・パネル禁止）に準拠させる。

- 旧: `ctx.layers.register({ id: "card-hand", fixed: true, ... })` による画面下部固定オーバーレイ（`hand-tray.tsx`）。
- 新: `ctx.hud.registerPanel({ id, title: "Hand", render })`（`hand-panel.tsx`）。HUD の「カード」セクション内に **HAND** パネルとして表示。

見た目は選択どおり**カード面サムネ**（各カードに「場に出す」ボタン）＋他者枚数。中身はローカル(localStorage)限定・枚数のみ awareness 共有という **privacy モデルは不変**。

## 変更

- `hand-tray.tsx` → `hand-panel.tsx`: 固定オーバーレイの wrapper を除去し HUD パネル本体に。play は `useApp()` 依存をやめ `onPlay(id)` を注入（プラグインが `card:play-from-hand` を emit）。
- `plugin.tsx`: `layers.register("card-hand")` を `hud.registerPanel(...)` に置換、teardown も更新。
- `sumOthers` を export しユニットテスト追加。既存テストの mock `ctx` に `hud` を追加。

## 検証（dev server 実機）

- ✅ 旧下部トレイが消え、Control HUD の「カード > HAND」にカード面サムネ＋「場に出す」が表示。
- ✅ Draw to hand → HAND パネルに札が並ぶ。「場に出す」クリックで場に出て手札が減り、パネルが即時更新（board 0→1 / hand 3→2）。
- ✅ プラグイン全 69 テスト / build / lint green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)