### PR TITLE
✨ feat(map): 領域塗り／塗りつぶしを無限ベース地形に対応（sampler ベース＋上限）

### DIFF
--- a/.changeset/map-region-fill-infinite.md
+++ b/.changeset/map-region-fill-infinite.md
@@ -1,0 +1,19 @@
+---
+"@edv4h/usketch-plugin-map": minor
+---
+
+map: 領域塗り／塗りつぶしを無限ベース地形に対応（sampler ベース＋上限で安全化）
+
+無限ベース地形（`baseSeed`）が有効なとき、塗りつぶし／領域塗りが**未編集セルの見た目どおりの
+地形（sampler = override ?? base）**を対象に flood するようになった。従来はスパースな override
+（`cells`）だけを見ていたため、生成された地形の上ではまともに塗れなかった。
+
+- 新規 `samplerFloodFill(sample, startCol, startRow, maxCells)`（`autotile.ts`）: サンプラ上を
+  **幅優先**で flood。無限に連結しうるので `maxCells`（8192）で上限を設け、上限に達したら
+  `truncated` を返す。
+- `map-tool` の `doFill` / `doRegionFill`: 無限ベースが有効なら sampler 経路を使い、**囲まれた
+  領域（上限内で自然終了）はそのまま塗り、囲まれていない開けた地形（上限到達）は塗らずに中止**
+  （`map:fill-aborted` イベントを発火）。有限ボードの従来挙動は不変。
+- 単体テスト（enclosed 充填・open 打ち切り・BFS・sampled 地形の尊重）を追加。
+
+後続: 中止時のユーザー通知（HUD トースト）と、`emptyTerrain`（無限の海）モードへの拡張。

--- a/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
@@ -12,7 +12,6 @@ import {
 	terrainAtCell,
 	worldToCell,
 } from "../autotile.js";
-import type { TerrainKey } from "../terrain.js";
 
 describe("cell keys", () => {
 	it("round-trips key <-> coords (incl. negatives)", () => {
@@ -156,9 +155,17 @@ describe("samplerFloodFill", () => {
 	});
 
 	it("returns an empty region for an undefined start (no base, no override)", () => {
-		const none: CellSampler = () => undefined as unknown as TerrainKey | undefined;
+		const none: CellSampler = () => undefined;
 		const res = samplerFloodFill(none, 0, 0, 8192);
 		expect(res.cells).toEqual([]);
+		expect(res.truncated).toBe(false);
+	});
+
+	it("does not flag an enclosed region whose size is exactly maxCells", () => {
+		// The 3x3 pocket has exactly 9 cells; with maxCells=9 it closes without a
+		// matching cell left over, so it must NOT be reported truncated.
+		const res = samplerFloodFill(enclosedSampler, 0, 0, 9);
+		expect(res.cells.length).toBe(9);
 		expect(res.truncated).toBe(false);
 	});
 

--- a/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
@@ -161,6 +161,14 @@ describe("samplerFloodFill", () => {
 		expect(res.truncated).toBe(false);
 	});
 
+	it("returns a deterministic empty result for a non-positive cap", () => {
+		for (const cap of [0, -1]) {
+			const res = samplerFloodFill(() => "grass", 0, 0, cap);
+			expect(res.cells).toEqual([]);
+			expect(res.truncated).toBe(false);
+		}
+	});
+
 	it("does not flag an enclosed region whose size is exactly maxCells", () => {
 		// The 3x3 pocket has exactly 9 cells; with maxCells=9 it closes without a
 		// matching cell left over, so it must NOT be reported truncated.

--- a/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/autotile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+	type CellSampler,
 	type Cells,
 	cellKey,
 	cellsBounds,
@@ -7,9 +8,11 @@ import {
 	floodFill,
 	parseCellKey,
 	regionFillCells,
+	samplerFloodFill,
 	terrainAtCell,
 	worldToCell,
 } from "../autotile.js";
+import type { TerrainKey } from "../terrain.js";
 
 describe("cell keys", () => {
 	it("round-trips key <-> coords (incl. negatives)", () => {
@@ -120,5 +123,52 @@ describe("regionFillCells", () => {
 		expect(new Set(regionFillCells(cells, 0, 0, new Set(["water"])))).toEqual(
 			new Set(["0,0", "1,0"]),
 		);
+	});
+});
+
+describe("samplerFloodFill", () => {
+	// A base of "water" everywhere, with a 3x3 pocket of "grass" (edges are the
+	// pocket's walls) centred at origin — models an enclosed region on infinite base.
+	const enclosedSampler: CellSampler = (c, r) =>
+		c >= -1 && c <= 1 && r >= -1 && r <= 1 ? "grass" : "water";
+
+	it("fills an enclosed region exactly, not truncated", () => {
+		const res = samplerFloodFill(enclosedSampler, 0, 0, 8192);
+		expect(res.truncated).toBe(false);
+		expect(new Set(res.cells)).toEqual(
+			new Set(["-1,-1", "0,-1", "1,-1", "-1,0", "0,0", "1,0", "-1,1", "0,1", "1,1"]),
+		);
+	});
+
+	it("honours the sampled (base) terrain, not just overrides", () => {
+		// Clicking the surrounding water floods the water region — which is open, so
+		// it truncates at the cap rather than filling the whole plane.
+		const res = samplerFloodFill(enclosedSampler, 5, 5, 200);
+		expect(res.truncated).toBe(true);
+		expect(res.cells.length).toBe(200);
+	});
+
+	it("truncates on an unbounded (single-terrain) field and caps output", () => {
+		const all: CellSampler = () => "water";
+		const res = samplerFloodFill(all, 0, 0, 100);
+		expect(res.truncated).toBe(true);
+		expect(res.cells.length).toBe(100);
+	});
+
+	it("returns an empty region for an undefined start (no base, no override)", () => {
+		const none: CellSampler = () => undefined as unknown as TerrainKey | undefined;
+		const res = samplerFloodFill(none, 0, 0, 8192);
+		expect(res.cells).toEqual([]);
+		expect(res.truncated).toBe(false);
+	});
+
+	it("expands breadth-first so a capped result clusters around the start", () => {
+		const all: CellSampler = () => "grass";
+		const res = samplerFloodFill(all, 0, 0, 5);
+		// BFS ring order: start, then its 4 neighbours (Manhattan distance ≤ 1).
+		for (const k of res.cells) {
+			const [c, r] = k.split(",").map(Number);
+			expect(Math.abs(c) + Math.abs(r)).toBeLessThanOrEqual(1);
+		}
 	});
 });

--- a/plugins/usketch-plugin-map/src/autotile.ts
+++ b/plugins/usketch-plugin-map/src/autotile.ts
@@ -178,6 +178,9 @@ export function samplerFloodFill(
 ): SamplerFloodResult {
 	const target = sample(startCol, startRow);
 	if (target === undefined) return { cells: [], truncated: false };
+	// Non-positive cap: nothing can be filled. Return a deterministic empty result
+	// rather than reporting a bogus truncation.
+	if (maxCells <= 0) return { cells: [], truncated: false };
 
 	const out: string[] = [];
 	const seen = new Set<string>([cellKey(startCol, startRow)]);

--- a/plugins/usketch-plugin-map/src/autotile.ts
+++ b/plugins/usketch-plugin-map/src/autotile.ts
@@ -186,8 +186,11 @@ export function samplerFloodFill(
 	while (head < queue.length) {
 		const [c, r] = queue[head++];
 		if (sample(c, r) !== target) continue;
-		out.push(cellKey(c, r));
+		// A matching cell we have no room for ⇒ the region extends past the cap, so
+		// it is not (provably) enclosed. A region of *exactly* maxCells cells closes
+		// with no matching cell left to dequeue, and is correctly reported enclosed.
 		if (out.length >= maxCells) return { cells: out, truncated: true };
+		out.push(cellKey(c, r));
 		for (const [nc, nr] of [
 			[c + 1, r],
 			[c - 1, r],

--- a/plugins/usketch-plugin-map/src/autotile.ts
+++ b/plugins/usketch-plugin-map/src/autotile.ts
@@ -146,3 +146,60 @@ export function regionFillCells(
 	if (start !== undefined && exclude.has(start)) return [];
 	return floodFill(cells, startCol, startRow, box);
 }
+
+/** A terrain lookup for any cell (override ?? base ?? empty); may be undefined. */
+export type CellSampler = (col: number, row: number) => TerrainKey | undefined;
+
+export interface SamplerFloodResult {
+	/** Cell keys forming the connected region (empty when the start is undefined). */
+	cells: string[];
+	/**
+	 * `true` if the flood hit `maxCells` before the region closed — i.e. the region
+	 * is not enclosed (or is larger than the cap). Callers should treat this as
+	 * "cannot fill" rather than filling an arbitrary blob.
+	 */
+	truncated: boolean;
+}
+
+/**
+ * Flood fill over a **sampler** (override ?? base ?? empty) rather than the sparse
+ * override map — this is what makes region fill work on the infinite base terrain,
+ * where unpainted cells still have a real (generated) terrain. Because that field
+ * is boundless, the flood is capped by `maxCells` and uses **breadth-first** order
+ * so a capped result is a compact blob around the start. If it hits the cap before
+ * the region closes, `truncated` is set and the caller aborts (the region is open,
+ * e.g. an infinite ocean). An `undefined` start terrain yields an empty region.
+ */
+export function samplerFloodFill(
+	sample: CellSampler,
+	startCol: number,
+	startRow: number,
+	maxCells: number,
+): SamplerFloodResult {
+	const target = sample(startCol, startRow);
+	if (target === undefined) return { cells: [], truncated: false };
+
+	const out: string[] = [];
+	const seen = new Set<string>([cellKey(startCol, startRow)]);
+	const queue: [number, number][] = [[startCol, startRow]];
+	let head = 0;
+	while (head < queue.length) {
+		const [c, r] = queue[head++];
+		if (sample(c, r) !== target) continue;
+		out.push(cellKey(c, r));
+		if (out.length >= maxCells) return { cells: out, truncated: true };
+		for (const [nc, nr] of [
+			[c + 1, r],
+			[c - 1, r],
+			[c, r + 1],
+			[c, r - 1],
+		] as const) {
+			const k = cellKey(nc, nr);
+			if (!seen.has(k)) {
+				seen.add(k);
+				queue.push([nc, nr]);
+			}
+		}
+	}
+	return { cells: out, truncated: false };
+}

--- a/plugins/usketch-plugin-map/src/map-tool.tsx
+++ b/plugins/usketch-plugin-map/src/map-tool.tsx
@@ -22,16 +22,23 @@ import {
 	cellsBounds,
 	floodFill,
 	regionFillCells,
+	samplerFloodFill,
 	worldToCell,
 } from "./autotile.js";
 import { createBase, getBaseMap, setBeacon } from "./base/base-ops.js";
 import { baseStateStore } from "./base/base-state.js";
+import { makeTerrainSampler, resolveBaseGen } from "./base-terrain.js";
 import { genStateStore } from "./gen-state.js";
 import { generateIntoBox, resolveTilemap } from "./generate.js";
 import { ICONS_BY_KEY } from "./icons.js";
 import { MAP_ICON_TYPE, makeMapIcon } from "./map-icon-shape.js";
-import { DEFAULT_TILE, type TileMapShapeData } from "./tilemap-shape.js";
+import { DEFAULT_TILE, seededTilemap, type TileMapShapeData } from "./tilemap-shape.js";
 import { toolStateStore } from "./tool-state.js";
+
+// Hard cap on a single sampler-based fill over the infinite base terrain. A truly
+// enclosed region terminates well below this; hitting it means the region is open
+// (e.g. an infinite ocean), so the fill is aborted rather than painting a blob.
+const MAX_FILL_CELLS = 8192;
 
 // Default colours cycled through when a base is auto-created on first beacon.
 const BASE_PALETTE = [
@@ -113,24 +120,71 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 		applyCells(ctx, stroke.tilemapId, cells);
 	}
 
+	/** The board's infinite-base config (seed + frozen gen), or null when off. */
+	function baseConfig(
+		ctx: ToolContext,
+	): { seed: number; gen: ReturnType<typeof resolveBaseGen> } | null {
+		const tm = seededTilemap(ctx.store.getShapes().values());
+		return tm?.baseSeed != null ? { seed: tm.baseSeed, gen: resolveBaseGen(tm.baseGen) } : null;
+	}
+
+	/**
+	 * Region isn't enclosed (open terrain, e.g. infinite ocean) — don't paint an
+	 * arbitrary capped blob. Signal it so a HUD can surface a message later (there
+	 * is no toast yet), and no-op the fill.
+	 */
+	function abortFill(ctx: ToolContext, scanned: number): void {
+		ctx.events.emit("map:fill-aborted", { reason: "not-enclosed", scanned });
+		console.warn(`[map] region fill aborted: region not enclosed (scanned ${scanned}+ cells)`);
+	}
+
+	/** Painted-cell bounds as a flood box, or undefined for an empty tilemap. */
+	function paintedBox(cells: Cells): CellBox | undefined {
+		if (Object.keys(cells).length === 0) return undefined;
+		const b = cellsBounds(cells, tile);
+		return {
+			minC: Math.floor(b.x / tile),
+			minR: Math.floor(b.y / tile),
+			maxC: Math.floor(b.x / tile) + b.width / tile - 1,
+			maxR: Math.floor(b.y / tile) + b.height / tile - 1,
+		};
+	}
+
+	/** Write `terrain` into every region key that differs; returns whether anything changed. */
+	function paintRegion(cells: Cells, keys: string[], terrain: string): boolean {
+		let changed = false;
+		for (const k of keys) {
+			if (cells[k] === terrain) continue;
+			cells[k] = terrain as Cells[string];
+			changed = true;
+		}
+		return changed;
+	}
+
 	function doFill(ctx: ToolContext, event: CanvasPointerEvent): void {
 		if (!stroke) return;
 		const [c, r] = worldToCell(event.worldPoint.x, event.worldPoint.y, tile);
 		const { terrain } = toolStateStore.get();
 		const cells = currentCells(ctx, stroke.tilemapId);
-		// Empty-cell fills are bounded to the current painted region so the flood
-		// is finite; painted-cell fills are naturally bounded by the region.
-		const b = cellsBounds(cells, tile);
-		const box: CellBox | undefined =
-			Object.keys(cells).length === 0
-				? undefined
-				: {
-						minC: Math.floor(b.x / tile),
-						minR: Math.floor(b.y / tile),
-						maxC: Math.floor(b.x / tile) + b.width / tile - 1,
-						maxR: Math.floor(b.y / tile) + b.height / tile - 1,
-					};
-		const keys = floodFill(cells, c, r, box);
+
+		const base = baseConfig(ctx);
+		if (base) {
+			// Infinite base: flood over the SAMPLED terrain (override ?? base) so the
+			// click's visible terrain is honoured, capped + aborted when not enclosed.
+			const sample = makeTerrainSampler(cells, base.seed, null, base.gen);
+			const res = samplerFloodFill(sample, c, r, MAX_FILL_CELLS);
+			if (res.truncated) {
+				abortFill(ctx, res.cells.length);
+				return;
+			}
+			if (!paintRegion(cells, res.cells, terrain)) return;
+			applyCells(ctx, stroke.tilemapId, cells);
+			return;
+		}
+
+		// Finite board: empty-cell fills are bounded to the current painted region
+		// so the flood is finite; painted-cell fills are naturally bounded.
+		const keys = floodFill(cells, c, r, paintedBox(cells));
 		if (keys.length === 0) return;
 		for (const k of keys) cells[k] = terrain;
 		applyCells(ctx, stroke.tilemapId, cells);
@@ -148,23 +202,26 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 		const { terrain, excludeTerrains } = toolStateStore.get();
 		const exclude = new Set(excludeTerrains);
 		const cells = currentCells(ctx, stroke.tilemapId);
-		const b = cellsBounds(cells, tile);
-		const box: CellBox | undefined =
-			Object.keys(cells).length === 0
-				? undefined
-				: {
-						minC: Math.floor(b.x / tile),
-						minR: Math.floor(b.y / tile),
-						maxC: Math.floor(b.x / tile) + b.width / tile - 1,
-						maxR: Math.floor(b.y / tile) + b.height / tile - 1,
-					};
-		let changed = false;
-		for (const k of regionFillCells(cells, c, r, exclude, box)) {
-			if (cells[k] === terrain) continue;
-			cells[k] = terrain;
-			changed = true;
+
+		const base = baseConfig(ctx);
+		if (base) {
+			const sample = makeTerrainSampler(cells, base.seed, null, base.gen);
+			const start = sample(c, r);
+			// Clicking a protected (or empty) terrain is a no-op; since the flood only
+			// spreads across `start`, it can never reach a protected cell.
+			if (start === undefined || exclude.has(start)) return;
+			const res = samplerFloodFill(sample, c, r, MAX_FILL_CELLS);
+			if (res.truncated) {
+				abortFill(ctx, res.cells.length);
+				return;
+			}
+			if (!paintRegion(cells, res.cells, terrain)) return;
+			applyCells(ctx, stroke.tilemapId, cells);
+			return;
 		}
-		if (!changed) return;
+
+		if (!paintRegion(cells, regionFillCells(cells, c, r, exclude, paintedBox(cells)), terrain))
+			return;
 		applyCells(ctx, stroke.tilemapId, cells);
 	}
 

--- a/plugins/usketch-plugin-map/src/map-tool.tsx
+++ b/plugins/usketch-plugin-map/src/map-tool.tsx
@@ -33,7 +33,7 @@ import { generateIntoBox, resolveTilemap } from "./generate.js";
 import { ICONS_BY_KEY } from "./icons.js";
 import { MAP_ICON_TYPE, makeMapIcon } from "./map-icon-shape.js";
 import type { TerrainKey } from "./terrain.js";
-import { DEFAULT_TILE, seededTilemap, type TileMapShapeData } from "./tilemap-shape.js";
+import { DEFAULT_TILE, isTileMap, seededTilemap, type TileMapShapeData } from "./tilemap-shape.js";
 import { toolStateStore } from "./tool-state.js";
 
 // Hard cap on a single sampler-based fill over the infinite base terrain. A truly
@@ -130,6 +130,21 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 	}
 
 	/**
+	 * Painted overrides as the RENDERER sees them: every tilemap's cells merged in
+	 * id order (highest id wins), matching `map-layer`. The fill sampler must read
+	 * this — not just the stroke tilemap — so the flooded region agrees with the
+	 * terrain the user actually clicked when several tilemaps coexist.
+	 */
+	function mergedOverrides(ctx: ToolContext): Cells {
+		const tms = [...ctx.store.getShapes().values()].filter(isTileMap);
+		if (tms.length <= 1) return tms[0] ? { ...tms[0].cells } : {};
+		return Object.assign(
+			{},
+			...[...tms].sort((a, b) => (a.id < b.id ? -1 : 1)).map((tm) => tm.cells),
+		);
+	}
+
+	/**
 	 * Region isn't enclosed (open terrain, e.g. infinite ocean) — don't paint an
 	 * arbitrary capped blob. Emit an event so a HUD can surface a message (no toast
 	 * yet), and no-op the fill. Intentionally no console output: an aborted open
@@ -170,9 +185,10 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 
 		const base = baseConfig(ctx);
 		if (base) {
-			// Infinite base: flood over the SAMPLED terrain (override ?? base) so the
-			// click's visible terrain is honoured, capped + aborted when not enclosed.
-			const sample = makeTerrainSampler(cells, base.seed, null, base.gen);
+			// Infinite base: flood over the SAMPLED terrain (merged overrides ?? base)
+			// so the click's visible terrain is honoured, capped + aborted when not
+			// enclosed. Read the merged view (all tilemaps) but write to the stroke one.
+			const sample = makeTerrainSampler(mergedOverrides(ctx), base.seed, null, base.gen);
 			const res = samplerFloodFill(sample, c, r, MAX_FILL_CELLS);
 			if (res.truncated) {
 				abortFill(ctx, res.cells.length);
@@ -206,7 +222,7 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 
 		const base = baseConfig(ctx);
 		if (base) {
-			const sample = makeTerrainSampler(cells, base.seed, null, base.gen);
+			const sample = makeTerrainSampler(mergedOverrides(ctx), base.seed, null, base.gen);
 			const start = sample(c, r);
 			// Clicking a protected (or empty) terrain is a no-op; since the flood only
 			// spreads across `start`, it can never reach a protected cell.

--- a/plugins/usketch-plugin-map/src/map-tool.tsx
+++ b/plugins/usketch-plugin-map/src/map-tool.tsx
@@ -131,12 +131,12 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 
 	/**
 	 * Region isn't enclosed (open terrain, e.g. infinite ocean) — don't paint an
-	 * arbitrary capped blob. Signal it so a HUD can surface a message later (there
-	 * is no toast yet), and no-op the fill.
+	 * arbitrary capped blob. Emit an event so a HUD can surface a message (no toast
+	 * yet), and no-op the fill. Intentionally no console output: an aborted open
+	 * fill is an expected user outcome, not a warning.
 	 */
 	function abortFill(ctx: ToolContext, scanned: number): void {
 		ctx.events.emit("map:fill-aborted", { reason: "not-enclosed", scanned });
-		console.warn(`[map] region fill aborted: region not enclosed (scanned ${scanned}+ cells)`);
 	}
 
 	/** Painted-cell bounds as a flood box, or undefined for an empty tilemap. */

--- a/plugins/usketch-plugin-map/src/map-tool.tsx
+++ b/plugins/usketch-plugin-map/src/map-tool.tsx
@@ -32,6 +32,7 @@ import { genStateStore } from "./gen-state.js";
 import { generateIntoBox, resolveTilemap } from "./generate.js";
 import { ICONS_BY_KEY } from "./icons.js";
 import { MAP_ICON_TYPE, makeMapIcon } from "./map-icon-shape.js";
+import type { TerrainKey } from "./terrain.js";
 import { DEFAULT_TILE, seededTilemap, type TileMapShapeData } from "./tilemap-shape.js";
 import { toolStateStore } from "./tool-state.js";
 
@@ -151,11 +152,11 @@ export function createMapToolDefinition(tile: number = DEFAULT_TILE): ToolDefini
 	}
 
 	/** Write `terrain` into every region key that differs; returns whether anything changed. */
-	function paintRegion(cells: Cells, keys: string[], terrain: string): boolean {
+	function paintRegion(cells: Cells, keys: string[], terrain: TerrainKey): boolean {
 		let changed = false;
 		for (const k of keys) {
 			if (cells[k] === terrain) continue;
-			cells[k] = terrain as Cells[string];
+			cells[k] = terrain;
 			changed = true;
 		}
 		return changed;


### PR DESCRIPTION
無限ベース地形（#937 / `baseSeed`）の上で **塗りつぶし・領域塗りが機能しなかった**問題を解消します。

### 背景
従来の flood はスパースな override（`cells`）だけを判定していたため、生成された未編集セルは全て「空」に見え、無限ベース上ではまともに塗れませんでした（連結領域が無限になりうる問題も）。

### 設計（A案 ＋ sampler ベース）
- **sampler ベース**: `sample(c,r) = override ?? base` を対象に flood。クリックした「見えている地形」を尊重。
- **上限で安全化**: base は総関数で無限に連結しうるため、`samplerFloodFill` は `maxCells=8192` の**幅優先** flood。上限到達で `truncated`。
- **囲まれていれば塗る／開けていれば中止（A案）**: 自然終了（enclosed）はそのまま塗り、上限到達（open、例: 無限の海）は塗らずに中止し `map:fill-aborted` を emit。
- 有限ボードの従来挙動は**不変**（`baseSeed` 未設定時は既存パス）。

### 変更
- `autotile.ts`: `samplerFloodFill` ＋ `CellSampler` / `SamplerFloodResult`。
- `map-tool.tsx`: `doFill`/`doRegionFill` に sampler 経路、`baseConfig`（seeded tilemap から seed+gen）、`abortFill`。
- 単体テスト（enclosed 充填・open 打ち切り・BFS・sampled 地形の尊重・undefined start）。map プラグイン計 **94 テスト**。

### 検証
- 実 build 済みモジュールを実ワールド（seed 12345）で実行し、**囲まれた森 681 セルの領域塗りがオートタイル込みで正しく再描画**、開けた海は上限で打ち切りを確認（スクショはチャットに添付）。
- typecheck / biome / build クリーン。

### 後続（スコープ外）
- 中止時のユーザー通知（HUD トースト）。
- `emptyTerrain`（無限の海）モードへの拡張。

🤖 Generated with [Claude Code](https://claude.com/claude-code)