### PR TITLE
✨ feat(card): カード手札を headless 化（host が独自UIを作れるように）#915

### DIFF
--- a/.changeset/card-hand-headless.md
+++ b/.changeset/card-hand-headless.md
@@ -1,0 +1,14 @@
+---
+"@edv4h/usketch-plugin-shape-card": minor
+---
+
+カード手札を headless 化：host が独自の手札 UI を作れるように（#915）
+
+手札の状態（localStorage 永続・awareness 枚数共有・`card:*` アクション/イベント）はプラグインが持ちつつ、UI を host が差し替えられるようにした。後方互換（既定は現行どおり HUD の Hand パネルを出す）。
+
+- `CreateCardPluginOptions.hand` を追加:
+  - `ui: "hud" | "none"`（既定 `"hud"`）— `"none"` で内蔵手札UIを一切登録しない（headless）。
+  - `store`— host 生成の `HandStore` を注入し**同一インスタンス共有**（同一タブでも `subscribe` が発火）。
+  - `onStore(store)` — プラグインが使う `HandStore` 実体を host へ渡す。
+- `createHandStore` / `HandStore` / `HandCardEntry` / `CardHandAwareness` を `index.ts` から export。
+- `card:to-hand` / `card-deck:draw-to-hand` / `card:play-from-hand` は headless でも従来どおり機能。

--- a/plugins/usketch-plugin-shape-card/src/__tests__/hand-headless.test.ts
+++ b/plugins/usketch-plugin-shape-card/src/__tests__/hand-headless.test.ts
@@ -1,0 +1,107 @@
+import type { PluginContext, ShapeData } from "@edv4h/usketch-shared";
+import { describe, expect, it, vi } from "vitest";
+import { CARD_TYPE } from "../factory.js";
+import { createHandStore } from "../hand-store.js";
+import { type CreateCardPluginOptions, createCardPlugin } from "../plugin.js";
+import type { CardTypeDefinition } from "../types.js";
+
+function makeCardType(): CardTypeDefinition {
+	return {
+		id: "playing-card",
+		label: "Playing",
+		aspectRatio: 2 / 3,
+		defaultSize: { width: 100, height: 150 },
+		icon: () => null as never,
+		createDefaultFields: () => ({}),
+		renderFront: () => null as never,
+		renderBack: () => null as never,
+		buildDeck: () => [{}, {}],
+	};
+}
+
+function cardShape(id: string): ShapeData {
+	return {
+		id,
+		type: CARD_TYPE,
+		x: 0,
+		y: 0,
+		width: 100,
+		height: 150,
+		style: { fill: "#fff", stroke: "#000", strokeWidth: 1, opacity: 1 },
+		meta: { cardType: "playing-card", isFlipped: false, fields: { rank: "A" } },
+	} as ShapeData;
+}
+
+/** Mock ctx with a spy on `hud.registerPanel` and a working event bus. */
+function harness(handOpts: CreateCardPluginOptions["hand"]) {
+	const shapes = new Map<string, ShapeData>();
+	const handlers = new Map<string, (p: unknown) => void>();
+	const registerPanel = vi.fn(() => () => {});
+	const noop = () => {};
+
+	const ctx = {
+		actions: { register: () => noop },
+		events: {
+			on: (type: string, cb: (p: unknown) => void) => {
+				handlers.set(type, cb);
+				return () => handlers.delete(type);
+			},
+			emit: (type: string, p: unknown) => handlers.get(type)?.(p),
+			off: noop,
+		},
+		transient: { registerType: noop, emit: noop },
+		shapes: { register: noop, get: () => undefined },
+		tools: { register: noop },
+		layers: { register: noop, unregister: noop },
+		hud: { registerPanel, registerSettings: () => noop },
+		shortcuts: { register: () => noop },
+		store: {
+			getShape: (id: string) => shapes.get(id),
+			getShapes: () => shapes,
+			getShapesSorted: () => [...shapes.values()],
+			getSelection: () => new Set<string>(),
+			addShape: (s: ShapeData) => shapes.set(s.id, s),
+			deleteShape: (id: string) => shapes.delete(id),
+			updateShape: noop,
+			setSelection: noop,
+			resetToDefaultTool: noop,
+		},
+		commands: { execute: (cmd: { execute(): void }) => cmd.execute() },
+	} as unknown as PluginContext;
+
+	createCardPlugin({ cardTypes: [makeCardType()], userId: "u1", hand: handOpts }).setup(ctx);
+
+	const emit = (type: string, id: string) => ctx.events.emit(type, { id });
+	return { shapes, emit, registerPanel };
+}
+
+describe("headless hand (issue #915)", () => {
+	it("registers the built-in HUD Hand panel by default", () => {
+		const { registerPanel } = harness(undefined);
+		expect(registerPanel).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not register any built-in hand UI when hand.ui is "none"', () => {
+		const { registerPanel } = harness({ ui: "none" });
+		expect(registerPanel).not.toHaveBeenCalled();
+	});
+
+	it("uses an injected hand store (same instance) — card:to-hand updates it", () => {
+		const store = createHandStore("u1");
+		const { shapes, emit } = harness({ ui: "none", store });
+		shapes.set("c1", cardShape("c1"));
+
+		emit("card:to-hand", "c1");
+
+		// The host's own store instance received the card (subscribe works same-tab).
+		expect(store.getHand().map((e) => e.id)).toEqual(["c1"]);
+		expect(shapes.has("c1")).toBe(false); // removed from the board
+	});
+
+	it("hands the store instance to the host via hand.onStore", () => {
+		const store = createHandStore("u1");
+		const onStore = vi.fn();
+		harness({ ui: "none", store, onStore });
+		expect(onStore).toHaveBeenCalledWith(store); // exact same instance
+	});
+});

--- a/plugins/usketch-plugin-shape-card/src/index.ts
+++ b/plugins/usketch-plugin-shape-card/src/index.ts
@@ -15,6 +15,12 @@ export {
 	createDeckShape,
 	DECK_TYPE,
 } from "./factory.js";
+export {
+	type CardHandAwareness,
+	createHandStore,
+	type HandCardEntry,
+	type HandStore,
+} from "./hand-store.js";
 export type { CreateCardPluginOptions } from "./plugin.js";
 export { createCardPlugin } from "./plugin.js";
 export { createCardTypeRegistry, EXAMPLE_CARD_TYPES } from "./registry.js";

--- a/plugins/usketch-plugin-shape-card/src/plugin.tsx
+++ b/plugins/usketch-plugin-shape-card/src/plugin.tsx
@@ -22,7 +22,12 @@ import {
 } from "./factory.js";
 import { getBounds, gridPositions, makeAspectResize, rectHitTest } from "./geometry.js";
 import { HandPanel } from "./hand-panel.js";
-import { type CardHandAwareness, createHandStore, type HandCardEntry } from "./hand-store.js";
+import {
+	type CardHandAwareness,
+	createHandStore,
+	type HandCardEntry,
+	type HandStore,
+} from "./hand-store.js";
 import {
 	injectPlacementStyles,
 	PLACEMENT_TRANSIENT_TYPE,
@@ -76,6 +81,31 @@ export interface CreateCardPluginOptions {
 	 * 既定で無効。後方互換で戻したい場合のみ `true`。
 	 */
 	legacyDoubleClickActions?: boolean;
+	/**
+	 * 手札(hand)の headless 運用オプション。手札の**状態**（localStorage 永続・awareness
+	 * 枚数共有・`card:*` アクション/イベント）はプラグインが持ちつつ、**UI を host が自作**
+	 * できるようにする。既定は現行どおり Control HUD の Hand パネルを出す（後方互換）。
+	 */
+	hand?: {
+		/**
+		 * 内蔵手札 UI の表示モード。`"hud"`（既定）は Control HUD の Hand パネルを登録。
+		 * `"none"` は内蔵 UI を一切登録しない（host が独自 UI を描く headless 運用）。
+		 * 状態・アクション・awareness 共有は `"none"` でも維持される。
+		 */
+		ui?: "hud" | "none";
+		/**
+		 * host 側で生成した {@link HandStore} を注入する。渡すとプラグインはこの**同一
+		 * インスタンス**を使うので、host UI が `subscribe` すれば同一タブ内の変更も受け取れる
+		 * （localStorage の storage イベントは同一タブで発火しない問題を回避）。省略時は
+		 * `userId`/`boardId` からプラグインが生成する。
+		 */
+		store?: HandStore;
+		/**
+		 * プラグインが実際に使う {@link HandStore}（注入 or 生成のいずれでも）を host へ渡す
+		 * コールバック。host UI の配線に使う。
+		 */
+		onStore?: (store: HandStore) => void;
+	};
 }
 
 // ── icons ──
@@ -406,7 +436,10 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 
 			// ── 手札(hand): 内容はローカル限定、枚数だけ awareness 共有（#671 / 真 private は #686） ──
 			const localUserId = opts.userId ?? "local";
-			const handStore = createHandStore(localUserId, opts.boardId);
+			// host が注入した store があればそれを使い（同一インスタンス共有 → 同一タブでも
+			// subscribe が発火）、無ければ userId/boardId から生成する。実インスタンスを onStore で host へ渡す。
+			const handStore = opts.hand?.store ?? createHandStore(localUserId, opts.boardId);
+			opts.hand?.onStore?.(handStore);
 			const awareness = opts.wsProvider?.awareness;
 
 			function broadcastHandCount() {
@@ -857,20 +890,24 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 
 			// ── 手札は Control HUD の「Hand」パネルとして登録（独自トレイUIは廃止） ──
 			// 自分の手札のみ中身を表示。他者は枚数のみ（awareness）。
-			const offHandPanel = ctx.hud.registerPanel({
-				id: "usketch-plugin-shape-card:hand",
-				title: "Hand",
-				order: 0,
-				render: () => (
-					<HandPanel
-						handStore={handStore}
-						registry={registry}
-						localUserId={localUserId}
-						awareness={awareness}
-						onPlay={(id) => ctx.events.emit("card:play-from-hand", { id })}
-					/>
-				),
-			});
+			// `hand.ui === "none"` の headless 運用では内蔵 UI を登録せず、host が自作する。
+			const offHandPanel =
+				opts.hand?.ui === "none"
+					? undefined
+					: ctx.hud.registerPanel({
+							id: "usketch-plugin-shape-card:hand",
+							title: "Hand",
+							order: 0,
+							render: () => (
+								<HandPanel
+									handStore={handStore}
+									registry={registry}
+									localUserId={localUserId}
+									awareness={awareness}
+									onPlay={(id) => ctx.events.emit("card:play-from-hand", { id })}
+								/>
+							),
+						});
 
 			// ── teardown ──
 			return () => {
@@ -886,7 +923,7 @@ export function createCardPlugin(opts: CreateCardPluginOptions = {}): UsketchPlu
 				offToHand();
 				offPlayFromHand();
 				for (const off of offActions) off();
-				offHandPanel();
+				offHandPanel?.();
 				awareness?.setLocalStateField("cardHand", null);
 			};
 		},


### PR DESCRIPTION
Closes #915

## 概要

カード手札(hand)を **headless 化**。状態（localStorage 永続・awareness 枚数共有・`card:*` アクション/イベント）はプラグインが持ちつつ、**UI を host が自由に差し替え**られるようにする。既定は現行どおり（HUD の Hand パネルを出す）＝**後方互換**。

## API（`CreateCardPluginOptions.hand`）

```ts
createCardPlugin({
  cardTypes: EXAMPLE_CARD_TYPES,
  userId, boardId, wsProvider,
  hand: {
    ui: "none",          // 内蔵手札UIを登録しない（既定 "hud"）
    store: myHandStore,  // host生成のHandStoreを注入＝同一インスタンス共有
    onStore: (s) => {},  // プラグインが使うHandStore実体を受け取る
  },
});
```

- **`ui: "hud" | "none"`**（既定 `"hud"`）: `"none"` で内蔵手札UI（HUD Hand パネル）を一切登録しない。state・actions・awareness 共有は維持。
- **`store`**: host が生成した `HandStore` を注入。プラグインは**同一インスタンス**を使うので、host UI が `subscribe` すれば**同一タブ内の変更も受け取れる**（localStorage の storage イベントが同一タブで発火しない問題を回避）。
- **`onStore(store)`**: プラグインが実際に使う `HandStore`（注入 or 生成）を host へ渡す。
- `createHandStore` / `HandStore` / `HandCardEntry` / `CardHandAwareness` を `index.ts` から **export**。
- `card:to-hand` / `card-deck:draw-to-hand` / `card:play-from-hand` は headless でも従来どおり機能。

これで host（weboard）は挙動・privacy モデルを変えずに、扇状レイアウト等の独自手札UIを実装できる。

## 検証

- ✅ 単体テスト4件追加（`hand-headless.test.ts`）: 既定でHUDパネル登録／`ui:"none"`で未登録／注入storeが同一インスタンスで `card:to-hand` 反映／`onStore` が実体を受け渡し。プラグイン全 73 テスト・build・typecheck・lint green。web typecheck green（後方互換）。

## 補足

Issue の要望 1〜4 をすべてカバー。privacy モデル（#686）とは独立、破壊的変更なし（opt-in）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)