### PR TITLE
✨ feat: プラグイン操作のホスト向けシーム（defineService）＋ 規約化

### DIFF
--- a/.changeset/map-service-seam.md
+++ b/.changeset/map-service-seam.md
@@ -1,0 +1,14 @@
+---
+"@edv4h/usketch-plugin-map": minor
+---
+
+map: ホスト向け `MapApi` サービスを追加（`getMapApi(app.services)` / #927・#946 の一般化）
+
+これまで #927（tool-state）・#946（無限地形）で場当たりに export していたホスト向け操作を、
+`defineService` の標準シームに集約。プラグインが `setup` で `mapService.provide(ctx.services, createMapApi(ctx.store))`
+し、ホストは `getMapApi(app.services)?.enableInfiniteTerrain({ seed })` のように、個別 export 名も
+store も知らずに駆動できる（プラグイン不在なら `undefined`）。
+
+`MapApi` は store バインド済みの無限地形操作（enable/disable/get/set/isEnabled）＋ reactive
+stores（`toolState` / `renderConfig`）を公開。既存の関数/ストア export は後方互換で維持。これが
+「操作ロジックは純関数、HUD はそれを呼ぶだけ、ホスト向けは service で公開」規約の参照実装。

--- a/.changeset/shared-define-service.md
+++ b/.changeset/shared-define-service.md
@@ -1,0 +1,13 @@
+---
+"@edv4h/usketch-shared": minor
+---
+
+shared: `defineService` — 型付きサービスハンドルで `ctx.services` / `app.services` を扱う
+
+プラグインが「ホスト向けの操作 API」を HUD 非依存で公開するための標準シーム。`defineService<T>(key)`
+が `ServiceHandle<T>`（`key` ＋型付き `provide`/`get`/`has`）を返す。provider と consumer が
+key・型でズレず、`ctx.services`（plugin）と `app.services`（host）は同一 registry なので同じ
+アクセサで両方に使える。プラグイン不在時は `get` が `undefined`（optional 扱い）。
+
+用途は docs/plugin-system-design.md を参照（操作ロジックは HUD クロージャに埋めず純関数化し、
+ホスト向けは `defineService` で公開する規約）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ v1の技術的知見を活かしつつ、MVPファーストで再構築する。
 - `docs/architecture-v2.md` — v2のアーキテクチャ設計
 - `docs/prd-ai-native.md` — AIネイティブ機能のPRD
 - `docs/prd-not-whiteboard.md` — Not Whiteboard（コミュニケーション空間）のPRD
-- `docs/plugin-system-design.md` — プラグインシステム設計。**プラグインの UI は必ず HUD に登録する**（独自ツールバー・パネルの実装は禁止）
+- `docs/plugin-system-design.md` — プラグインシステム設計。**プラグインの UI は必ず HUD に登録する**（独自ツールバー・パネルの実装は禁止）。**操作ロジックは HUD の `set`/`run` クロージャに埋めず、`BoardStore` を受け取る純関数として最初から公開 export し、HUD はそれを呼ぶだけにする**。ホスト向けの型付き API は `defineService`（`@edv4h/usketch-shared`）でサービスとして公開する（参照実装: `usketch-plugin-map` の `map-service.ts` = `getMapApi`）
 
 ## ファイル命名規則
 

--- a/docs/plugin-system-design.md
+++ b/docs/plugin-system-design.md
@@ -88,6 +88,31 @@ interface LayerManager {
 
 境界は「ワールドを描いているか / コントロールを置いているか」。ページの上に浮かぶコントロールは HUD、キャンバスの一部として描かれるものはレイヤー。
 
+### 操作ロジックは HUD ハンドラに埋めない（ホストから駆動可能にする）
+
+UI は HUD に集約するが、**HUD の `set` / action の `run` クロージャに操作ロジックを書いてはいけない**。ロジックは「`BoardStore` を受け取る純関数」または「module-scope の reactive store」として実装し、**最初から公開 export** する。HUD ハンドラはそれを呼ぶだけの薄い層にする。
+
+理由: HUD は UI の1消費者にすぎない。ホストは独自 UI（ActionRing / ラジアル / 独自ツールバー）やプログラムから操作したいことがあり、ロジックがクロージャに閉じていると再実装を強いられる（#927 tool-state, #946 無限地形はこの後追い対応だった）。
+
+**レジストリは既にホストから到達可能**: `createApp()` が返す `AppInstance` は `app.actions` / `app.hud` / `app.services` をそのまま公開する（全プラグイン横断の singleton、`packages/core/src/create-app.ts`）。`app.actions.get(id).run(args)` や `app.hud.getSettings()` の descriptor `.set(name,value)` でどのプラグインの操作も駆動できる。ただしこれらは stringly-typed で discoverable でない。
+
+**型付きのホスト向け API は `defineService` シームで公開する**（推奨・標準）:
+
+1. 操作を素の関数として実装（例: `enableInfiniteTerrain(store, opts)`）。
+2. それらを API オブジェクトに束ね、`ctx.services` に provide する。
+   ```ts
+   // xxx-service.ts
+   import { defineService, type ServiceRegistry, type BoardStore } from "@edv4h/usketch-shared";
+   export interface XxxApi { doThing(): void; /* ... */ }
+   export const xxxService = defineService<XxxApi>("usketch-plugin-xxx"); // key はプラグイン id
+   export function createXxxApi(store: BoardStore): XxxApi { return { doThing: () => op(store) }; }
+   export function getXxxApi(services: ServiceRegistry): XxxApi | undefined { return xxxService.get(services); }
+   // plugin setup: const off = xxxService.provide(ctx.services, createXxxApi(ctx.store)); // teardown で off()
+   ```
+3. ホストは `getXxxApi(app.services)?.doThing()` で駆動。プラグイン不在なら `undefined`（optional に扱える）。
+
+`ctx.services` と `app.services` は同一 registry なので、`getXxxApi(services)` は plugin↔plugin でも host↔plugin でも同じアクセサで使える。**参照実装は `usketch-plugin-map` の `map-service.ts`（`mapService` / `getMapApi`）**。
+
 #### なぜ
 
 1. **`order` が手管理のグローバル名前空間になる。** プラグイン同士が番号を取り合い、実際に衝突している（`shape-connector` の labelEditor と `domain-design` のプロパティバーは 82〜84 を手作業で調整している）。HUD に集約すれば、レイヤーの order はコアが持つ1つで済む。

--- a/packages/shared/src/__tests__/service.test.ts
+++ b/packages/shared/src/__tests__/service.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { defineService } from "../service.js";
+import type { ServiceRegistry } from "../types/plugin.js";
+
+/** Minimal in-memory ServiceRegistry (mirrors packages/core's implementation). */
+function fakeServices(): ServiceRegistry {
+	const map = new Map<string, unknown>();
+	return {
+		provide: <T>(key: string, service: T) => {
+			map.set(key, service);
+			return () => {
+				if (map.get(key) === service) map.delete(key);
+			};
+		},
+		get: <T>(key: string) => map.get(key) as T | undefined,
+		has: (key: string) => map.has(key),
+	};
+}
+
+interface DemoApi {
+	ping(): string;
+}
+
+describe("defineService", () => {
+	it("round-trips a typed service through provide/get", () => {
+		const services = fakeServices();
+		const demo = defineService<DemoApi>("demo");
+		expect(demo.key).toBe("demo");
+		expect(demo.get(services)).toBeUndefined();
+		expect(demo.has(services)).toBe(false);
+
+		demo.provide(services, { ping: () => "pong" });
+		expect(demo.has(services)).toBe(true);
+		expect(demo.get(services)?.ping()).toBe("pong");
+	});
+
+	it("returns undefined when the providing plugin is absent (optional)", () => {
+		const demo = defineService<DemoApi>("demo");
+		expect(demo.get(fakeServices())).toBeUndefined();
+	});
+
+	it("unprovide removes the service", () => {
+		const services = fakeServices();
+		const demo = defineService<DemoApi>("demo");
+		const off = demo.provide(services, { ping: () => "pong" });
+		off();
+		expect(demo.get(services)).toBeUndefined();
+	});
+
+	it("the same handle works for two registries (ctx.services vs app.services)", () => {
+		// In createApp these are the same object; the accessor must be registry-agnostic.
+		const a = fakeServices();
+		const demo = defineService<DemoApi>("demo");
+		demo.provide(a, { ping: () => "a" });
+		expect(demo.get(a)?.ping()).toBe("a");
+		expect(demo.get(fakeServices())).toBeUndefined();
+	});
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,7 @@
 // Geometry
+
+// Service seam (typed host-facing plugin APIs over ctx.services / app.services)
+export { defineService, type ServiceHandle } from "./service.js";
 export type { BoundingBox, Point, Viewport } from "./types/geometry.js";
 // LOD
 export type { LodController, LodPolicy, LodPolicyContext, RenderMode } from "./types/lod.js";

--- a/packages/shared/src/service.ts
+++ b/packages/shared/src/service.ts
@@ -1,0 +1,37 @@
+import type { ServiceRegistry } from "./types/plugin.js";
+
+/**
+ * A typed handle to a plugin-provided service (the `ctx.services` IoC seam). Pairs
+ * a string `key` with typed `provide`/`get` so a provider and its consumers can't
+ * drift on the key or the type, and so the SAME accessor works for both a plugin's
+ * `ctx.services` and the host's `app.services` — they are the same registry object.
+ *
+ * This is the sanctioned way for a plugin to expose a **host-facing operation API**
+ * without going through the Control HUD: author the operations as plain functions,
+ * bundle them into an API object, `provide` it under a `ServiceHandle` in `setup`,
+ * and let hosts reach it via `handle.get(app.services)`. The plugin being absent is
+ * a first-class case — `get` returns `undefined`. See docs/plugin-system-design.md.
+ */
+export interface ServiceHandle<T> {
+	/** The registry key. Namespace it (e.g. the plugin id) to avoid collisions. */
+	readonly key: string;
+	/** Provide the service — call once in the plugin's `setup`. Returns an unprovide fn. */
+	provide(services: ServiceRegistry, api: T): () => void;
+	/** The provided service, or `undefined` when the providing plugin is absent. */
+	get(services: ServiceRegistry): T | undefined;
+	/** Whether the service is currently provided. */
+	has(services: ServiceRegistry): boolean;
+}
+
+/**
+ * Define a typed {@link ServiceHandle}. `key` should be namespaced — the plugin id
+ * is the natural choice (e.g. `"usketch-plugin-map"`).
+ */
+export function defineService<T>(key: string): ServiceHandle<T> {
+	return {
+		key,
+		provide: (services, api) => services.provide<T>(key, api),
+		get: (services) => services.get<T>(key),
+		has: (services) => services.has(key),
+	};
+}

--- a/plugins/usketch-plugin-map/src/__tests__/map-service.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/map-service.test.ts
@@ -1,0 +1,56 @@
+import type { BoardStore, ServiceRegistry, ShapeData } from "@edv4h/usketch-shared";
+import { describe, expect, it } from "vitest";
+import { createMapApi, getMapApi, mapService } from "../map-service.js";
+
+function fakeStore(initial: ShapeData[] = []): BoardStore {
+	const shapes = new Map<string, ShapeData>(initial.map((s) => [s.id, s]));
+	return {
+		getShapes: () => shapes,
+		getShape: (id: string) => shapes.get(id),
+		addShape: (s: ShapeData) => shapes.set(s.id, s),
+		updateShape: (id: string, patch: Partial<ShapeData>) => {
+			const s = shapes.get(id);
+			if (s) shapes.set(id, { ...s, ...patch });
+		},
+		deleteShape: (id: string) => shapes.delete(id),
+	} as unknown as BoardStore;
+}
+
+function fakeServices(): ServiceRegistry {
+	const map = new Map<string, unknown>();
+	return {
+		provide: <T>(key: string, service: T) => {
+			map.set(key, service);
+			return () => map.delete(key);
+		},
+		get: <T>(key: string) => map.get(key) as T | undefined,
+		has: (key: string) => map.has(key),
+	};
+}
+
+describe("map service seam", () => {
+	it("getMapApi is undefined until the plugin provides it (optional plugin)", () => {
+		expect(getMapApi(fakeServices())).toBeUndefined();
+	});
+
+	it("provides a store-bound API a host can drive without the HUD", () => {
+		const store = fakeStore();
+		const services = fakeServices();
+		mapService.provide(services, createMapApi(store));
+
+		const api = getMapApi(services);
+		expect(api).toBeDefined();
+		expect(api?.isInfiniteTerrainEnabled()).toBe(false);
+		const seed = api?.enableInfiniteTerrain({ seed: 42 });
+		expect(seed).toBe(42);
+		expect(api?.getInfiniteSeed()).toBe(42); // reflected on the bound store
+		api?.setInfiniteSeed(null);
+		expect(api?.isInfiniteTerrainEnabled()).toBe(false);
+	});
+
+	it("exposes the tool/render reactive stores", () => {
+		const api = createMapApi(fakeStore());
+		expect(typeof api.toolState.get).toBe("function");
+		expect(typeof api.renderConfig.subscribe).toBe("function");
+	});
+});

--- a/plugins/usketch-plugin-map/src/__tests__/map-service.test.ts
+++ b/plugins/usketch-plugin-map/src/__tests__/map-service.test.ts
@@ -21,7 +21,11 @@ function fakeServices(): ServiceRegistry {
 	return {
 		provide: <T>(key: string, service: T) => {
 			map.set(key, service);
-			return () => map.delete(key);
+			// Match core's createServiceRegistry: a stale unprovide must not delete a
+			// newer provide (instance check).
+			return () => {
+				if (map.get(key) === service) map.delete(key);
+			};
 		},
 		get: <T>(key: string) => map.get(key) as T | undefined,
 		has: (key: string) => map.has(key),

--- a/plugins/usketch-plugin-map/src/index.ts
+++ b/plugins/usketch-plugin-map/src/index.ts
@@ -34,6 +34,10 @@ export {
 	setInfiniteSeed,
 } from "./infinite-terrain.js";
 export { MAP_ICON_TYPE, type MapIconShapeData } from "./map-icon-shape.js";
+// ── Host-facing service (recommended seam; #927/#946 pattern generalized) ──
+// `getMapApi(app.services)?.enableInfiniteTerrain({ seed })` from a host, without
+// the Control HUD and without importing individual helpers (undefined if absent).
+export { createMapApi, getMapApi, type MapApi, mapService } from "./map-service.js";
 export { MAP_TOOL_ID } from "./map-tool-id.js";
 export type { ColorMode } from "./palette.js";
 export { createMapPlugin, type MapPluginOptions } from "./plugin.js";

--- a/plugins/usketch-plugin-map/src/map-service.ts
+++ b/plugins/usketch-plugin-map/src/map-service.ts
@@ -27,7 +27,10 @@ export interface MapApi {
 	isInfiniteTerrainEnabled(): boolean;
 	/** A number enables/re-seeds, `null` disables. */
 	setInfiniteSeed(seed: number | null): void;
-	// ── App-local reactive stores backing the map tool + Tweaks (get/set/subscribe) ──
+	// ── Reactive stores backing the map tool + Tweaks (get/set/subscribe). NOTE:
+	//    these are MODULE-SCOPED singletons, not bound to this store like the ops
+	//    above — so multiple AppInstances in the same JS runtime SHARE them. They are
+	//    app-local per-user presentation state (never synced across clients). ──
 	toolState: ReactiveStore<MapToolState>;
 	renderConfig: ReactiveStore<MapRenderConfig>;
 }

--- a/plugins/usketch-plugin-map/src/map-service.ts
+++ b/plugins/usketch-plugin-map/src/map-service.ts
@@ -1,0 +1,57 @@
+// The map plugin's host-facing API, published on the `ctx.services` seam so a host
+// (or any other plugin) can drive map operations WITHOUT the Control HUD and
+// without importing individual helpers. This is the reference for the convention
+// in docs/plugin-system-design.md: operation logic lives in plain functions, the
+// HUD/actions call them, and the same functions are bundled into a service.
+import { type BoardStore, defineService, type ServiceRegistry } from "@edv4h/usketch-shared";
+import {
+	disableInfiniteTerrain,
+	type EnableInfiniteTerrainOptions,
+	enableInfiniteTerrain,
+	getInfiniteSeed,
+	isInfiniteTerrainEnabled,
+	setInfiniteSeed,
+} from "./infinite-terrain.js";
+import type { ReactiveStore } from "./reactive-store.js";
+import { type MapRenderConfig, renderConfigStore } from "./render-config.js";
+import { type MapToolState, toolStateStore } from "./tool-state.js";
+
+/** The map plugin's host-facing operations + live stores. */
+export interface MapApi {
+	// ── Infinite base terrain (store-bound; the host needn't pass the store) ──
+	/** Enable/re-seed the infinite base terrain. Returns the applied integer seed. */
+	enableInfiniteTerrain(opts?: EnableInfiniteTerrainOptions): number;
+	disableInfiniteTerrain(): void;
+	/** Current effective seed, or `null` when disabled. */
+	getInfiniteSeed(): number | null;
+	isInfiniteTerrainEnabled(): boolean;
+	/** A number enables/re-seeds, `null` disables. */
+	setInfiniteSeed(seed: number | null): void;
+	// ── App-local reactive stores backing the map tool + Tweaks (get/set/subscribe) ──
+	toolState: ReactiveStore<MapToolState>;
+	renderConfig: ReactiveStore<MapRenderConfig>;
+}
+
+/** Typed service handle for the map API. Provide in `setup`, get via {@link getMapApi}. */
+export const mapService = defineService<MapApi>("usketch-plugin-map");
+
+/** Build the API bound to a specific board store (called in the plugin's setup). */
+export function createMapApi(store: BoardStore): MapApi {
+	return {
+		enableInfiniteTerrain: (opts) => enableInfiniteTerrain(store, opts),
+		disableInfiniteTerrain: () => disableInfiniteTerrain(store),
+		getInfiniteSeed: () => getInfiniteSeed(store),
+		isInfiniteTerrainEnabled: () => isInfiniteTerrainEnabled(store),
+		setInfiniteSeed: (seed) => setInfiniteSeed(store, seed),
+		toolState: toolStateStore,
+		renderConfig: renderConfigStore,
+	};
+}
+
+/**
+ * Host accessor: `getMapApi(app.services)?.enableInfiniteTerrain({ seed })`. Returns
+ * `undefined` when the map plugin isn't active. Works with `ctx.services` too.
+ */
+export function getMapApi(services: ServiceRegistry): MapApi | undefined {
+	return mapService.get(services);
+}

--- a/plugins/usketch-plugin-map/src/plugin.tsx
+++ b/plugins/usketch-plugin-map/src/plugin.tsx
@@ -56,10 +56,6 @@ export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 		name: "RPG マップ",
 
 		setup(ctx: PluginContext) {
-			// ── Host-facing API (ctx.services seam) — lets a host or another plugin
-			//    drive map operations without the Control HUD. See map-service.ts. ──
-			const unprovideService = mapService.provide(ctx.services, createMapApi(ctx.store));
-
 			// ── Shapes (tilemap + base-map = data-only substrates, map-icon = foreground) ──
 			ctx.shapes.register(TILEMAP_TYPE, createTileMapShapeDefinition(tile));
 			ctx.shapes.register(BASE_MAP_TYPE, createBaseMapShapeDefinition(tile));
@@ -198,6 +194,13 @@ export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 					};
 				},
 			});
+
+			// ── Host-facing API (ctx.services seam) — lets a host or another plugin
+			//    drive map operations without the Control HUD. See map-service.ts.
+			//    Provided LAST, after every throw-prone registration above, so a setup
+			//    failure can't leak the service (createApp only rolls back a returned
+			//    teardown). ──
+			const unprovideService = mapService.provide(ctx.services, createMapApi(ctx.store));
 
 			return () => {
 				unprovideService();

--- a/plugins/usketch-plugin-map/src/plugin.tsx
+++ b/plugins/usketch-plugin-map/src/plugin.tsx
@@ -15,6 +15,7 @@ import {
 } from "./infinite-terrain.js";
 import { MAP_ICON_TYPE, mapIconShapeDefinition } from "./map-icon-shape.js";
 import { MapTerrainLayer } from "./map-layer.js";
+import { createMapApi, mapService } from "./map-service.js";
 import { createMapToolDefinition } from "./map-tool.js";
 import { MAP_TOOL_ID } from "./map-tool-id.js";
 import type { ColorMode } from "./palette.js";
@@ -55,6 +56,10 @@ export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 		name: "RPG マップ",
 
 		setup(ctx: PluginContext) {
+			// ── Host-facing API (ctx.services seam) — lets a host or another plugin
+			//    drive map operations without the Control HUD. See map-service.ts. ──
+			const unprovideService = mapService.provide(ctx.services, createMapApi(ctx.store));
+
 			// ── Shapes (tilemap + base-map = data-only substrates, map-icon = foreground) ──
 			ctx.shapes.register(TILEMAP_TYPE, createTileMapShapeDefinition(tile));
 			ctx.shapes.register(BASE_MAP_TYPE, createBaseMapShapeDefinition(tile));
@@ -195,6 +200,7 @@ export function createMapPlugin(options: MapPluginOptions = {}): UsketchPlugin {
 			});
 
 			return () => {
+				unprovideService();
 				ctx.layers.unregister(TERRAIN_LAYER_ID);
 				ctx.layers.unregister(BASE_LAYER_ID);
 				ctx.layers.unregister(ENTER_BANNER_ID);


### PR DESCRIPTION
「HUD からしか操作できず呼び出し先で困る」問題（#927 tool-state, #946 無限地形が後追い対応だった）の**根本対策**。

### 判明した本質
配管は既にある — `createApp()` の `AppInstance` は `app.actions` / `app.hud` / `app.services` をホストに公開しており、HUD はその1消費者にすぎません。痛みは (1) 操作ロジックが HUD の `set`/`run` クロージャに埋まり第一級の import 可能な操作でない、(2) レジストリ経由は stringly-typed で discoverable でない、の2点でした。

### 対策（規約＋services シーム）
- **`@edv4h/usketch-shared`: `defineService<T>(key)`** — 型付き `ServiceHandle`（`provide`/`get`/`has`）。`ctx.services`（plugin）と `app.services`（host）は同一 registry なので同じアクセサで両用。プラグイン不在なら `get` が `undefined`。
- **`@edv4h/usketch-plugin-map`: `MapApi` サービス（参照実装）** — `setup` で `mapService.provide(ctx.services, createMapApi(ctx.store))`。ホストは `getMapApi(app.services)?.enableInfiniteTerrain({ seed })` で、個別 export 名も store も知らず駆動可能。store バインド済みの無限地形操作＋reactive stores を公開。既存 export は後方互換で維持。
- **規約を明文化**（`docs/plugin-system-design.md` ＋ `CLAUDE.md`）: 操作ロジックは HUD クロージャに埋めず `BoardStore` を受け取る純関数にし、HUD はそれを呼ぶだけ。ホスト向け型付き API は `defineService` で公開。→ 「後追いで export を足す」サイクルを断つ。

### 使い方（weboard の「無限地形デフォルト ON」）
```ts
import { getMapApi } from "@edv4h/usketch-plugin-map";
const app = await createApp({ store, plugins });
getMapApi(app.services)?.enableInfiniteTerrain({ seed: 12345 });
```

### 検証
- shared 100 テスト（`defineService` の round-trip / optional / unprovide）＋ map 108 テスト（`MapApi` の store バインド駆動 / 不在時 undefined）。
- shared/map build・typecheck・biome クリーン、web typecheck（79 tasks）通過。

### 後続（スコープ外）
- map 以外のプラグイン（side-panel / freedraw 等）を同シームへ順次移行。必要なら lint ルール化で規約を機械強制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)