### PR TITLE
✨ feat(map): ツール状態の公開 reactive store を export (#927)

### DIFF
--- a/.changeset/map-tool-state-api.md
+++ b/.changeset/map-tool-state-api.md
@@ -1,0 +1,21 @@
+---
+"@edv4h/usketch-plugin-map": minor
+---
+
+map: ツール状態の公開 reactive store を export（#927）— ホスト独自 UI から mode/terrain/icon を駆動可能に
+
+Control HUD（`debug-hud`）以外の UI（ActionRing / ラジアルメニュー / 独自ツールバー等）から
+マップツールの状態を切り替えられるよう、内部の app-local reactive store を公開した。
+`renderConfigStore` と同じ「public reactive store（get/set/subscribe）」パターンで一貫。
+
+追加 export（`@edv4h/usketch-plugin-map`）:
+
+- `toolStateStore` ＋ `type MapToolState` ＋ `useMapToolState()` — mode / terrain / iconKey / excludeTerrains
+- `MAP_MODES`（`brush|eraser|fill|region|stamp|generate|base` の順序付き配列。`MapMode` はこれから派生）
+- `rangeEraseStore` ＋ `type RangeEraseTargets` ＋ `useRangeEraseTargets()`
+- `genStateStore` ＋ `type GenState` / `type WorldRect` ＋ `useGenState()`
+- `baseStateStore` ＋ `type BaseToolState` ＋ `useBaseState()`
+- `type ReactiveStore`（各 store の共通インターフェース）
+
+既に export 済みの `TERRAINS` / `ICONS` / `MAP_MODES` と組み合わせて、ホストが Control HUD に
+依存しないツール切替 UI を実装できる。いずれも同期対象外（presentation/interaction state）。

--- a/plugins/usketch-plugin-map/src/index.ts
+++ b/plugins/usketch-plugin-map/src/index.ts
@@ -3,7 +3,9 @@ export {
 	type BaseInfo,
 	type BaseMapShapeData,
 } from "./base/base-map-shape.js";
+export { type BaseToolState, baseStateStore, useBaseState } from "./base/base-state.js";
 export { computeTerritory, type Territory } from "./base/territory.js";
+export { type GenState, genStateStore, useGenState, type WorldRect } from "./gen-state.js";
 export {
 	GENERATORS,
 	type GenContext,
@@ -16,9 +18,27 @@ export { MAP_TOOL_ID } from "./map-tool-id.js";
 export type { ColorMode } from "./palette.js";
 export { createMapPlugin, type MapPluginOptions } from "./plugin.js";
 export {
+	type RangeEraseTargets,
+	rangeEraseStore,
+	useRangeEraseTargets,
+} from "./range-erase-state.js";
+// ── Public tool-state stores (#927) ──
+// App-local reactive stores (get/set/subscribe) driving the map tool. Exported
+// so hosts can build their own tool UI (ActionRing / radial picker / toolbar)
+// without the Control HUD — same "public reactive store" shape as
+// `renderConfigStore`. Not synced across clients (presentation/interaction state).
+export type { ReactiveStore } from "./reactive-store.js";
+export {
 	type LineStyle,
 	type MapRenderConfig,
 	renderConfigStore,
 } from "./render-config.js";
 export { TERRAINS, type TerrainDef, type TerrainKey } from "./terrain.js";
 export { DEFAULT_TILE, TILEMAP_TYPE, type TileMapShapeData } from "./tilemap-shape.js";
+export {
+	MAP_MODES,
+	type MapMode,
+	type MapToolState,
+	toolStateStore,
+	useMapToolState,
+} from "./tool-state.js";

--- a/plugins/usketch-plugin-map/src/tool-state.ts
+++ b/plugins/usketch-plugin-map/src/tool-state.ts
@@ -4,7 +4,22 @@ import { useSyncExternalStore } from "react";
 import { createReactiveStore } from "./reactive-store.js";
 import type { TerrainKey } from "./terrain.js";
 
-export type MapMode = "brush" | "eraser" | "fill" | "region" | "stamp" | "generate" | "base";
+/**
+ * All map-tool modes, in canonical order. Exported so a host UI (ActionRing /
+ * radial picker / custom toolbar) can enumerate the modes at runtime instead of
+ * hardcoding the union. `MapMode` is derived from this array — single source.
+ */
+export const MAP_MODES = [
+	"brush",
+	"eraser",
+	"fill",
+	"region",
+	"stamp",
+	"generate",
+	"base",
+] as const;
+
+export type MapMode = (typeof MAP_MODES)[number];
 
 export interface MapToolState {
 	mode: MapMode;


### PR DESCRIPTION
Closes #927

`@edv4h/usketch-plugin-map` のツール状態（mode / terrain / icon）を **Control HUD 以外のホスト独自 UI**（ActionRing / ラジアルメニュー / 独自ツールバー）から切り替えられるよう、内部の app-local reactive store を公開しました。既に公開済みの `renderConfigStore` と同じ **public reactive store（get/set/subscribe）** パターンで一貫させています（同期対象外の presentation/interaction state）。

### 追加 export（`@edv4h/usketch-plugin-map`）
- `toolStateStore` ＋ `type MapToolState` ＋ `useMapToolState()` — `mode` / `terrain` / `iconKey` / `excludeTerrains`
- `MAP_MODES` — `brush|eraser|fill|region|stamp|generate|base` の順序付き配列（`MapMode` はこれから派生＝単一ソース。型ではなく**実行時に列挙可能**な値）
- `rangeEraseStore` ＋ `type RangeEraseTargets` ＋ `useRangeEraseTargets()`
- `genStateStore` ＋ `type GenState` / `type WorldRect` ＋ `useGenState()`
- `baseStateStore` ＋ `type BaseToolState` ＋ `useBaseState()`
- `type ReactiveStore`（各 store 共通 IF）

### 使い方（ホスト UI 例）
```ts
import { toolStateStore, MAP_MODES, TERRAINS, ICONS, useMapToolState } from "@edv4h/usketch-plugin-map";
// 独自 ActionRing から：
toolStateStore.set({ mode: "brush", terrain: "grass" });
// React で購読：
const { mode, terrain } = useMapToolState();
```

### 検証
- 既存 `MapMode` 型は `MAP_MODES` から派生（union は不変）。map プラグイン typecheck / build / test（**70件**）緑、biome クリーン。
- 依存追加なし（lockfile 変更なし）。

関連: #673