### PR TITLE
✨ feat(card): 出現演出を手札から場に出したときだけに限定

### DIFF
--- a/.changeset/placement-anim-hand-only.md
+++ b/.changeset/placement-anim-hand-only.md
@@ -1,0 +1,7 @@
+---
+"@edv4h/usketch-plugin-shape-card": patch
+---
+
+カードの出現演出（placement アニメ）を「手札から場に出したとき」だけに限定
+
+これまではデッキドロー / 複数ドロー / デッキをバラす / 手動ドロー / 移動でも placement アニメ（deal/slam 等）が再生されていた。演出が意味を持つ「手札プレイ」に絞り、`playCardFromHand` 以外の `emitPlacement` 呼び出し（`shapes:move-end` 購読を含む）を撤去した。

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -240,18 +240,8 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				return type === CARD_TYPE || (enableDeck && type === DECK_TYPE);
 			}
 
-			// 新規配置時のアニメは描画ツール / デッキ操作の確定点で明示的に emit する
-			// （shape:added を購読すると、保存済みボードのロード時に全カードが一斉に
-			// アニメしてしまうため、対話的な配置だけに絞る）。
-
-			// 移動後: shapes:move-end
-			const offMoveEnd = ctx.events.on<{ shapeIds: string[] }>("shapes:move-end", (data) => {
-				if (!data?.shapeIds) return;
-				for (const id of data.shapeIds) {
-					const shape = ctx.store.getShape(id);
-					if (shape && isCardLike(shape.type)) emitPlacement(shape);
-				}
-			});
+			// 出現演出（placement アニメ）は「手札から場に出したとき」だけに限定する。
+			// デッキドロー / バラし / 手動ドロー / 移動では再生しない（playCardFromHand のみ emit）。
 
 			// ── flip / deck-draw インタラクション（ダブルクリック検出） ──
 			let lastClickTime = 0;
@@ -310,7 +300,6 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				};
 				ctx.commands.execute(command);
 				ctx.store.setSelection([newCard.id]);
-				emitPlacement(newCard);
 			}
 
 			// N 個の zIndex を「全 shape の上」に積んで返す。各値は直前を含めて計算するので
@@ -368,7 +357,6 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 					},
 				});
 				ctx.store.setSelection(newCards.map((c) => c.id));
-				for (const c of newCards) emitPlacement(c);
 			}
 
 			const SPREAD_GAP = 16;
@@ -795,7 +783,6 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 						if (draft && draft.width > 2 && draft.height > 2) {
 							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, draft));
 							toolCtx.store.setSelection([draft.id]);
-							emitPlacement(draft);
 						} else if (def) {
 							// クリック: 既定サイズで配置（クリック点を中心に）
 							const placed = createCardShape(def, {
@@ -805,7 +792,6 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 							});
 							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, placed));
 							toolCtx.store.setSelection([placed.id]);
-							emitPlacement(placed);
 						}
 						drawState = null;
 						toolCtx.store.resetToDefaultTool();
@@ -862,7 +848,6 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 							});
 							toolCtx.commands.execute(createAddShapeCommand(toolCtx.store, deck));
 							toolCtx.store.setSelection([deck.id]);
-							emitPlacement(deck);
 							toolCtx.store.resetToDefaultTool();
 						},
 					});
@@ -888,7 +873,6 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 			// ── teardown ──
 			return () => {
 				offSelectType();
-				offMoveEnd();
 				offPointerDown?.();
 				offShuffleEvent();
 				offShuffleShortcut?.();


### PR DESCRIPTION
## 概要

カードの**出現演出（placement アニメ: deal / slam 等）を「手札から場に出したとき」だけ**に限定する。

これまでは以下すべてで再生されていた:
- デッキから1枚ドロー / 複数ドロー / デッキをバラす
- 描画ツールでの手動カード配置
- カードの移動（`shapes:move-end`）

演出が最も意味を持つ「手札プレイ」に絞り、`playCardFromHand` 以外の `emitPlacement` 呼び出しをすべて撤去（move-end 購読ハンドラごと削除）。`emitPlacement` の呼び出しは `playCardFromHand` の1箇所のみになった。

## 検証（dev server 実機・transient.emit をフックして計測）

playing-card（`slam-medium`）デッキで:
- Draw cards to board(3) → placement transient **0**（演出なし）
- Draw to hand(1) → placement transient **0**（演出なし）
- Play from hand → `card-placement` transient **発火**（＋場のカードが増加）

プラグイン全 65 テスト / build / lint green。

## 判断が必要な点（要フィードバック）

「出現演出は手札から出した時だけ」を素直に解釈し、**カード移動時のリプレイ（`shapes:move-end` による slam-on-drag）も撤去**しました。ドラッグで札を「ドン！」と置く演出を残したい場合は戻せます。その場合は教えてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)